### PR TITLE
feat: improve space when rebuilding

### DIFF
--- a/generator/build.rs
+++ b/generator/build.rs
@@ -1,47 +1,20 @@
-use std::{fs::File, io, path::Path};
+use std::{fs::File, path::Path};
 
 use zip::ZipArchive;
 
-fn unzip_file_to_location(file_path: &Path, destination: &Path) -> io::Result<()> {
-    let file = File::open(file_path)?;
-    let mut archive = ZipArchive::new(file)?;
-
-    for i in 0..archive.len() {
-        let mut file = archive.by_index(i)?;
-
-        // todo: mangled name good?
-        let outpath = destination.join(file.mangled_name());
-
-        if (*file.name()).ends_with('/') {
-            std::fs::create_dir_all(&outpath)?;
-        } else {
-            if let Some(p) = outpath.parent() {
-                if !p.exists() {
-                    std::fs::create_dir_all(p)?;
-                }
-            }
-            let mut outfile = File::create(&outpath)?;
-            io::copy(&mut file, &mut outfile)?;
-        }
-    }
-
-    Ok(())
-}
-
 fn main() {
-    // step 1 unzip generated.zip to OUT_DIR
-    let out_dir = std::env::var("OUT_DIR").unwrap();
-    let out_dir = Path::new(&out_dir);
-
     let root = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let root = Path::new(&root);
 
     let generated_zip = root.join("generated.zip");
 
-    unzip_file_to_location(&generated_zip, out_dir).unwrap();
+    let file = File::open(generated_zip).unwrap();
+    let mut archive = ZipArchive::new(file).unwrap();
+
+    let registries = archive.by_name("generated/reports/registries.json").unwrap();
 
     generator_build::GeneratorConfig {
-        input: out_dir.join("generated"),
+        registries,
         output: None,
     }
     .build()

--- a/generator/build.rs
+++ b/generator/build.rs
@@ -11,7 +11,9 @@ fn main() {
     let file = File::open(generated_zip).unwrap();
     let mut archive = ZipArchive::new(file).unwrap();
 
-    let registries = archive.by_name("generated/reports/registries.json").unwrap();
+    let registries = archive
+        .by_name("generated/reports/registries.json")
+        .unwrap();
 
     generator_build::GeneratorConfig {
         registries,


### PR DESCRIPTION
- no longer unzips the generated.zip file to the OUT_DIR when a single file can easily be read from the zip file
- this prevents multiple unzips in the `target` directory when the build is run multiple times