### PR TITLE
perf: use spin mutex for GLOBAL_PACKETS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,6 +1767,7 @@ dependencies = [
  "sha2",
  "signal-hook",
  "smallvec 2.0.0-alpha.5",
+ "spin",
  "thread-priority",
  "tracing",
  "tracing-flame",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -54,6 +54,7 @@ jemallocator = "0.5.4"
 jemalloc-ctl = "0.5.4"
 libc = "0.2.153"
 fastrand = "2.0.2"
+spin = "0.9.8"
 rayon-local.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -137,7 +137,6 @@ pub struct Game {
     last_ms_per_tick: VecDeque<f64>,
     tick_on: u64,
     incoming: flume::Receiver<ClientConnection>,
-    req_packets: flume::Sender<()>,
 }
 
 impl Game {
@@ -183,7 +182,7 @@ impl Game {
             }
         });
 
-        let (incoming, req_packets) = server(shutdown_rx)?;
+        let incoming = server(shutdown_rx)?;
 
         let mut world = World::new();
 
@@ -216,7 +215,6 @@ impl Game {
             last_ms_per_tick: VecDeque::default(),
             tick_on: 0,
             incoming,
-            req_packets,
         };
 
         game.last_ticks.push_back(Instant::now());
@@ -297,8 +295,6 @@ impl Game {
         self.world.send(Gametick);
         self.world.send(BroadcastPackets);
 
-        self.req_packets.send(()).unwrap();
-
         #[expect(
             clippy::cast_precision_loss,
             reason = "realistically, nanoseconds between last tick will not be greater than 2^52 \
@@ -354,10 +350,7 @@ fn process_packets(
 ) {
     // uuid to entity id map
 
-    let packets: Vec<_> = {
-        let mut packets = GLOBAL_PACKETS.lock().unwrap();
-        core::mem::take(&mut packets)
-    };
+    let packets: Vec<_> = core::mem::take(&mut *GLOBAL_PACKETS.lock());
 
     let lookup = lookup.0;
 


### PR DESCRIPTION
Before this, packets that were received could take 2 ticks to be processed because they need to be moved from LOCAL_PACKETS to GLOBAL_PACKETS. To fix this, LOCAL_PACKETS is removed and a spin lock is used for GLOBAL_PACKETS.

This fixes #94 because the increased ping is a symptom of packets taking up to 2 ticks to be handled. With this fix, ping over localhost should just be the wait_duration for each tick (usually 50ms, but varies slightly)