### PR TITLE
Add support for configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 profiling
 *.svg
 *.zip
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
  "quote",
  "rustc-hash",
  "syn",
- "toml_edit",
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -1738,6 +1738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "server"
 version = "0.1.0"
 dependencies = [
@@ -1763,12 +1772,14 @@ dependencies = [
  "rand_distr",
  "rayon",
  "rayon-local",
+ "serde",
  "serde_json",
  "sha2",
  "signal-hook",
  "smallvec 2.0.0-alpha.5",
  "spin",
  "thread-priority",
+ "toml",
  "tracing",
  "tracing-flame",
  "tracing-subscriber",
@@ -2039,10 +2050,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.9",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -2052,7 +2078,20 @@ checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.5",
 ]
 
 [[package]]
@@ -2584,6 +2623,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -56,6 +56,8 @@ libc = "0.2.153"
 fastrand = "2.0.2"
 spin = "0.9.8"
 rayon-local.workspace = true
+serde = { version = "1.0.193", features = ["derive"] }
+toml = "0.8.12"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = "0.6.3"

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1,7 +1,6 @@
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use evenio::component::Component;
 use serde::{Deserialize, Serialize};
 use spin::lazy::Lazy;
 use tracing::{info, instrument};
@@ -10,7 +9,7 @@ pub static CONFIG: Lazy<Config> = Lazy::new(|| {
     Config::load("run/config.toml").unwrap()
 });
 
-#[derive(Serialize, Deserialize, Debug, Component)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
     pub border_diameter: Option<f64>,
     pub max_players: i32,

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1,0 +1,49 @@
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use evenio::component::Component;
+use serde::{Deserialize, Serialize};
+use spin::lazy::Lazy;
+use tracing::{info, instrument};
+
+pub static CONFIG: Lazy<Config> = Lazy::new(|| {
+    Config::load("run/config.toml").unwrap()
+});
+
+#[derive(Serialize, Deserialize, Debug, Component)]
+pub struct Config {
+    pub border_diameter: Option<f64>,
+    pub max_players: i32,
+    pub view_distance: i32,
+    pub simulation_distance: i32,
+    pub server_desc: String
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            border_diameter: Some(100.0),
+            max_players: 10_000,
+            view_distance: 32,
+            simulation_distance: 10,
+            server_desc: "10k babyyyy".to_owned()
+        }
+    }
+}
+
+impl Config {
+    #[instrument(skip_all)]
+    pub fn load<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
+        info!("loading configuration file");
+        if path.as_ref().exists() {
+            let mut file = File::open(path)?;
+            let mut contents = String::default();
+            file.read_to_string(&mut contents)?;
+            let config = toml::from_str::<Config>(contents.as_str())?;
+            Ok(config)
+        } else {
+            info!("configuration file not found, using defaults");
+            Ok(Self::default())
+        }
+    }
+}

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1,13 +1,10 @@
-use std::fs::File;
-use std::io::Read;
-use std::path::Path;
+use std::{fs::File, io::Read, path::Path};
+
 use serde::{Deserialize, Serialize};
 use spin::lazy::Lazy;
 use tracing::{info, instrument};
 
-pub static CONFIG: Lazy<Config> = Lazy::new(|| {
-    Config::load("run/config.toml").unwrap()
-});
+pub static CONFIG: Lazy<Config> = Lazy::new(|| Config::load("run/config.toml").unwrap());
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
@@ -15,7 +12,7 @@ pub struct Config {
     pub max_players: i32,
     pub view_distance: i32,
     pub simulation_distance: i32,
-    pub server_desc: String
+    pub server_desc: String,
 }
 
 impl Default for Config {
@@ -25,7 +22,7 @@ impl Default for Config {
             max_players: 10_000,
             view_distance: 32,
             simulation_distance: 10,
-            server_desc: "10k babyyyy".to_owned()
+            server_desc: "10k babyyyy".to_owned(),
         }
     }
 }
@@ -38,7 +35,7 @@ impl Config {
             let mut file = File::open(path)?;
             let mut contents = String::default();
             file.read_to_string(&mut contents)?;
-            let config = toml::from_str::<Config>(contents.as_str())?;
+            let config = toml::from_str::<Self>(contents.as_str())?;
             Ok(config)
         } else {
             info!("configuration file not found, using defaults");

--- a/crates/server/src/global.rs
+++ b/crates/server/src/global.rs
@@ -9,14 +9,12 @@ pub struct Shared {
 
 #[derive(Component)]
 pub struct Global {
-    pub world_border_diameter: Option<f64>,
     pub tick: i64,
 }
 
 impl Default for Global {
     fn default() -> Self {
         Self {
-            world_border_diameter: Some(100.0),
             tick: 0,
         }
     }

--- a/crates/server/src/global.rs
+++ b/crates/server/src/global.rs
@@ -12,10 +12,9 @@ pub struct Global {
     pub tick: i64,
 }
 
+#[expect(clippy::derivable_impls, reason = "default impl for explicitness")]
 impl Default for Global {
     fn default() -> Self {
-        Self {
-            tick: 0,
-        }
+        Self { tick: 0 }
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -21,6 +21,7 @@ use evenio::prelude::*;
 use jemalloc_ctl::{epoch, stats};
 use ndarray::s;
 use signal_hook::iterator::Signals;
+use spin::Lazy;
 use tracing::{info, instrument, warn};
 use valence_protocol::math::Vec3;
 
@@ -41,6 +42,7 @@ mod bits;
 mod quad_tree;
 
 pub mod bounding_box;
+mod config;
 
 // A zero-sized component, often called a "marker" or "tag".
 #[derive(Component)]
@@ -151,6 +153,7 @@ impl Game {
     #[instrument]
     pub fn init() -> anyhow::Result<Self> {
         info!("Starting mc-server");
+        Lazy::force(&config::CONFIG);
 
         // if linux
         #[cfg(target_os = "linux")]

--- a/crates/server/src/net.rs
+++ b/crates/server/src/net.rs
@@ -41,7 +41,7 @@ use valence_protocol::{
 };
 use valence_registry::{BiomeRegistry, RegistryCodec};
 
-use crate::SHARED;
+use crate::{config, SHARED};
 
 const DEFAULT_SPEED: u32 = 1024 * 1024;
 
@@ -175,9 +175,9 @@ impl WriterComm {
             is_hardcore: false,
             dimension_names: Cow::Owned(dimension_names),
             registry_codec: Cow::Borrowed(&registry_codec),
-            max_players: 10_000.into(),
-            view_distance: 32.into(), // max view distance
-            simulation_distance: 10.into(),
+            max_players: config::CONFIG.max_players.into(),
+            view_distance: config::CONFIG.view_distance.into(), // max view distance
+            simulation_distance: config::CONFIG.simulation_distance.into(),
             reduced_debug_info: false,
             enable_respawn_screen: false,
             dimension_name: dimension_name.into(),
@@ -549,11 +549,11 @@ impl Io {
             },
             "players": {
                 "online": player_count,
-                "max": 10_000,
+                "max": config::CONFIG.max_players,
                 "sample": [],
             },
             "favicon": favicon,
-            "description": "10k babyyyyy",
+            "description": config::CONFIG.server_desc.clone(),
         });
 
         let json = serde_json::to_string_pretty(&json)?;

--- a/crates/server/src/system/player_join_world.rs
+++ b/crates/server/src/system/player_join_world.rs
@@ -15,7 +15,10 @@ use valence_protocol::{
 };
 use valence_registry::{biome::BiomeId, RegistryIdx};
 
-use crate::{bits::BitStorage, chunk::heightmap, net::Packets, singleton::player_lookup::PlayerLookup, KickPlayer, Player, PlayerJoinWorld, Uuid, SHARED, config};
+use crate::{
+    bits::BitStorage, chunk::heightmap, config, net::Packets,
+    singleton::player_lookup::PlayerLookup, KickPlayer, Player, PlayerJoinWorld, Uuid, SHARED,
+};
 
 #[instrument(skip_all)]
 pub fn player_join_world(

--- a/run/config.toml
+++ b/run/config.toml
@@ -1,0 +1,5 @@
+border_diameter = 300.0
+max_players = 10000
+view_distance = 32
+simulation_distance = 10
+server_desc = "10k babyyyyyyyyyy"


### PR DESCRIPTION
Add global configuration that reads from `run/config.toml`.

Closes #97 