### PR TITLE
perf: improve memory usage (now ~50MB / 1000 players)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [profile.dev]
-opt-level = 1
+#opt-level = 1
 
 [profile.dev.package."*"]
 opt-level = 3
@@ -26,6 +26,11 @@ opt-level = 3
 lto = "fat"
 codegen-units = 1
 panic = "abort"
+
+# custom release-debug profile
+[profile.release-debug]
+inherits = "release"
+debug = true
 
 [profile.bench]
 #debug = true

--- a/crates/server/src/system/player_join_world.rs
+++ b/crates/server/src/system/player_join_world.rs
@@ -193,6 +193,8 @@ pub fn player_join_world(
 
     buf.append_packet(&spawn_player).unwrap();
 
+    encoder.deallocate_on_process();
+
     info!("Player {} joined the world", current_player.name);
 }
 


### PR DESCRIPTION
https://doc.rust-lang.org/beta/alloc/vec/struct.Vec.html#guarantees
> `Vec` will never automatically shrink itself, even if completely empty

When chunks are sent, there is a significant allocation in the first gametick. This commit implements re-allocating after the first gametick.

With 1000 players before:
![image](https://github.com/andrewgazelka/hyperion/assets/7644264/3f7828e0-093e-46c6-a109-6c1f89a868e2)

after:
![image](https://github.com/andrewgazelka/hyperion/assets/7644264/197a8b32-c0c7-4f83-9a9c-84cf7af4b1bc)

