### PR TITLE
perf: reduce unnecessary packets

### DIFF
--- a/crates/server/src/system/clean_up_io.rs
+++ b/crates/server/src/system/clean_up_io.rs
@@ -45,17 +45,17 @@ pub fn clean_up_io(
             .shared
             .player_count
             .fetch_sub(num_removed as u32, Ordering::Relaxed);
+
+        broadcast
+            .append_packet(&play::EntitiesDestroyS2c {
+                entity_ids: despawn_ids.into(),
+            })
+            .unwrap();
+
+        broadcast
+            .append_packet(&play::PlayerRemoveS2c {
+                uuids: despawn_uuids.into(),
+            })
+            .unwrap();
     }
-
-    broadcast
-        .append_packet(&play::EntitiesDestroyS2c {
-            entity_ids: despawn_ids.into(),
-        })
-        .unwrap();
-
-    broadcast
-        .append_packet(&play::PlayerRemoveS2c {
-            uuids: despawn_uuids.into(),
-        })
-        .unwrap();
 }

--- a/crates/server/src/system/player_join_world.rs
+++ b/crates/server/src/system/player_join_world.rs
@@ -158,6 +158,16 @@ pub fn player_join_world(
         })
         .unwrap();
 
+    let tick = global.tick;
+    let time_of_day = tick % 24000;
+
+    encoder
+        .encode(&play::WorldTimeUpdateS2c {
+            world_age: tick,
+            time_of_day,
+        })
+        .unwrap();
+
     // todo: cache
     for (id, _, uuid, pose) in &players {
         let entity_id = VarInt(id.index().0 as i32);

--- a/crates/server/src/system/update_time.rs
+++ b/crates/server/src/system/update_time.rs
@@ -12,12 +12,15 @@ pub fn update_time(
     let tick = global.tick;
     let time_of_day = tick % 24000;
 
-    let pkt = valence_protocol::packets::play::WorldTimeUpdateS2c {
-        world_age: tick,
-        time_of_day,
-    };
+    // Only sync with the client every 5 seconds
+    if tick % (20 * 5) == 0 {
+        let pkt = valence_protocol::packets::play::WorldTimeUpdateS2c {
+            world_age: tick,
+            time_of_day,
+        };
 
-    broadcast.get_round_robin().append_packet(&pkt).unwrap();
+        broadcast.get_round_robin().append_packet(&pkt).unwrap();
+    }
 
     // update the tick
     global.tick += 1;


### PR DESCRIPTION
Don't send player remove packets unless needed. Only sync time every 5 seconds.