### PR TITLE
fix: packet encoding

### DIFF
--- a/crates/server/src/events.rs
+++ b/crates/server/src/events.rs
@@ -127,6 +127,7 @@ impl<A: Allocator + Debug> ScratchBuffer for Scratch<A> {
     type Allocator = A;
 
     fn obtain(&mut self) -> &mut Vec<u8, Self::Allocator> {
+        self.inner.clear();
         &mut self.inner
     }
 }
@@ -138,14 +139,6 @@ impl<'a> From<&'a Bump> for BumpScratch<'a> {
         Self {
             inner: Vec::with_capacity_in(MAX_PACKET_SIZE, bump),
         }
-    }
-}
-
-impl<'a> BumpScratch<'a> {
-    pub fn obtain(&mut self) -> &mut Vec<u8, &'a Bump> {
-        // clear scratch before we get
-        self.inner.clear();
-        &mut self.inner
     }
 }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -174,7 +174,7 @@ impl Game {
         world.add_handler(system::ingress::add_player);
         world.add_handler(system::ingress::remove_player);
         world.add_handler(system::ingress::recv_data);
-        world.add_handler(system::ingress::send_data);
+        world.add_handler(system::ingress::sent_data);
 
         world.add_handler(system::init_player);
         world.add_handler(system::player_join_world);

--- a/crates/server/src/net/linux.rs
+++ b/crates/server/src/net/linux.rs
@@ -268,6 +268,8 @@ impl ServerDef for LinuxServer {
                                 result
                             );
                             Self::shutdown(&mut submission, fd);
+
+                            f(ServerEvent::RemovePlayer { fd: Fd(fd) });
                         }
                         cmp::Ordering::Equal => {
                             // This should never happen as long as write is never passed an empty buffer:

--- a/crates/server/src/system/ingress.rs
+++ b/crates/server/src/system/ingress.rs
@@ -76,7 +76,7 @@ pub struct RecvData<'a, 'b, 'c> {
 }
 
 #[derive(Event)]
-pub struct SendData {
+pub struct SentData {
     fd: Fd,
 }
 
@@ -101,7 +101,7 @@ pub fn generate_ingress_events(world: &mut World, server: &mut Server, scratch: 
                 world.send(RecvData { fd, data, scratch });
             }
             ServerEvent::SentData { fd } => {
-                world.send(SendData { fd });
+                world.send(SentData { fd });
             }
         })
         .unwrap();
@@ -156,8 +156,8 @@ pub fn remove_player(
 // The `Receiver<Tick>` parameter tells our handler to listen for the `Tick` event.
 #[instrument(skip_all, level = "trace")]
 #[allow(clippy::too_many_arguments, reason = "todo")]
-pub fn send_data(
-    r: Receiver<SendData>,
+pub fn sent_data(
+    r: Receiver<SentData>,
     mut players: Fetcher<&mut Packets>,
     fd_lookup: Single<&FdLookup>,
 ) {
@@ -219,6 +219,7 @@ pub fn recv_data(
 
     decoder.queue_slice(data);
 
+    // todo: error  on low compression: "decompressed packet length of 2 is <= the compression threshold of 2"
     while let Some(frame) = decoder.try_next_packet().unwrap() {
         match *login_state {
             LoginState::Handshake => process_handshake(login_state, &frame).unwrap(),


### PR DESCRIPTION
packe encoding was bugged and often resulted in disconnects for a couple of reasons:

1. compression threshold used `>=` instead of `>` which caused packets to be compressed when they shouldn't have been
2. the scratch buffer was not *always* cleared before use, causing old data to be appended to the new packet