### PR TITLE
fix: handle truncated writes

### DIFF
--- a/crates/server/src/net/encoder.rs
+++ b/crates/server/src/net/encoder.rs
@@ -71,6 +71,7 @@ where
     pkt.encode_with_id(&mut cursor)?;
 
     let data_len = cursor.position() as usize - data_write_start as usize;
+    dbg!(data_len);
 
     let packet_len_size = VarInt(data_len as i32).written_size();
 

--- a/crates/server/src/net/linux.rs
+++ b/crates/server/src/net/linux.rs
@@ -232,7 +232,10 @@ impl<'a> Iterator for LinuxServerIterator<'a> {
                             // TODO: Check that write wasn't truncated
                             trace!("successful write response");
 
-                            return Some(ServerEvent::SentData { fd: Fd(fd) });
+                            return Some(ServerEvent::SentData {
+                                fd: Fd(fd),
+                                bytes_sent: result as u32,
+                            });
                         }
                     }
                 }

--- a/crates/server/src/system/egress.rs
+++ b/crates/server/src/system/egress.rs
@@ -6,6 +6,7 @@ use tracing::{instrument, log::warn};
 
 use crate::{
     components::LoginState,
+    net::IoBufs,
     event::Egress,
     net::{encoder::DataWriteInfo, Broadcast, Fd, Packets, ServerDef, WriteItem},
 };

--- a/crates/server/src/system/egress.rs
+++ b/crates/server/src/system/egress.rs
@@ -6,7 +6,6 @@ use tracing::{instrument, log::warn};
 
 use crate::{
     components::LoginState,
-    net::IoBufs,
     event::Egress,
     net::{encoder::DataWriteInfo, Broadcast, Fd, Packets, ServerDef, WriteItem},
 };


### PR DESCRIPTION
This draft currently supports resending truncated packets if only one buffer is sent per player per tick (in theory; haven't tested this). However it doesn't handle the event where the server does the following:
```
write(100 bytes)
write(10 bytes)
submit()
```
and the completion events have:
```
write(100 bytes) = 50 bytes written
write(10 bytes) = 10 bytes written
```
I'm not sure what the best way to solve this would be.
