### PR TITLE
perf: remove unnecessary allocations

### DIFF
--- a/crates/server/src/event.rs
+++ b/crates/server/src/event.rs
@@ -151,13 +151,11 @@ pub struct Shoved {
 
 /// An event when server stats are updated.
 #[derive(Event)]
-pub struct Stats<'a, 'b> {
+pub struct Stats {
     /// The number of milliseconds per tick in the last second.
     pub ms_per_tick_mean_1s: f64,
     /// The number of milliseconds per tick in the last 5 seconds.
     pub ms_per_tick_mean_5s: f64,
-
-    pub scratch: &'b mut BumpScratch<'a>,
 }
 
 // todo: naming? this seems bad
@@ -267,10 +265,7 @@ pub struct Scratches {
 
 // todo: why need two life times?
 #[derive(Event)]
-pub struct Gametick<'a, 'b> {
-    pub bump: &'a RayonLocal<Bump>,
-    pub scratch: &'b mut RayonLocal<BumpScratch<'a>>,
-}
+pub struct Gametick;
 
 /// An event that is sent when it is time to send packets to clients.
 #[derive(Event)]


### PR DESCRIPTION
SIGNIFICANTLY reduces mspt on macOS when idling (by factor of 10 probably)

![image](https://github.com/andrewgazelka/hyperion/assets/7644264/2de69d8c-1c92-47e2-bc01-6394e8746b9d)
