### PR TITLE
feat: add stats boss bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1602,16 +1602,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,19 +1670,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndarray"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "rawpointer",
-]
-
-[[package]]
 name = "no_denormals"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,15 +1692,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,15 +1699,6 @@ checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
  "arrayvec",
  "itoa",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -2060,12 +2019,6 @@ dependencies = [
  "num-traits",
  "rand",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -2440,7 +2393,6 @@ dependencies = [
  "libdeflater",
  "mio",
  "more-asserts",
- "ndarray",
  "no_denormals",
  "num-format",
  "once_cell",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -33,7 +33,6 @@ signal-hook = "0.3.17"
 uuid = { version = "1.8.0", features = ["v3"] }
 rand_distr = "0.4.3"
 rayon = "1.10.0"
-ndarray = "0.15.6"
 libc = "0.2.153"
 spin = "0.9.8"
 serde = { version = "1.0.197", features = ["derive"] }

--- a/crates/server/src/event.rs
+++ b/crates/server/src/event.rs
@@ -160,10 +160,7 @@ pub struct Shoved {
 /// An event when server stats are updated.
 #[derive(Event)]
 pub struct Stats {
-    /// The number of milliseconds per tick in the last second.
-    pub ms_per_tick_mean_1s: f64,
-    /// The number of milliseconds per tick in the last 5 seconds.
-    pub ms_per_tick_mean_5s: f64,
+    pub ms_per_tick: f64,
 }
 
 // todo: naming? this seems bad


### PR DESCRIPTION
This commit adds a boss bar to the server that shows the current server stats.

This includes:
- ms/tick
- player count

- ms/tick is colored red if it is over 10ms/tick and measures proportion of ms/tick out of 20ms/tick.
- player count is colored white and measures proportion of players out of 10k.