### PR TITLE
feat: arrow speeds and depletion

### DIFF
--- a/crates/server/src/event.rs
+++ b/crates/server/src/event.rs
@@ -27,7 +27,9 @@ pub struct ClickEvent {
 
 /// An event that is sent when a player interacts with an item.
 #[derive(TargetedEvent, Debug)]
-pub struct ItemInteract;
+pub struct ItemInteract {
+    pub hand: Hand,
+}
 
 /// The type of click that the player performed.
 #[derive(Copy, Clone, Debug)]

--- a/crates/server/src/inventory.rs
+++ b/crates/server/src/inventory.rs
@@ -342,7 +342,7 @@ impl PlayerInventory {
 
     /// get slot of hand
     #[must_use]
-    pub fn get_hand_slot(&mut self, hand: Hand) -> usize {
+    pub const fn get_hand_slot(&self, hand: Hand) -> usize {
         match hand {
             Hand::Main => self.main_hand as usize,
             Hand::Off => 45,
@@ -357,7 +357,7 @@ impl PlayerInventory {
 
     /// get item in hand
     #[must_use]
-    pub fn get_hand(&mut self, hand: Hand) -> &ItemStack {
+    pub const fn get_hand(&self, hand: Hand) -> &ItemStack {
         &self.items.slots[self.get_hand_slot(hand)]
     }
 
@@ -368,7 +368,7 @@ impl PlayerInventory {
 
     /// get item in the off hand
     #[must_use]
-    pub fn get_off_hand(&self) -> &ItemStack {
+    pub const fn get_off_hand(&self) -> &ItemStack {
         &self.items.slots[45]
     }
 
@@ -379,7 +379,7 @@ impl PlayerInventory {
 
     /// get item in the main hand
     #[must_use]
-    pub fn get_main_hand(&self) -> &ItemStack {
+    pub const fn get_main_hand(&self) -> &ItemStack {
         &self.items.slots[self.main_hand as usize]
     }
 
@@ -401,7 +401,7 @@ impl PlayerInventory {
 
     /// get helmet slot 5
     #[must_use]
-    pub fn get_helmet(&self) -> &ItemStack {
+    pub const fn get_helmet(&self) -> &ItemStack {
         &self.items.slots[5]
     }
 
@@ -413,7 +413,7 @@ impl PlayerInventory {
 
     /// get chestplate slot 6
     #[must_use]
-    pub fn get_chestplate(&self) -> &ItemStack {
+    pub const fn get_chestplate(&self) -> &ItemStack {
         &self.items.slots[6]
     }
 
@@ -425,7 +425,7 @@ impl PlayerInventory {
 
     /// get leggings slot 7
     #[must_use]
-    pub fn get_leggings(&self) -> &ItemStack {
+    pub const fn get_leggings(&self) -> &ItemStack {
         &self.items.slots[7]
     }
 
@@ -437,7 +437,7 @@ impl PlayerInventory {
 
     /// get boots slot 8
     #[must_use]
-    pub fn get_boots(&self) -> &ItemStack {
+    pub const fn get_boots(&self) -> &ItemStack {
         &self.items.slots[8]
     }
 

--- a/crates/server/src/packets.rs
+++ b/crates/server/src/packets.rs
@@ -257,11 +257,11 @@ pub fn player_interact_item(
     query: &PacketSwitchQuery,
     sender: &mut ThreadLocalIngressSender,
 ) -> anyhow::Result<()> {
-    let _packet = play::PlayerInteractItemC2s::decode(&mut data)?;
+    let packet = play::PlayerInteractItemC2s::decode(&mut data)?;
 
     let id = query.id;
 
-    sender.send_to(id, event::ItemInteract);
+    sender.send_to(id, event::ItemInteract { hand: packet.hand });
 
     Ok(())
 }

--- a/crates/server/src/system/inventory_systems.rs
+++ b/crates/server/src/system/inventory_systems.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, time::SystemTime};
 
 use anyhow::{bail, Context};
 use evenio::{
@@ -19,7 +19,7 @@ use crate::{
     components::{InGameName, Player},
     event,
     event::{ChatMessage, ClickEvent, Command, ItemInteract, UpdateEquipment},
-    inventory::PlayerInventory,
+    inventory::{Interaction, PlayerInventory},
     net::{Compose, StreamId},
 };
 
@@ -29,7 +29,10 @@ pub fn item_interact(
     _compose: Compose,
     _sender: Sender<UpdateEquipment>,
 ) {
-    r.query.inventory.interact();
+    r.query.inventory.interaction = Some(Interaction {
+        start: SystemTime::now(),
+        hand: r.event.hand,
+    });
 }
 
 #[derive(Query)]

--- a/crates/server/src/system/release_item.rs
+++ b/crates/server/src/system/release_item.rs
@@ -38,8 +38,8 @@ pub fn release_item(
         UpdateInventory,
     )>,
 ) {
-    let mut query = r.query;
-    let inventory = &mut query.inventory;
+    let query = r.query;
+    let inventory = query.inventory;
 
     let Some(interaction) = mem::take(&mut inventory.interaction) else {
         error!("client attempted to release item without using one first");
@@ -55,7 +55,7 @@ pub fn release_item(
     // duration.
     let duration = interaction.start.elapsed().unwrap().as_secs_f32() - 0.05;
 
-    if duration < 0.140175 {
+    if duration < 0.140_175 {
         // The arrow was not shot. Note that the bow draw and release packets are not tied to a specific
         // tick when sent over the network, so the client may believe that the bow was drawn for
         // enough time to shoot an arrow and remove an arrow from the inventory on the client side

--- a/crates/server/src/system/update_equipment.rs
+++ b/crates/server/src/system/update_equipment.rs
@@ -19,7 +19,7 @@ pub fn update_main_hand(
     sender: Sender<UpdateEquipment>,
 ) {
     let (entity_id, inventory) = r.query;
-    if inventory.set_main_hand(r.event.slot + 36).is_ok() {
+    if inventory.set_main_hand_slot(r.event.slot + 36).is_ok() {
         // send event
         sender.send_to(entity_id, UpdateEquipment);
     }


### PR DESCRIPTION
This uses correct arrow speeds and removes arrows from the inventory when they're shot. This also includes some minor refactoring to the inventory API that I thought would've been useful for implementing this but ended up not using, but I left the changes in here since it'll likely be useful later.

Many of the calculations for arrow speed are based off of [Cuberite](https://github.com/cuberite/cuberite/blob/a66a67c2ab50aee3f17015eb48df92e11d9597a1/src/Items/ItemBow.h#L47), modified to be more efficient.