### PR TITLE
fix .devcontainer.json

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,12 +1,9 @@
 {
   "name": "Debian",
-  "build" : {
-    "dockerfile": "Dockerfile-dev"
-  },
-  "mounts": [
-    "type=volume,target=${containerWorkspaceFolder}/target"
-  ],
   "forwardPorts": [25565],
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1": {}
+  },
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
removed the broken docker setup and just added the default rust feature.
if you start the codespace and run

`cargo run —bin nyc`
`cargo run —bin hyperion-proxy 0.0.0.0:25565`

everything runs successfully