### PR TITLE
fix: Add rate limiting & reuse HTTP client to reduce memory usage

### DIFF
--- a/crates/hyperion/src/ingress/mod.rs
+++ b/crates/hyperion/src/ingress/mod.rs
@@ -80,6 +80,7 @@ fn process_login(
     decoder: &PacketDecoder,
     comms: &Comms,
     skins_collection: SkinHandler,
+    mojang: MojangClient,
     packet: &BorrowedPacketFrame<'_>,
     stream_id: NetworkStreamRef,
     compose: &Compose,
@@ -127,8 +128,6 @@ fn process_login(
         .name("player_join")
         .spawn_on(
             async move {
-                let mojang = MojangClient::default();
-
                 let skin = match PlayerSkin::from_uuid(uuid, &mojang, &skins_collection).await {
                     Ok(Some(skin)) => skin,
                     Err(e) => {
@@ -434,6 +433,7 @@ impl Module for IngressModule {
             &AsyncRuntime($),
             &Comms($),
             &SkinHandler($),
+            &MojangClient($),
             &GlobalEventHandlers($),
             &mut PacketDecoder,
             &mut PacketState,
@@ -460,6 +460,7 @@ impl Module for IngressModule {
                 tasks,
                 comms,
                 skins_collection,
+                mojang,
                 handlers,
                 decoder,
                 login_state,
@@ -524,6 +525,7 @@ impl Module for IngressModule {
                                 decoder,
                                 comms,
                                 skins_collection.clone(),
+                                mojang.clone(),
                                 &frame,
                                 io_ref,
                                 compose,

--- a/crates/hyperion/src/lib.rs
+++ b/crates/hyperion/src/lib.rs
@@ -52,6 +52,7 @@ use libdeflater::CompressionLvl;
 use simulation::{blocks::Blocks, util::generate_biome_registry, Comms, SimModule, StreamLookup};
 use storage::{Db, Events, GlobalEventHandlers, SkinHandler, ThreadLocal};
 use tracing::info;
+use util::mojang::MojangClient;
 pub use uuid;
 pub use valence_protocol;
 use valence_protocol::{CompressionThreshold, Encode, Packet};
@@ -197,6 +198,7 @@ impl Hyperion {
 
         world.component::<Db>();
         world.component::<SkinHandler>();
+        world.component::<MojangClient>();
         world.component::<Events>();
 
         world.component::<EntitySize>();
@@ -222,6 +224,8 @@ impl Hyperion {
 
         world.set(db);
         world.set(skins);
+
+        world.set(MojangClient::new(&runtime));
 
         let (receive_state, egress_comm) = init_proxy_comms(&runtime, address);
 

--- a/crates/hyperion/src/lib.rs
+++ b/crates/hyperion/src/lib.rs
@@ -20,7 +20,7 @@
 #![feature(split_array)]
 #![feature(never_type)]
 #![feature(f16)]
-
+#![feature(duration_constructors)]
 // todo: deny more and completely fix panics
 // #![deny(
 //     clippy::expect_used,
@@ -67,7 +67,10 @@ mod common;
 pub use common::*;
 use hyperion_crafting::CraftingRegistry;
 
-use crate::simulation::{EntitySize, Player};
+use crate::{
+    simulation::{EntitySize, Player},
+    util::mojang::ApiProvider,
+};
 
 pub mod egress;
 pub mod ingress;
@@ -225,7 +228,7 @@ impl Hyperion {
         world.set(db);
         world.set(skins);
 
-        world.set(MojangClient::new(&runtime));
+        world.set(MojangClient::new(&runtime, ApiProvider::MAT_DOES_DEV));
 
         let (receive_state, egress_comm) = init_proxy_comms(&runtime, address);
 


### PR DESCRIPTION
Addresses high memory usage in the Mojang API client by:
- Reuse single reqwest::Client instance instead of creating new ones
- Implement rate limiting via Semaphore to prevent request flooding
- Add configurable API providers (Mojang/matdoes.dev) with different rate limits
- Auto-reset rate limits using tokio intervals

Breaking changes:
- Remove `MojangClient::default()` in favor of explicit initialization

The previous implementation would create many HTTP clients and flood the API with 
requests, leading to excessive memory usage. This fix ensures proper request 
pacing and connection reuse.