### PR TITLE
feat: implement configurable world saves & improve async runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,16 +983,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,17 +992,6 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1722,7 +1701,6 @@ dependencies = [
  "bytes",
  "colored",
  "derive_more",
- "dirs-next",
  "divan",
  "enumset",
  "fastrand 2.1.1",
@@ -1908,7 +1886,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "directories",
- "dirs-next",
  "flate2",
  "flecs_ecs",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.11.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd016a0ddc7cb13661bf5576073ce07330a693f8608a1320b4e20561cc12cdc"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
+name = "const-oid"
+version = "0.10.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ff6be19477a1bd5441f382916a89bc2a0b2c35db6d41e0f6e8538bf6d6463f"
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +866,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b8ce8218c97789f16356e7896b3714f26c2ee1079b79c0b7ae7064bb9089fa"
+dependencies = [
+ "getrandom",
+ "hybrid-array",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,8 +958,28 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-pre.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2e3d6615d99707295a9673e889bf363a04b2a466bd320c65a72536f7577379"
+dependencies = [
+ "block-buffer 0.11.0-rc.3",
+ "const-oid",
+ "crypto-common 0.2.0-rc.1",
+]
+
+[[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
 ]
 
 [[package]]
@@ -944,6 +990,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -971,8 +1029,7 @@ dependencies = [
 [[package]]
 name = "divan"
 version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e05d17bd4ff1c1e7998ed4623d2efd91f72f1e24141ac33aac9377974270e1f"
+source = "git+https://github.com/nvzqz/divan#b005ba45695758d994377ef9edcbf6e09328a71a"
 dependencies = [
  "cfg-if",
  "clap",
@@ -985,8 +1042,7 @@ dependencies = [
 [[package]]
 name = "divan-macros"
 version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b4464d46ce68bfc7cb76389248c7c254def7baca8bece0693b02b83842c4c88"
+source = "git+https://github.com/nvzqz/divan#b005ba45695758d994377ef9edcbf6e09328a71a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1288,8 +1344,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1567,6 +1626,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
+name = "hybrid-array"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a9a965bb102c1c891fb017c09a05c965186b1265a207640f323ddd009f9deb"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,7 +1761,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "tango-bench",
  "tar",
  "thiserror",
@@ -1838,7 +1906,19 @@ dependencies = [
 name = "hyperion-utils"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "directories",
+ "dirs-next",
+ "flate2",
  "flecs_ecs",
+ "futures-util",
+ "hex",
+ "reqwest",
+ "sha2 0.11.0-pre.4",
+ "tar",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2258,7 +2338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2519,6 +2599,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -3145,10 +3231,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "windows-registry",
@@ -3238,9 +3326,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.38"
+version = "0.38.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
+checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3447,7 +3535,18 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "540c0893cce56cdbcfebcec191ec8e0f470dd1889b6e7a0b503e310a94a168f5"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-pre.9",
 ]
 
 [[package]]
@@ -4481,6 +4580,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
 resolver = '2'
 
 [workspace.dependencies]
+tokio-util = { version = "0.7.12" , features = ["full"]}
 anyhow = '1.0.86'
 approx = '0.5.1'
 arrayvec = '0.7.4'
@@ -47,7 +48,7 @@ compact_str = '0.8.0'
 criterion = '0.5.1'
 derive-build = '0.1.1'
 dirs-next = '2.0.0'
-divan = '0.1.14'
+divan = { git = "https://github.com/nvzqz/divan" }
 enumset = '1.1.5'
 fastrand = '2.1.0'
 glam = '0.29.0'
@@ -160,7 +161,7 @@ default-features = false
 version = '0.3.6'
 
 [workspace.dependencies.reqwest]
-features = ['rustls-tls']
+features = ['rustls-tls', 'stream']
 version = '0.12.9'
 
 [workspace.dependencies.roaring]

--- a/crates/hyperion-utils/Cargo.toml
+++ b/crates/hyperion-utils/Cargo.toml
@@ -2,6 +2,17 @@ cargo-features = ["edition2024"]
 
 [dependencies]
 flecs_ecs.workspace = true
+anyhow = "1.0.92"
+directories = "5.0.1"
+sha2 = "0.11.0-pre.4"
+hex.workspace = true
+tracing.workspace = true
+reqwest.workspace = true
+flate2 = "1.0.34"
+tar.workspace = true
+tokio-util.workspace = true
+tokio.workspace = true
+futures-util = "0.3.31"
 
 [lints]
 workspace = true

--- a/crates/hyperion-utils/src/cached_save.rs
+++ b/crates/hyperion-utils/src/cached_save.rs
@@ -1,0 +1,79 @@
+use std::path::PathBuf;
+
+use anyhow::Context;
+use directories::ProjectDirs;
+use flecs_ecs::{
+    core::{World, WorldGet},
+    macros::Component,
+};
+use futures_util::stream::StreamExt;
+use sha2::{Digest, digest::Update};
+use tar::Archive;
+use tokio_util::io::{StreamReader, SyncIoBridge};
+use tracing::info;
+
+use crate::AppId;
+
+pub fn cached_save<U: reqwest::IntoUrl + 'static>(
+    world: &World,
+    url: U,
+) -> impl Future<Output = anyhow::Result<PathBuf>> + 'static {
+    let project_dirs = world
+        .get::<&AppId>(
+            |AppId {
+                 qualifier,
+                 organization,
+                 application,
+             }| { ProjectDirs::from(qualifier, organization, application) },
+        )
+        .expect("failed to get AppId");
+
+    let cache = project_dirs.cache_dir();
+
+    let mut hasher = sha2::Sha256::new();
+    let url_str = url.as_str().to_string();
+    Digest::update(&mut hasher, url_str.as_bytes());
+    // Get the final hash result
+    let url_sha = hasher.finalize();
+    let url_sha = hex::encode(url_sha);
+
+    let directory = cache.join(url_sha);
+
+    async move {
+        if directory.exists() {
+            info!("using cached NewYork load");
+        } else {
+            // download
+            let response = reqwest::get(url)
+                .await
+                .with_context(|| format!("failed to get {url_str}"))?;
+
+            let byte_stream = response.bytes_stream();
+            // Convert the byte stream into an AsyncRead
+
+            let reader = StreamReader::new(byte_stream.map(|result| {
+                result.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+            }));
+
+            let directory = directory.clone();
+            let handle = tokio::task::spawn_blocking(move || {
+                let reader = SyncIoBridge::new(reader);
+                let reader = std::io::BufReader::new(reader);
+                let reader = flate2::read::GzDecoder::new(reader);
+
+                // Create the archive in the blocking context
+                let mut archive = Archive::new(reader);
+
+                archive
+                    .unpack(&directory)
+                    .context("failed to unpack archive")?;
+
+                anyhow::Ok(())
+            });
+
+            handle.await??;
+        }
+
+        Ok(directory)
+    }
+}

--- a/crates/hyperion-utils/src/cached_save.rs
+++ b/crates/hyperion-utils/src/cached_save.rs
@@ -2,12 +2,9 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use directories::ProjectDirs;
-use flecs_ecs::{
-    core::{World, WorldGet},
-    macros::Component,
-};
+use flecs_ecs::core::{World, WorldGet};
 use futures_util::stream::StreamExt;
-use sha2::{Digest, digest::Update};
+use sha2::Digest;
 use tar::Archive;
 use tokio_util::io::{StreamReader, SyncIoBridge};
 use tracing::info;

--- a/crates/hyperion-utils/src/lib.rs
+++ b/crates/hyperion-utils/src/lib.rs
@@ -1,4 +1,11 @@
-use flecs_ecs::prelude::Entity;
+use flecs_ecs::{
+    core::World,
+    macros::Component,
+    prelude::{Entity, Module},
+};
+
+mod cached_save;
+pub use cached_save::cached_save;
 
 pub trait EntityExt {
     fn minecraft_id(&self) -> i32;
@@ -53,5 +60,25 @@ impl EntityExt for Entity {
 
         let raw = (u64::from(most_significant) << 32) | u64::from(least_significant);
         Self(raw)
+    }
+}
+
+/// Represents application identification information used for caching and other system-level operations
+#[derive(Component)]
+pub struct AppId {
+    /// The qualifier/category of the application (e.g. "com", "org", "hyperion")
+    pub qualifier: String,
+    /// The organization that created the application (e.g. "andrewgazelka")
+    pub organization: String,
+    /// The specific application name (e.g. "proof-of-concept")
+    pub application: String,
+}
+
+#[derive(Component)]
+pub struct HyperionUtilsModule;
+
+impl Module for HyperionUtilsModule {
+    fn module(world: &World) {
+        world.component::<AppId>();
     }
 }

--- a/crates/hyperion/Cargo.toml
+++ b/crates/hyperion/Cargo.toml
@@ -32,7 +32,6 @@ bytemuck.workspace = true
 byteorder.workspace = true
 bytes.workspace = true
 derive_more.workspace = true
-dirs-next.workspace = true
 enumset.workspace = true
 fastrand.workspace = true
 flecs_ecs.workspace = true

--- a/crates/hyperion/src/common/runtime.rs
+++ b/crates/hyperion/src/common/runtime.rs
@@ -6,18 +6,21 @@ use derive_more::{Deref, DerefMut};
 use flecs_ecs::{core::World, macros::Component};
 use kanal::{Receiver, Sender};
 
+/// Type alias for world callback functions
+pub type WorldCallback = Box<dyn FnOnce(&World)>;
+
 /// Wrapper around [`tokio::runtime::Runtime`]
 #[derive(Component, Deref, DerefMut, Clone)]
 pub struct AsyncRuntime {
     #[deref]
     #[deref_mut]
     runtime: Arc<tokio::runtime::Runtime>,
-    sender: Sender<Box<dyn FnOnce(&World)>>,
+    sender: Sender<WorldCallback>,
 }
 
 #[derive(Component)]
 pub struct Tasks {
-    pub(crate) tasks: Receiver<Box<dyn FnOnce(&World)>>,
+    pub(crate) tasks: Receiver<WorldCallback>,
 }
 
 impl AsyncRuntime {
@@ -39,7 +42,7 @@ impl AsyncRuntime {
         });
     }
 
-    pub(crate) fn new(sender: Sender<Box<dyn FnOnce(&World)>>) -> Self {
+    pub(crate) fn new(sender: Sender<WorldCallback>) -> Self {
         Self {
             runtime: Arc::new(
                 tokio::runtime::Builder::new_multi_thread()

--- a/crates/hyperion/src/common/runtime.rs
+++ b/crates/hyperion/src/common/runtime.rs
@@ -3,30 +3,53 @@
 use std::sync::Arc;
 
 use derive_more::{Deref, DerefMut};
-use flecs_ecs::macros::Component;
+use flecs_ecs::{core::World, macros::Component};
+use kanal::{Receiver, Sender};
 
 /// Wrapper around [`tokio::runtime::Runtime`]
 #[derive(Component, Deref, DerefMut, Clone)]
 pub struct AsyncRuntime {
+    #[deref]
+    #[deref_mut]
     runtime: Arc<tokio::runtime::Runtime>,
+    sender: Sender<Box<dyn FnOnce(&World)>>,
 }
 
-impl Default for AsyncRuntime {
-    fn default() -> Self {
-        #[expect(
-            clippy::unwrap_used,
-            reason = "this is very unlikely to fail and even if it does it will be in \
-                      initialization"
-        )]
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            // .worker_threads(2)
-            .enable_all()
-            // .thread_stack_size(1024 * 1024) // 1 MiB
-            .build()
-            .unwrap();
+#[derive(Component)]
+pub struct Tasks {
+    pub(crate) tasks: Receiver<Box<dyn FnOnce(&World)>>,
+}
 
-        let runtime = Arc::new(runtime);
+impl AsyncRuntime {
+    pub fn schedule<T: 'static>(
+        &self,
+        future: impl Future<Output = T> + Send + 'static,
+        handler: fn(T, &World),
+    ) {
+        let sender = self.sender.clone();
 
-        Self { runtime }
+        self.spawn(async move {
+            let result = future.await;
+
+            let to_send = move |world: &World| {
+                handler(result, world);
+            };
+
+            sender.send(Box::new(to_send)).unwrap();
+        });
+    }
+
+    pub(crate) fn new(sender: Sender<Box<dyn FnOnce(&World)>>) -> Self {
+        Self {
+            runtime: Arc::new(
+                tokio::runtime::Builder::new_multi_thread()
+                    // .worker_threads(2)
+                    .enable_all()
+                    // .thread_stack_size(1024 * 1024) // 1 MiB
+                    .build()
+                    .unwrap(),
+            ),
+            sender,
+        }
     }
 }

--- a/crates/hyperion/src/egress/player_join/mod.rs
+++ b/crates/hyperion/src/egress/player_join/mod.rs
@@ -130,7 +130,7 @@ pub fn player_join_world(
 
     let pkt = play::PlayerSpawnPositionS2c {
         position: position.as_dvec3().into(),
-        angle: **yaw as f32,
+        angle: **yaw,
     };
 
     bundle.add_packet(&pkt, world)?;
@@ -172,8 +172,8 @@ pub fn player_join_world(
     bundle.add_packet(
         &play::PlayerPositionLookS2c {
             position: position.as_dvec3(),
-            yaw: **yaw as f32,
-            pitch: **pitch as f32,
+            yaw: **yaw,
+            pitch: **pitch,
             flags: PlayerPositionLookFlags::default(),
             teleport_id: 1.into(),
         },
@@ -255,8 +255,8 @@ pub fn player_join_world(
                         entity_id: VarInt(query_entity.minecraft_id()),
                         player_uuid: uuid.0,
                         position: position.as_dvec3(),
-                        yaw: ByteAngle::from_degrees(**yaw as f32),
-                        pitch: ByteAngle::from_degrees(**pitch as f32),
+                        yaw: ByteAngle::from_degrees(**yaw),
+                        pitch: ByteAngle::from_degrees(**pitch),
                     };
 
                     bundle
@@ -357,8 +357,8 @@ pub fn player_join_world(
         entity_id: current_entity_id,
         player_uuid: uuid,
         position: position.as_dvec3(),
-        yaw: ByteAngle::from_degrees(**yaw as f32),
-        pitch: ByteAngle::from_degrees(**pitch as f32),
+        yaw: ByteAngle::from_degrees(**yaw),
+        pitch: ByteAngle::from_degrees(**pitch),
     };
     compose
         .broadcast(&spawn_player, system_id)
@@ -507,9 +507,9 @@ pub fn spawn_entity_packet(
         object_uuid: *uuid,
         kind: VarInt(kind.get()),
         position: position.as_dvec3(),
-        yaw: ByteAngle::from_degrees(**yaw as f32),
-        pitch: ByteAngle::from_degrees(**pitch as f32),
-        head_yaw: ByteAngle::from_degrees(**yaw as f32), // todo: unsure if this is correct
+        yaw: ByteAngle::from_degrees(**yaw),
+        pitch: ByteAngle::from_degrees(**pitch),
+        head_yaw: ByteAngle::from_degrees(**yaw), // todo: unsure if this is correct
         data: VarInt::default(),
         velocity: Velocity([0; 3]),
     }

--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -155,8 +155,8 @@ impl Module for EntityStateSyncModule {
                         let pkt = play::EntityPositionS2c {
                             entity_id,
                             position: position.as_dvec3(),
-                            yaw: ByteAngle::from_degrees(**yaw as f32),
-                            pitch: ByteAngle::from_degrees(**pitch as f32),
+                            yaw: ByteAngle::from_degrees(**yaw),
+                            pitch: ByteAngle::from_degrees(**pitch),
                             on_ground: false,
                         };
 
@@ -167,7 +167,7 @@ impl Module for EntityStateSyncModule {
 
                         let pkt = play::EntitySetHeadYawS2c {
                             entity_id,
-                            head_yaw: ByteAngle::from_degrees(**yaw as f32),
+                            head_yaw: ByteAngle::from_degrees(**yaw),
                         };
 
                         compose

--- a/crates/hyperion/src/lib.rs
+++ b/crates/hyperion/src/lib.rs
@@ -50,7 +50,7 @@ use ingress::IngressModule;
 #[cfg(unix)]
 use libc::{RLIMIT_NOFILE, getrlimit, setrlimit};
 use libdeflater::CompressionLvl;
-use simulation::{Comms, SimModule, StreamLookup, blocks::Blocks, util::generate_biome_registry};
+use simulation::{Comms, SimModule, StreamLookup, blocks::Blocks};
 use storage::{Events, GlobalEventHandlers, LocalDb, SkinHandler, ThreadLocal};
 use tracing::{info, info_span};
 use util::mojang::MojangClient;

--- a/crates/hyperion/src/simulation/blocks/manager.rs
+++ b/crates/hyperion/src/simulation/blocks/manager.rs
@@ -4,6 +4,7 @@ use std::{
     sync::Arc,
 };
 
+use anyhow::ensure;
 use glam::IVec2;
 use tokio::{
     fs::File,
@@ -12,7 +13,6 @@ use tokio::{
 };
 
 use super::region::Region;
-use crate::simulation::util::get_proof_of_concept_save;
 
 enum RegionRequest {
     Get {
@@ -27,9 +27,12 @@ pub struct RegionManager {
 }
 
 impl RegionManager {
-    pub fn new(runtime: &Runtime) -> anyhow::Result<Self> {
-        let save = runtime.block_on(get_proof_of_concept_save())?;
+    pub fn new(runtime: &Runtime, save: &Path) -> anyhow::Result<Self> {
+        println!("region manager root: {save:?}");
         let root = save.join("region");
+
+        ensure!(root.exists(), "{} directory does not exist", root.display());
+
         let (sender, receiver) = mpsc::channel(100);
 
         runtime.spawn(RegionManagerTask::new(root.clone(), receiver).run());

--- a/crates/hyperion/src/simulation/blocks/mod.rs
+++ b/crates/hyperion/src/simulation/blocks/mod.rs
@@ -17,7 +17,6 @@ use rustc_hash::FxBuildHasher;
 use shared::WorldShared;
 use tracing::error;
 use valence_generated::block::BlockState;
-use valence_registry::BiomeRegistry;
 use valence_server::layer::chunk::Chunk;
 
 use crate::{CHUNK_HEIGHT_SPAN, runtime::AsyncRuntime, simulation::util::generate_biome_registry};

--- a/crates/hyperion/src/simulation/blocks/shared.rs
+++ b/crates/hyperion/src/simulation/blocks/shared.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, path::Path};
 
 use anyhow::Context;
 use tokio::runtime::Runtime;
@@ -14,8 +14,12 @@ pub struct WorldShared {
 }
 
 impl WorldShared {
-    pub(crate) fn new(biomes: &BiomeRegistry, runtime: &Runtime) -> anyhow::Result<Self> {
-        let regions = RegionManager::new(runtime).context("failed to get anvil data")?;
+    pub(crate) fn new(
+        biomes: &BiomeRegistry,
+        runtime: &Runtime,
+        path: &Path,
+    ) -> anyhow::Result<Self> {
+        let regions = RegionManager::new(runtime, path).context("failed to get anvil data")?;
 
         let biome_to_id = biomes
             .iter()

--- a/crates/hyperion/src/simulation/handlers.rs
+++ b/crates/hyperion/src/simulation/handlers.rs
@@ -77,8 +77,8 @@ fn change_position_or_correct_client(query: &mut PacketSwitchQuery<'_>, proposed
         // Correct client position
         let pkt = play::PlayerPositionLookS2c {
             position: pose.position.as_dvec3(),
-            yaw: query.yaw.yaw as f32,
-            pitch: query.pitch.pitch as f32,
+            yaw: query.yaw.yaw,
+            pitch: query.pitch.pitch,
             flags: PlayerPositionLookFlags::default(),
             teleport_id: VarInt(fastrand::i32(..)),
         };

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -27,7 +27,7 @@ pub mod util;
 #[derive(Component, Default, Debug, Deref, DerefMut)]
 pub struct StreamLookup {
     /// The UUID of all players
-    inner: rustc_hash::FxHashMap<u64, Entity>,
+    inner: FxHashMap<u64, Entity>,
 }
 
 #[derive(Component, Default, Debug, Deref, DerefMut)]
@@ -302,14 +302,14 @@ pub struct Yaw {
 
 impl Display for Yaw {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let yaw = self.yaw as f32;
+        let yaw = self.yaw;
         write!(f, "{yaw}")
     }
 }
 
 impl Display for Pitch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let pitch = self.pitch as f32;
+        let pitch = self.pitch;
         write!(f, "{pitch}")
     }
 }
@@ -331,8 +331,8 @@ pub struct EntitySize {
 
 impl Display for EntitySize {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let half_width = self.half_width as f32;
-        let height = self.height as f32;
+        let half_width = self.half_width;
+        let height = self.height;
         write!(f, "{half_width}x{height}")
     }
 }
@@ -375,8 +375,8 @@ impl ChunkPosition {
 
 #[must_use]
 pub fn aabb(position: Vec3, size: EntitySize) -> Aabb {
-    let half_width = size.half_width as f32;
-    let height = size.height as f32;
+    let half_width = size.half_width;
+    let height = size.height;
     Aabb::new(
         position - Vec3::new(half_width, 0.0, half_width),
         position + Vec3::new(half_width, height, half_width),

--- a/crates/hyperion/src/simulation/util.rs
+++ b/crates/hyperion/src/simulation/util.rs
@@ -4,7 +4,6 @@ use anyhow::{Context, bail};
 use flate2::bufread::GzDecoder;
 use serde::Deserialize;
 use tar::Archive;
-use tracing::info;
 use valence_nbt::{Compound, Value, value::ValueRef};
 use valence_registry::{
     BiomeRegistry,
@@ -111,55 +110,6 @@ pub fn generate_biome_registry() -> anyhow::Result<BiomeRegistry> {
     }
 
     Ok(biome_registry)
-}
-
-pub async fn get_proof_of_concept_save() -> anyhow::Result<PathBuf> {
-    // $HOME/.hyperion
-    let home_dir = dirs_next::home_dir().context("could not find home directory")?;
-
-    let hyperion = home_dir.join(".hyperion");
-
-    if !hyperion.exists() {
-        // create
-        info!("creating .hyperion");
-        tokio::fs::create_dir_all(&hyperion)
-            .await
-            .context("failed to create .hyperion")?;
-    }
-
-    let new_york_dir = hyperion.join("NewYork");
-
-    if new_york_dir.exists() {
-        info!("using cached NewYork load");
-    } else {
-        // download
-        info!("downloading NewYork.tar.gz");
-
-        // https://github.com/andrewgazelka/maps/raw/main/NewYork.tar.gz
-        let url = "https://github.com/andrewgazelka/maps/raw/main/NewYork.tar.gz";
-
-        let response = reqwest::get(url)
-            .await
-            .context("failed to get NewYork.tar.gz")?;
-
-        let bytes = response
-            .bytes()
-            .await
-            .context("failed to get response bytes")?;
-
-        info!("extracting NewYork.tar.gz");
-
-        let decompressed = GzDecoder::new(bytes.as_ref());
-
-        // Create a new archive from the decompressed file.
-        let mut archive = Archive::new(decompressed);
-
-        archive
-            .unpack(&hyperion)
-            .context("failed to unpack NewYork.tar.gz")?;
-    }
-
-    Ok(new_york_dir)
 }
 
 /// Returns the minimum number of bits needed to represent the integer `n`.

--- a/crates/hyperion/src/simulation/util.rs
+++ b/crates/hyperion/src/simulation/util.rs
@@ -1,9 +1,7 @@
-use std::{path::PathBuf, sync::LazyLock};
+use std::sync::LazyLock;
 
 use anyhow::{Context, bail};
-use flate2::bufread::GzDecoder;
 use serde::Deserialize;
-use tar::Archive;
 use valence_nbt::{Compound, Value, value::ValueRef};
 use valence_registry::{
     BiomeRegistry,

--- a/events/proof-of-concept/src/lib.rs
+++ b/events/proof-of-concept/src/lib.rs
@@ -62,7 +62,7 @@ impl Module for ProofOfConceptModule {
 
             runtime.schedule(f, |result, world| {
                 let save = result.unwrap();
-                world.set(Blocks::new(&world, &save).unwrap());
+                world.set(Blocks::new(world, &save).unwrap());
             });
         });
     }


### PR DESCRIPTION
- Add `hyperion-utils` module with cached save functionality for world data
- Refactor async runtime to handle scheduled tasks with world context
- Move world loading logic out of simulation module into utilities
- Add `AppId` component for system-level operations and caching
- Update dependencies including `divan` and add streaming features to `reqwest`
- Make block loading more flexible by accepting custom save paths