### PR TITLE
feat: `/replace` command for placeholder blocks → mineable ores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2046,6 +2046,7 @@ checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.1",
+ "rayon",
  "serde",
 ]
 
@@ -2858,6 +2859,7 @@ dependencies = [
  "dotenvy",
  "fastrand 2.2.0",
  "flecs_ecs",
+ "gxhash",
  "hyperion",
  "hyperion-clap",
  "hyperion-inventory",
@@ -2866,6 +2868,7 @@ dependencies = [
  "hyperion-scheduled",
  "hyperion-text",
  "hyperion-utils",
+ "rayon",
  "roaring",
  "rustc-hash 2.0.0",
  "tikv-jemallocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ glam = '0.29.0'
 heapless = '0.8.0'
 heed = '0.20.5'
 hex = '0.4.3'
-indexmap = '2.6.0'
+indexmap = { version = '2.6.0', features = ['rayon'] }
 itertools = '0.13.0'
 kanal = '0.1.0-pre8'
 libc = '0.2.155'

--- a/crates/hyperion-inventory/src/lib.rs
+++ b/crates/hyperion-inventory/src/lib.rs
@@ -59,6 +59,16 @@ impl<const N: usize> Inventory<N> {
         Ok(())
     }
 
+    pub fn items(&self) -> impl Iterator<Item = (u16, &ItemStack)> + '_ {
+        self.slots.iter().enumerate().filter_map(|(idx, item)| {
+            if item.is_empty() {
+                None
+            } else {
+                Some((u16::try_from(idx).unwrap(), item))
+            }
+        })
+    }
+
     #[must_use]
     pub const fn slots(&self) -> &[ItemStack; N] {
         &self.slots

--- a/crates/hyperion-rank-tree/src/inventory.rs
+++ b/crates/hyperion-rank-tree/src/inventory.rs
@@ -3,13 +3,33 @@ use valence_protocol::ItemKind;
 
 use crate::{
     util::{AttackDamage, ItemBuilder},
-    Rank,
+    Rank, Team,
 };
 
+impl Team {
+    pub const fn build_item(self) -> ItemBuilder {
+        let kind = match self {
+            Self::Red => ItemKind::RedTerracotta,
+            Self::White => ItemKind::WhiteTerracotta,
+            Self::Blue => ItemKind::BlueTerracotta,
+        };
+
+        ItemBuilder::new(kind)
+    }
+}
+
 impl Rank {
-    #[must_use]
-    pub fn inventory(self) -> PlayerInventory {
-        let mut inventory = PlayerInventory::default();
+    pub fn apply_inventory(self, team: Team, inventory: &mut PlayerInventory) {
+        const PICKAXE_SLOT: u16 = 1;
+        const BUILD_SLOT: u16 = 2;
+        const ARROW_SLOT: u16 = 7;
+        const GUI_SLOT: u16 = 8;
+
+        let default_pickaxe = ItemBuilder::new(ItemKind::WoodenPickaxe).build();
+        inventory.set_hotbar(PICKAXE_SLOT, default_pickaxe);
+
+        let default_build_item = team.build_item().count(16).build();
+        inventory.set_hotbar(BUILD_SLOT, default_build_item);
 
         match self {
             Self::Stick => {
@@ -29,7 +49,7 @@ impl Rank {
 
                 let arrow = ItemBuilder::new(ItemKind::Arrow).count(64).build();
 
-                inventory.set_hotbar(7, arrow);
+                inventory.set_hotbar(ARROW_SLOT, arrow);
             }
             Self::Sword => {
                 let sword = ItemBuilder::new(ItemKind::StoneSword)
@@ -78,8 +98,6 @@ impl Rank {
             .name("Upgrades")
             .build();
 
-        inventory.set_hotbar(8, upgrade_item);
-
-        inventory
+        inventory.set_hotbar(GUI_SLOT, upgrade_item);
     }
 }

--- a/crates/hyperion-rank-tree/src/lib.rs
+++ b/crates/hyperion-rank-tree/src/lib.rs
@@ -21,3 +21,9 @@ pub enum Rank {
     Knight,
     Builder,
 }
+
+pub enum Team {
+    Red,
+    White,
+    Blue,
+}

--- a/crates/hyperion/src/simulation/blocks/chunk.rs
+++ b/crates/hyperion/src/simulation/blocks/chunk.rs
@@ -6,6 +6,7 @@ use valence_generated::block::BlockState;
 use valence_server::layer::chunk::Chunk;
 
 use super::loader::parse::ColumnData;
+use crate::simulation::blocks::loader::parse::section::Section;
 
 pub const START_Y: i16 = -64;
 
@@ -79,6 +80,26 @@ impl Column {
             data,
             position,
         }
+    }
+
+    pub fn sections(&self) -> impl Iterator<Item = (IVec3, &Section)> + '_ {
+        let column_start_position = IVec3::new(
+            self.position.x << 4,
+            i32::from(START_Y),
+            self.position.y << 4,
+        );
+
+        self.data
+            .sections
+            .iter()
+            .enumerate()
+            .map(move |(section_idx, section)| {
+                let section_y = i32::try_from(section_idx).unwrap();
+                let section_y = section_y * 16;
+                let section_start = column_start_position + IVec3::new(0, section_y, 0);
+
+                (section_start, section)
+            })
     }
 
     pub fn blocks_in_range(

--- a/crates/hyperion/src/simulation/blocks/loader/parse/section.rs
+++ b/crates/hyperion/src/simulation/blocks/loader/parse/section.rs
@@ -1,3 +1,4 @@
+use glam::IVec3;
 use more_asserts::debug_assert_lt;
 use roaring::RoaringBitmap;
 use valence_generated::block::BlockState;
@@ -35,6 +36,14 @@ impl Section {
             sky_light: Some([0xff; 2048]),
             ..Self::default()
         }
+    }
+
+    pub fn idx_to_xyz(idx: usize) -> IVec3 {
+        let idx = i32::try_from(idx).unwrap();
+        let x = idx & 0xF;
+        let z = idx >> 4 & 0xF;
+        let y = idx >> 8;
+        IVec3::new(x, y, z)
     }
 }
 

--- a/events/proof-of-concept/Cargo.toml
+++ b/events/proof-of-concept/Cargo.toml
@@ -20,6 +20,8 @@ rustc-hash.workspace = true
 tracing-subscriber.workspace = true
 tracing-tracy.workspace = true
 tracing.workspace = true
+rayon.workspace = true
+gxhash.workspace = true
 
 [dev-dependencies]
 tracing = {workspace = true, features = ["release_max_level_info"]}

--- a/events/proof-of-concept/src/command.rs
+++ b/events/proof-of-concept/src/command.rs
@@ -1,10 +1,13 @@
 use flecs_ecs::core::World;
 use hyperion_clap::{MinecraftCommand, hyperion_command::CommandRegistry};
 
-use crate::command::{fly::FlyCommand, rank::RankCommand, speed::SpeedCommand, xp::XpCommand};
+use crate::command::{
+    fly::FlyCommand, rank::RankCommand, replace::ReplaceCommand, speed::SpeedCommand, xp::XpCommand,
+};
 
 mod fly;
 mod rank;
+mod replace;
 mod speed;
 mod xp;
 
@@ -13,4 +16,5 @@ pub fn register(registry: &mut CommandRegistry, world: &World) {
     FlyCommand::register(registry, world);
     RankCommand::register(registry, world);
     XpCommand::register(registry, world);
+    ReplaceCommand::register(registry, world);
 }

--- a/events/proof-of-concept/src/command/replace.rs
+++ b/events/proof-of-concept/src/command/replace.rs
@@ -1,0 +1,146 @@
+use std::collections::{HashSet, VecDeque};
+
+use flecs_ecs::core::{Entity, EntityViewGet, World, WorldGet};
+use gxhash::GxBuildHasher;
+use hyperion::{BlockState, glam::IVec3, simulation::blocks::Blocks};
+use rayon::iter::ParallelIterator;
+
+#[derive(clap::Parser, Debug)]
+#[command(name = "replace")]
+pub struct ReplaceCommand;
+
+/// Picks a random ore based on weighted probabilities
+/// Weights are roughly based on real Minecraft ore distribution
+fn pick_ore() -> BlockState {
+    // Total weight is 100 for easy percentage calculation
+    const WEIGHTS: [(BlockState, u32); 5] = [
+        (BlockState::COBBLESTONE, 40), // 40%
+        (BlockState::COPPER_ORE, 35),  // 35%
+        (BlockState::IRON_ORE, 15),    // 15%
+        (BlockState::GOLD_ORE, 8),     // 8%
+        (BlockState::EMERALD_ORE, 2),  // 2%
+    ];
+
+    let total_weight: u32 = WEIGHTS.iter().map(|(_, w)| w).sum();
+    let mut roll = fastrand::u32(0..total_weight);
+
+    for (block, weight) in WEIGHTS {
+        if roll < weight {
+            return block;
+        }
+        roll -= weight;
+    }
+
+    // Fallback (should never happen due to math)
+    BlockState::STONE
+}
+
+/// When replacing an existing ore, picks what to replace it with
+/// Uses a simple ratio system for clarity
+fn pick_given_ore(ore: BlockState) -> BlockState {
+    // Ratio of 5:3:2 for stone:cobble:original
+    const TOTAL_PARTS: u32 = 10;
+    let roll = fastrand::u32(0..TOTAL_PARTS);
+
+    match roll {
+        0..=4 => BlockState::STONE,       // 5/10 = 50%
+        5..=7 => BlockState::COBBLESTONE, // 3/10 = 30%
+        _ => ore,                         // 2/10 = 20%
+    }
+}
+
+const ADJACENT: [IVec3; 6] = [
+    IVec3::new(-1, 0, 0),
+    IVec3::new(1, 0, 0),
+    IVec3::new(0, -1, 0),
+    IVec3::new(0, 1, 0),
+    IVec3::new(0, 0, -1),
+    IVec3::new(0, 0, 1),
+];
+
+/// Groups connected positions in 3D space
+/// Returns a vector of groups, where each group is a vector of connected positions
+fn group(positions: &HashSet<IVec3, GxBuildHasher>) -> Vec<Vec<IVec3>> {
+    let mut visited: HashSet<IVec3, GxBuildHasher> = HashSet::default();
+    let mut groups: Vec<Vec<IVec3>> = Vec::new();
+
+    // Iterate through all positions
+    for &start_pos in positions {
+        // Skip if already visited
+        if visited.contains(&start_pos) {
+            continue;
+        }
+
+        // Start a new group
+        let mut current_group = Vec::new();
+        let mut queue = VecDeque::new();
+
+        queue.push_back(start_pos);
+        visited.insert(start_pos);
+        current_group.push(start_pos);
+
+        // Process all connected positions
+        while let Some(current_pos) = queue.pop_front() {
+            // Check all adjacent positions
+            for offset in ADJACENT {
+                let neighbor = current_pos + offset;
+
+                // If neighbor exists in positions and hasn't been visited
+                if positions.contains(&neighbor) && !visited.contains(&neighbor) {
+                    visited.insert(neighbor);
+                    queue.push_back(neighbor);
+                    current_group.push(neighbor);
+                }
+            }
+        }
+
+        // Add the completed group
+        groups.push(current_group);
+    }
+
+    groups
+}
+
+impl hyperion_clap::MinecraftCommand for ReplaceCommand {
+    fn execute(self, world: &World, caller: Entity) {
+        world.get::<&mut Blocks>(|blocks| {
+            let started_time = std::time::Instant::now();
+
+            let concrete_positions: HashSet<_, GxBuildHasher> =
+                blocks.par_scan_for(BlockState::ORANGE_CONCRETE).collect();
+
+            let scan_time = started_time.elapsed();
+
+            let len = concrete_positions.len();
+
+            let groups = group(&concrete_positions);
+
+            for group in groups {
+                let ore = pick_ore();
+                for position in group {
+                    blocks.set_block(position, pick_given_ore(ore)).unwrap();
+                }
+            }
+
+            let elapsed = started_time.elapsed();
+
+            // 317ms debug
+            // -> 37ms release
+            let msg = hyperion::chat!(
+                "Replaced {len} concrete blocks in {elapsed:?} with scan time {scan_time:?}"
+            );
+
+            world.get::<&hyperion::net::Compose>(|compose| {
+                caller
+                    .entity_view(world)
+                    .get::<&hyperion::net::NetworkStreamRef>(|stream| {
+                        let mut bundle = hyperion::net::DataBundle::new(compose);
+                        bundle.add_packet(&msg, world).unwrap();
+                        bundle
+                            .send(world, *stream, hyperion::system_registry::SystemId(8))
+                            .unwrap();
+                    });
+            });
+        });
+    }
+}


### PR DESCRIPTION
- Add command to convert orange concrete (placeholder) into mineable ore deposits
- Implement weighted random ore selection (40% cobble, 35% copper, 15% iron, etc)
- Group connected blocks to create natural-looking ore veins
- Preserve ore type within each group/vein for realistic deposits
- Use parallel block scanning for efficient world traversal