### PR TITLE
fix(commands): `/fly` properly toggles

### DIFF
--- a/crates/hyperion-clap/src/lib.rs
+++ b/crates/hyperion-clap/src/lib.rs
@@ -26,7 +26,11 @@ use valence_protocol::{
 pub trait MinecraftCommand: Parser + CommandPermission {
     fn execute(self, world: &World, caller: Entity);
 
+    fn pre_register(_world: &World) {}
+
     fn register(registry: &mut CommandRegistry, world: &World) {
+        Self::pre_register(world);
+
         let cmd = Self::command();
         let name = cmd.get_name();
 

--- a/events/tag/src/command/fly.rs
+++ b/events/tag/src/command/fly.rs
@@ -1,5 +1,8 @@
 use clap::Parser;
-use flecs_ecs::core::{Entity, EntityViewGet, World, WorldGet};
+use flecs_ecs::{
+    core::{Entity, EntityViewGet, World, WorldGet},
+    macros::Component,
+};
 use hyperion::{
     net::{Compose, DataBundle, NetworkStreamRef, agnostic},
     system_registry::SystemId,
@@ -9,6 +12,9 @@ use hyperion::{
 };
 use hyperion_clap::{CommandPermission, MinecraftCommand};
 
+#[derive(Component)]
+pub struct Flight;
+
 #[derive(Parser, CommandPermission, Debug)]
 #[command(name = "fly")]
 #[command_permission(group = "Moderator")]
@@ -16,17 +22,25 @@ pub struct FlyCommand;
 
 impl MinecraftCommand for FlyCommand {
     fn execute(self, world: &World, caller: Entity) {
-        let chat = agnostic::chat("§aFlying enabled");
-
         world.get::<&Compose>(|compose| {
+            let allow_flight: bool = !caller.entity_view(world).has::<Flight>();
+
+            let chat_packet = if allow_flight {
+                agnostic::chat("§aFlying enabled")
+            } else {
+                agnostic::chat("§cFlying disabled")
+            };
+
+            caller.entity_view(world).add_if::<Flight>(allow_flight);
+
             caller
                 .entity_view(world)
                 .get::<&NetworkStreamRef>(|stream| {
-                    let packet = fly_packet();
+                    let packet = fly_packet(allow_flight);
 
                     let mut bundle = DataBundle::new(compose);
                     bundle.add_packet(&packet, world).unwrap();
-                    bundle.add_packet(&chat, world).unwrap();
+                    bundle.add_packet(&chat_packet, world).unwrap();
 
                     bundle.send(world, *stream, SystemId(8)).unwrap();
                 });
@@ -34,7 +48,7 @@ impl MinecraftCommand for FlyCommand {
     }
 }
 
-fn fly_packet() -> PlayerAbilitiesS2c {
+fn fly_packet(allow_flight: bool) -> PlayerAbilitiesS2c {
     const SPEED_METER_PER_SECOND: f32 = 10.92;
 
     // guessing.. idk what the actual conversion is
@@ -42,8 +56,8 @@ fn fly_packet() -> PlayerAbilitiesS2c {
 
     PlayerAbilitiesS2c {
         flags: PlayerAbilitiesFlags::default()
-            .with_flying(true)
-            .with_allow_flying(true),
+            .with_flying(allow_flight)
+            .with_allow_flying(allow_flight),
         flying_speed: SOME_CONVERSION,
         fov_modifier: 0.0,
     }


### PR DESCRIPTION
Update the fly command to toggle flying state instead of only enabling it.
Add proper component initialization for the Flight component:
- Track flight state in Flight component
- Register Flight component with meta for UI visibility
- Automatically add Flight component to new Players
- Update packet flags based on current flight state
- Fixes #607