### PR TITLE
perf: remove regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,7 +1794,6 @@ dependencies = [
  "gxhash",
  "hyperion",
  "indexmap",
- "regex",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,10 +190,6 @@ version = '0.16.1'
 default-features = false
 version = '0.3.6'
 
-[workspace.dependencies.regex]
-features = ['perf-dfa-full']
-version = '1.11.1'
-
 [workspace.dependencies.reqwest]
 features = ['rustls-tls', 'stream']
 version = '0.12.9'

--- a/crates/hyperion-command/Cargo.toml
+++ b/crates/hyperion-command/Cargo.toml
@@ -9,12 +9,11 @@ readme = "README.md"
 publish = false
 
 [dependencies]
-flecs_ecs = {workspace = true}
-gxhash = {workspace = true}
-hyperion = {workspace = true}
-indexmap = {workspace = true}
-regex = {workspace = true}
-tracing = {workspace = true}
+flecs_ecs = { workspace = true }
+gxhash = { workspace = true }
+hyperion = { workspace = true }
+indexmap = { workspace = true }
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/hyperion-command/src/system.rs
+++ b/crates/hyperion-command/src/system.rs
@@ -11,7 +11,6 @@ use hyperion::{
     storage::{EventQueue, GlobalEventHandlers},
     system_registry::SystemId,
 };
-use regex::Regex;
 
 use crate::component::CommandRegistry;
 
@@ -20,8 +19,6 @@ pub struct CommandSystemModule;
 
 impl Module for CommandSystemModule {
     fn module(world: &World) {
-        static COMMAND_REGEX: OnceLock<Regex> = OnceLock::new();
-
         system!(
             "execute_command",
             world,
@@ -69,24 +66,19 @@ impl Module for CommandSystemModule {
             }
         });
 
-        let command_regex = Regex::new(r"/(?P<command>\w+).*").unwrap();
-        COMMAND_REGEX.set(command_regex).unwrap();
-
         world.get::<&mut GlobalEventHandlers>(|handlers| {
             handlers.completion.register(|query, completion| {
                 let input = completion.query;
 
                 // should be in form "/{command}"
-                let command_regex = COMMAND_REGEX.get().unwrap();
-                let Some(captures) = command_regex.captures(input) else {
-                    return;
-                };
+                let command = input.strip_prefix("/").unwrap_or(input)
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or("");
 
-                let Some(command) = captures.name("command") else {
+                if command.is_empty() {
                     return;
-                };
-
-                let command = command.as_str();
+                }
 
                 query.world.get::<&CommandRegistry>(|registry| {
                     let Some(cmd) = registry.commands.get(command) else {

--- a/crates/hyperion-command/src/system.rs
+++ b/crates/hyperion-command/src/system.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Write, sync::OnceLock};
+use std::fmt::Write;
 
 use flecs_ecs::{
     core::{EntityViewGet, QueryBuilderImpl, SystemAPI, TermBuilderImpl, World, WorldGet},
@@ -71,7 +71,9 @@ impl Module for CommandSystemModule {
                 let input = completion.query;
 
                 // should be in form "/{command}"
-                let command = input.strip_prefix("/").unwrap_or(input)
+                let command = input
+                    .strip_prefix("/")
+                    .unwrap_or(input)
                     .split_whitespace()
                     .next()
                     .unwrap_or("");


### PR DESCRIPTION
RegEx is really slow. If used in something like chat commands where they are potentially spammed all the time it can lead to bad performance.