### PR TITLE
refactor: unnamed tuple

### DIFF
--- a/crates/hyperion/src/simulation/metadata/living_entity.rs
+++ b/crates/hyperion/src/simulation/metadata/living_entity.rs
@@ -84,11 +84,11 @@ impl Default for Health {
 impl Health {
     #[must_use]
     pub fn is_dead(&self) -> bool {
-        self.value <= 0.0
+        self.0 <= 0.0
     }
 
     pub fn damage(&mut self, damage: f32) {
-        self.update(self.value - damage);
+        self.update(self.0 - damage);
     }
 
     fn update(&mut self, value: f32) {
@@ -96,11 +96,11 @@ impl Health {
             return;
         }
 
-        self.value = value.clamp(0.0, 20.0);
+        self.0 = value.clamp(0.0, 20.0);
     }
 
     pub fn heal(&mut self, heal: f32) {
-        self.update(self.value + heal);
+        self.update(self.0 + heal);
     }
 }
 
@@ -111,7 +111,7 @@ impl Display for Health {
             clippy::cast_possible_truncation,
             reason = "we want saturating ceiling"
         )]
-        let normal = usize::try_from(self.value.ceil() as isize).unwrap_or(0);
+        let normal = usize::try_from(self.0.ceil() as isize).unwrap_or(0);
 
         let full_hearts = normal / 2;
         for _ in 0..full_hearts {

--- a/crates/hyperion/src/simulation/metadata/mod.rs
+++ b/crates/hyperion/src/simulation/metadata/mod.rs
@@ -190,13 +190,12 @@ macro_rules! define_metadata_component {
             derive_more::Deref,
             derive_more::DerefMut,
             derive_more::Constructor,
+            derive_more::From,
             Debug
         )]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[meta]
-        pub struct $name {
-            value: $type,
-        }
+        pub struct $name($type);
 
         #[allow(warnings)]
         impl PartialOrd for $name
@@ -204,7 +203,7 @@ macro_rules! define_metadata_component {
             $type: PartialOrd,
         {
             fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-                self.value.partial_cmp(&other.value)
+                self.0.partial_cmp(&other.0)
             }
         }
 
@@ -214,7 +213,7 @@ macro_rules! define_metadata_component {
             const INDEX: u8 = $index;
 
             fn to_type(self) -> Self::Type {
-                self.value
+                self.0
             }
         }
     };


### PR DESCRIPTION
`#[meta]` with named tuple single value is not showing up properly in flecs explorer

<img width="447" alt="image" src="https://github.com/user-attachments/assets/8b87883f-8fe0-47ab-bb86-d08fdebaf025">

where if I had struct with `value` it would look like

<img width="452" alt="Google Chrome 2024-12-03 11 28 04" src="https://github.com/user-attachments/assets/fb616bf1-e5c1-43ab-b3df-91bd28e9d35a">
