### PR TITLE
feat: add `ClickMode` to GUI API

### DIFF
--- a/crates/hyperion-gui/src/lib.rs
+++ b/crates/hyperion-gui/src/lib.rs
@@ -164,7 +164,7 @@ impl Gui {
                     return;
                 }
 
-                let slot = event.slot_idx as usize;
+                let slot = usize::from(event.slot_idx);
                 let Some(item) = items.get(&slot) else {
                     return;
                 };

--- a/crates/hyperion-gui/src/lib.rs
+++ b/crates/hyperion-gui/src/lib.rs
@@ -10,6 +10,7 @@ use hyperion::{
     valence_protocol::{
         ItemStack, VarInt,
         packets::play::{
+            click_slot_c2s::ClickMode,
             close_screen_s2c::CloseScreenS2c,
             inventory_s2c::InventoryS2c,
             open_screen_s2c::{OpenScreenS2c, WindowType},
@@ -48,7 +49,7 @@ pub struct Gui {
 #[derive(Clone)]
 pub struct GuiItem {
     item: ItemStack,
-    on_click: fn(Entity),
+    on_click: fn(Entity, ClickMode),
 }
 
 /// Thread-local non-zero id means that it will be very unlikely that one player will have two
@@ -157,17 +158,21 @@ impl Gui {
             let items = self.items.clone();
             let gui = self.clone();
             event_handlers.click.register(move |query, event| {
+                let button = event.mode;
+
                 if event.window_id != window_id {
                     return;
                 }
 
-                let slot = usize::from(event.slot_idx);
+                let slot = event.slot_idx as usize;
                 let Some(item) = items.get(&slot) else {
                     return;
                 };
 
-                (item.on_click)(player);
+                (item.on_click)(player, button);
                 gui.draw(query.world, player);
+                // TODO: REDRAW USER INVENTORY
+                // IF THEY SHIFT CLICK IT STAYS IN THEIR INVENTORY
             });
         });
     }
@@ -178,7 +183,7 @@ impl Gui {
 }
 
 impl GuiItem {
-    pub fn new(item: ItemStack, on_click: fn(Entity)) -> Self {
+    pub fn new(item: ItemStack, on_click: fn(Entity, ClickMode)) -> Self {
         Self { item, on_click }
     }
 }

--- a/events/tag/src/command/gui.rs
+++ b/events/tag/src/command/gui.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use flecs_ecs::core::{Entity, World};
+use hyperion::valence_protocol::packets::play::click_slot_c2s::ClickMode;
 use hyperion_clap::{CommandPermission, MinecraftCommand};
 use hyperion_gui::{ContainerType, Gui, GuiItem};
 use hyperion_item::builder::ItemBuilder;
@@ -19,8 +20,14 @@ impl MinecraftCommand for GuiCommand {
                 .name("Information")
                 .glowing()
                 .build(),
-            |_player| {
-                debug!("Clicked on info item");
+            |_player, click_mode| match click_mode {
+                ClickMode::Click => debug!("Left Click"),
+                ClickMode::ShiftClick => debug!("Shift Click"),
+                ClickMode::Hotbar => debug!("Hotbar"),
+                ClickMode::CreativeMiddleClick => debug!("Creative Middle Click"),
+                ClickMode::DropKey => debug!("Drop Key"),
+                ClickMode::Drag => debug!("Drag"),
+                ClickMode::DoubleClick => debug!("Double Click"),
             },
         );
 


### PR DESCRIPTION
ClickMode for flexibility on how the player clicked an item on the GUI

Also there is a bug where the player is able to shift click and take the items. Not sure how to prevent this.