### PR TITLE
feat: use `gen_blocks` instead of `coroutines`

### DIFF
--- a/crates/hyperion-proxy/src/lib.rs
+++ b/crates/hyperion-proxy/src/lib.rs
@@ -1,10 +1,9 @@
 #![feature(maybe_uninit_slice)]
 #![feature(allocator_api)]
 #![feature(let_chains)]
-#![feature(coroutines)]
 #![feature(never_type)]
-#![feature(iter_from_coroutine)]
 #![feature(stmt_expr_attributes)]
+#![feature(gen_blocks)]
 #![allow(
     clippy::redundant_pub_crate,
     clippy::cast_possible_truncation,

--- a/crates/hyperion-proxy/src/player.rs
+++ b/crates/hyperion-proxy/src/player.rs
@@ -266,8 +266,7 @@ fn apply_exclusions<'a>(
     exclusions: Option<&'a ExclusionsManager>,
     player_id: u64,
 ) -> impl Iterator<Item = IoSlice<'a>> + 'a {
-    let coroutine = #[coroutine]
-    move || {
+    gen move {
         let mut current_offset = 0;
 
         if let Some(exclusions) = exclusions {
@@ -305,9 +304,8 @@ fn apply_exclusions<'a>(
             let remaining_slice = &packet_data[current_offset..];
             yield IoSlice::new(remaining_slice);
         }
-    };
-
-    core::iter::from_coroutine(coroutine).filter(|iovec| !iovec.is_empty())
+    }
+    .filter(|iovec| !iovec.is_empty())
 }
 
 trait RangeExt {

--- a/crates/hyperion/src/lib.rs
+++ b/crates/hyperion/src/lib.rs
@@ -15,7 +15,6 @@
 #![feature(let_chains)]
 #![feature(ptr_metadata)]
 #![feature(stmt_expr_attributes)]
-#![feature(coroutines)]
 #![feature(array_try_map)]
 #![feature(split_array)]
 #![feature(never_type)]

--- a/events/tag/src/lib.rs
+++ b/events/tag/src/lib.rs
@@ -1,9 +1,6 @@
 #![feature(allocator_api)]
 #![feature(let_chains)]
-#![feature(coroutines)]
 #![feature(stmt_expr_attributes)]
-#![feature(coroutine_trait)]
-#![feature(iter_from_coroutine)]
 #![feature(exact_size_is_empty)]
 
 use std::{collections::HashSet, net::ToSocketAddrs};


### PR DESCRIPTION
The `gen` is a reserved keyword in 2024 edition; let's use `gen_blocks` instead.