### PR TITLE
feat(core): send more combat related packets

### DIFF
--- a/crates/hyperion/src/simulation/metadata/living_entity.rs
+++ b/crates/hyperion/src/simulation/metadata/living_entity.rs
@@ -75,12 +75,6 @@ impl Default for Health {
     }
 }
 
-// impl Default for Health {
-//     fn default() -> Self {
-//         Self(20.0)
-//     }
-// }
-
 impl Health {
     #[must_use]
     pub fn is_dead(&self) -> bool {
@@ -92,10 +86,6 @@ impl Health {
     }
 
     fn update(&mut self, value: f32) {
-        if self.is_dead() {
-            return;
-        }
-
         self.value = value.clamp(0.0, 20.0);
     }
 

--- a/events/tag/src/module/attack.rs
+++ b/events/tag/src/module/attack.rs
@@ -8,13 +8,25 @@ use flecs_ecs::{
 };
 use hyperion::{
     net::{
-        agnostic, packets::{BossBarAction, BossBarS2c}, Compose, ConnectionId
+        Compose, ConnectionId, agnostic,
+        packets::{BossBarAction, BossBarS2c},
     },
-    simulation::{event, metadata::{entity::Pose, living_entity::Health}, PacketState, Player, Position, Velocity},
+    simulation::{
+        PacketState, Player, Position, Velocity, event,
+        metadata::{entity::Pose, living_entity::Health},
+    },
     storage::EventQueue,
     uuid::Uuid,
     valence_protocol::{
-        ident, math::{DVec3, Vec3}, nbt, packets::play::{self, boss_bar_s2c::{BossBarColor, BossBarDivision, BossBarFlags}, entity_attributes_s2c::AttributeProperty}, text::IntoText, ItemKind, ItemStack, Particle, VarInt
+        ItemKind, ItemStack, Particle, VarInt, ident,
+        math::{DVec3, Vec3},
+        nbt,
+        packets::play::{
+            self,
+            boss_bar_s2c::{BossBarColor, BossBarDivision, BossBarFlags},
+            entity_attributes_s2c::AttributeProperty,
+        },
+        text::IntoText,
     },
 };
 use hyperion_inventory::PlayerInventory;


### PR DESCRIPTION
Changes:
- Send HealthUpdateS2c to update health on the client
- Send DamageTiltS2c to trigger the damage tilt on the client (still needs to calculate where the damage comes from)
- Send EntityDamageS2c to display a red outline hover the client taking damage
- Send knockback sound to nearby clients
- Send DeathMessageS2c to trigger the client's respawn sequence
- Broadcast EntityStatusS2c when a player is killed
- Set killed player pose to `Dying`

Missing:
- Handle respawn
- Handle critical hits