### PR TITLE
perf: docker use musl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,25 @@
-# Define base arguments for versioning and optimization
+# Define base arguments
 ARG RUST_NIGHTLY_VERSION=nightly-2024-11-29
 ARG RUSTFLAGS="-Z share-generics=y -Z threads=8"
 ARG CARGO_HOME=/usr/local/cargo
+ARG ALPINE_VERSION=3.21
 
-# Use Ubuntu as base image
-FROM ubuntu:22.04 AS packages
+# Use Alpine as base image for packages
+FROM alpine:${ALPINE_VERSION} AS packages
 
-# Prevent apt from prompting for user input
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install essential build packages
-FROM ubuntu:22.04 AS packages
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
-    apt-get install -y \
-        curl \
-        build-essential \
-        libssl-dev \
-        pkg-config \
-        cmake \
-        perl \
-        gcc \
-        linux-headers-generic \
-        libclang1 \
-        llvm-dev \
-        libclang-dev \
-    && rm -rf /var/lib/apt/lists/*
+# Install packages needed for build
+RUN apk add --no-cache \
+    curl \
+    build-base \
+    openssl-dev \
+    pkgconfig \
+    cmake \
+    perl \
+    gcc \
+    linux-headers \
+    clang-dev \
+    llvm-dev \
+    musl-dev
 
 # Base builder stage with Rust installation
 FROM packages AS builder-base
@@ -34,9 +28,11 @@ ARG RUSTFLAGS
 ARG CARGO_HOME
 ENV RUSTFLAGS=${RUSTFLAGS}
 ENV CARGO_HOME=${CARGO_HOME}
+
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_NIGHTLY_VERSION} && \
     $CARGO_HOME/bin/rustup component add rust-src && \
     $CARGO_HOME/bin/rustc --version
+
 ENV PATH="${CARGO_HOME}/bin:${PATH}"
 WORKDIR /app
 COPY . .
@@ -47,7 +43,7 @@ RUN --mount=type=cache,target=${CARGO_HOME}/registry \
     cargo fetch
 
 # Release builder
-FROM builder-base AS build-release
+FROM builder-base AS build
 ARG CARGO_HOME
 RUN --mount=type=cache,target=${CARGO_HOME}/registry \
     --mount=type=cache,target=${CARGO_HOME}/git \
@@ -57,28 +53,25 @@ RUN --mount=type=cache,target=${CARGO_HOME}/registry \
     cp target/release-full/hyperion-proxy /app/build/ && \
     cp target/release-full/tag /app/build/
 
-# Runtime base image
-FROM ubuntu:22.04 AS runtime-base
-RUN apt-get update && \
-    apt-get install -y \
-        libssl3 \
-        ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+# Runtime base image (using scratch instead of Alpine)
+FROM scratch AS runtime-base
+COPY --from=packages /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENV RUST_BACKTRACE=1 \
     RUST_LOG=info
 
 # Hyperion Proxy Release
 FROM runtime-base AS hyperion-proxy
-COPY --from=build-release /app/build/hyperion-proxy /
+COPY --from=build /app/build/hyperion-proxy /
 LABEL org.opencontainers.image.source="https://github.com/andrewgazelka/hyperion" \
       org.opencontainers.image.description="Hyperion Proxy Server" \
       org.opencontainers.image.version="0.1.0"
 EXPOSE 8080
 ENTRYPOINT ["/hyperion-proxy"]
 CMD ["0.0.0.0:8080"]
-# NYC Release
+
+# Tag Release
 FROM runtime-base AS tag
-COPY --from=build-release /app/build/tag /
+COPY --from=build /app/build/tag /
 LABEL org.opencontainers.image.source="https://github.com/andrewgazelka/hyperion" \
       org.opencontainers.image.description="Hyperion Tag Event" \
       org.opencontainers.image.version="0.1.0"


### PR DESCRIPTION
Issue:

```
1.07 error: failed to run custom build command for `flecs_ecs_sys v0.1.2 (https://github.com/Indra-db/Flecs-Rust#24b5a0de)`
61.07
61.07 Caused by:
61.07   process didn't exit successfully: `/app/target/release-full/build/flecs_ecs_sys-d33e12337364c9c5/build-script-build` (exit status: 101)
61.07   --- stdout
61.07   cargo:rerun-if-changed=src/flecs.h
61.07   cargo:rerun-if-changed=src/flecs.c
61.07   cargo:rerun-if-changed=src/flecs_rust.h
61.07   cargo:rerun-if-changed=src/flecs_rust.c
61.07   cargo:rerun-if-changed=build.rs
61.07   OUT_DIR = Some(/app/target/release-full/build/flecs_ecs_sys-f23c7681e8b422aa/out)
61.07   TARGET = Some(aarch64-unknown-linux-musl)
61.07   HOST = Some(aarch64-unknown-linux-musl)
61.07   cargo:rerun-if-env-changed=CC_aarch64-unknown-linux-musl
61.07   CC_aarch64-unknown-linux-musl = None
61.07   cargo:rerun-if-env-changed=CC_aarch64_unknown_linux_musl
61.07   CC_aarch64_unknown_linux_musl = None
61.07   cargo:rerun-if-env-changed=HOST_CC
61.07   HOST_CC = None
61.07   cargo:rerun-if-env-changed=CC
61.07   CC = None
61.07   cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
61.07   RUSTC_WRAPPER = None
61.07   cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
61.07   CRATE_CC_NO_DEFAULTS = None
61.07   DEBUG = Some(false)
61.07   CARGO_CFG_TARGET_FEATURE = Some(neon)
61.07   cargo:rerun-if-env-changed=CFLAGS_aarch64-unknown-linux-musl
61.07   CFLAGS_aarch64-unknown-linux-musl = None
61.07   cargo:rerun-if-env-changed=CFLAGS_aarch64_unknown_linux_musl
61.07   CFLAGS_aarch64_unknown_linux_musl = None
61.07   cargo:rerun-if-env-changed=HOST_CFLAGS
61.07   HOST_CFLAGS = None
61.07   cargo:rerun-if-env-changed=CFLAGS
61.07   CFLAGS = None
61.07   CARGO_ENCODED_RUSTFLAGS = Some(-Zshare-generics=y-Zthreads=8)
61.07   cargo:rerun-if-env-changed=AR_aarch64-unknown-linux-musl
61.07   AR_aarch64-unknown-linux-musl = None
61.07   cargo:rerun-if-env-changed=AR_aarch64_unknown_linux_musl
61.07   AR_aarch64_unknown_linux_musl = None
61.07   cargo:rerun-if-env-changed=HOST_AR
61.07   HOST_AR = None
61.07   cargo:rerun-if-env-changed=AR
61.07   AR = None
61.07   cargo:rerun-if-env-changed=ARFLAGS_aarch64-unknown-linux-musl
61.07   ARFLAGS_aarch64-unknown-linux-musl = None
61.07   cargo:rerun-if-env-changed=ARFLAGS_aarch64_unknown_linux_musl
61.07   ARFLAGS_aarch64_unknown_linux_musl = None
61.07   cargo:rerun-if-env-changed=HOST_ARFLAGS
61.07   HOST_ARFLAGS = None
61.07   cargo:rerun-if-env-changed=ARFLAGS
61.07   ARFLAGS = None
61.07   cargo:rustc-link-lib=static=flecs
61.07   cargo:rustc-link-search=native=/app/target/release-full/build/flecs_ecs_sys-f23c7681e8b422aa/out
61.07
61.07   --- stderr
61.07   thread 'main' panicked at /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/bindgen-0.70.1/lib.rs:622:27:
61.07   Unable to find libclang: "the `libclang` shared library at /usr/lib/llvm19/lib/libclang.so.19.1.4 could not be opened: Dynamic loading not supported"
61.07   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
61.07 warning: build failed, waiting for other jobs to finish...
------
Dockerfile:48
--------------------
  47 |     ARG CARGO_HOME
  48 | >>> RUN --mount=type=cache,target=${CARGO_HOME}/registry \
  49 | >>>     --mount=type=cache,target=${CARGO_HOME}/git \
  50 | >>>     --mount=type=cache,target=/app/target \
  51 | >>>     cargo build --profile release-full --frozen && \
  52 | >>>     mkdir -p /app/build && \
  53 | >>>     cp target/release-full/hyperion-proxy /app/build/ && \
  54 | >>>     cp target/release-full/tag /app/build/
  55 |
--------------------
ERROR: failed to solve: process "/bin/sh -c cargo build --profile release-full --frozen &&     mkdir -p /app/build &&     cp target/release-full/hyperion-proxy /app/build/ &&     cp target/release-full/tag /app/build/" did not complete successfully: exit code: 101
```