### PR TITLE
fix(dependabot): disable on rust code

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 15
-    groups:
-      all-cargo-dependencies:
-        patterns:
-          - "*"
   - package-ecosystem: "gradle"
     directory: "/extractor/"
     schedule:


### PR DESCRIPTION
Dependabot is currently causing issues by trying to update `glam` to a new major release (0.29 -> 0.30) automatically. Dependabot is not that useful because we can always update dependencies as needed for bug fixes and new features.