### PR TITLE
feat(proto): network NBT and text components for Minecraft 26.2

### DIFF
--- a/crates/hyperion-minecraft-proto/src/error.rs
+++ b/crates/hyperion-minecraft-proto/src/error.rs
@@ -88,15 +88,16 @@ impl fmt::Display for Error {
             Self::InvalidTagType(id) => write!(f, "invalid NBT tag type: {id}"),
             Self::UnexpectedEndTag => f.write_str("NBT value was a bare TAG_End"),
             Self::NbtTooDeep => f.write_str("NBT nested deeper than 512 levels"),
-            Self::InvalidModifiedUtf8 => {
-                f.write_str("NBT string was not valid modified UTF-8")
-            }
+            Self::InvalidModifiedUtf8 => f.write_str("NBT string was not valid modified UTF-8"),
             Self::MissingField(name) => write!(f, "missing required field: {name}"),
             Self::WrongTagType {
                 field,
                 expected,
                 found,
-            } => write!(f, "field {field} should be {expected}, found tag type {found}"),
+            } => write!(
+                f,
+                "field {field} should be {expected}, found tag type {found}"
+            ),
             Self::UnknownVariant { name, value } => write!(f, "invalid {name}: {value}"),
             Self::NoMatchingCodec(name) => write!(f, "no {name} matched the fields present"),
         }

--- a/crates/hyperion-minecraft-proto/src/error.rs
+++ b/crates/hyperion-minecraft-proto/src/error.rs
@@ -38,6 +38,34 @@ pub enum Error {
     },
     /// Bytes remained after decoding a packet that should have consumed all of them.
     TrailingBytes(usize),
+    /// A tag type byte named no NBT tag, or named `TAG_End` where a value was due.
+    InvalidTagType(u8),
+    /// An NBT value was a bare `TAG_End`, which `ByteBufCodecs.tagCodec` rejects.
+    UnexpectedEndTag,
+    /// NBT nested past `NbtAccounter`'s 512-deep limit.
+    NbtTooDeep,
+    /// An NBT string was malformed modified UTF-8, or held an unpaired surrogate.
+    InvalidModifiedUtf8,
+    /// A codec required a field the value did not carry.
+    MissingField(&'static str),
+    /// A field held a tag of the wrong type for its codec.
+    WrongTagType {
+        /// Field whose value was wrong.
+        field: &'static str,
+        /// Tag type the codec wanted.
+        expected: &'static str,
+        /// Tag type actually present.
+        found: u8,
+    },
+    /// A string discriminant had no meaning in this protocol version.
+    UnknownVariant {
+        /// Name of the type the value was being decoded into.
+        name: &'static str,
+        /// The value that was not recognised.
+        value: String,
+    },
+    /// No alternative in a `FuzzyCodec` matched the fields present.
+    NoMatchingCodec(&'static str),
 }
 
 impl fmt::Display for Error {
@@ -57,6 +85,20 @@ impl fmt::Display for Error {
             Self::InvalidUtf8 => f.write_str("string field was not valid UTF-8"),
             Self::InvalidEnum { name, value } => write!(f, "invalid {name} discriminant: {value}"),
             Self::TrailingBytes(n) => write!(f, "{n} trailing bytes after packet body"),
+            Self::InvalidTagType(id) => write!(f, "invalid NBT tag type: {id}"),
+            Self::UnexpectedEndTag => f.write_str("NBT value was a bare TAG_End"),
+            Self::NbtTooDeep => f.write_str("NBT nested deeper than 512 levels"),
+            Self::InvalidModifiedUtf8 => {
+                f.write_str("NBT string was not valid modified UTF-8")
+            }
+            Self::MissingField(name) => write!(f, "missing required field: {name}"),
+            Self::WrongTagType {
+                field,
+                expected,
+                found,
+            } => write!(f, "field {field} should be {expected}, found tag type {found}"),
+            Self::UnknownVariant { name, value } => write!(f, "invalid {name}: {value}"),
+            Self::NoMatchingCodec(name) => write!(f, "no {name} matched the fields present"),
         }
     }
 }

--- a/crates/hyperion-minecraft-proto/src/lib.rs
+++ b/crates/hyperion-minecraft-proto/src/lib.rs
@@ -12,6 +12,7 @@ pub mod codec;
 pub mod generated;
 pub mod nbt;
 pub mod packets;
+pub mod text;
 
 mod error;
 

--- a/crates/hyperion-minecraft-proto/src/lib.rs
+++ b/crates/hyperion-minecraft-proto/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod codec;
 pub mod generated;
+pub mod nbt;
 pub mod packets;
 
 mod error;

--- a/crates/hyperion-minecraft-proto/src/nbt/mod.rs
+++ b/crates/hyperion-minecraft-proto/src/nbt/mod.rs
@@ -1,0 +1,704 @@
+//! Network NBT.
+//!
+//! Network NBT is not file NBT. `FriendlyByteBuf.writeNbt` goes through
+//! `NbtIo.writeAnyTag`, which writes a type byte and then the payload; the
+//! named-root form lives in `NbtIo.writeUnnamedTag`, which the network never
+//! calls. So the root carries neither a name nor the empty-name length prefix
+//! that a file root still has.
+//!
+//! A root `TAG_End` stands for absence: `FriendlyByteBuf.readNbt` maps it to
+//! `null`, which is why [`decode_optional`] exists alongside the [`Decode`]
+//! impl. `ByteBufCodecs.tagCodec` rejects that case, and so does [`Tag`]'s own
+//! impl.
+//!
+//! What is deliberately not reproduced is `NbtAccounter`'s byte quota. Those
+//! numbers (48 bytes for a compound, 36 for a map entry) size Java heap
+//! objects, not wire bytes, and they exist because Java allocates before it
+//! knows the input is short. A [`Reader`] is already backed by the whole
+//! message, so the check that matters here is that a declared length is
+//! actually present, which every array and list read does before reserving.
+//! The 512-deep nesting limit is real and is enforced.
+
+pub(crate) mod mutf8;
+
+use std::borrow::Cow;
+
+use crate::{Decode, Encode, Error, Reader, Result, Writer};
+
+/// Deepest nesting a tag may reach (`Tag.MAX_DEPTH`, `NbtAccounter.MAX_STACK_DEPTH`).
+pub const MAX_DEPTH: usize = 512;
+
+/// `TAG_End`, which on the wire means "no value".
+pub const TAG_END: u8 = 0;
+/// `TAG_Byte`.
+pub const TAG_BYTE: u8 = 1;
+/// `TAG_Short`.
+pub const TAG_SHORT: u8 = 2;
+/// `TAG_Int`.
+pub const TAG_INT: u8 = 3;
+/// `TAG_Long`.
+pub const TAG_LONG: u8 = 4;
+/// `TAG_Float`.
+pub const TAG_FLOAT: u8 = 5;
+/// `TAG_Double`.
+pub const TAG_DOUBLE: u8 = 6;
+/// `TAG_Byte_Array`.
+pub const TAG_BYTE_ARRAY: u8 = 7;
+/// `TAG_String`.
+pub const TAG_STRING: u8 = 8;
+/// `TAG_List`.
+pub const TAG_LIST: u8 = 9;
+/// `TAG_Compound`.
+pub const TAG_COMPOUND: u8 = 10;
+/// `TAG_Int_Array`.
+pub const TAG_INT_ARRAY: u8 = 11;
+/// `TAG_Long_Array`.
+pub const TAG_LONG_ARRAY: u8 = 12;
+
+/// One NBT value.
+///
+/// There is no `End` variant: `TAG_End` is a terminator and an absence marker,
+/// never a value a field can hold. Strings and byte arrays borrow the input
+/// where they can, so decoding a typical compound allocates only for its own
+/// entry list.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Tag<'a> {
+    /// A signed byte, which is also how NBT spells a boolean.
+    Byte(i8),
+    /// A signed short.
+    Short(i16),
+    /// A signed int.
+    Int(i32),
+    /// A signed long.
+    Long(i64),
+    /// A single-precision float.
+    Float(f32),
+    /// A double-precision float.
+    Double(f64),
+    /// A length-prefixed run of bytes.
+    ByteArray(Cow<'a, [u8]>),
+    /// A modified-UTF-8 string.
+    String(Cow<'a, str>),
+    /// A list, which since 1.21.5 may hold mixed types. See [`List`].
+    List(List<'a>),
+    /// A map of names to tags.
+    Compound(Compound<'a>),
+    /// A length-prefixed run of big-endian ints.
+    IntArray(Vec<i32>),
+    /// A length-prefixed run of big-endian longs.
+    LongArray(Vec<i64>),
+}
+
+impl<'a> Tag<'a> {
+    /// The type byte that introduces this tag.
+    #[must_use]
+    pub const fn id(&self) -> u8 {
+        match self {
+            Self::Byte(_) => TAG_BYTE,
+            Self::Short(_) => TAG_SHORT,
+            Self::Int(_) => TAG_INT,
+            Self::Long(_) => TAG_LONG,
+            Self::Float(_) => TAG_FLOAT,
+            Self::Double(_) => TAG_DOUBLE,
+            Self::ByteArray(_) => TAG_BYTE_ARRAY,
+            Self::String(_) => TAG_STRING,
+            Self::List(_) => TAG_LIST,
+            Self::Compound(_) => TAG_COMPOUND,
+            Self::IntArray(_) => TAG_INT_ARRAY,
+            Self::LongArray(_) => TAG_LONG_ARRAY,
+        }
+    }
+
+    /// The string this tag holds, if it is one.
+    #[must_use]
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::String(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// The compound this tag holds, if it is one.
+    #[must_use]
+    pub const fn as_compound(&self) -> Option<&Compound<'a>> {
+        match self {
+            Self::Compound(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// The list this tag holds, if it is one.
+    #[must_use]
+    pub const fn as_list(&self) -> Option<&List<'a>> {
+        match self {
+            Self::List(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// This tag read as a boolean, which NBT stores as a byte.
+    #[must_use]
+    pub const fn as_bool(&self) -> Option<bool> {
+        match self {
+            Self::Byte(value) => Some(*value != 0),
+            _ => None,
+        }
+    }
+
+    /// This tag widened to an `i64`, for any of the integral types.
+    #[must_use]
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            Self::Byte(value) => Some(i64::from(*value)),
+            Self::Short(value) => Some(i64::from(*value)),
+            Self::Int(value) => Some(i64::from(*value)),
+            Self::Long(value) => Some(*value),
+            _ => None,
+        }
+    }
+
+    fn write_payload(&self, writer: &mut Writer, depth: usize) -> Result<()> {
+        match self {
+            Self::Byte(value) => writer.i8(*value),
+            Self::Short(value) => writer.i16(*value),
+            Self::Int(value) => writer.i32(*value),
+            Self::Long(value) => writer.i64(*value),
+            Self::Float(value) => writer.f32(*value),
+            Self::Double(value) => writer.f64(*value),
+            Self::ByteArray(value) => {
+                writer.i32(length_prefix(value.len())?);
+                writer.raw(value);
+            }
+            Self::String(value) => mutf8::write(writer, value)?,
+            Self::List(value) => value.write_payload(writer, depth)?,
+            Self::Compound(value) => value.write_payload(writer, depth)?,
+            Self::IntArray(value) => {
+                writer.i32(length_prefix(value.len())?);
+                for element in value {
+                    writer.i32(*element);
+                }
+            }
+            Self::LongArray(value) => {
+                writer.i32(length_prefix(value.len())?);
+                for element in value {
+                    writer.i64(*element);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Read a tag that cannot contain another one.
+    ///
+    /// Containers are handled by [`read_nested`], which is where the whole
+    /// depth question lives; keeping them out of here is what lets that
+    /// function be a loop.
+    fn read_leaf(reader: &mut Reader<'a>, id: u8) -> Result<Self> {
+        Ok(match id {
+            TAG_BYTE => Self::Byte(reader.i8()?),
+            TAG_SHORT => Self::Short(reader.i16()?),
+            TAG_INT => Self::Int(reader.i32()?),
+            TAG_LONG => Self::Long(reader.i64()?),
+            TAG_FLOAT => Self::Float(reader.f32()?),
+            TAG_DOUBLE => Self::Double(reader.f64()?),
+            TAG_BYTE_ARRAY => {
+                let length = counted(reader, 1)?;
+                Self::ByteArray(Cow::Borrowed(reader.take(length)?))
+            }
+            TAG_STRING => Self::String(mutf8::read(reader)?),
+            TAG_INT_ARRAY => {
+                let length = counted(reader, 4)?;
+                let mut values = Vec::with_capacity(length);
+                for _ in 0..length {
+                    values.push(reader.i32()?);
+                }
+                Self::IntArray(values)
+            }
+            TAG_LONG_ARRAY => {
+                let length = counted(reader, 8)?;
+                let mut values = Vec::with_capacity(length);
+                for _ in 0..length {
+                    values.push(reader.i64()?);
+                }
+                Self::LongArray(values)
+            }
+            other => return Err(Error::InvalidTagType(other)),
+        })
+    }
+}
+
+impl Encode for Tag<'_> {
+    /// Write the tag as `NbtIo.writeAnyTag` does: type byte, then payload.
+    fn encode(&self, writer: &mut Writer) -> Result<()> {
+        writer.u8(self.id());
+        self.write_payload(writer, 0)
+    }
+}
+
+impl<'a> Decode<'a> for Tag<'a> {
+    /// Read one tag, rejecting a root `TAG_End`.
+    ///
+    /// This is `ByteBufCodecs.tagCodec`, which turns the `null` that
+    /// `FriendlyByteBuf.readNbt` would return into a decoder error.
+    fn decode(reader: &mut Reader<'a>) -> Result<Self> {
+        decode_optional(reader)?.ok_or(Error::UnexpectedEndTag)
+    }
+}
+
+/// Write an optional tag, spelling `None` as a bare `TAG_End`.
+///
+/// This is `FriendlyByteBuf.writeNbt`, which substitutes `EndTag.INSTANCE` for
+/// a null tag, and `ByteBufCodecs.optionalTagCodec`.
+///
+/// # Errors
+/// Propagates whatever the tag's own encoding fails on.
+pub fn encode_optional(tag: Option<&Tag<'_>>, writer: &mut Writer) -> Result<()> {
+    match tag {
+        Some(tag) => tag.encode(writer),
+        None => {
+            writer.u8(TAG_END);
+            Ok(())
+        }
+    }
+}
+
+/// Read an optional tag, reading a bare `TAG_End` as `None`.
+///
+/// # Errors
+/// Returns an error on a malformed tag or truncated input.
+pub fn decode_optional<'a>(reader: &mut Reader<'a>) -> Result<Option<Tag<'a>>> {
+    let id = reader.u8()?;
+    if id == TAG_END {
+        return Ok(None);
+    }
+    read_nested(reader, id).map(Some)
+}
+
+/// A map of names to tags.
+///
+/// Entries keep insertion order. The server's `CompoundTag` is a `HashMap` and
+/// so has no order at all, which means byte-for-byte agreement with a vanilla
+/// encoder is not a property either side can offer; keeping order at least
+/// makes this crate's own output reproducible. Equality ignores order, matching
+/// Java's map equality.
+#[derive(Debug, Clone, Default)]
+pub struct Compound<'a> {
+    entries: Vec<(Cow<'a, str>, Tag<'a>)>,
+}
+
+impl<'a> Compound<'a> {
+    /// An empty compound.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    /// Number of entries.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// True when there are no entries.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The tag stored under `name`.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&Tag<'a>> {
+        self.entries
+            .iter()
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| value)
+    }
+
+    /// Store `value` under `name`, replacing and returning any previous tag.
+    pub fn insert(&mut self, name: impl Into<Cow<'a, str>>, value: Tag<'a>) -> Option<Tag<'a>> {
+        let name = name.into();
+        match self.entries.iter_mut().find(|(key, _)| *key == name) {
+            Some(entry) => Some(std::mem::replace(&mut entry.1, value)),
+            None => {
+                self.entries.push((name, value));
+                None
+            }
+        }
+    }
+
+    /// Store `value` under `name` when `value` is present, and do nothing when
+    /// it is not.
+    ///
+    /// Every optional field in a component codec behaves this way: DFU's
+    /// `optionalFieldOf` omits the key rather than writing a null.
+    pub fn insert_optional(&mut self, name: &'static str, value: Option<Tag<'a>>) {
+        if let Some(value) = value {
+            self.insert(name, value);
+        }
+    }
+
+    /// Remove and return the tag stored under `name`.
+    pub fn remove(&mut self, name: &str) -> Option<Tag<'a>> {
+        let index = self.entries.iter().position(|(key, _)| key == name)?;
+        Some(self.entries.remove(index).1)
+    }
+
+    /// The entries in insertion order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &Tag<'a>)> {
+        self.entries
+            .iter()
+            .map(|(name, value)| (name.as_ref(), value))
+    }
+
+    fn write_payload(&self, writer: &mut Writer, depth: usize) -> Result<()> {
+        if depth >= MAX_DEPTH {
+            return Err(Error::NbtTooDeep);
+        }
+        for (name, value) in &self.entries {
+            writer.u8(value.id());
+            mutf8::write(writer, name)?;
+            value.write_payload(writer, depth + 1)?;
+        }
+        writer.u8(TAG_END);
+        Ok(())
+    }
+
+}
+
+impl PartialEq for Compound<'_> {
+    /// Order-insensitive, because the server's `CompoundTag` is a map.
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len()
+            && self
+                .entries
+                .iter()
+                .all(|(name, value)| other.get(name) == Some(value))
+    }
+}
+
+impl<'a> FromIterator<(Cow<'a, str>, Tag<'a>)> for Compound<'a> {
+    fn from_iter<I: IntoIterator<Item = (Cow<'a, str>, Tag<'a>)>>(iter: I) -> Self {
+        let mut compound = Self::new();
+        for (name, value) in iter {
+            compound.insert(name, value);
+        }
+        compound
+    }
+}
+
+impl Encode for Compound<'_> {
+    /// Write the compound as a whole tag, which is `ByteBufCodecs.compoundTagCodec`.
+    fn encode(&self, writer: &mut Writer) -> Result<()> {
+        writer.u8(TAG_COMPOUND);
+        self.write_payload(writer, 0)
+    }
+}
+
+impl<'a> Decode<'a> for Compound<'a> {
+    fn decode(reader: &mut Reader<'a>) -> Result<Self> {
+        match Tag::decode(reader)? {
+            Tag::Compound(compound) => Ok(compound),
+            other => Err(Error::WrongTagType {
+                field: "root",
+                expected: "TAG_Compound",
+                found: other.id(),
+            }),
+        }
+    }
+}
+
+/// A sequence of tags.
+///
+/// The wire form still names one element type, but since 1.21.5 a list whose
+/// elements disagree is written as a list of compounds with each element boxed
+/// under the empty key. `ListTag.identifyRawElementType`, `wrapIfNeeded` and
+/// `addAndUnwrap` between them make that invisible to callers, and so does
+/// this: push whatever you like and the encoding sorts itself out.
+///
+/// The boxing is not free of edge cases. A list of compounds where one of them
+/// happens to be a single entry under the empty key gets that element boxed
+/// too, so it survives the unboxing on the far side; `isWrapper` is the check
+/// that catches it.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct List<'a> {
+    elements: Vec<Tag<'a>>,
+}
+
+/// The key `ListTag` boxes mismatched elements under (`ListTag.WRAPPER_MARKER`).
+const WRAPPER_MARKER: &str = "";
+
+impl<'a> List<'a> {
+    /// An empty list.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            elements: Vec::new(),
+        }
+    }
+
+    /// Number of elements.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// True when there are no elements.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    /// Append an element.
+    pub fn push(&mut self, tag: Tag<'a>) {
+        self.elements.push(tag);
+    }
+
+    /// The elements in order.
+    #[must_use]
+    pub fn as_slice(&self) -> &[Tag<'a>] {
+        &self.elements
+    }
+
+    /// The element type this list would be written with
+    /// (`ListTag.identifyRawElementType`).
+    ///
+    /// `TAG_End` for an empty list, the shared type for a uniform one, and
+    /// `TAG_Compound` for a mixed one whatever the elements actually are.
+    #[must_use]
+    pub fn element_type(&self) -> u8 {
+        let mut uniform = TAG_END;
+        for element in &self.elements {
+            let id = element.id();
+            if uniform == TAG_END {
+                uniform = id;
+            } else if uniform != id {
+                return TAG_COMPOUND;
+            }
+        }
+        uniform
+    }
+
+    fn write_payload(&self, writer: &mut Writer, depth: usize) -> Result<()> {
+        if depth >= MAX_DEPTH {
+            return Err(Error::NbtTooDeep);
+        }
+        let element_type = self.element_type();
+        writer.u8(element_type);
+        writer.i32(length_prefix(self.elements.len())?);
+        for element in &self.elements {
+            if element_type == TAG_COMPOUND && needs_wrapping(element) {
+                // Written inline rather than by building the wrapper compound,
+                // which would clone the element for no reason.
+                writer.u8(element.id());
+                mutf8::write(writer, WRAPPER_MARKER)?;
+                element.write_payload(writer, depth + 2)?;
+                writer.u8(TAG_END);
+            } else {
+                element.write_payload(writer, depth + 1)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// `ListTag.addAndUnwrap`: undo the boxing a mixed list applied.
+    fn push_unwrapped(&mut self, tag: Tag<'a>) {
+        match tag {
+            Tag::Compound(mut compound) if compound.len() == 1 => {
+                match compound.remove(WRAPPER_MARKER) {
+                    Some(inner) => self.elements.push(inner),
+                    None => self.elements.push(Tag::Compound(compound)),
+                }
+            }
+            other => self.elements.push(other),
+        }
+    }
+}
+
+impl<'a> FromIterator<Tag<'a>> for List<'a> {
+    fn from_iter<I: IntoIterator<Item = Tag<'a>>>(iter: I) -> Self {
+        Self {
+            elements: iter.into_iter().collect(),
+        }
+    }
+}
+
+/// `ListTag.wrapIfNeeded` with the element type already known to be compound.
+fn needs_wrapping(tag: &Tag<'_>) -> bool {
+    match tag {
+        // A one-entry compound keyed on the marker is indistinguishable from a
+        // box, so it gets one of its own to survive the round trip.
+        Tag::Compound(compound) => compound.len() == 1 && compound.get(WRAPPER_MARKER).is_some(),
+        _ => true,
+    }
+}
+
+/// Read one tag of a known type without recursing.
+///
+/// `CompoundTag.load` and `ListTag.load` recurse in Java and lean on
+/// `NbtAccounter.pushDepth` to stop at 512. Transcribing that shape into Rust
+/// puts a much larger frame on a much smaller stack: a straight recursive
+/// decoder overflows a test thread's two megabytes somewhere short of 512
+/// levels, so the guard aborts the process instead of returning an error, and
+/// the input that does it is three bytes per level. An explicit stack keeps
+/// the limit exactly where Mojang put it and makes it an error again.
+fn read_nested<'a>(reader: &mut Reader<'a>, root: u8) -> Result<Tag<'a>> {
+    let mut stack: Vec<Frame<'a>> = Vec::new();
+    let mut wanted = root;
+
+    loop {
+        // Read the value the innermost unfinished container is waiting for,
+        // descending for as long as that value is itself a container.
+        let mut value = loop {
+            match wanted {
+                TAG_COMPOUND => {
+                    push_depth(&stack)?;
+                    let Some(name) = read_entry_name(reader, &mut wanted)? else {
+                        break Tag::Compound(Compound::new());
+                    };
+                    stack.push(Frame::Compound {
+                        compound: Compound::new(),
+                        name,
+                    });
+                }
+                TAG_LIST => {
+                    push_depth(&stack)?;
+                    let element_type = reader.u8()?;
+                    let count = read_count(reader)?;
+                    if element_type == TAG_END && count > 0 {
+                        // `loadList` throws "Missing type on ListTag" here, and
+                        // it does so before looking at the input, so this check
+                        // has to come before the one below.
+                        return Err(Error::InvalidTagType(TAG_END));
+                    }
+                    if count == 0 {
+                        break Tag::List(List::new());
+                    }
+                    // Every element costs at least one byte, so the input that
+                    // is left bounds the count and the reservation cannot be
+                    // inflated.
+                    ensure_available(reader, count, 1)?;
+                    stack.push(Frame::List {
+                        list: List {
+                            elements: Vec::with_capacity(count),
+                        },
+                        element_type,
+                        remaining: count,
+                    });
+                    wanted = element_type;
+                }
+                leaf => break Tag::read_leaf(reader, leaf)?,
+            }
+        };
+
+        // Hand the finished value to its parent, completing parents as they
+        // fill, until one of them still wants another value.
+        loop {
+            let Some(frame) = stack.last_mut() else {
+                return Ok(value);
+            };
+            match frame {
+                Frame::Compound { compound, name } => {
+                    let key = std::mem::replace(name, Cow::Borrowed(""));
+                    compound.insert(key, value);
+                    match read_entry_name(reader, &mut wanted)? {
+                        Some(next) => {
+                            *name = next;
+                            break;
+                        }
+                        None => value = stack.pop().expect("frame present").finish(),
+                    }
+                }
+                Frame::List {
+                    list,
+                    element_type,
+                    remaining,
+                } => {
+                    list.push_unwrapped(value);
+                    *remaining -= 1;
+                    if *remaining > 0 {
+                        wanted = *element_type;
+                        break;
+                    }
+                    value = stack.pop().expect("frame present").finish();
+                }
+            }
+        }
+    }
+}
+
+/// A container waiting for the value being read to be handed back to it.
+enum Frame<'a> {
+    Compound {
+        compound: Compound<'a>,
+        /// Key the value under construction belongs to.
+        name: Cow<'a, str>,
+    },
+    List {
+        list: List<'a>,
+        element_type: u8,
+        remaining: usize,
+    },
+}
+
+impl<'a> Frame<'a> {
+    fn finish(self) -> Tag<'a> {
+        match self {
+            Self::Compound { compound, .. } => Tag::Compound(compound),
+            Self::List { list, .. } => Tag::List(list),
+        }
+    }
+}
+
+/// Read a compound entry header, or `None` at the terminating `TAG_End`.
+fn read_entry_name<'a>(reader: &mut Reader<'a>, wanted: &mut u8) -> Result<Option<Cow<'a, str>>> {
+    let id = reader.u8()?;
+    if id == TAG_END {
+        return Ok(None);
+    }
+    *wanted = id;
+    mutf8::read(reader).map(Some)
+}
+
+/// `NbtAccounter.pushDepth`, with the stack's own height standing in for its
+/// counter.
+const fn push_depth(stack: &[Frame<'_>]) -> Result<()> {
+    if stack.len() >= MAX_DEPTH {
+        return Err(Error::NbtTooDeep);
+    }
+    Ok(())
+}
+
+/// A length that is about to be written as a signed int.
+fn length_prefix(length: usize) -> Result<i32> {
+    i32::try_from(length).map_err(|_| Error::NegativeLength(-1))
+}
+
+/// Read an element count and refuse one the remaining input cannot supply.
+///
+/// This is what stands in for `NbtAccounter`: the count is attacker-controlled
+/// and feeds a reservation, so it is checked against bytes actually present
+/// before anything is allocated.
+fn counted(reader: &mut Reader<'_>, stride: usize) -> Result<usize> {
+    let count = read_count(reader)?;
+    ensure_available(reader, count, stride)?;
+    Ok(count)
+}
+
+/// Read an element count, rejecting a negative one as `readListCount` does.
+fn read_count(reader: &mut Reader<'_>) -> Result<usize> {
+    let count = reader.i32()?;
+    usize::try_from(count).map_err(|_| Error::NegativeLength(count))
+}
+
+const fn ensure_available(reader: &Reader<'_>, count: usize, stride: usize) -> Result<()> {
+    let needed = count.saturating_mul(stride);
+    if needed > reader.remaining_len() {
+        return Err(Error::UnexpectedEof {
+            needed,
+            available: reader.remaining_len(),
+        });
+    }
+    Ok(())
+}

--- a/crates/hyperion-minecraft-proto/src/nbt/mod.rs
+++ b/crates/hyperion-minecraft-proto/src/nbt/mod.rs
@@ -364,7 +364,6 @@ impl<'a> Compound<'a> {
         writer.u8(TAG_END);
         Ok(())
     }
-
 }
 
 impl PartialEq for Compound<'_> {

--- a/crates/hyperion-minecraft-proto/src/nbt/mutf8.rs
+++ b/crates/hyperion-minecraft-proto/src/nbt/mutf8.rs
@@ -1,0 +1,164 @@
+//! Java's modified UTF-8, which is what NBT strings are.
+//!
+//! `StringTag.write` calls `DataOutput.writeUTF`, so an NBT string is not UTF-8:
+//! `U+0000` travels as the two bytes `C0 80`, and a supplementary character
+//! travels as its two UTF-16 surrogates at three bytes each rather than as one
+//! four-byte sequence. The length prefix is an unsigned short counting encoded
+//! bytes, which is why NBT strings cap out well below the protocol's own string
+//! limit.
+
+use std::borrow::Cow;
+
+use crate::{Error, Reader, Result, Writer};
+
+/// Longest encoding the unsigned-short prefix can describe.
+pub const MAX_ENCODED_LENGTH: usize = 65_535;
+
+/// Append `value` the way `DataOutput.writeUTF` would.
+///
+/// # Errors
+/// Returns [`Error::StringTooLong`] when the encoding needs more than
+/// [`MAX_ENCODED_LENGTH`] bytes, which is where Java throws
+/// `UTFDataFormatException`.
+pub fn write(writer: &mut Writer, value: &str) -> Result<()> {
+    let length = encoded_length(value);
+    let Ok(prefix) = u16::try_from(length) else {
+        return Err(Error::StringTooLong {
+            length,
+            max: MAX_ENCODED_LENGTH,
+        });
+    };
+    writer.u16(prefix);
+
+    // A supplementary character is the only reason UTF-8 and modified UTF-8
+    // disagree on a non-null string, and it always begins with a byte at or
+    // above 0xF0, so this scan decides the whole string in one pass.
+    if value.bytes().all(|byte| byte != 0 && byte < 0xF0) {
+        writer.raw(value.as_bytes());
+        return Ok(());
+    }
+
+    for character in value.chars() {
+        let code_point = u32::from(character);
+        match code_point {
+            // U+0000 goes out as two bytes so that no null appears in the
+            // encoding, which is the whole point of the "modified" in the name.
+            0 | 0x0080..=0x07FF => write_two(writer, code_point),
+            0x0001..=0x007F => writer.u8(low_byte(code_point)),
+            0x0800..=0xFFFF => write_three(writer, code_point),
+            _ => {
+                let offset = code_point - 0x1_0000;
+                write_three(writer, 0xD800 + (offset >> 10));
+                write_three(writer, 0xDC00 + (offset & 0x3FF));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Read a string the way `DataInput.readUTF` would.
+///
+/// Borrows the input when its bytes are already valid UTF-8 meaning the same
+/// text, which covers every string that carries no null and no supplementary
+/// character — in practice almost all of them.
+///
+/// # Errors
+/// Returns [`Error::InvalidModifiedUtf8`] on a malformed sequence or on an
+/// unpaired surrogate, and [`Error::UnexpectedEof`] on truncated input.
+pub fn read<'a>(reader: &mut Reader<'a>) -> Result<Cow<'a, str>> {
+    let length = usize::from(reader.u16()?);
+    decode(reader.take(length)?)
+}
+
+fn decode(bytes: &[u8]) -> Result<Cow<'_, str>> {
+    if bytes.iter().all(|byte| *byte < 0xF0) {
+        if let Ok(text) = std::str::from_utf8(bytes) {
+            return Ok(Cow::Borrowed(text));
+        }
+    }
+    decode_surrogates(bytes).map(Cow::Owned)
+}
+
+/// The path for strings whose bytes are not also their UTF-8 spelling.
+///
+/// Java hands back a `String` of UTF-16 code units and never inspects them, so
+/// it accepts an unpaired surrogate; `str` cannot hold one, so this rejects
+/// input the server would have taken. Nothing vanilla emits such a string.
+fn decode_surrogates(bytes: &[u8]) -> Result<String> {
+    let mut out = String::with_capacity(bytes.len());
+    let mut position = 0;
+    while position < bytes.len() {
+        let unit = read_unit(bytes, &mut position)?;
+        let code_point = match unit {
+            0xD800..=0xDBFF => {
+                let low = read_unit(bytes, &mut position)?;
+                if !(0xDC00..=0xDFFF).contains(&low) {
+                    return Err(Error::InvalidModifiedUtf8);
+                }
+                0x1_0000 + ((unit - 0xD800) << 10) + (low - 0xDC00)
+            }
+            0xDC00..=0xDFFF => return Err(Error::InvalidModifiedUtf8),
+            _ => unit,
+        };
+        out.push(char::from_u32(code_point).ok_or(Error::InvalidModifiedUtf8)?);
+    }
+    Ok(out)
+}
+
+/// Decode one UTF-16 code unit, advancing `position` past the bytes it used.
+fn read_unit(bytes: &[u8], position: &mut usize) -> Result<u32> {
+    let lead = u32::from(*bytes.get(*position).ok_or(Error::InvalidModifiedUtf8)?);
+    let width = match lead >> 4 {
+        0x0..=0x7 => 1,
+        0xC | 0xD => 2,
+        0xE => 3,
+        _ => return Err(Error::InvalidModifiedUtf8),
+    };
+    let mut value = match width {
+        1 => lead,
+        2 => lead & 0x1F,
+        _ => lead & 0x0F,
+    };
+    for offset in 1..width {
+        let byte = u32::from(
+            *bytes
+                .get(*position + offset)
+                .ok_or(Error::InvalidModifiedUtf8)?,
+        );
+        if byte & 0xC0 != 0x80 {
+            return Err(Error::InvalidModifiedUtf8);
+        }
+        value = (value << 6) | (byte & 0x3F);
+    }
+    *position += width;
+    Ok(value)
+}
+
+fn encoded_length(value: &str) -> usize {
+    value
+        .chars()
+        .map(|character| match u32::from(character) {
+            0 | 0x0080..=0x07FF => 2,
+            0x0001..=0x007F => 1,
+            0x0800..=0xFFFF => 3,
+            // Two surrogates, three bytes each.
+            _ => 6,
+        })
+        .sum()
+}
+
+fn write_two(writer: &mut Writer, code_point: u32) {
+    writer.u8(0xC0 | low_byte(code_point >> 6));
+    writer.u8(0x80 | low_byte(code_point & 0x3F));
+}
+
+fn write_three(writer: &mut Writer, code_point: u32) {
+    writer.u8(0xE0 | low_byte(code_point >> 12));
+    writer.u8(0x80 | low_byte((code_point >> 6) & 0x3F));
+    writer.u8(0x80 | low_byte(code_point & 0x3F));
+}
+
+/// Byte zero of `value`, which every caller has already masked to fit.
+const fn low_byte(value: u32) -> u8 {
+    (value & 0xFF).to_le_bytes()[0]
+}

--- a/crates/hyperion-minecraft-proto/src/text/contents.rs
+++ b/crates/hyperion-minecraft-proto/src/text/contents.rs
@@ -1,0 +1,367 @@
+//! What a component says, before styling.
+//!
+//! Each variant is one entry in `ComponentSerialization.bootstrap`, and each
+//! is recognised by the mandatory field its codec requires. Vanilla's
+//! `FuzzyCodec` tries the alternatives in the iteration order of a
+//! `HashBiMap`, which is not the registration order and not specified; the
+//! mandatory fields are disjoint, so the order only decides which error a
+//! malformed value gets. This decodes in the order Mojang registers them.
+//!
+//! `object` is new and is easy to miss: a component can now be an atlas
+//! sprite or a player head rendered inline, with a text `fallback` for
+//! clients that cannot draw it.
+
+use std::borrow::Cow;
+
+use crate::{
+    Error, Result,
+    nbt::{Compound, List, Tag},
+    text::{
+        Component, field,
+        style::{borrowed_string, tag_bool},
+    },
+};
+
+/// The body of a component.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Contents<'a> {
+    /// Literal text (`PlainTextContents`).
+    Text(Cow<'a, str>),
+    /// A translation key resolved against the client's language
+    /// (`TranslatableContents`).
+    Translatable(Translatable<'a>),
+    /// The key currently bound to an action, resolved by the client
+    /// (`KeybindContents`).
+    Keybind(Cow<'a, str>),
+    /// A scoreboard value (`ScoreContents`).
+    Score(Score<'a>),
+    /// The names of the entities an entity selector matches
+    /// (`SelectorContents`).
+    Selector {
+        /// The selector source text, for example `@a[team=red]`.
+        selector: Cow<'a, str>,
+        /// What to put between names. Defaults to `", "` when absent.
+        separator: Option<Box<Component<'a>>>,
+    },
+    /// NBT read out of the world at render time (`NbtContents`).
+    Nbt(NbtContents<'a>),
+    /// A sprite drawn inline (`ObjectContents`).
+    Object {
+        /// What to draw.
+        object: ObjectInfo<'a>,
+        /// What to show instead when the client will not draw it.
+        fallback: Option<Box<Component<'a>>>,
+    },
+}
+
+/// A translation key and its substitutions.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Translatable<'a> {
+    /// Translation key.
+    pub key: Cow<'a, str>,
+    /// Text to use when the client has no translation for `key`.
+    pub fallback: Option<Cow<'a, str>>,
+    /// Values substituted for the `%s` placeholders, in order.
+    pub with: Vec<Argument<'a>>,
+}
+
+/// One substitution in a translatable component.
+///
+/// `TranslatableContents.ARG_CODEC` takes either a primitive or a whole
+/// component, and `isAllowedPrimitiveArgument` limits the primitive side to a
+/// number, a boolean or a string. NBT has no boolean, so a boolean argument
+/// arrives as [`Argument::Byte`] and there is no separate variant for it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Argument<'a> {
+    /// A byte, which is also how a boolean argument arrives.
+    Byte(i8),
+    /// A short.
+    Short(i16),
+    /// An int.
+    Int(i32),
+    /// A long.
+    Long(i64),
+    /// A float.
+    Float(f32),
+    /// A double.
+    Double(f64),
+    /// A string.
+    String(Cow<'a, str>),
+    /// A nested component.
+    Component(Box<Component<'a>>),
+}
+
+/// A scoreboard lookup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Score<'a> {
+    /// A player name, an entity selector, or `*` for the reading player.
+    pub name: Cow<'a, str>,
+    /// Objective to read.
+    pub objective: Cow<'a, str>,
+}
+
+/// An NBT lookup rendered into the message.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NbtContents<'a> {
+    /// NBT path to read.
+    pub path: Cow<'a, str>,
+    /// Parse each result as a component rather than showing it as NBT.
+    pub interpret: bool,
+    /// Show results without the syntax colouring NBT normally gets.
+    ///
+    /// Mutually exclusive with `interpret`; `NbtContents.MAP_CODEC`'s
+    /// `validate` rejects both at once.
+    pub plain: bool,
+    /// What to put between results.
+    pub separator: Option<Box<Component<'a>>>,
+    /// Where to read from.
+    pub source: DataSource<'a>,
+}
+
+/// Where an NBT component reads from (`DataSources`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataSource<'a> {
+    /// A block entity, addressed by a coordinate expression.
+    Block(Cow<'a, str>),
+    /// Entities matched by a selector.
+    Entity(Cow<'a, str>),
+    /// A command storage namespace.
+    Storage(Cow<'a, str>),
+}
+
+/// What an object component draws (`ObjectInfos`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum ObjectInfo<'a> {
+    /// A sprite from a texture atlas.
+    Atlas {
+        /// Atlas id. `minecraft:blocks` when absent (`AtlasIds.BLOCKS`).
+        atlas: Cow<'a, str>,
+        /// Sprite id within the atlas.
+        sprite: Cow<'a, str>,
+    },
+    /// A player's head.
+    Player {
+        /// A `ResolvableProfile`: either a bare name or a compound of name,
+        /// id and properties. Kept verbatim, since resolving it is the
+        /// session server's job and not this crate's.
+        player: Tag<'a>,
+        /// Whether to draw the hat layer. True when absent.
+        hat: bool,
+    },
+}
+
+/// `AtlasSprite.DEFAULT_ATLAS`.
+pub const DEFAULT_ATLAS: &str = "minecraft:blocks";
+
+impl<'a> Contents<'a> {
+    pub(super) fn write_into<'t>(&'t self, compound: &mut Compound<'t>) {
+        match self {
+            Self::Text(text) => {
+                compound.insert("text", borrowed_string(text));
+            }
+            Self::Translatable(translatable) => {
+                compound.insert("translate", borrowed_string(&translatable.key));
+                compound.insert_optional(
+                    "fallback",
+                    translatable.fallback.as_deref().map(borrowed_string),
+                );
+                if !translatable.with.is_empty() {
+                    compound.insert(
+                        "with",
+                        Tag::List(
+                            translatable
+                                .with
+                                .iter()
+                                .map(Argument::to_tag)
+                                .collect::<List<'t>>(),
+                        ),
+                    );
+                }
+            }
+            Self::Keybind(name) => {
+                compound.insert("keybind", borrowed_string(name));
+            }
+            Self::Score(score) => {
+                let mut inner = Compound::new();
+                inner.insert("name", borrowed_string(&score.name));
+                inner.insert("objective", borrowed_string(&score.objective));
+                compound.insert("score", Tag::Compound(inner));
+            }
+            Self::Selector {
+                selector,
+                separator,
+            } => {
+                compound.insert("selector", borrowed_string(selector));
+                compound
+                    .insert_optional("separator", separator.as_ref().map(|value| value.to_tag()));
+            }
+            Self::Nbt(nbt) => {
+                compound.insert("nbt", borrowed_string(&nbt.path));
+                if nbt.interpret {
+                    compound.insert("interpret", tag_bool(true));
+                }
+                if nbt.plain {
+                    compound.insert("plain", tag_bool(true));
+                }
+                compound.insert_optional(
+                    "separator",
+                    nbt.separator.as_ref().map(|value| value.to_tag()),
+                );
+                let (key, value) = match &nbt.source {
+                    DataSource::Block(value) => ("block", value),
+                    DataSource::Entity(value) => ("entity", value),
+                    DataSource::Storage(value) => ("storage", value),
+                };
+                compound.insert(key, borrowed_string(value));
+            }
+            Self::Object { object, fallback } => {
+                match object {
+                    ObjectInfo::Atlas { atlas, sprite } => {
+                        if atlas != DEFAULT_ATLAS {
+                            compound.insert("atlas", borrowed_string(atlas));
+                        }
+                        compound.insert("sprite", borrowed_string(sprite));
+                    }
+                    ObjectInfo::Player { player, hat } => {
+                        compound.insert("player", player.clone());
+                        if !*hat {
+                            compound.insert("hat", tag_bool(false));
+                        }
+                    }
+                }
+                compound.insert_optional("fallback", fallback.as_ref().map(|value| value.to_tag()));
+            }
+        }
+    }
+
+    pub(super) fn read_from(compound: &Compound<'a>) -> Result<Self> {
+        if let Some(text) = field::optional_string(compound, "text")? {
+            return Ok(Self::Text(text));
+        }
+        if let Some(key) = field::optional_string(compound, "translate")? {
+            return Ok(Self::Translatable(Translatable {
+                key,
+                fallback: field::optional_string(compound, "fallback")?,
+                with: read_arguments(compound)?,
+            }));
+        }
+        if let Some(name) = field::optional_string(compound, "keybind")? {
+            return Ok(Self::Keybind(name));
+        }
+        if compound.get("score").is_some() {
+            let inner = field::compound(compound, "score")?;
+            return Ok(Self::Score(Score {
+                name: field::string(inner, "name")?,
+                objective: field::string(inner, "objective")?,
+            }));
+        }
+        if let Some(selector) = field::optional_string(compound, "selector")? {
+            return Ok(Self::Selector {
+                selector,
+                separator: read_component(compound, "separator")?,
+            });
+        }
+        if let Some(path) = field::optional_string(compound, "nbt")? {
+            return Ok(Self::Nbt(NbtContents {
+                path,
+                interpret: field::bool_or(compound, "interpret", false)?,
+                plain: field::bool_or(compound, "plain", false)?,
+                separator: read_component(compound, "separator")?,
+                source: DataSource::read_from(compound)?,
+            }));
+        }
+        if let Some(object) = ObjectInfo::read_from(compound)? {
+            return Ok(Self::Object {
+                object,
+                fallback: read_component(compound, "fallback")?,
+            });
+        }
+        Err(Error::NoMatchingCodec("component contents"))
+    }
+}
+
+impl<'a> DataSource<'a> {
+    fn read_from(compound: &Compound<'a>) -> Result<Self> {
+        if let Some(value) = field::optional_string(compound, "entity")? {
+            return Ok(Self::Entity(value));
+        }
+        if let Some(value) = field::optional_string(compound, "block")? {
+            return Ok(Self::Block(value));
+        }
+        if let Some(value) = field::optional_string(compound, "storage")? {
+            return Ok(Self::Storage(value));
+        }
+        Err(Error::NoMatchingCodec("nbt data source"))
+    }
+}
+
+impl<'a> ObjectInfo<'a> {
+    fn read_from(compound: &Compound<'a>) -> Result<Option<Self>> {
+        if let Some(sprite) = field::optional_string(compound, "sprite")? {
+            return Ok(Some(Self::Atlas {
+                atlas: field::optional_string(compound, "atlas")?
+                    .unwrap_or(Cow::Borrowed(DEFAULT_ATLAS)),
+                sprite,
+            }));
+        }
+        if let Some(player) = compound.get("player") {
+            return Ok(Some(Self::Player {
+                player: player.clone(),
+                hat: field::bool_or(compound, "hat", true)?,
+            }));
+        }
+        Ok(None)
+    }
+}
+
+impl<'a> Argument<'a> {
+    fn to_tag(&self) -> Tag<'_> {
+        match self {
+            Self::Byte(value) => Tag::Byte(*value),
+            Self::Short(value) => Tag::Short(*value),
+            Self::Int(value) => Tag::Int(*value),
+            Self::Long(value) => Tag::Long(*value),
+            Self::Float(value) => Tag::Float(*value),
+            Self::Double(value) => Tag::Double(*value),
+            Self::String(value) => borrowed_string(value),
+            Self::Component(component) => component.to_tag(),
+        }
+    }
+
+    fn from_tag(tag: &Tag<'a>) -> Result<Self> {
+        Ok(match tag {
+            Tag::Byte(value) => Self::Byte(*value),
+            Tag::Short(value) => Self::Short(*value),
+            Tag::Int(value) => Self::Int(*value),
+            Tag::Long(value) => Self::Long(*value),
+            Tag::Float(value) => Self::Float(*value),
+            Tag::Double(value) => Self::Double(*value),
+            // A string is a primitive argument, never a collapsed component:
+            // ARG_CODEC tries the primitive codec first.
+            Tag::String(value) => Self::String(value.clone()),
+            other => Self::Component(Box::new(Component::from_tag(other)?)),
+        })
+    }
+}
+
+fn read_arguments<'a>(compound: &Compound<'a>) -> Result<Vec<Argument<'a>>> {
+    let Some(tag) = compound.get("with") else {
+        return Ok(Vec::new());
+    };
+    let list = tag.as_list().ok_or_else(|| Error::WrongTagType {
+        field: "with",
+        expected: "TAG_List",
+        found: tag.id(),
+    })?;
+    list.as_slice().iter().map(Argument::from_tag).collect()
+}
+
+fn read_component<'a>(
+    compound: &Compound<'a>,
+    field: &'static str,
+) -> Result<Option<Box<Component<'a>>>> {
+    compound
+        .get(field)
+        .map(|tag| Component::from_tag(tag).map(Box::new))
+        .transpose()
+}

--- a/crates/hyperion-minecraft-proto/src/text/event.rs
+++ b/crates/hyperion-minecraft-proto/src/text/event.rs
@@ -1,0 +1,305 @@
+//! Click and hover events.
+//!
+//! Both are `Action.CODEC.dispatch("action", ...)`, so each travels as a
+//! compound with an `action` string naming the variant and that variant's own
+//! fields alongside it.
+//!
+//! `ClickEvent.Action.OPEN_FILE` has no variant here. It exists in the enum
+//! but `Action.CODEC` is `UNSAFE_CODEC.validate(filterForSerialization)`, and
+//! `filterForSerialization` rejects any action whose `allowFromServer` is
+//! false. `validate` runs on encode and decode alike, so `open_file` cannot
+//! legally appear on the wire in either direction; it is reachable only from a
+//! local resource pack.
+
+use std::borrow::Cow;
+
+use crate::{
+    Error, Result,
+    nbt::{Compound, Tag},
+    text::{Component, field, style::borrowed_string},
+};
+
+/// What clicking a component does.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ClickEvent<'a> {
+    /// Open a URL. The client validates the scheme before following it.
+    OpenUrl(Cow<'a, str>),
+    /// Run a command as the player.
+    RunCommand(Cow<'a, str>),
+    /// Put a command in the chat box without sending it.
+    SuggestCommand(Cow<'a, str>),
+    /// Open a dialog.
+    ///
+    /// `Dialog.CODEC` resolves a `Holder<Dialog>`, so the value is either a
+    /// registry id or a whole inline dialog whose shape depends on the
+    /// registries the connection was sent. It is kept verbatim rather than
+    /// modelled, since nothing here can resolve it.
+    ShowDialog(Tag<'a>),
+    /// Turn to a page of the open book. One-based; zero is rejected.
+    ChangePage(i32),
+    /// Copy a string to the system clipboard.
+    CopyToClipboard(Cow<'a, str>),
+    /// A custom event delivered to server-side listeners.
+    Custom {
+        /// Identifier the listener registered under.
+        id: Cow<'a, str>,
+        /// Arbitrary payload.
+        payload: Option<Tag<'a>>,
+    },
+}
+
+impl<'a> ClickEvent<'a> {
+    /// The `action` discriminant.
+    #[must_use]
+    pub const fn action(&self) -> &'static str {
+        match self {
+            Self::OpenUrl(_) => "open_url",
+            Self::RunCommand(_) => "run_command",
+            Self::SuggestCommand(_) => "suggest_command",
+            Self::ShowDialog(_) => "show_dialog",
+            Self::ChangePage(_) => "change_page",
+            Self::CopyToClipboard(_) => "copy_to_clipboard",
+            Self::Custom { .. } => "custom",
+        }
+    }
+
+    pub(super) fn to_tag(&self) -> Tag<'_> {
+        let mut compound = Compound::new();
+        compound.insert("action", borrowed_string(self.action()));
+        match self {
+            Self::OpenUrl(url) => {
+                compound.insert("url", borrowed_string(url));
+            }
+            Self::RunCommand(command) | Self::SuggestCommand(command) => {
+                compound.insert("command", borrowed_string(command));
+            }
+            Self::ShowDialog(dialog) => {
+                compound.insert("dialog", dialog.clone());
+            }
+            Self::ChangePage(page) => {
+                compound.insert("page", Tag::Int(*page));
+            }
+            Self::CopyToClipboard(value) => {
+                compound.insert("value", borrowed_string(value));
+            }
+            Self::Custom { id, payload } => {
+                compound.insert("id", borrowed_string(id));
+                compound.insert_optional("payload", payload.clone());
+            }
+        }
+        Tag::Compound(compound)
+    }
+
+    pub(super) fn from_tag(tag: &Tag<'a>) -> Result<Self> {
+        let compound = as_compound(tag, "click_event")?;
+        let action = field::string(compound, "action")?;
+        Ok(match action.as_ref() {
+            "open_url" => Self::OpenUrl(field::string(compound, "url")?),
+            "run_command" => Self::RunCommand(field::string(compound, "command")?),
+            "suggest_command" => Self::SuggestCommand(field::string(compound, "command")?),
+            "show_dialog" => Self::ShowDialog(field::required(compound, "dialog")?.clone()),
+            "change_page" => {
+                let page = field::int(compound, "page")?;
+                if page < 1 {
+                    // ExtraCodecs.POSITIVE_INT.
+                    return Err(Error::UnknownVariant {
+                        name: "ClickEvent page",
+                        value: page.to_string(),
+                    });
+                }
+                Self::ChangePage(page)
+            }
+            "copy_to_clipboard" => Self::CopyToClipboard(field::string(compound, "value")?),
+            "custom" => Self::Custom {
+                id: field::string(compound, "id")?,
+                payload: compound.get("payload").cloned(),
+            },
+            other => {
+                return Err(Error::UnknownVariant {
+                    name: "ClickEvent action",
+                    value: other.to_owned(),
+                });
+            }
+        })
+    }
+}
+
+/// What hovering over a component shows.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HoverEvent<'a> {
+    /// Show another component as a tooltip.
+    ShowText(Box<Component<'a>>),
+    /// Show an item's tooltip.
+    ///
+    /// The fields are `ItemStackTemplate.MAP_CODEC` inlined into the event
+    /// compound rather than nested under a key of their own.
+    ShowItem {
+        /// Item registry id.
+        id: Cow<'a, str>,
+        /// Stack size, 1 to 99. Omitted from the wire when it is 1.
+        count: i32,
+        /// Data component patch, kept verbatim: decoding it needs the
+        /// connection's data-component registry, which this crate has no view
+        /// of. Absent and empty are the same thing, and both encode to absent.
+        components: Option<Compound<'a>>,
+    },
+    /// Show an entity's tooltip.
+    ShowEntity {
+        /// Entity type registry id.
+        id: Cow<'a, str>,
+        /// Entity uuid, which travels as four big-endian ints.
+        uuid: u128,
+        /// Custom name to show above the type line.
+        name: Option<Box<Component<'a>>>,
+    },
+}
+
+/// `ExtraCodecs.intRange(1, 99)` in `ItemStackTemplate.MAP_CODEC`.
+const MAX_STACK_COUNT: i32 = 99;
+
+impl<'a> HoverEvent<'a> {
+    /// The `action` discriminant.
+    #[must_use]
+    pub const fn action(&self) -> &'static str {
+        match self {
+            Self::ShowText(_) => "show_text",
+            Self::ShowItem { .. } => "show_item",
+            Self::ShowEntity { .. } => "show_entity",
+        }
+    }
+
+    pub(super) fn to_tag(&self) -> Tag<'_> {
+        let mut compound = Compound::new();
+        compound.insert("action", borrowed_string(self.action()));
+        match self {
+            Self::ShowText(value) => {
+                compound.insert("value", value.to_tag());
+            }
+            Self::ShowItem {
+                id,
+                count,
+                components,
+            } => {
+                compound.insert("id", borrowed_string(id));
+                if *count != 1 {
+                    compound.insert("count", Tag::Int(*count));
+                }
+                if let Some(components) = components {
+                    if !components.is_empty() {
+                        compound.insert("components", Tag::Compound(components.clone()));
+                    }
+                }
+            }
+            Self::ShowEntity { id, uuid, name } => {
+                compound.insert("id", borrowed_string(id));
+                compound.insert("uuid", uuid_tag(*uuid));
+                compound.insert_optional("name", name.as_ref().map(|name| name.to_tag()));
+            }
+        }
+        Tag::Compound(compound)
+    }
+
+    pub(super) fn from_tag(tag: &Tag<'a>) -> Result<Self> {
+        let compound = as_compound(tag, "hover_event")?;
+        let action = field::string(compound, "action")?;
+        Ok(match action.as_ref() {
+            "show_text" => Self::ShowText(Box::new(Component::from_tag(field::required(
+                compound, "value",
+            )?)?)),
+            "show_item" => {
+                let count = field::int_or(compound, "count", 1)?;
+                if !(1..=MAX_STACK_COUNT).contains(&count) {
+                    return Err(Error::UnknownVariant {
+                        name: "show_item count",
+                        value: count.to_string(),
+                    });
+                }
+                Self::ShowItem {
+                    id: field::string(compound, "id")?,
+                    count,
+                    components: compound
+                        .get("components")
+                        .and_then(Tag::as_compound)
+                        .filter(|components| !components.is_empty())
+                        .cloned(),
+                }
+            }
+            "show_entity" => Self::ShowEntity {
+                id: field::string(compound, "id")?,
+                uuid: read_uuid(field::required(compound, "uuid")?)?,
+                name: compound
+                    .get("name")
+                    .map(|name| Component::from_tag(name).map(Box::new))
+                    .transpose()?,
+            },
+            other => {
+                return Err(Error::UnknownVariant {
+                    name: "HoverEvent action",
+                    value: other.to_owned(),
+                });
+            }
+        })
+    }
+}
+
+/// `UUIDUtil.uuidToIntArray`: the sixteen big-endian bytes, read as four ints.
+fn uuid_tag<'a>(uuid: u128) -> Tag<'a> {
+    let bytes = uuid.to_be_bytes();
+    Tag::IntArray(
+        (0..4)
+            .map(|index| {
+                let start = index * 4;
+                i32::from_be_bytes([
+                    bytes[start],
+                    bytes[start + 1],
+                    bytes[start + 2],
+                    bytes[start + 3],
+                ])
+            })
+            .collect(),
+    )
+}
+
+/// `UUIDUtil.LENIENT_CODEC`: four ints, or a dashed string as a fallback.
+fn read_uuid(tag: &Tag<'_>) -> Result<u128> {
+    match tag {
+        Tag::IntArray(values) if values.len() == 4 => {
+            let mut bytes = [0u8; 16];
+            for (index, value) in values.iter().enumerate() {
+                bytes[index * 4..index * 4 + 4].copy_from_slice(&value.to_be_bytes());
+            }
+            Ok(u128::from_be_bytes(bytes))
+        }
+        Tag::String(value) => parse_dashed_uuid(value).ok_or_else(|| Error::UnknownVariant {
+            name: "uuid",
+            value: value.to_string(),
+        }),
+        other => Err(Error::WrongTagType {
+            field: "uuid",
+            expected: "TAG_Int_Array of four",
+            found: other.id(),
+        }),
+    }
+}
+
+fn parse_dashed_uuid(value: &str) -> Option<u128> {
+    let mut digits = String::with_capacity(32);
+    for (index, part) in value.split('-').enumerate() {
+        if index >= 5 {
+            return None;
+        }
+        digits.push_str(part);
+    }
+    if digits.len() != 32 {
+        return None;
+    }
+    u128::from_str_radix(&digits, 16).ok()
+}
+
+fn as_compound<'a, 'c>(tag: &'c Tag<'a>, field: &'static str) -> Result<&'c Compound<'a>> {
+    tag.as_compound().ok_or_else(|| Error::WrongTagType {
+        field,
+        expected: "TAG_Compound",
+        found: tag.id(),
+    })
+}

--- a/crates/hyperion-minecraft-proto/src/text/field.rs
+++ b/crates/hyperion-minecraft-proto/src/text/field.rs
@@ -1,0 +1,100 @@
+//! Reading typed values out of a decoded compound.
+//!
+//! Each helper is one DFU combinator: `fieldOf` is [`required`],
+//! `optionalFieldOf` is [`optional`], and `optionalFieldOf(name, default)` is
+//! the `_or` pair. Absent means absent; a present field of the wrong type is
+//! an error rather than a silent default, matching `DataResult`.
+
+use std::borrow::Cow;
+
+use crate::{
+    Error, Result,
+    nbt::{Compound, Tag},
+};
+
+pub(super) fn required<'a, 'c>(
+    compound: &'c Compound<'a>,
+    field: &'static str,
+) -> Result<&'c Tag<'a>> {
+    compound.get(field).ok_or(Error::MissingField(field))
+}
+
+pub(super) fn string<'a>(compound: &Compound<'a>, field: &'static str) -> Result<Cow<'a, str>> {
+    as_string(required(compound, field)?, field)
+}
+
+pub(super) fn optional_string<'a>(
+    compound: &Compound<'a>,
+    field: &'static str,
+) -> Result<Option<Cow<'a, str>>> {
+    compound
+        .get(field)
+        .map(|tag| as_string(tag, field))
+        .transpose()
+}
+
+pub(super) fn int(compound: &Compound<'_>, field: &'static str) -> Result<i32> {
+    as_int(required(compound, field)?, field)
+}
+
+pub(super) fn optional_int(compound: &Compound<'_>, field: &'static str) -> Result<Option<i32>> {
+    compound
+        .get(field)
+        .map(|tag| as_int(tag, field))
+        .transpose()
+}
+
+pub(super) fn int_or(compound: &Compound<'_>, field: &'static str, default: i32) -> Result<i32> {
+    Ok(optional_int(compound, field)?.unwrap_or(default))
+}
+
+pub(super) fn optional_bool(compound: &Compound<'_>, field: &'static str) -> Result<Option<bool>> {
+    compound
+        .get(field)
+        .map(|tag| {
+            tag.as_bool().ok_or_else(|| Error::WrongTagType {
+                field,
+                expected: "TAG_Byte",
+                found: tag.id(),
+            })
+        })
+        .transpose()
+}
+
+pub(super) fn bool_or(compound: &Compound<'_>, field: &'static str, default: bool) -> Result<bool> {
+    Ok(optional_bool(compound, field)?.unwrap_or(default))
+}
+
+pub(super) fn compound<'a, 'c>(
+    compound: &'c Compound<'a>,
+    field: &'static str,
+) -> Result<&'c Compound<'a>> {
+    let tag = required(compound, field)?;
+    tag.as_compound().ok_or_else(|| Error::WrongTagType {
+        field,
+        expected: "TAG_Compound",
+        found: tag.id(),
+    })
+}
+
+fn as_string<'a>(tag: &Tag<'a>, field: &'static str) -> Result<Cow<'a, str>> {
+    match tag {
+        Tag::String(value) => Ok(value.clone()),
+        other => Err(Error::WrongTagType {
+            field,
+            expected: "TAG_String",
+            found: other.id(),
+        }),
+    }
+}
+
+const fn as_int(tag: &Tag<'_>, field: &'static str) -> Result<i32> {
+    match tag {
+        Tag::Int(value) => Ok(*value),
+        other => Err(Error::WrongTagType {
+            field,
+            expected: "TAG_Int",
+            found: other.id(),
+        }),
+    }
+}

--- a/crates/hyperion-minecraft-proto/src/text/mod.rs
+++ b/crates/hyperion-minecraft-proto/src/text/mod.rs
@@ -1,0 +1,192 @@
+//! Text components.
+//!
+//! Since 1.20.3 a component on the wire is NBT, not JSON:
+//! `ComponentSerialization.STREAM_CODEC` is
+//! `ByteBufCodecs.fromCodecWithRegistries(CODEC)`, which runs the DFU codec
+//! against `NbtOps.INSTANCE` and hands the resulting tag to
+//! `ByteBufCodecs.tagCodec`. So [`Component`] encodes through [`crate::nbt`]
+//! and carries no JSON anywhere. The two places JSON survives are the status
+//! response and the login disconnect, both of which run before any registry
+//! has been sent; those stay strings in [`crate::packets`].
+//!
+//! Three shapes decode to a component, because the top-level codec is
+//! `Codec.either(Codec.either(STRING, list), fullCodec)`:
+//!
+//! - a bare string is a literal with no style,
+//! - a non-empty list is its first element with the rest appended as children,
+//! - a compound is contents, `extra` and style flattened together.
+//!
+//! Encoding only ever produces the first and the third. `tryCollapseToString`
+//! decides: a literal with no style and no children goes out as a bare string,
+//! and everything else as a compound. A vanilla server encoding
+//! `Component.literal("hi")` writes five bytes, `08 00 02 68 69`, and not a
+//! compound with a `text` field.
+//!
+//! There is no `type` field. The compound form is dispatched by which
+//! mandatory field is present, `text` or `translate` or `keybind` and so on:
+//! `createLegacyComponentMatcher` builds a `StrictEither` over a `FuzzyCodec`,
+//! and `StrictEither.encode` always delegates to the fuzzy side. A `type`
+//! field is accepted on decode and never written.
+
+pub mod contents;
+pub mod event;
+pub mod style;
+
+mod field;
+
+use std::borrow::Cow;
+
+pub use crate::text::{
+    contents::{Argument, Contents, DataSource, NbtContents, ObjectInfo, Score, Translatable},
+    event::{ClickEvent, HoverEvent},
+    style::{NamedColor, Style, TextColor},
+};
+use crate::{
+    Decode, Encode, Error, Reader, Result, Writer,
+    nbt::{Compound, List, Tag},
+};
+
+/// A piece of formatted text.
+///
+/// A component is its contents, the children that follow it, and the style
+/// both it and those children inherit.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Component<'a> {
+    /// What this component says.
+    pub contents: Contents<'a>,
+    /// Children appended after the contents, inheriting this style.
+    pub extra: Vec<Component<'a>>,
+    /// Formatting.
+    pub style: Style<'a>,
+}
+
+impl<'a> Component<'a> {
+    /// A literal string with no style and no children.
+    pub fn text(text: impl Into<Cow<'a, str>>) -> Self {
+        Self::from_contents(Contents::Text(text.into()))
+    }
+
+    /// A translation key with no arguments.
+    pub fn translatable(key: impl Into<Cow<'a, str>>) -> Self {
+        Self::from_contents(Contents::Translatable(Translatable {
+            key: key.into(),
+            fallback: None,
+            with: Vec::new(),
+        }))
+    }
+
+    /// A component with the given contents, no style and no children.
+    #[must_use]
+    pub const fn from_contents(contents: Contents<'a>) -> Self {
+        Self {
+            contents,
+            extra: Vec::new(),
+            style: Style::new(),
+        }
+    }
+
+    /// The same component with `style` applied.
+    #[must_use]
+    pub fn with_style(mut self, style: Style<'a>) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// The same component with `child` appended.
+    #[must_use]
+    pub fn append(mut self, child: Self) -> Self {
+        self.extra.push(child);
+        self
+    }
+
+    /// The literal text this component collapses to, if it collapses at all
+    /// (`Component.tryCollapseToString`).
+    #[must_use]
+    pub fn try_collapse_to_str(&self) -> Option<&str> {
+        match &self.contents {
+            Contents::Text(text) if self.extra.is_empty() && self.style.is_empty() => Some(text),
+            _ => None,
+        }
+    }
+
+    /// The NBT this component encodes to.
+    #[must_use]
+    pub fn to_tag(&self) -> Tag<'_> {
+        if let Some(text) = self.try_collapse_to_str() {
+            return Tag::String(Cow::Borrowed(text));
+        }
+        let mut compound = Compound::new();
+        self.contents.write_into(&mut compound);
+        if !self.extra.is_empty() {
+            compound.insert(
+                "extra",
+                Tag::List(self.extra.iter().map(Self::to_tag).collect::<List<'_>>()),
+            );
+        }
+        self.style.write_into(&mut compound);
+        Tag::Compound(compound)
+    }
+
+    /// Read a component out of decoded NBT.
+    ///
+    /// # Errors
+    /// Returns an error when no content codec matches, when a field has the
+    /// wrong type, or when a discriminant is unknown.
+    pub fn from_tag(tag: &Tag<'a>) -> Result<Self> {
+        match tag {
+            Tag::String(text) => Ok(Self::text(text.clone())),
+            Tag::List(list) => {
+                // ExtraCodecs.nonEmptyList, then ComponentSerialization
+                // .createFromList: the head absorbs the tail as children.
+                let (head, tail) = list
+                    .as_slice()
+                    .split_first()
+                    .ok_or(Error::MissingField("component list"))?;
+                let mut component = Self::from_tag(head)?;
+                for element in tail {
+                    component.extra.push(Self::from_tag(element)?);
+                }
+                Ok(component)
+            }
+            Tag::Compound(compound) => Ok(Self {
+                contents: Contents::read_from(compound)?,
+                extra: read_extra(compound)?,
+                style: Style::read_from(compound)?,
+            }),
+            other => Err(Error::WrongTagType {
+                field: "component",
+                expected: "TAG_String, TAG_List or TAG_Compound",
+                found: other.id(),
+            }),
+        }
+    }
+}
+
+impl Encode for Component<'_> {
+    fn encode(&self, writer: &mut Writer) -> Result<()> {
+        self.to_tag().encode(writer)
+    }
+}
+
+impl<'a> Decode<'a> for Component<'a> {
+    fn decode(reader: &mut Reader<'a>) -> Result<Self> {
+        Self::from_tag(&Tag::decode(reader)?)
+    }
+}
+
+fn read_extra<'a>(compound: &Compound<'a>) -> Result<Vec<Component<'a>>> {
+    let Some(tag) = compound.get("extra") else {
+        return Ok(Vec::new());
+    };
+    let list = tag.as_list().ok_or_else(|| Error::WrongTagType {
+        field: "extra",
+        expected: "TAG_List",
+        found: tag.id(),
+    })?;
+    if list.is_empty() {
+        // ExtraCodecs.nonEmptyList rejects a present-but-empty list rather
+        // than treating it as the default.
+        return Err(Error::MissingField("extra"));
+    }
+    list.as_slice().iter().map(Component::from_tag).collect()
+}

--- a/crates/hyperion-minecraft-proto/src/text/style.rs
+++ b/crates/hyperion-minecraft-proto/src/text/style.rs
@@ -1,0 +1,302 @@
+//! Component styling.
+//!
+//! Every field is optional and every absent field inherits from the parent,
+//! which is why the booleans are `Option<bool>` rather than `bool`: `Style`
+//! distinguishes "not set" from "set to false", and `applyTo` relies on it.
+//!
+//! The field names are `snake_case`. `clickEvent` and `hoverEvent` were
+//! renamed to `click_event` and `hover_event` when the format moved to NBT;
+//! documentation written for the JSON era still shows the old spelling, and
+//! `Style.Serializer.MAP_CODEC` is where the current one is fixed.
+
+use std::borrow::Cow;
+
+use crate::{
+    Error, Result,
+    nbt::{Compound, Tag},
+    text::{
+        event::{ClickEvent, HoverEvent},
+        field,
+    },
+};
+
+/// Formatting applied to a component and inherited by its children.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Style<'a> {
+    /// Text colour.
+    pub color: Option<TextColor>,
+    /// Drop-shadow colour as packed ARGB, where zero means no shadow.
+    pub shadow_color: Option<i32>,
+    /// Bold.
+    pub bold: Option<bool>,
+    /// Italic.
+    pub italic: Option<bool>,
+    /// Underlined.
+    pub underlined: Option<bool>,
+    /// Struck through.
+    pub strikethrough: Option<bool>,
+    /// Obfuscated, the scrambling "magic" format.
+    pub obfuscated: Option<bool>,
+    /// What clicking the text does.
+    pub click_event: Option<ClickEvent<'a>>,
+    /// What hovering over the text shows.
+    pub hover_event: Option<HoverEvent<'a>>,
+    /// Text inserted into the chat box when the text is shift-clicked.
+    pub insertion: Option<Cow<'a, str>>,
+    /// Font resource id.
+    ///
+    /// Only `FontDescription.Resource` has a serialisation; the sprite
+    /// variants exist so that an object component can point the renderer at a
+    /// glyph, and `FontDescription.CODEC` refuses to encode them.
+    pub font: Option<Cow<'a, str>>,
+}
+
+impl<'a> Style<'a> {
+    /// A style that sets nothing.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            color: None,
+            shadow_color: None,
+            bold: None,
+            italic: None,
+            underlined: None,
+            strikethrough: None,
+            obfuscated: None,
+            click_event: None,
+            hover_event: None,
+            insertion: None,
+            font: None,
+        }
+    }
+
+    /// True when no field is set, which is `Style.EMPTY`.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.color.is_none()
+            && self.shadow_color.is_none()
+            && self.bold.is_none()
+            && self.italic.is_none()
+            && self.underlined.is_none()
+            && self.strikethrough.is_none()
+            && self.obfuscated.is_none()
+            && self.click_event.is_none()
+            && self.hover_event.is_none()
+            && self.insertion.is_none()
+            && self.font.is_none()
+    }
+
+    pub(super) fn write_into<'t>(&'t self, compound: &mut Compound<'t>) {
+        compound.insert_optional("color", self.color.map(TextColor::to_tag));
+        compound.insert_optional("shadow_color", self.shadow_color.map(Tag::Int));
+        compound.insert_optional("bold", self.bold.map(tag_bool));
+        compound.insert_optional("italic", self.italic.map(tag_bool));
+        compound.insert_optional("underlined", self.underlined.map(tag_bool));
+        compound.insert_optional("strikethrough", self.strikethrough.map(tag_bool));
+        compound.insert_optional("obfuscated", self.obfuscated.map(tag_bool));
+        compound.insert_optional(
+            "click_event",
+            self.click_event.as_ref().map(ClickEvent::to_tag),
+        );
+        compound.insert_optional(
+            "hover_event",
+            self.hover_event.as_ref().map(HoverEvent::to_tag),
+        );
+        compound.insert_optional("insertion", self.insertion.as_deref().map(borrowed_string));
+        compound.insert_optional("font", self.font.as_deref().map(borrowed_string));
+    }
+
+    pub(super) fn read_from(compound: &Compound<'a>) -> Result<Self> {
+        Ok(Self {
+            color: field::optional_string(compound, "color")?
+                .map(|name| TextColor::parse(&name))
+                .transpose()?,
+            shadow_color: field::optional_int(compound, "shadow_color")?,
+            bold: field::optional_bool(compound, "bold")?,
+            italic: field::optional_bool(compound, "italic")?,
+            underlined: field::optional_bool(compound, "underlined")?,
+            strikethrough: field::optional_bool(compound, "strikethrough")?,
+            obfuscated: field::optional_bool(compound, "obfuscated")?,
+            click_event: compound
+                .get("click_event")
+                .map(ClickEvent::from_tag)
+                .transpose()?,
+            hover_event: compound
+                .get("hover_event")
+                .map(HoverEvent::from_tag)
+                .transpose()?,
+            insertion: field::optional_string(compound, "insertion")?,
+            font: field::optional_string(compound, "font")?,
+        })
+    }
+}
+
+/// A text colour, which travels as either a name or a `#RRGGBB` string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextColor {
+    /// One of the sixteen legacy colours, written as its name.
+    Named(NamedColor),
+    /// A 24-bit colour, written as `#RRGGBB` with uppercase hex digits.
+    Rgb(u32),
+}
+
+impl TextColor {
+    /// Parse the string form (`TextColor.parseColor`).
+    ///
+    /// # Errors
+    /// Returns [`Error::UnknownVariant`] for an unknown name or a hex value
+    /// outside 24 bits.
+    pub fn parse(value: &str) -> Result<Self> {
+        if let Some(digits) = value.strip_prefix('#') {
+            let parsed = u32::from_str_radix(digits, 16)
+                .ok()
+                .filter(|rgb| *rgb <= 0x00FF_FFFF);
+            return parsed.map(Self::Rgb).ok_or_else(|| Error::UnknownVariant {
+                name: "TextColor",
+                value: value.to_owned(),
+            });
+        }
+        NamedColor::parse(value)
+            .map(Self::Named)
+            .ok_or_else(|| Error::UnknownVariant {
+                name: "TextColor",
+                value: value.to_owned(),
+            })
+    }
+
+    /// The 24-bit value this colour renders as.
+    #[must_use]
+    pub const fn rgb(self) -> u32 {
+        match self {
+            Self::Named(named) => named.rgb(),
+            Self::Rgb(value) => value,
+        }
+    }
+
+    fn to_tag<'a>(self) -> Tag<'a> {
+        match self {
+            Self::Named(named) => Tag::String(Cow::Borrowed(named.as_str())),
+            Self::Rgb(value) => Tag::String(Cow::Owned(format!("#{value:06X}"))),
+        }
+    }
+}
+
+/// The sixteen colours `ChatFormatting` predates the hex form with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NamedColor {
+    /// `black`.
+    Black,
+    /// `dark_blue`.
+    DarkBlue,
+    /// `dark_green`.
+    DarkGreen,
+    /// `dark_aqua`.
+    DarkAqua,
+    /// `dark_red`.
+    DarkRed,
+    /// `dark_purple`.
+    DarkPurple,
+    /// `gold`.
+    Gold,
+    /// `gray`.
+    Gray,
+    /// `dark_gray`.
+    DarkGray,
+    /// `blue`.
+    Blue,
+    /// `green`.
+    Green,
+    /// `aqua`.
+    Aqua,
+    /// `red`.
+    Red,
+    /// `light_purple`.
+    LightPurple,
+    /// `yellow`.
+    Yellow,
+    /// `white`.
+    White,
+}
+
+impl NamedColor {
+    /// Every colour, in the order `TextColor` declares them.
+    pub const ALL: [Self; 16] = [
+        Self::Black,
+        Self::DarkBlue,
+        Self::DarkGreen,
+        Self::DarkAqua,
+        Self::DarkRed,
+        Self::DarkPurple,
+        Self::Gold,
+        Self::Gray,
+        Self::DarkGray,
+        Self::Blue,
+        Self::Green,
+        Self::Aqua,
+        Self::Red,
+        Self::LightPurple,
+        Self::Yellow,
+        Self::White,
+    ];
+
+    /// The serialised name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Black => "black",
+            Self::DarkBlue => "dark_blue",
+            Self::DarkGreen => "dark_green",
+            Self::DarkAqua => "dark_aqua",
+            Self::DarkRed => "dark_red",
+            Self::DarkPurple => "dark_purple",
+            Self::Gold => "gold",
+            Self::Gray => "gray",
+            Self::DarkGray => "dark_gray",
+            Self::Blue => "blue",
+            Self::Green => "green",
+            Self::Aqua => "aqua",
+            Self::Red => "red",
+            Self::LightPurple => "light_purple",
+            Self::Yellow => "yellow",
+            Self::White => "white",
+        }
+    }
+
+    /// The 24-bit value this colour renders as, as `TextColor.named` registers it.
+    #[must_use]
+    pub const fn rgb(self) -> u32 {
+        match self {
+            Self::Black => 0x0000_0000,
+            Self::DarkBlue => 0x0000_00AA,
+            Self::DarkGreen => 0x0000_AA00,
+            Self::DarkAqua => 0x0000_AAAA,
+            Self::DarkRed => 0x00AA_0000,
+            Self::DarkPurple => 0x00AA_00AA,
+            Self::Gold => 0x00FF_AA00,
+            Self::Gray => 0x00AA_AAAA,
+            Self::DarkGray => 0x0055_5555,
+            Self::Blue => 0x0055_55FF,
+            Self::Green => 0x0055_FF55,
+            Self::Aqua => 0x0055_FFFF,
+            Self::Red => 0x00FF_5555,
+            Self::LightPurple => 0x00FF_55FF,
+            Self::Yellow => 0x00FF_FF55,
+            Self::White => 0x00FF_FFFF,
+        }
+    }
+
+    /// The colour with this name, if there is one.
+    #[must_use]
+    pub fn parse(name: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|color| color.as_str() == name)
+    }
+}
+
+/// NBT has no boolean type; `NbtOps.createBoolean` writes a byte.
+pub(super) const fn tag_bool<'a>(value: bool) -> Tag<'a> {
+    Tag::Byte(if value { 1 } else { 0 })
+}
+
+pub(super) const fn borrowed_string(value: &str) -> Tag<'_> {
+    Tag::String(Cow::Borrowed(value))
+}

--- a/crates/hyperion-minecraft-proto/tests/nbt.rs
+++ b/crates/hyperion-minecraft-proto/tests/nbt.rs
@@ -71,7 +71,10 @@ fn scalars_match_vanilla() {
 
 #[test]
 fn arrays_match_vanilla() {
-    matches_vanilla(&Tag::ByteArray(Cow::Borrowed(&[1, 0xFE, 3])), "070000000301FE03");
+    matches_vanilla(
+        &Tag::ByteArray(Cow::Borrowed(&[1, 0xFE, 3])),
+        "070000000301FE03",
+    );
     matches_vanilla(&Tag::IntArray(vec![1, -2]), "0B0000000200000001FFFFFFFE");
     matches_vanilla(&Tag::LongArray(vec![7]), "0C000000010000000000000007");
 }
@@ -203,10 +206,7 @@ fn a_compound_that_looks_like_a_box_gets_boxed_too() {
 
 #[test]
 fn nested_list_matches_vanilla() {
-    matches_vanilla(
-        &list([list([Tag::Byte(1)])]),
-        "090900000001010000000101",
-    );
+    matches_vanilla(&list([list([Tag::Byte(1)])]), "090900000001010000000101");
 }
 
 #[test]

--- a/crates/hyperion-minecraft-proto/tests/nbt.rs
+++ b/crates/hyperion-minecraft-proto/tests/nbt.rs
@@ -1,0 +1,312 @@
+//! Network NBT tests.
+//!
+//! Every expected byte string in this file came out of the Minecraft 26.2
+//! server jar itself, not out of a specification. A small harness on the
+//! classpath of the bundled `server-26.2.jar` built each value with Mojang's
+//! own classes, wrote it with `NbtIo.writeAnyTag` — the same call
+//! `FriendlyByteBuf.writeNbt` makes — and printed the hex. So an assertion
+//! failing here means this crate and the vanilla server disagree, which is the
+//! only disagreement worth testing for.
+
+use std::borrow::Cow;
+
+use hyperion_minecraft_proto::{
+    Decode, Encode, Error, Reader, Writer,
+    nbt::{Compound, List, Tag, decode_optional, encode_optional},
+};
+
+/// Parse the hex the vanilla harness printed.
+fn vanilla(hex: &str) -> Vec<u8> {
+    assert!(hex.len().is_multiple_of(2), "odd-length hex: {hex}");
+    (0..hex.len() / 2)
+        .map(|index| {
+            u8::from_str_radix(&hex[index * 2..index * 2 + 2], 16).expect("hex digit pair")
+        })
+        .collect()
+}
+
+fn encode(tag: &Tag<'_>) -> Vec<u8> {
+    let mut writer = Writer::new();
+    tag.encode(&mut writer).expect("encode");
+    writer.into_vec()
+}
+
+/// Assert this crate writes what vanilla wrote, and reads back what it wrote.
+fn matches_vanilla(tag: &Tag<'_>, hex: &str) {
+    let expected = vanilla(hex);
+    assert_eq!(encode(tag), expected, "encoding mismatch for {tag:?}");
+
+    let mut reader = Reader::new(&expected);
+    let decoded = Tag::decode(&mut reader).expect("decode");
+    reader.finish().expect("tag fully consumed");
+    assert_eq!(&decoded, tag, "decoding mismatch");
+}
+
+const fn string(value: &str) -> Tag<'_> {
+    Tag::String(Cow::Borrowed(value))
+}
+
+fn list<'a>(elements: impl IntoIterator<Item = Tag<'a>>) -> Tag<'a> {
+    Tag::List(elements.into_iter().collect())
+}
+
+fn compound<'a>(entries: impl IntoIterator<Item = (&'a str, Tag<'a>)>) -> Compound<'a> {
+    entries
+        .into_iter()
+        .map(|(name, value)| (Cow::Borrowed(name), value))
+        .collect()
+}
+
+// --- primitives -----------------------------------------------------------
+
+#[test]
+fn scalars_match_vanilla() {
+    matches_vanilla(&Tag::Byte(-1), "01FF");
+    matches_vanilla(&Tag::Short(0x1234), "021234");
+    matches_vanilla(&Tag::Int(0x0102_0304), "0301020304");
+    matches_vanilla(&Tag::Long(-2), "04FFFFFFFFFFFFFFFE");
+    matches_vanilla(&Tag::Float(1.0), "053F800000");
+    matches_vanilla(&Tag::Double(0.5), "063FE0000000000000");
+}
+
+#[test]
+fn arrays_match_vanilla() {
+    matches_vanilla(&Tag::ByteArray(Cow::Borrowed(&[1, 0xFE, 3])), "070000000301FE03");
+    matches_vanilla(&Tag::IntArray(vec![1, -2]), "0B0000000200000001FFFFFFFE");
+    matches_vanilla(&Tag::LongArray(vec![7]), "0C000000010000000000000007");
+}
+
+// --- strings --------------------------------------------------------------
+
+#[test]
+fn ascii_string_matches_vanilla() {
+    matches_vanilla(&string("hello"), "08000568656C6C6F");
+}
+
+#[test]
+fn null_is_written_as_two_bytes() {
+    // Modified UTF-8's whole point: `StringTag.write` calls
+    // `DataOutput.writeUTF`, which spells U+0000 as C0 80 so that no null
+    // appears inside the encoding. The prefix counts four bytes for three
+    // characters.
+    matches_vanilla(&string("a\0b"), "08000461C08062");
+}
+
+#[test]
+fn supplementary_character_is_written_as_surrogates() {
+    // U+1F600 is one four-byte sequence in UTF-8 and two three-byte sequences
+    // in modified UTF-8, one per UTF-16 surrogate. A decoder that treats NBT
+    // strings as UTF-8 rejects this string outright.
+    matches_vanilla(&string("\u{1F600}"), "080006EDA0BDEDB880");
+}
+
+#[test]
+fn two_byte_sequence_matches_utf8() {
+    matches_vanilla(&string("h\u{e9}"), "08000368C3A9");
+}
+
+#[test]
+fn unpaired_surrogate_is_rejected() {
+    // Java hands back a `String` holding a lone surrogate; `str` cannot, so
+    // this is the one place the decoder is stricter than the server.
+    let bytes = vanilla("080003EDA0BD");
+    let mut reader = Reader::new(&bytes);
+    assert_eq!(Tag::decode(&mut reader), Err(Error::InvalidModifiedUtf8));
+}
+
+#[test]
+fn string_longer_than_the_prefix_is_rejected() {
+    let long = "x".repeat(70_000);
+    let mut writer = Writer::new();
+    assert!(matches!(
+        string(&long).encode(&mut writer),
+        Err(Error::StringTooLong { max: 65_535, .. })
+    ));
+}
+
+// --- compounds ------------------------------------------------------------
+
+#[test]
+fn root_compound_has_no_name() {
+    // The difference between network and file NBT. `NbtIo.writeAnyTag` writes
+    // the type byte and goes straight to the payload; `writeUnnamedTag`, which
+    // the file format uses, writes an empty name between the two. Two bytes,
+    // and getting it wrong desynchronises every packet that carries NBT.
+    matches_vanilla(&Tag::Compound(Compound::new()), "0A00");
+    matches_vanilla(
+        &Tag::Compound(compound([("a", Tag::Int(1))])),
+        "0A030001610000000100",
+    );
+}
+
+#[test]
+fn compound_equality_ignores_order() {
+    // `CompoundTag` is a `HashMap`, so two encodings differing only in field
+    // order are the same value.
+    let one = compound([("a", Tag::Int(1)), ("b", Tag::Int(2))]);
+    let other = compound([("b", Tag::Int(2)), ("a", Tag::Int(1))]);
+    assert_eq!(one, other);
+}
+
+#[test]
+fn duplicate_keys_keep_the_last() {
+    // `loadCompound` does `values.put(key, tag)`, so a repeated key overwrites.
+    let bytes = vanilla("0A0300016100000001030001610000000200");
+    let mut reader = Reader::new(&bytes);
+    let Tag::Compound(decoded) = Tag::decode(&mut reader).expect("decode") else {
+        panic!("expected a compound");
+    };
+    assert_eq!(decoded.len(), 1);
+    assert_eq!(decoded.get("a"), Some(&Tag::Int(2)));
+}
+
+// --- lists ----------------------------------------------------------------
+
+#[test]
+fn uniform_list_matches_vanilla() {
+    matches_vanilla(
+        &list([Tag::Int(1), Tag::Int(2)]),
+        "0903000000020000000100000002",
+    );
+}
+
+#[test]
+fn empty_list_declares_tag_end() {
+    // `identifyRawElementType` returns 0 when there is nothing to type.
+    matches_vanilla(&Tag::List(List::new()), "090000000000");
+}
+
+#[test]
+fn mixed_list_boxes_every_element() {
+    // Since 1.21.5 a list whose elements disagree is written as a list of
+    // compounds, each element under the empty key. Anyone still reading the
+    // pre-1.21.5 rule that lists are homogeneous will mis-parse this.
+    matches_vanilla(
+        &list([Tag::Int(1), string("x")]),
+        "090A00000002030000000000010008000000017800",
+    );
+}
+
+#[test]
+fn a_compound_that_looks_like_a_box_gets_boxed_too() {
+    // `{"": 5}` is indistinguishable from a boxed 5, so `wrapIfNeeded` boxes it
+    // again and the far side unboxes exactly once. The neighbouring compound,
+    // which is not a box, passes through untouched.
+    matches_vanilla(
+        &list([
+            Tag::Compound(compound([("", Tag::Int(5))])),
+            Tag::Compound(compound([("k", Tag::Int(6))])),
+        ]),
+        "090A000000020A00000300000000000500000300016B0000000600",
+    );
+}
+
+#[test]
+fn nested_list_matches_vanilla() {
+    matches_vanilla(
+        &list([list([Tag::Byte(1)])]),
+        "090900000001010000000101",
+    );
+}
+
+#[test]
+fn a_typed_list_cannot_claim_end_elements() {
+    // `loadList` throws "Missing type on ListTag" rather than reading zero-byte
+    // elements forever.
+    let bytes = vanilla("090000000001");
+    let mut reader = Reader::new(&bytes);
+    assert_eq!(Tag::decode(&mut reader), Err(Error::InvalidTagType(0)));
+}
+
+// --- absence --------------------------------------------------------------
+
+#[test]
+fn a_root_end_tag_means_absent() {
+    let mut writer = Writer::new();
+    encode_optional(None, &mut writer).expect("encode");
+    assert_eq!(writer.as_slice(), [0x00]);
+
+    let bytes = [0x00];
+    let mut reader = Reader::new(&bytes);
+    assert_eq!(decode_optional(&mut reader).expect("decode"), None);
+}
+
+#[test]
+fn tag_codec_rejects_a_root_end_tag() {
+    // `ByteBufCodecs.tagCodec` turns the null into "Expected non-null compound
+    // tag" rather than passing it on.
+    let bytes = [0x00];
+    let mut reader = Reader::new(&bytes);
+    assert_eq!(Tag::decode(&mut reader), Err(Error::UnexpectedEndTag));
+}
+
+// --- hostile input --------------------------------------------------------
+
+#[test]
+fn an_array_longer_than_the_input_is_rejected_before_allocating() {
+    // The length is attacker-controlled and feeds a reservation. Four bytes of
+    // header claiming two billion ints must fail, not allocate 8 GB.
+    let bytes = vanilla("0B7FFFFFFF");
+    let mut reader = Reader::new(&bytes);
+    assert!(matches!(
+        Tag::decode(&mut reader),
+        Err(Error::UnexpectedEof { .. })
+    ));
+}
+
+#[test]
+fn a_list_longer_than_the_input_is_rejected_before_allocating() {
+    let bytes = vanilla("09037FFFFFFF");
+    let mut reader = Reader::new(&bytes);
+    assert!(matches!(
+        Tag::decode(&mut reader),
+        Err(Error::UnexpectedEof { .. })
+    ));
+}
+
+#[test]
+fn a_negative_array_length_is_rejected() {
+    let bytes = vanilla("0BFFFFFFFF");
+    let mut reader = Reader::new(&bytes);
+    assert_eq!(Tag::decode(&mut reader), Err(Error::NegativeLength(-1)));
+}
+
+#[test]
+fn nesting_past_the_limit_is_rejected() {
+    // `NbtAccounter.pushDepth` stops at 512 levels. Without the same limit a
+    // recursive decoder blows the stack on 25 bytes of input in a loop.
+    // One root compound, then 600 compounds each the sole entry of the one
+    // above it: type byte, empty name, payload.
+    let mut bytes = vec![0x0A];
+    for _ in 0..600 {
+        bytes.extend_from_slice(&[0x0A, 0x00, 0x00]);
+    }
+    bytes.resize(bytes.len() + 601, 0x00);
+    let mut reader = Reader::new(&bytes);
+    assert_eq!(Tag::decode(&mut reader), Err(Error::NbtTooDeep));
+}
+
+#[test]
+fn an_unknown_tag_type_is_rejected() {
+    let bytes = vanilla("0D");
+    let mut reader = Reader::new(&bytes);
+    assert_eq!(Tag::decode(&mut reader), Err(Error::InvalidTagType(13)));
+}
+
+#[test]
+fn a_maximally_nested_tag_survives_a_round_trip() {
+    // 512 levels is legal, so encoding and dropping one has to work as well as
+    // decoding it. Recursion in any of the three is a crash rather than an
+    // error, and the input that reaches the limit is three bytes per level.
+    let depth = 512;
+    let mut bytes = vec![0x0A];
+    for _ in 0..depth - 1 {
+        bytes.extend_from_slice(&[0x0A, 0x00, 0x00]);
+    }
+    bytes.resize(bytes.len() + depth, 0x00);
+
+    let mut reader = Reader::new(&bytes);
+    let decoded = Tag::decode(&mut reader).expect("decode at the limit");
+    reader.finish().expect("tag fully consumed");
+    assert_eq!(encode(&decoded), bytes);
+}

--- a/crates/hyperion-minecraft-proto/tests/text.rs
+++ b/crates/hyperion-minecraft-proto/tests/text.rs
@@ -1,0 +1,518 @@
+//! Text component tests.
+//!
+//! The expected bytes came out of the Minecraft 26.2 server jar. A harness on
+//! the classpath of the bundled `server-26.2.jar` built each component with
+//! Mojang's own classes, ran `ComponentSerialization.CODEC.encodeStart` against
+//! `NbtOps.INSTANCE` — which is what `fromCodecWithRegistries` does before it
+//! reaches the wire — and printed `NbtIo.writeAnyTag`'s output as hex.
+//!
+//! Comparing raw bytes only works one way round. `CompoundTag` is a `HashMap`,
+//! so the field order in a vanilla encoding is whatever the hash table
+//! happened to produce and no implementation can reproduce it on purpose. So
+//! [`agrees_with_vanilla`] compares decoded values instead: the vanilla bytes
+//! must decode to the expected component, and this crate's encoding of that
+//! component must be the same NBT document as the vanilla bytes. Field order
+//! is the only freedom that leaves.
+
+use std::borrow::Cow;
+
+use hyperion_minecraft_proto::{
+    Decode, Encode, Error, Reader, Writer,
+    nbt::{Compound, Tag},
+    text::{
+        Argument, ClickEvent, Component, Contents, DataSource, HoverEvent, NamedColor, NbtContents,
+        ObjectInfo, Score, Style, TextColor, Translatable,
+    },
+};
+
+fn vanilla(hex: &str) -> Vec<u8> {
+    assert!(hex.len().is_multiple_of(2), "odd-length hex: {hex}");
+    (0..hex.len() / 2)
+        .map(|index| {
+            u8::from_str_radix(&hex[index * 2..index * 2 + 2], 16).expect("hex digit pair")
+        })
+        .collect()
+}
+
+fn decode_tag(bytes: &[u8]) -> Tag<'_> {
+    let mut reader = Reader::new(bytes);
+    let tag = Tag::decode(&mut reader).expect("decode NBT");
+    reader.finish().expect("tag fully consumed");
+    tag
+}
+
+/// Assert this crate reads vanilla's bytes as `expected`, and writes `expected`
+/// as the same NBT document vanilla wrote.
+fn agrees_with_vanilla(expected: &Component<'_>, hex: &str) {
+    let bytes = vanilla(hex);
+    let theirs = decode_tag(&bytes);
+
+    let decoded = Component::from_tag(&theirs).expect("decode component");
+    assert_eq!(&decoded, expected, "decoded {hex}");
+
+    let mut writer = Writer::new();
+    expected.encode(&mut writer).expect("encode");
+    let mine = writer.into_vec();
+    assert_eq!(
+        decode_tag(&mine),
+        theirs,
+        "encoded a different document than vanilla: {mine:02X?}"
+    );
+}
+
+fn styled<'a>(text: &'a str, style: Style<'a>) -> Component<'a> {
+    Component::text(text).with_style(style)
+}
+
+const fn string(value: &str) -> Tag<'_> {
+    Tag::String(Cow::Borrowed(value))
+}
+
+fn compound<'a>(entries: impl IntoIterator<Item = (&'a str, Tag<'a>)>) -> Tag<'a> {
+    Tag::Compound(
+        entries
+            .into_iter()
+            .map(|(name, value)| (Cow::Borrowed(name), value))
+            .collect(),
+    )
+}
+
+fn list<'a>(elements: impl IntoIterator<Item = Tag<'a>>) -> Tag<'a> {
+    Tag::List(elements.into_iter().collect())
+}
+
+// --- the collapsed form ---------------------------------------------------
+
+#[test]
+fn a_bare_literal_is_a_string_not_a_compound() {
+    // `tryCollapseToString`: a literal with no style and no children is a bare
+    // TAG_String. Five bytes, and no `text` field anywhere.
+    agrees_with_vanilla(&Component::text("hi"), "0800026869");
+    agrees_with_vanilla(&Component::text(""), "080000");
+}
+
+#[test]
+fn a_styled_literal_is_a_compound() {
+    agrees_with_vanilla(
+        &styled("hi", Style {
+            bold: Some(true),
+            ..Style::new()
+        }),
+        "0A0800047465787400026869010004626F6C640100",
+    );
+}
+
+#[test]
+fn a_list_is_its_head_with_the_tail_appended() {
+    // The decode-only third shape. `createFromList` copies the first element
+    // and appends the rest to it, and nothing ever encodes back to a list.
+    let component = Component::from_tag(&list([string("a"), string("b")])).expect("decode");
+    assert_eq!(component, Component::text("a").append(Component::text("b")));
+}
+
+#[test]
+fn an_empty_extra_list_is_rejected() {
+    // ExtraCodecs.nonEmptyList, rather than treating it as no children.
+    let tag = compound([("text", string("a")), ("extra", list([]))]);
+    assert_eq!(Component::from_tag(&tag), Err(Error::MissingField("extra")));
+}
+
+// --- contents -------------------------------------------------------------
+
+#[test]
+fn children_carry_their_own_style() {
+    agrees_with_vanilla(
+        &styled("a", Style {
+            bold: Some(true),
+            ..Style::new()
+        })
+        .append(styled("b", Style {
+            italic: Some(true),
+            ..Style::new()
+        })),
+        "0A09000565787472610A00000001080004746578740001620100066974616C6963010008000474657874000161010004626F6C640100",
+    );
+}
+
+#[test]
+fn extra_holds_collapsed_children() {
+    agrees_with_vanilla(
+        &Component::text("a").append(Component::text("b")),
+        "0A090005657874726108000000010001620800047465787400016100",
+    );
+}
+
+#[test]
+fn translatable_arguments_collapse_to_primitives() {
+    // A component argument that collapses to a string is written as that
+    // string: ARG_CODEC's component branch runs the same collapse the top
+    // level does, and its primitive branch reads it back as a string rather
+    // than as a component.
+    agrees_with_vanilla(
+        &Component::from_contents(Contents::Translatable(Translatable {
+            key: Cow::Borrowed("chat.type.text"),
+            fallback: None,
+            with: vec![
+                Argument::String(Cow::Borrowed("Notch")),
+                Argument::String(Cow::Borrowed("hi")),
+            ],
+        })),
+        "0A09000477697468080000000200054E6F746368000268690800097472616E736C617465000E636861742E747970652E7465787400",
+    );
+}
+
+#[test]
+fn translatable_fallback_round_trips() {
+    agrees_with_vanilla(
+        &Component::from_contents(Contents::Translatable(Translatable {
+            key: Cow::Borrowed("k"),
+            fallback: Some(Cow::Borrowed("fb")),
+            with: Vec::new(),
+        })),
+        "0A08000866616C6C6261636B000266620800097472616E736C61746500016B00",
+    );
+}
+
+#[test]
+fn keybind_round_trips() {
+    agrees_with_vanilla(
+        &Component::from_contents(Contents::Keybind(Cow::Borrowed("key.jump"))),
+        "0A0800076B657962696E6400086B65792E6A756D7000",
+    );
+}
+
+#[test]
+fn score_nests_under_its_own_key() {
+    // The one content type whose fields are not flat: MAP_CODEC is
+    // `INNER_CODEC.fieldOf("score")`.
+    agrees_with_vanilla(
+        &Component::from_contents(Contents::Score(Score {
+            name: Cow::Borrowed("Notch"),
+            objective: Cow::Borrowed("obj"),
+        })),
+        "0A0A000573636F72650800046E616D6500054E6F7463680800096F626A65637469766500036F626A0000",
+    );
+}
+
+#[test]
+fn selector_separator_round_trips() {
+    agrees_with_vanilla(
+        &Component::from_contents(Contents::Selector {
+            selector: Cow::Borrowed("@a"),
+            separator: Some(Box::new(Component::text(", "))),
+        }),
+        "0A08000873656C6563746F7200024061080009736570617261746F7200022C2000",
+    );
+}
+
+#[test]
+fn nbt_source_is_flattened_alongside_the_path() {
+    // `plain` is absent because it is false, which is its default; `interpret`
+    // is present because it is not. `plain` itself is new in 26.x.
+    agrees_with_vanilla(
+        &Component::from_contents(Contents::Nbt(NbtContents {
+            path: Cow::Borrowed("foo.bar"),
+            interpret: true,
+            plain: false,
+            separator: None,
+            source: DataSource::Storage(Cow::Borrowed("minecraft:store")),
+        })),
+        "0A0800036E62740007666F6F2E626172010009696E746572707265740108000773746F72616765000F6D696E6563726166743A73746F726500",
+    );
+}
+
+#[test]
+fn an_object_component_omits_the_default_atlas() {
+    // `object` is the content type the older documentation does not have at
+    // all. `atlas` defaults to minecraft:blocks and vanishes when it matches.
+    agrees_with_vanilla(
+        &Component::from_contents(Contents::Object {
+            object: ObjectInfo::Atlas {
+                atlas: Cow::Borrowed("minecraft:blocks"),
+                sprite: Cow::Borrowed("minecraft:stone"),
+            },
+            fallback: None,
+        }),
+        "0A080006737072697465000F6D696E6563726166743A73746F6E6500",
+    );
+}
+
+#[test]
+fn contents_with_no_recognised_field_are_rejected() {
+    let tag = compound([("bold", Tag::Byte(1))]);
+    assert_eq!(
+        Component::from_tag(&tag),
+        Err(Error::NoMatchingCodec("component contents"))
+    );
+}
+
+// --- style ----------------------------------------------------------------
+
+#[test]
+fn a_named_colour_is_its_name() {
+    agrees_with_vanilla(
+        &styled("hi", Style {
+            color: Some(TextColor::Named(NamedColor::Red)),
+            ..Style::new()
+        }),
+        "0A080005636F6C6F720003726564080004746578740002686900",
+    );
+}
+
+#[test]
+fn an_rgb_colour_is_uppercase_hex() {
+    // `String.format(Locale.ROOT, "#%06X", value)`.
+    agrees_with_vanilla(
+        &styled("hi", Style {
+            color: Some(TextColor::Rgb(0x0012_3456)),
+            ..Style::new()
+        }),
+        "0A080005636F6C6F72000723313233343536080004746578740002686900",
+    );
+}
+
+#[test]
+fn every_named_colour_survives_its_name() {
+    for color in NamedColor::ALL {
+        assert_eq!(NamedColor::parse(color.as_str()), Some(color));
+        assert_eq!(
+            TextColor::parse(color.as_str()),
+            Ok(TextColor::Named(color))
+        );
+    }
+    assert_eq!(NamedColor::Gold.rgb(), 0x00FF_AA00);
+}
+
+#[test]
+fn an_unknown_colour_is_rejected() {
+    assert!(TextColor::parse("puce").is_err());
+    // Out of 24 bits.
+    assert!(TextColor::parse("#1123456").is_err());
+}
+
+#[test]
+fn all_five_flags_round_trip_including_the_false_ones() {
+    // `Style` distinguishes unset from false, so `italic: 0b` has to survive.
+    agrees_with_vanilla(
+        &styled("x", Style {
+            bold: Some(true),
+            italic: Some(false),
+            underlined: Some(true),
+            strikethrough: Some(false),
+            obfuscated: Some(true),
+            ..Style::new()
+        }),
+        "0A01000A756E6465726C696E65640108000474657874000178010004626F6C640101000D737472696B657468726F756768000100066974616C69630001000A6F6266757363617465640100",
+    );
+}
+
+#[test]
+fn shadow_colour_is_a_packed_argb_int() {
+    agrees_with_vanilla(
+        &styled("x", Style {
+            shadow_color: Some(0x1122_3344),
+            ..Style::new()
+        }),
+        "0A03000C736861646F775F636F6C6F72112233440800047465787400017800",
+    );
+}
+
+#[test]
+fn insertion_and_font_round_trip() {
+    agrees_with_vanilla(
+        &styled("x", Style {
+            insertion: Some(Cow::Borrowed("ins")),
+            font: Some(Cow::Borrowed("minecraft:alt")),
+            ..Style::new()
+        }),
+        "0A080009696E73657274696F6E0003696E7308000474657874000178080004666F6E74000D6D696E6563726166743A616C7400",
+    );
+}
+
+// --- events ---------------------------------------------------------------
+
+#[test]
+fn click_events_round_trip() {
+    agrees_with_vanilla(
+        &styled("go", Style {
+            click_event: Some(ClickEvent::RunCommand(Cow::Borrowed("/say hi"))),
+            ..Style::new()
+        }),
+        "0A0A000B636C69636B5F6576656E74080006616374696F6E000B72756E5F636F6D6D616E64080007636F6D6D616E6400072F73617920686900080004746578740002676F00",
+    );
+    agrees_with_vanilla(
+        &styled("go", Style {
+            click_event: Some(ClickEvent::OpenUrl(Cow::Borrowed("https://example.com"))),
+            ..Style::new()
+        }),
+        "0A0A000B636C69636B5F6576656E74080006616374696F6E00086F70656E5F75726C08000375726C001368747470733A2F2F6578616D706C652E636F6D00080004746578740002676F00",
+    );
+}
+
+#[test]
+fn open_file_cannot_appear_on_the_wire() {
+    // `Action.CODEC` is `UNSAFE_CODEC.validate(filterForSerialization)`, and
+    // `validate` runs on decode too, so `open_file` is not a click event a
+    // connection can carry in either direction.
+    let tag = compound([
+        ("text", string("x")),
+        (
+            "click_event",
+            compound([("action", string("open_file")), ("path", string("/"))]),
+        ),
+    ]);
+    assert!(matches!(
+        Component::from_tag(&tag),
+        Err(Error::UnknownVariant { .. })
+    ));
+}
+
+#[test]
+fn change_page_rejects_zero() {
+    // ExtraCodecs.POSITIVE_INT.
+    let tag = compound([
+        ("text", string("x")),
+        (
+            "click_event",
+            compound([("action", string("change_page")), ("page", Tag::Int(0))]),
+        ),
+    ]);
+    assert!(matches!(
+        Component::from_tag(&tag),
+        Err(Error::UnknownVariant { .. })
+    ));
+}
+
+#[test]
+fn hover_show_text_round_trips() {
+    agrees_with_vanilla(
+        &styled("go", Style {
+            hover_event: Some(HoverEvent::ShowText(Box::new(Component::text("tip")))),
+            ..Style::new()
+        }),
+        "0A080004746578740002676F0A000B686F7665725F6576656E74080006616374696F6E000973686F775F7465787408000576616C756500037469700000",
+    );
+}
+
+#[test]
+fn hover_show_entity_writes_the_uuid_as_four_ints() {
+    // `UUIDUtil.LENIENT_CODEC` encodes through `UUIDUtil.CODEC`, which is an
+    // int stream: the sixteen big-endian bytes read as four big-endian ints,
+    // not a dashed string.
+    agrees_with_vanilla(
+        &styled("e", Style {
+            hover_event: Some(HoverEvent::ShowEntity {
+                id: Cow::Borrowed("minecraft:pig"),
+                uuid: 0x0011_2233_4455_6677_8899_AABB_CCDD_EEFF,
+                name: None,
+            }),
+            ..Style::new()
+        }),
+        "0A080004746578740001650A000B686F7665725F6576656E74080006616374696F6E000B73686F775F656E746974790800026964000D6D696E6563726166743A7069670B0004757569640000000400112233445566778899AABBCCDDEEFF0000",
+    );
+}
+
+#[test]
+fn a_dashed_uuid_is_accepted_on_the_way_in() {
+    // The `STRING_CODEC` alternative in `LENIENT_CODEC`. Nothing writes it, so
+    // this only has to decode.
+    let tag = compound([
+        ("text", string("e")),
+        (
+            "hover_event",
+            compound([
+                ("action", string("show_entity")),
+                ("id", string("minecraft:pig")),
+                ("uuid", string("00112233-4455-6677-8899-aabbccddeeff")),
+            ]),
+        ),
+    ]);
+    let component = Component::from_tag(&tag).expect("decode");
+    let Some(HoverEvent::ShowEntity { uuid, .. }) = component.style.hover_event else {
+        panic!("expected a show_entity hover");
+    };
+    assert_eq!(uuid, 0x0011_2233_4455_6677_8899_AABB_CCDD_EEFF);
+}
+
+#[test]
+fn hover_show_item_inlines_the_stack_fields() {
+    // `ItemStackTemplate.MAP_CODEC` is grouped straight into the event
+    // compound, so `id` and `count` sit next to `action` rather than under an
+    // `item` key. `count` is absent when it is 1.
+    agrees_with_vanilla(
+        &styled("i", Style {
+            hover_event: Some(HoverEvent::ShowItem {
+                id: Cow::Borrowed("minecraft:stone"),
+                count: 3,
+                components: None,
+            }),
+            ..Style::new()
+        }),
+        "0A080004746578740001690A000B686F7665725F6576656E74030005636F756E7400000003080006616374696F6E000973686F775F6974656D0800026964000F6D696E6563726166743A73746F6E650000",
+    );
+}
+
+// --- the packet-level codec -----------------------------------------------
+
+#[test]
+fn a_component_decodes_through_the_codec_traits() {
+    let bytes = vanilla("0800026869");
+    let mut reader = Reader::new(&bytes);
+    let component = Component::decode(&mut reader).expect("decode");
+    reader.finish().expect("component fully consumed");
+    assert_eq!(component, Component::text("hi"));
+}
+
+#[test]
+fn an_unknown_field_is_ignored() {
+    // A `MapCodec` reads the keys it knows and leaves the rest, so a component
+    // from a newer server still decodes.
+    let tag = compound([
+        ("text", string("hi")),
+        ("flarg", string("xy")),
+        ("more", Tag::Byte(1)),
+    ]);
+    assert_eq!(
+        Component::from_tag(&tag).expect("decode"),
+        Component::text("hi")
+    );
+}
+
+#[test]
+fn a_type_field_is_tolerated_but_never_written() {
+    // `StrictEither.decode` switches to the discriminated codec when `type` is
+    // present; `StrictEither.encode` always uses the fuzzy one, so nothing
+    // vanilla emits ever carries it.
+    let tag = compound([("type", string("text")), ("text", string("hi"))]);
+    let component = Component::from_tag(&tag).expect("decode");
+    assert_eq!(component, Component::text("hi"));
+
+    let mut writer = Writer::new();
+    component.encode(&mut writer).expect("encode");
+    assert!(matches!(
+        decode_tag(writer.as_slice()),
+        Tag::Compound(_) | Tag::String(_)
+    ));
+    assert!(!writer.as_slice().windows(4).any(|window| window == b"type"));
+}
+
+#[test]
+fn a_verbatim_payload_survives_a_click_event() {
+    // `ClickEvent.Custom.payload` is `ExtraCodecs.NBT`, so whatever the sender
+    // put there comes back unchanged.
+    let mut payload = Compound::new();
+    payload.insert("n", Tag::Long(7));
+    let component = styled("x", Style {
+        click_event: Some(ClickEvent::Custom {
+            id: Cow::Borrowed("example:thing"),
+            payload: Some(Tag::Compound(payload)),
+        }),
+        ..Style::new()
+    });
+
+    let mut writer = Writer::new();
+    component.encode(&mut writer).expect("encode");
+    let bytes = writer.into_vec();
+    let mut reader = Reader::new(&bytes);
+    assert_eq!(Component::decode(&mut reader).expect("decode"), component);
+}


### PR DESCRIPTION
Two modules in `hyperion-minecraft-proto`: `nbt` for the network NBT form, and `text` for chat components, which since 1.20.3 are NBT rather than JSON. Both are transcribed from the decompiled 26.2 server sources and tested against bytes the server jar itself produced.

## Network NBT

`FriendlyByteBuf.writeNbt` goes through `NbtIo.writeAnyTag`: type byte, then payload. The named-root form is `writeUnnamedTag`, which the network never calls, so the root has neither a name nor the empty-name length prefix a file root still carries. A root `TAG_End` means absent, which is why `decode_optional` exists next to the `Decode` impl.

All thirteen tag types, both directions. Strings are Java modified UTF-8 — `U+0000` as `C0 80`, supplementary characters as CESU-8 surrogate pairs — and are borrowed from the input whenever their bytes are also their UTF-8 spelling, which covers everything without a null or an emoji in it.

Mixed-type lists work the way `ListTag` has done since 1.21.5: the element type becomes `TAG_Compound` and every element is boxed under the empty key, including a compound that already looks like a box. Anyone still reading the pre-1.21.5 rule that lists are homogeneous will mis-parse those.

**Decoding is iterative, and that is not a style choice.** Transcribing `CompoundTag.load` and `ListTag.load` as written puts two large frames per level on a two-megabyte test thread, which overflows short of the 512 levels `NbtAccounter` allows. The guard aborted the process instead of returning an error, on three bytes of input per level. An explicit stack puts the limit back where Mojang has it. There is a test that decodes, re-encodes and drops a tag at exactly 512.

The byte-quota half of `NbtAccounter` is deliberately not reproduced: 48 bytes for a compound, 36 for a map entry — those size Java heap objects, not wire bytes, and they exist because Java allocates before it knows the input is short. What a slice-backed reader needs instead is that a declared length is actually present, and every array and list read checks that before reserving.

## Text components

`ComponentSerialization.STREAM_CODEC` is `fromCodecWithRegistries(CODEC)`, which runs the DFU codec against `NbtOps` and hands the tag to `tagCodec`. So `Component` encodes through the `nbt` module and there is no JSON anywhere. The two survivors are the status response and the login disconnect, both of which run before any registry has been sent; those stay strings in `packets`.

All seven content types, the full `Style`, `extra`, and click and hover events.

### Where the source disagrees with the usual documentation

- **A bare literal is a string, not a compound.** `tryCollapseToString`: a literal with no style and no children encodes as a bare `TAG_String`. Vanilla writes `Component.literal("hi")` as `08 00 02 68 69`, five bytes, with no `text` field anywhere.
- **`click_event` and `hover_event`**, not `clickEvent` and `hoverEvent`. `Style.Serializer.MAP_CODEC` fixes the current spelling; JSON-era documentation still shows the old one.
- **There is a seventh content type, `object`**, for an atlas sprite or a player head drawn inline with a text fallback. `NbtContents` also gained a `plain` flag, mutually exclusive with `interpret`.
- **`open_file` cannot appear on the wire.** `Action.CODEC` is `UNSAFE_CODEC.validate(filterForSerialization)` and `validate` runs on decode as well as encode, so it is not a click event a connection can carry in either direction. It has no variant here.
- **A `show_entity` uuid is four big-endian ints**, not a dashed string. `UUIDUtil.LENIENT_CODEC` encodes through `UUIDUtil.CODEC`, an int stream. The string form decodes as a fallback and is never written.
- **`show_item` inlines the stack fields.** `ItemStackTemplate.MAP_CODEC` is grouped straight into the event compound, so `id` and `count` sit next to `action` rather than under an `item` key.
- **There is no `type` field.** `StrictEither.encode` always delegates to the fuzzy codec, so the compound form is dispatched by which mandatory field is present. A `type` field is accepted on decode and never written.

## Test evidence

Every expected byte string came out of the Minecraft 26.2 server jar. A harness on the classpath of the bundled `server-26.2.jar` built each value with Mojang's own classes and printed the hex of `NbtIo.writeAnyTag` — for components, of `ComponentSerialization.CODEC.encodeStart(NbtOps.INSTANCE, ...)` first. So a failing assertion means this crate and the vanilla server disagree, which is the only disagreement worth testing for.

`CompoundTag` is a `HashMap`, so field order in a vanilla encoding is whatever the hash table produced and no implementation can reproduce it on purpose. The component tests therefore assert two things instead of comparing raw bytes: the vanilla bytes decode to the expected component, and this crate's encoding of that component is the same NBT document. Field order is the only freedom that leaves. The NBT tests, whose compounds have at most one entry, compare bytes directly.

```
$ cargo test -p hyperion-minecraft-proto
     Running tests/nbt.rs
test result: ok. 25 passed; 0 failed
     Running tests/text.rs
test result: ok. 32 passed; 0 failed
     Running tests/wire.rs
test result: ok. 18 passed; 0 failed

$ nix run .#lint
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 38.83s
lint rc=0
```

## What is not here

Three values are carried as verbatim NBT rather than modelled, because resolving them needs registries this crate has no view of: a `show_dialog` `Holder<Dialog>`, a `show_item` `DataComponentPatch`, and a player sprite `ResolvableProfile`. They round-trip unchanged.

One thing the source does not settle: `FuzzyCodec` tries its alternatives in the iteration order of a `HashBiMap`, which is neither the registration order nor specified. The mandatory fields are disjoint, so the order only decides which error a malformed value gets; this decodes in the order `ComponentSerialization.bootstrap` registers them.

One place this is stricter than the server: Java's `readUTF` hands back a `String` that may hold an unpaired surrogate, and `str` cannot, so such a string is rejected rather than accepted. Nothing vanilla emits one.

`src/error.rs` gained eight variants. It is not in the paths this branch was meant to own, but `Error` is the crate's one error type and a parallel one in `nbt` would have read like a different author. The additions are appended at the end of the enum and of the `Display` match, so a conflict with a parallel branch should be trivial.
