### PR TITLE
feat(proto): plain integers in packet fields, with the encoding in an attribute

### DIFF
--- a/crates/hyperion-minecraft-proto-derive/README.md
+++ b/crates/hyperion-minecraft-proto-derive/README.md
@@ -33,13 +33,20 @@ pub struct Hello<'a> {
 
 | attribute | effect |
 | --- | --- |
+| `#[proto(varint)]` | write the innermost `i32` seven bits per byte |
+| `#[proto(varlong)]` | write the innermost `i64` seven bits per byte |
 | `#[proto(max_len = N)]` | limit on the innermost string, in UTF-16 code units |
 | `#[proto(max_count = N)]` | limit on the innermost collection's element count |
 | `#[proto(with = path)]` | use `path::encode` and `path::decode` for this field |
 
-`max_len` and `max_count` thread through `Option<_>` and `Vec<_>` to the type
-they constrain, so `#[proto(max_len = 1024)] pages: Vec<&'a str>` bounds each
-page rather than the list.
+How wide a number is belongs to the value and lives in its type; how many bytes
+it costs belongs to the wire and lives in the attribute. A field is therefore
+`#[proto(varint)] pub entity_id: i32` and a caller writes `entity_id: 42`.
+
+Each of these describes a type nested somewhere under the field's own, so the
+derive walks through `Option<_>` and `Vec<_>` until it finds it:
+`#[proto(max_len = 1024)] pages: Vec<&'a str>` bounds each page rather than the
+list, and `#[proto(varint)] passengers: Vec<i32>` writes each id as a `VarInt`.
 
 ## What it refuses
 
@@ -49,5 +56,10 @@ Every one of these is a compile error rather than a silent approximation:
   read what follows
 - more than one lifetime, since the derive would have to guess which one the
   reader lends to
-- a `with` beside a limit, since the limit would never be applied
+- a `with` beside anything else, since the rest would never be applied
+- `max_len` beside `varint` or `varlong`, since no one type is both a string
+  and an integer
+- an attribute that reached the bottom of a field without finding the type it
+  describes, such as `max_count` on a field holding no collection: dropping it
+  would leave a codec that looks constrained and is not
 - a union

--- a/crates/hyperion-minecraft-proto-derive/src/attr.rs
+++ b/crates/hyperion-minecraft-proto-derive/src/attr.rs
@@ -2,13 +2,70 @@
 
 use syn::{Attribute, Expr, LitInt, Path, Result, spanned::Spanned};
 
-/// What a `#[proto(...)]` attribute says about one field.
-#[derive(Default)]
-pub struct Field {
+/// How an integer is written, where the wire's choice is not the one its Rust
+/// type implies.
+///
+/// How wide a number is belongs to the value and so lives in the type; how
+/// many bytes it costs on the wire belongs to the wire and lives here.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Encoding {
+    /// An `i32`, seven bits per byte.
+    VarInt,
+    /// An `i64`, seven bits per byte.
+    VarLong,
+}
+
+/// What a `#[proto(...)]` attribute asks of the types *inside* a field.
+///
+/// Each of these applies to one type nested somewhere under the field's own,
+/// so the derive walks the field type until it finds the type each describes.
+#[derive(Clone, Copy, Default)]
+pub struct Reach {
     /// `max_len = N`: the innermost string's limit in UTF-16 code units.
     pub max_len: Option<usize>,
     /// `max_count = N`: the innermost collection's element limit.
     pub max_count: Option<usize>,
+    /// `varint` or `varlong`: how the innermost integer is written.
+    pub encoding: Option<Encoding>,
+}
+
+impl Reach {
+    /// Whether anything here still has to reach a type inside the field's own.
+    pub const fn is_empty(self) -> bool {
+        self.max_len.is_none() && self.max_count.is_none() && self.encoding.is_none()
+    }
+
+    /// The same options with the collection limit spent, for the element type
+    /// of the list that just applied it.
+    pub const fn count_applied(self) -> Self {
+        Self {
+            max_count: None,
+            ..self
+        }
+    }
+
+    /// What is left once a string or byte slice has taken its length limit.
+    pub const fn len_applied(self) -> Self {
+        Self {
+            max_len: None,
+            ..self
+        }
+    }
+
+    /// What is left once an integer has taken its encoding.
+    pub const fn encoding_applied(self) -> Self {
+        Self {
+            encoding: None,
+            ..self
+        }
+    }
+}
+
+/// What a `#[proto(...)]` attribute says about one field.
+#[derive(Default)]
+pub struct Field {
+    /// What has to reach a type nested inside this field's own.
+    pub reach: Reach,
     /// `with = path`: a module supplying `encode` and `decode` for this field.
     pub with: Option<Path>,
 }
@@ -20,26 +77,53 @@ impl Field {
         for attr in attrs.iter().filter(|a| a.path().is_ident("proto")) {
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("max_len") {
-                    out.max_len = Some(usize_value(&meta.value()?.parse()?)?);
+                    out.reach.max_len = Some(usize_value(&meta.value()?.parse()?)?);
                 } else if meta.path.is_ident("max_count") {
-                    out.max_count = Some(usize_value(&meta.value()?.parse()?)?);
+                    out.reach.max_count = Some(usize_value(&meta.value()?.parse()?)?);
+                } else if meta.path.is_ident("varint") {
+                    out.set_encoding(Encoding::VarInt, &meta)?;
+                } else if meta.path.is_ident("varlong") {
+                    out.set_encoding(Encoding::VarLong, &meta)?;
                 } else if meta.path.is_ident("with") {
                     out.with = Some(meta.value()?.parse()?);
                 } else {
-                    return Err(meta.error("expected `max_len`, `max_count` or `with`"));
+                    return Err(meta
+                        .error("expected `varint`, `varlong`, `max_len`, `max_count` or `with`"));
                 }
                 Ok(())
             })?;
         }
-        if out.with.is_some() && (out.max_len.is_some() || out.max_count.is_some()) {
-            // A `with` module owns the whole field, so a limit beside it would
-            // be silently ignored rather than enforced somewhere unexpected.
+        if out.with.is_some() && !out.reach.is_empty() {
+            // A `with` module owns the whole field, so anything beside it
+            // would be silently ignored rather than applied somewhere
+            // unexpected.
             return Err(syn::Error::new(
                 attrs[0].span(),
-                "`with` supplies the whole codec, so it cannot be combined with a limit",
+                "`with` supplies the whole codec, so nothing else can apply to the field",
+            ));
+        }
+        if out.reach.max_len.is_some() && out.reach.encoding.is_some() {
+            // Both describe the one type at the bottom of the field, and no
+            // type is both a string and an integer.
+            return Err(syn::Error::new(
+                attrs[0].span(),
+                "`max_len` describes a string and `varint`/`varlong` an integer, so one field \
+                 cannot want both",
             ));
         }
         Ok(out)
+    }
+
+    fn set_encoding(
+        &mut self,
+        encoding: Encoding,
+        meta: &syn::meta::ParseNestedMeta<'_>,
+    ) -> Result<()> {
+        if self.reach.encoding.is_some_and(|already| already != encoding) {
+            return Err(meta.error("a value has one wire encoding, and two are named here"));
+        }
+        self.reach.encoding = Some(encoding);
+        Ok(())
     }
 }
 

--- a/crates/hyperion-minecraft-proto-derive/src/attr.rs
+++ b/crates/hyperion-minecraft-proto-derive/src/attr.rs
@@ -119,7 +119,9 @@ impl Field {
         encoding: Encoding,
         meta: &syn::meta::ParseNestedMeta<'_>,
     ) -> Result<()> {
-        if self.reach.encoding.is_some_and(|already| already != encoding) {
+        if let Some(already) = self.reach.encoding
+            && already != encoding
+        {
             return Err(meta.error("a value has one wire encoding, and two are named here"));
         }
         self.reach.encoding = Some(encoding);

--- a/crates/hyperion-minecraft-proto-derive/src/expand.rs
+++ b/crates/hyperion-minecraft-proto-derive/src/expand.rs
@@ -226,24 +226,17 @@ fn shape(ty: &Type) -> Shape<'_> {
     }
 }
 
-/// Whether the derive has to walk into the type rather than delegate to its
-/// `Encode`/`Decode` impl. It does exactly when a limit has to reach a type
-/// nested inside the field's own.
-const fn limited(options: &attr::Field) -> bool {
-    options.max_len.is_some() || options.max_count.is_some()
-}
-
 fn encode_value(place: &TokenStream, ty: &Type, options: &attr::Field) -> Result<TokenStream> {
     let krate = krate();
     if let Some(path) = &options.with {
         return Ok(quote!(#path::encode(#place, writer)?;));
     }
-    if !limited(options) {
+    if options.reach.is_empty() {
         return Ok(quote!(#krate::Encode::encode(#place, writer)?;));
     }
     // Bound to a name first: the place is an expression like `&self.pages`,
     // and `&self.pages.iter()` would borrow the iterator rather than the field.
-    let body = encode_limited(&quote!(value), ty, options, 0)?;
+    let body = encode_reaching(&quote!(value), ty, options.reach, 0)?;
     Ok(quote! {
         {
             let value = #place;
@@ -252,17 +245,22 @@ fn encode_value(place: &TokenStream, ty: &Type, options: &attr::Field) -> Result
     })
 }
 
-fn encode_limited(
+/// Encode a field by walking into its type until every option has found the
+/// type it describes.
+///
+/// `place` is always a reference, at every depth: the field is borrowed on the
+/// way in, `Option::as_ref` and `slice::iter` keep it so.
+fn encode_reaching(
     place: &TokenStream,
     ty: &Type,
-    options: &attr::Field,
+    reach: attr::Reach,
     depth: usize,
 ) -> Result<TokenStream> {
     let krate = krate();
     match shape(ty) {
         Shape::Option(inner) => {
             let binding = format_ident!("value_{}", depth);
-            let body = encode_limited(&quote!(#binding), inner, options, depth + 1)?;
+            let body = encode_reaching(&quote!(#binding), inner, reach, depth + 1)?;
             Ok(quote! {
                 writer.bool(#place.is_some());
                 if let ::core::option::Option::Some(#binding) = #place.as_ref() {
@@ -272,8 +270,8 @@ fn encode_limited(
         }
         Shape::Vec(inner) => {
             let binding = format_ident!("item_{}", depth);
-            let body = encode_limited(&quote!(#binding), inner, options, depth + 1)?;
-            let max = count_limit(options.max_count);
+            let body = encode_reaching(&quote!(#binding), inner, reach.count_applied(), depth + 1)?;
+            let max = count_limit(reach.max_count);
             Ok(quote! {
                 #krate::codec::write_count(writer, #place.len(), #max)?;
                 for #binding in #place.iter() {
@@ -282,14 +280,24 @@ fn encode_limited(
             })
         }
         Shape::Str => {
-            let max = require_len(options, ty)?;
+            let max = require_len(reach, ty, "a string")?;
             Ok(quote!(writer.string_with_limit(#place, #max)?;))
         }
         Shape::Bytes => {
-            let max = require_len(options, ty)?;
+            let max = require_len(reach, ty, "a byte slice")?;
             Ok(quote!(writer.byte_array_with_limit(#place, #max)?;))
         }
-        Shape::Opaque => Ok(quote!(#krate::Encode::encode(#place, writer)?;)),
+        Shape::Opaque => match reach.encoding {
+            Some(encoding) => {
+                unapplied(reach.encoding_applied(), ty, "an integer")?;
+                let write = format_ident!("{}", encoding_method(encoding));
+                Ok(quote!(writer.#write(*#place);))
+            }
+            None => {
+                unapplied(reach, ty, "a type with a codec of its own")?;
+                Ok(quote!(#krate::Encode::encode(#place, writer)?;))
+            }
+        },
     }
 }
 
@@ -298,17 +306,17 @@ fn decode_value(ty: &Type, options: &attr::Field) -> Result<TokenStream> {
     if let Some(path) = &options.with {
         return Ok(quote!(#path::decode(reader)?));
     }
-    if !limited(options) {
+    if options.reach.is_empty() {
         return Ok(quote!(#krate::Decode::decode(reader)?));
     }
-    decode_limited(ty, options)
+    decode_reaching(ty, options.reach)
 }
 
-fn decode_limited(ty: &Type, options: &attr::Field) -> Result<TokenStream> {
+fn decode_reaching(ty: &Type, reach: attr::Reach) -> Result<TokenStream> {
     let krate = krate();
     match shape(ty) {
         Shape::Option(inner) => {
-            let body = decode_limited(inner, options)?;
+            let body = decode_reaching(inner, reach)?;
             Ok(quote! {
                 if reader.bool()? {
                     ::core::option::Option::Some(#body)
@@ -318,8 +326,8 @@ fn decode_limited(ty: &Type, options: &attr::Field) -> Result<TokenStream> {
             })
         }
         Shape::Vec(inner) => {
-            let body = decode_limited(inner, options)?;
-            let max = count_limit(options.max_count);
+            let body = decode_reaching(inner, reach.count_applied())?;
+            let max = count_limit(reach.max_count);
             // The capacity is clamped to the bytes actually available, because
             // the count is attacker-controlled and every element costs at
             // least one byte.
@@ -337,24 +345,67 @@ fn decode_limited(ty: &Type, options: &attr::Field) -> Result<TokenStream> {
             })
         }
         Shape::Str => {
-            let max = require_len(options, ty)?;
+            let max = require_len(reach, ty, "a string")?;
             Ok(quote!(reader.string_with_limit(#max)?))
         }
         Shape::Bytes => {
-            let max = require_len(options, ty)?;
+            let max = require_len(reach, ty, "a byte slice")?;
             Ok(quote!(reader.byte_array_with_limit(#max)?))
         }
-        Shape::Opaque => Ok(quote!(#krate::Decode::decode(reader)?)),
+        Shape::Opaque => match reach.encoding {
+            Some(encoding) => {
+                unapplied(reach.encoding_applied(), ty, "an integer")?;
+                let read = format_ident!("{}", encoding_method(encoding));
+                Ok(quote!(reader.#read()?))
+            }
+            None => {
+                unapplied(reach, ty, "a type with a codec of its own")?;
+                Ok(quote!(#krate::Decode::decode(reader)?))
+            }
+        },
     }
 }
 
-fn require_len(options: &attr::Field, ty: &Type) -> Result<usize> {
-    options.max_len.ok_or_else(|| {
+/// The `Reader` and `Writer` method for an encoding. They share a name, which
+/// is what lets one lookup serve both directions.
+const fn encoding_method(encoding: attr::Encoding) -> &'static str {
+    match encoding {
+        attr::Encoding::VarInt => "var_int",
+        attr::Encoding::VarLong => "var_long",
+    }
+}
+
+fn require_len(reach: attr::Reach, ty: &Type, leaf: &str) -> Result<usize> {
+    // Whatever else was asked for is reported first: it names a type this
+    // field does not contain, which is the more surprising of the two.
+    unapplied(reach.len_applied(), ty, leaf)?;
+    reach.max_len.ok_or_else(|| {
         syn::Error::new(
             ty.span(),
-            "`max_count` reached a string or byte slice; use `max_len`",
+            format!("this field bottoms out in {leaf}, whose limit is `max_len`"),
         )
     })
+}
+
+/// Refuse an option that reached the bottom of a field without finding the
+/// type it describes.
+///
+/// Dropping one silently would produce a codec that looks constrained and is
+/// not, which is the failure this derive exists to rule out.
+fn unapplied(reach: attr::Reach, ty: &Type, leaf: &str) -> Result<()> {
+    let name = if reach.max_len.is_some() {
+        "`max_len`"
+    } else if reach.max_count.is_some() {
+        "`max_count`"
+    } else if reach.encoding.is_some() {
+        "`varint`/`varlong`"
+    } else {
+        return Ok(());
+    };
+    Err(syn::Error::new(
+        ty.span(),
+        format!("{name} found nothing to apply to: this field bottoms out in {leaf}"),
+    ))
 }
 
 fn count_limit(max: Option<usize>) -> TokenStream {

--- a/crates/hyperion-minecraft-proto-derive/src/expand.rs
+++ b/crates/hyperion-minecraft-proto-derive/src/expand.rs
@@ -190,7 +190,9 @@ enum Shape<'a> {
     Str,
     /// `&[u8]`, whose limit is a byte count rather than a character count.
     Bytes,
-    /// Anything else, which carries its own `Encode`/`Decode`.
+    /// Anything else. This is where the walk stops, so it is both the type
+    /// that carries its own `Encode`/`Decode` and the integer an encoding
+    /// attribute was reaching for.
     Opaque,
 }
 
@@ -312,6 +314,8 @@ fn decode_value(ty: &Type, options: &attr::Field) -> Result<TokenStream> {
     decode_reaching(ty, options.reach)
 }
 
+/// Decode a field by the same walk [`encode_reaching`] makes, so that the two
+/// stop at the same type and read what the other wrote.
 fn decode_reaching(ty: &Type, reach: attr::Reach) -> Result<TokenStream> {
     let krate = krate();
     match shape(ty) {

--- a/crates/hyperion-minecraft-proto-derive/src/lib.rs
+++ b/crates/hyperion-minecraft-proto-derive/src/lib.rs
@@ -41,15 +41,27 @@
 //!
 //! | attribute | effect |
 //! | --- | --- |
+//! | `#[proto(varint)]` | write the innermost `i32` seven bits per byte |
+//! | `#[proto(varlong)]` | write the innermost `i64` seven bits per byte |
 //! | `#[proto(max_len = N)]` | limit on the innermost string, in UTF-16 code units |
 //! | `#[proto(max_count = N)]` | limit on the innermost collection's element count |
 //! | `#[proto(with = path)]` | use `path::encode` and `path::decode` for this field |
 //!
-//! `max_len` and `max_count` thread through `Option<_>` and `Vec<_>` to the
-//! type they constrain, so `#[proto(max_len = 1024)] pages: Vec<&'a str>`
-//! bounds each page rather than the list. Both limits are enforced on write as
-//! well as on read: the server checks on read only, but a value that cannot be
-//! read is one that should never have been sent.
+//! How wide a number is belongs to the value and lives in its type; how many
+//! bytes it costs belongs to the wire and lives here. A field is therefore
+//! `#[proto(varint)] pub entity_id: i32`, and a caller writes `entity_id: 42`.
+//!
+//! Every one of these describes a type nested somewhere under the field's own,
+//! so the derive walks through `Option<_>` and `Vec<_>` until it finds it:
+//! `#[proto(max_len = 1024)] pages: Vec<&'a str>` bounds each page rather than
+//! the list, and `#[proto(varint)] passengers: Vec<i32>` writes each id as a
+//! `VarInt` while the count keeps its own encoding. Reaching the bottom of a
+//! field with something still unapplied is a compile error, since a codec that
+//! looks constrained and is not is the failure this derive exists to rule out.
+//!
+//! Limits are enforced on write as well as on read: the server checks on read
+//! only, but a value that cannot be read is one that should never have been
+//! sent.
 //!
 //! [`Error::InvalidEnum`]: ../hyperion_minecraft_proto/enum.Error.html
 

--- a/crates/hyperion-minecraft-proto/README.md
+++ b/crates/hyperion-minecraft-proto/README.md
@@ -32,15 +32,34 @@ committed copy can disagree with the filter.
 ## What a generated packet looks like
 
 ```rust
-use hyperion_minecraft_proto::{PROTOCOL_VERSION, VarInt, packets::handshake, types::ClientIntent};
+use hyperion_minecraft_proto::{PROTOCOL_VERSION, packets::handshake, types::ClientIntent};
 
 let hello = handshake::serverbound::Intention {
-    protocol_version: VarInt(PROTOCOL_VERSION),
+    protocol_version: PROTOCOL_VERSION,
     host_name: "localhost",
     port: 25565,
     intention: ClientIntent::Login,
 };
 ```
+
+A number is a number. How many bytes it costs on the wire is the wire's
+business, so the struct behind that call site is
+
+```rust,ignore
+pub struct Intention<'a> {
+    #[proto(varint)]
+    pub protocol_version: i32,
+    #[proto(max_len = 32767)]
+    pub host_name: &'a str,
+    pub port: i16,
+    pub intention: ClientIntent,
+}
+```
+
+and `VarInt` never appears where a caller has to type it. A type still appears
+where it means something the wire distinguishes and Rust does not: `BlockPos`
+is eight bytes with three coordinates in them, and `RegistryId` is an index
+into a named registry rather than a count.
 
 177 of the 180 packet classes whose layout the extractor recovered in full are
 generated. **A layout it could not follow all the way has no struct at all**, so

--- a/crates/hyperion-minecraft-proto/build.rs
+++ b/crates/hyperion-minecraft-proto/build.rs
@@ -320,12 +320,52 @@ struct Traits {
     eq: bool,
 }
 
+/// How the wire writes an integer, where its Rust type does not say.
+///
+/// A field is the plain integer plus the attribute naming the encoding, since
+/// how many bytes a number costs is the wire's business and not the caller's.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Encoding {
+    VarInt,
+    VarLong,
+}
+
+impl Encoding {
+    /// What the field's `#[proto(...)]` says.
+    const fn attribute(self) -> &'static str {
+        match self {
+            Self::VarInt => "varint",
+            Self::VarLong => "varlong",
+        }
+    }
+
+    /// The Rust type a field with this encoding has.
+    const fn plain(self) -> &'static str {
+        match self {
+            Self::VarInt => "i32",
+            Self::VarLong => "i64",
+        }
+    }
+
+    /// The type that carries the encoding itself, for a position no attribute
+    /// reaches.
+    const fn wrapper(self) -> &'static str {
+        match self {
+            Self::VarInt => "VarInt",
+            Self::VarLong => "VarLong",
+        }
+    }
+}
+
 /// A lowered field or element type.
 #[derive(Clone)]
 struct Lowered {
     ty: String,
     traits: Traits,
     limits: Limits,
+    /// Set when `ty` is a plain integer whose wire form the field's attribute
+    /// has to name.
+    encoding: Option<Encoding>,
     doc: Option<String>,
     /// A module supplying the whole field's codec, where the derive's
     /// structural rules do not describe the layout.
@@ -338,12 +378,14 @@ impl Lowered {
             ty: ty.to_owned(),
             traits,
             limits: Limits::default(),
+            encoding: None,
             doc: None,
             with: None,
         }
     }
 
-    /// Put this type inside a combinator, keeping what still applies.
+    /// Put this type inside a combinator the derive threads a field attribute
+    /// through, which is `Option` and `Vec`.
     fn wrap(self, ty: String, copy: bool) -> Result<Self, String> {
         if self.with.is_some() {
             // The derive applies a custom codec to a whole field, so it cannot
@@ -361,6 +403,28 @@ impl Lowered {
             doc: None,
             ..self
         })
+    }
+
+    /// The `#[proto(...)]` attribute this type needs where it is used as a
+    /// field, if any.
+    ///
+    /// The encoding comes first because it says what the value is; the limits
+    /// only say how much of it there may be.
+    fn attribute(&self) -> Option<String> {
+        if let Some(with) = self.with {
+            return Some(format!("#[proto(with = {with})]"));
+        }
+        let mut parts = Vec::new();
+        if let Some(encoding) = self.encoding {
+            parts.push(encoding.attribute().to_owned());
+        }
+        if let Some(len) = self.limits.len {
+            parts.push(format!("max_len = {len}"));
+        }
+        if let Some(count) = self.limits.count {
+            parts.push(format!("max_count = {count}"));
+        }
+        (!parts.is_empty()).then(|| format!("#[proto({})]", parts.join(", ")))
     }
 }
 
@@ -383,16 +447,6 @@ impl Limits {
         })
     }
 
-    fn render(self) -> Option<String> {
-        let mut parts = Vec::new();
-        if let Some(len) = self.len {
-            parts.push(format!("max_len = {len}"));
-        }
-        if let Some(count) = self.count {
-            parts.push(format!("max_count = {count}"));
-        }
-        (!parts.is_empty()).then(|| format!("#[proto({})]", parts.join(", ")))
-    }
 }
 
 fn pick(a: Option<u64>, b: Option<u64>, what: &str) -> Result<Option<u64>, String> {
@@ -670,31 +724,36 @@ const REFUSED: &str = "//\n// Layouts the extractor recovered in full but this g
 
 /// A scalar wire kind and its Rust spelling, with the derives it permits.
 ///
+/// The width of a number is the value's own property and is in the type; how
+/// many bytes it costs is the wire's, and is in the encoding column, which
+/// becomes the field's `#[proto(...)]`. That is why `varint` and `i32` share
+/// a Rust type and differ only in the third column.
+///
 /// Anything not listed has no Rust spelling yet, and a packet that reaches one
 /// goes unwritten rather than approximated.
-const SCALARS: [(&str, &str, bool, bool, bool); 21] = [
-    // kind, rust type, borrows, copy, eq
-    ("unit", "()", false, true, true),
-    ("bool", "bool", false, true, true),
-    ("i8", "i8", false, true, true),
-    ("u8", "u8", false, true, true),
-    ("i16", "i16", false, true, true),
-    ("u16", "u16", false, true, true),
-    ("i32", "i32", false, true, true),
-    ("i64", "i64", false, true, true),
-    ("f32", "f32", false, true, false),
-    ("f64", "f64", false, true, false),
-    ("varint", "VarInt", false, true, true),
-    ("varlong", "VarLong", false, true, true),
-    ("uuid", "Uuid", false, true, true),
-    ("block_pos", "BlockPos", false, true, true),
-    ("chunk_pos", "ChunkPos", false, true, true),
-    ("block_hit_result", "BlockHitResult", false, true, false),
-    ("identifier", "Identifier<'a>", true, true, true),
-    ("string", "&'a str", true, true, true),
-    ("byte_array", "&'a [u8]", true, true, true),
-    ("long_array", "Vec<i64>", false, false, true),
-    ("varint_array", "Vec<VarInt>", false, false, true),
+const SCALARS: [(&str, &str, Option<Encoding>, bool, bool, bool); 21] = [
+    // kind, rust type, encoding, borrows, copy, eq
+    ("unit", "()", None, false, true, true),
+    ("bool", "bool", None, false, true, true),
+    ("i8", "i8", None, false, true, true),
+    ("u8", "u8", None, false, true, true),
+    ("i16", "i16", None, false, true, true),
+    ("u16", "u16", None, false, true, true),
+    ("i32", "i32", None, false, true, true),
+    ("i64", "i64", None, false, true, true),
+    ("f32", "f32", None, false, true, false),
+    ("f64", "f64", None, false, true, false),
+    ("varint", "i32", Some(Encoding::VarInt), false, true, true),
+    ("varlong", "i64", Some(Encoding::VarLong), false, true, true),
+    ("uuid", "Uuid", None, false, true, true),
+    ("block_pos", "BlockPos", None, false, true, true),
+    ("chunk_pos", "ChunkPos", None, false, true, true),
+    ("block_hit_result", "BlockHitResult", None, false, true, false),
+    ("identifier", "Identifier<'a>", None, true, true, true),
+    ("string", "&'a str", None, true, true, true),
+    ("byte_array", "&'a [u8]", None, true, true, true),
+    ("long_array", "Vec<i64>", None, false, false, true),
+    ("varint_array", "Vec<i32>", Some(Encoding::VarInt), false, false, true),
 ];
 
 /// Types the generated code may name, all re-exported at the crate root so
@@ -763,8 +822,11 @@ impl Generator<'_> {
         }
 
         let kind = wire["kind"].as_str().unwrap_or("unresolved");
-        if let Some(&(_, ty, borrows, copy, eq)) = SCALARS.iter().find(|entry| entry.0 == kind) {
+        if let Some(&(_, ty, encoding, borrows, copy, eq)) =
+            SCALARS.iter().find(|entry| entry.0 == kind)
+        {
             let mut lowered = Lowered::scalar(ty, Traits { borrows, copy, eq });
+            lowered.encoding = encoding;
             // A string's limit is UTF-16 code units and a byte array's is
             // bytes; `max_len` means "the length this type is measured in".
             if matches!(kind, "string" | "byte_array") {
@@ -816,20 +878,27 @@ impl Generator<'_> {
             }
             "list" => {
                 let inner = self.lower(&wire["of"], at, scope, &singular(label))?;
+                if inner.limits.count.is_some() {
+                    // One field carries one collection limit, and it would be
+                    // applied to the outer list rather than to this one.
+                    return Err("two collection limits in one field".to_owned());
+                }
                 let ty = format!("Vec<{}>", inner.ty);
                 let count = wire["max"].as_u64();
                 let mut out = inner.wrap(ty, false)?;
-                out.limits = out.limits.merge(Limits { len: None, count })?;
+                out.limits.count = count;
                 Ok(out)
             }
             "length_prefixed" => {
                 let inner = self.lower(&wire["of"], at, scope, label)?;
+                let inner = self.seal(inner, at)?;
                 self.note_import(at, "LengthPrefixed");
                 let ty = format!("LengthPrefixed<{}>", inner.ty);
                 inner.wrap(ty, true)
             }
             "holder" => {
                 let inner = self.lower(&wire["of"], at, scope, label)?;
+                let inner = self.seal(inner, at)?;
                 self.note_import(at, "Holder");
                 let ty = format!("Holder<{}>", inner.ty);
                 let doc = wire["registry"]
@@ -842,25 +911,22 @@ impl Generator<'_> {
             }
             "either" => {
                 let left = self.lower(&wire["left"], at, scope, label)?;
+                let left = self.seal(left, at)?;
                 let right = self.lower(&wire["right"], at, scope, label)?;
-                self.note_import(at, "Either");
-                let ty = format!("Either<{}, {}>", left.ty, right.ty);
-                let limits = left.limits.merge(right.limits)?;
-                let traits = Traits {
-                    borrows: left.traits.borrows || right.traits.borrows,
-                    copy: left.traits.copy && right.traits.copy,
-                    eq: left.traits.eq && right.traits.eq,
-                };
-                let merged = Lowered {
-                    limits,
-                    ..Lowered::scalar(&ty, traits)
-                };
+                let right = self.seal(right, at)?;
                 if left.with.is_some() || right.with.is_some() {
                     return Err(
                         "a custom codec inside `Either` needs a hand-written packet".to_owned()
                     );
                 }
-                Ok(merged)
+                self.note_import(at, "Either");
+                let ty = format!("Either<{}, {}>", left.ty, right.ty);
+                let traits = Traits {
+                    borrows: left.traits.borrows || right.traits.borrows,
+                    copy: left.traits.copy && right.traits.copy,
+                    eq: left.traits.eq && right.traits.eq,
+                };
+                Ok(Lowered::scalar(&ty, traits))
             }
             "enum" => self.lower_enum(wire, at, scope),
             "map" => self.lower_map(wire, at, scope, label),
@@ -1001,6 +1067,27 @@ impl Generator<'_> {
         let result = self.define_named(reference, &target, at, scope);
         self.active.remove(reference);
         result
+    }
+
+    /// Give a lowered value a type that describes its own wire form, for a
+    /// position no field attribute reaches.
+    ///
+    /// The derive threads `#[proto(...)]` through `Option` and `Vec` and no
+    /// further, so an integer under `Holder`, `LengthPrefixed` or `Either`
+    /// goes back to the wrapper type that carries its encoding. A limit has no
+    /// such spelling, so a field wanting one there is refused rather than
+    /// generated without it.
+    fn seal(&mut self, mut lowered: Lowered, at: &Place) -> Result<Lowered, String> {
+        if lowered.limits != Limits::default() {
+            return Err("a limit inside this combinator needs a hand-written packet".to_owned());
+        }
+        if let Some(encoding) = lowered.encoding.take() {
+            // Only `i32` and `i64` ever carry an encoding, and only under
+            // `Option` and `Vec`, so this cannot rewrite an unrelated name.
+            lowered.ty = lowered.ty.replace(encoding.plain(), encoding.wrapper());
+            self.note_import(at, encoding.wrapper());
+        }
+        Ok(lowered)
     }
 
     /// Record that a file names one of the crate's own types.
@@ -1212,10 +1299,8 @@ impl Generator<'_> {
             }
             let _unused = writeln!(out, "#[derive({})]", derive_list(lowered.traits).join(", "));
             let attr = lowered
-                .with
-                .map(|with| format!("#[proto(with = {with})] "))
-                .or_else(|| lowered.limits.render().map(|attr| format!("{attr} ")))
-                .unwrap_or_default();
+                .attribute()
+                .map_or_else(String::new, |attr| format!("{attr} "));
             let _unused = writeln!(
                 out,
                 "pub struct {name}{lifetime}({attr}pub {});",
@@ -1266,9 +1351,7 @@ impl Generator<'_> {
             if let Some(doc) = &lowered.doc {
                 let _unused = writeln!(out, "    /// {doc}");
             }
-            if let Some(with) = lowered.with {
-                let _unused = writeln!(out, "    #[proto(with = {with})]");
-            } else if let Some(attr) = lowered.limits.render() {
+            if let Some(attr) = lowered.attribute() {
                 let _unused = writeln!(out, "    {attr}");
             }
             let _unused = writeln!(out, "    pub {rust}: {},", lowered.ty);

--- a/crates/hyperion-minecraft-proto/build.rs
+++ b/crates/hyperion-minecraft-proto/build.rs
@@ -446,7 +446,6 @@ impl Limits {
             count: pick(self.count, other.count, "max_count")?,
         })
     }
-
 }
 
 fn pick(a: Option<u64>, b: Option<u64>, what: &str) -> Result<Option<u64>, String> {
@@ -722,38 +721,62 @@ const REFUSED: &str = "//\n// Layouts the extractor recovered in full but this g
 // Lowering a wire tree to Rust
 // ---------------------------------------------------------------------------
 
+/// A plain value: copied freely, compared exactly, owning its own bytes.
+const VALUE: Traits = Traits {
+    borrows: false,
+    copy: true,
+    eq: true,
+};
+/// A value with a float somewhere in it, which rules out `Eq` and `Hash`.
+const FLOATING: Traits = Traits { eq: false, ..VALUE };
+/// A value that points into the buffer it was read from.
+const BORROWED: Traits = Traits {
+    borrows: true,
+    ..VALUE
+};
+/// A heap-allocated list, which rules out `Copy`.
+const LIST: Traits = Traits {
+    copy: false,
+    ..VALUE
+};
+/// An NBT tree: borrowed, heap-backed, and with floats in it.
+const NBT: Traits = Traits {
+    borrows: true,
+    copy: false,
+    eq: false,
+};
+
 /// A scalar wire kind and its Rust spelling, with the derives it permits.
 ///
-/// The width of a number is the value's own property and is in the type; how
-/// many bytes it costs is the wire's, and is in the encoding column, which
-/// becomes the field's `#[proto(...)]`. That is why `varint` and `i32` share
-/// a Rust type and differ only in the third column.
+/// How wide a number is belongs to the value and is in the type column; how
+/// many bytes it costs belongs to the wire and is in the encoding column,
+/// which becomes the field's `#[proto(...)]`. That is why `varint` and `i32`
+/// share a Rust type and differ only in the third column.
 ///
 /// Anything not listed has no Rust spelling yet, and a packet that reaches one
 /// goes unwritten rather than approximated.
-const SCALARS: [(&str, &str, Option<Encoding>, bool, bool, bool); 21] = [
-    // kind, rust type, encoding, borrows, copy, eq
-    ("unit", "()", None, false, true, true),
-    ("bool", "bool", None, false, true, true),
-    ("i8", "i8", None, false, true, true),
-    ("u8", "u8", None, false, true, true),
-    ("i16", "i16", None, false, true, true),
-    ("u16", "u16", None, false, true, true),
-    ("i32", "i32", None, false, true, true),
-    ("i64", "i64", None, false, true, true),
-    ("f32", "f32", None, false, true, false),
-    ("f64", "f64", None, false, true, false),
-    ("varint", "i32", Some(Encoding::VarInt), false, true, true),
-    ("varlong", "i64", Some(Encoding::VarLong), false, true, true),
-    ("uuid", "Uuid", None, false, true, true),
-    ("block_pos", "BlockPos", None, false, true, true),
-    ("chunk_pos", "ChunkPos", None, false, true, true),
-    ("block_hit_result", "BlockHitResult", None, false, true, false),
-    ("identifier", "Identifier<'a>", None, true, true, true),
-    ("string", "&'a str", None, true, true, true),
-    ("byte_array", "&'a [u8]", None, true, true, true),
-    ("long_array", "Vec<i64>", None, false, false, true),
-    ("varint_array", "Vec<i32>", Some(Encoding::VarInt), false, false, true),
+const SCALARS: [(&str, &str, Option<Encoding>, Traits); 21] = [
+    ("unit", "()", None, VALUE),
+    ("bool", "bool", None, VALUE),
+    ("i8", "i8", None, VALUE),
+    ("u8", "u8", None, VALUE),
+    ("i16", "i16", None, VALUE),
+    ("u16", "u16", None, VALUE),
+    ("i32", "i32", None, VALUE),
+    ("i64", "i64", None, VALUE),
+    ("f32", "f32", None, FLOATING),
+    ("f64", "f64", None, FLOATING),
+    ("varint", "i32", Some(Encoding::VarInt), VALUE),
+    ("varlong", "i64", Some(Encoding::VarLong), VALUE),
+    ("uuid", "Uuid", None, VALUE),
+    ("block_pos", "BlockPos", None, VALUE),
+    ("chunk_pos", "ChunkPos", None, VALUE),
+    ("block_hit_result", "BlockHitResult", None, FLOATING),
+    ("identifier", "Identifier<'a>", None, BORROWED),
+    ("string", "&'a str", None, BORROWED),
+    ("byte_array", "&'a [u8]", None, BORROWED),
+    ("long_array", "Vec<i64>", None, LIST),
+    ("varint_array", "Vec<i32>", Some(Encoding::VarInt), LIST),
 ];
 
 /// Types the generated code may name, all re-exported at the crate root so
@@ -822,10 +845,8 @@ impl Generator<'_> {
         }
 
         let kind = wire["kind"].as_str().unwrap_or("unresolved");
-        if let Some(&(_, ty, encoding, borrows, copy, eq)) =
-            SCALARS.iter().find(|entry| entry.0 == kind)
-        {
-            let mut lowered = Lowered::scalar(ty, Traits { borrows, copy, eq });
+        if let Some(&(_, ty, encoding, traits)) = SCALARS.iter().find(|entry| entry.0 == kind) {
+            let mut lowered = Lowered::scalar(ty, traits);
             lowered.encoding = encoding;
             // A string's limit is UTF-16 code units and a byte array's is
             // bytes; `max_len` means "the length this type is measured in".
@@ -843,20 +864,12 @@ impl Generator<'_> {
                     doc: wire["registry"]
                         .as_str()
                         .map(|registry| format!("Index into `{registry}`.")),
-                    ..Lowered::scalar("RegistryId", Traits {
-                        borrows: false,
-                        copy: true,
-                        eq: true,
-                    })
+                    ..Lowered::scalar("RegistryId", VALUE)
                 })
             }
             "nbt" => {
                 self.note_import(at, "nbt");
-                Ok(Lowered::scalar("nbt::Tag<'a>", Traits {
-                    borrows: true,
-                    copy: false,
-                    eq: false,
-                }))
+                Ok(Lowered::scalar("nbt::Tag<'a>", NBT))
             }
             // A root `TAG_End` means absent here, which is not the
             // boolean-prefixed `Option` the derive writes by default.
@@ -864,11 +877,7 @@ impl Generator<'_> {
                 self.note_import(at, "nbt");
                 Ok(Lowered {
                     with: Some("crate::nbt::optional"),
-                    ..Lowered::scalar("Option<nbt::Tag<'a>>", Traits {
-                        borrows: true,
-                        copy: false,
-                        eq: false,
-                    })
+                    ..Lowered::scalar("Option<nbt::Tag<'a>>", NBT)
                 })
             }
             "option" => {
@@ -986,11 +995,7 @@ impl Generator<'_> {
         let placed = Placed {
             place,
             name,
-            traits: Traits {
-                borrows: false,
-                copy: true,
-                eq: true,
-            },
+            traits: VALUE,
         };
         self.placed.insert(owner.to_owned(), placed.clone());
         Ok(Lowered::scalar(&self.reference(&placed, at), placed.traits))
@@ -1282,11 +1287,7 @@ impl Generator<'_> {
                 "#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Encode, Decode)]\n",
             );
             let _unused = writeln!(out, "pub struct {name};");
-            return Ok((out, Traits {
-                borrows: false,
-                copy: true,
-                eq: true,
-            }));
+            return Ok((out, VALUE));
         }
         if kind != "struct" {
             // One value with nothing around it: the server's codec for
@@ -1311,11 +1312,9 @@ impl Generator<'_> {
 
         let empty = Vec::new();
         let mut fields = Vec::new();
-        let mut traits = Traits {
-            borrows: false,
-            copy: true,
-            eq: true,
-        };
+        // The derives start at the most permissive and each field takes away
+        // what it cannot support.
+        let mut traits = VALUE;
         let mut seen: BTreeSet<String> = BTreeSet::new();
         for field in resolved["fields"].as_array().unwrap_or(&empty) {
             let label = field["name"].as_str().unwrap_or("value");

--- a/crates/hyperion-minecraft-proto/src/types.rs
+++ b/crates/hyperion-minecraft-proto/src/types.rs
@@ -1,24 +1,30 @@
 //! The value types a packet field can have.
 //!
 //! Each one exists because the wire distinguishes something Rust's primitives
-//! do not. A `VarInt` and an `i32` are both 32-bit signed integers and are
-//! different numbers of bytes; a [`BlockPos`] and an `i64` are the same eight
-//! bytes and mean different things. Giving each its own type is what lets
-//! `#[derive(Encode, Decode)]` read a field's wire form off its Rust type
-//! instead of being told.
+//! do not: a [`BlockPos`] and an `i64` are the same eight bytes and mean
+//! different things.
+//!
+//! How many bytes a *number* costs is not one of those distinctions. That is
+//! the wire's choice about a value Rust already has a type for, so it lives in
+//! `#[proto(varint)]` on the field rather than in a wrapper the caller has to
+//! spell; see [`crate::Encode`]'s derive. [`VarInt`] and [`VarLong`] remain
+//! for the positions an attribute cannot reach, such as inside an [`Either`].
 
 use std::fmt;
 
 use crate::{Decode, Encode, Error, Reader, Result, Writer, codec};
 
-/// A 32-bit signed integer written seven bits per byte.
+/// An `i32` that carries its own seven-bits-per-byte encoding.
 ///
-/// Most integers in the protocol are this rather than a fixed four bytes,
-/// which is why it is the type that appears and `i32` is the exception.
+/// A packet field says this with `#[proto(varint)]` and stays an `i32`. This
+/// type is for the positions where no attribute reaches the value: a type
+/// parameter of [`Either`], [`Holder`] or [`LengthPrefixed`], and the codec
+/// layer's own plumbing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct VarInt(pub i32);
 
-/// A 64-bit signed integer written seven bits per byte.
+/// An `i64` that carries its own seven-bits-per-byte encoding, as [`VarInt`]
+/// does for `i32`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct VarLong(pub i64);
 

--- a/crates/hyperion-minecraft-proto/tests/derive.rs
+++ b/crates/hyperion-minecraft-proto/tests/derive.rs
@@ -3,9 +3,7 @@
 //! These are the shapes the generator emits, exercised on hand-written types
 //! so a failure points at the derive rather than at a packet layout.
 
-use hyperion_minecraft_proto::{
-    Decode, Encode, Error, Identifier, Reader, Result, Uuid, VarInt, Writer,
-};
+use hyperion_minecraft_proto::{Decode, Encode, Error, Identifier, Reader, Result, Uuid, Writer};
 
 fn round_trip<'a, T>(value: &T, bytes: &'a [u8])
 where
@@ -30,16 +28,48 @@ fn a_unit_struct_occupies_no_bytes() {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
-struct Newtype(VarInt);
+struct Newtype(#[proto(varint)] i32);
 
 #[test]
 fn a_newtype_is_its_field() {
-    round_trip(&Newtype(VarInt(300)), &[0xAC, 0x02]);
+    round_trip(&Newtype(300), &[0xAC, 0x02]);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
+struct Encodings {
+    plain: i32,
+    #[proto(varint)]
+    short: i32,
+    #[proto(varlong)]
+    long: i64,
+    #[proto(varint)]
+    maybe: Option<i32>,
+}
+
+#[test]
+fn an_encoding_attribute_selects_the_wire_form_of_a_plain_integer() {
+    // The same 300 four ways: four fixed bytes, two `VarInt` bytes, two
+    // `VarLong` bytes, and the same again behind a present-flag.
+    round_trip(
+        &Encodings {
+            plain: 300,
+            short: 300,
+            long: 300,
+            maybe: Some(300),
+        },
+        &[
+            0x00, 0x00, 0x01, 0x2C, // plain
+            0xAC, 0x02, // short
+            0xAC, 0x02, // long
+            0x01, 0xAC, 0x02, // maybe
+        ],
+    );
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
 struct Fields<'a> {
-    count: VarInt,
+    #[proto(varint)]
+    count: i32,
     flag: bool,
     name: &'a str,
     id: Uuid,
@@ -49,7 +79,7 @@ struct Fields<'a> {
 fn fields_are_written_in_declaration_order() {
     round_trip(
         &Fields {
-            count: VarInt(1),
+            count: 1,
             flag: true,
             name: "hi",
             id: Uuid(0),
@@ -64,8 +94,8 @@ fn fields_are_written_in_declaration_order() {
 struct Bounded<'a> {
     #[proto(max_len = 4)]
     short: &'a str,
-    #[proto(max_count = 2)]
-    few: Vec<VarInt>,
+    #[proto(varint, max_count = 2)]
+    few: Vec<i32>,
     #[proto(max_len = 3)]
     maybe: Option<&'a str>,
     #[proto(max_len = 2)]
@@ -77,7 +107,7 @@ fn limits_reach_the_type_they_constrain() {
     round_trip(
         &Bounded {
             short: "abcd",
-            few: vec![VarInt(7)],
+            few: vec![7],
             maybe: Some("xy"),
             pages: vec!["a", "b"],
         },
@@ -194,7 +224,8 @@ fn with_replaces_the_whole_field_codec() {
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 struct Nested<'a> {
-    outer: VarInt,
+    #[proto(varint)]
+    outer: i32,
     inner: Fields<'a>,
     list: Vec<Fields<'a>>,
     id: Option<Identifier<'a>>,
@@ -203,7 +234,7 @@ struct Nested<'a> {
 #[test]
 fn nested_structs_delegate_to_their_own_codecs() {
     let inner = Fields {
-        count: VarInt(2),
+        count: 2,
         flag: false,
         name: "a",
         id: Uuid(1),
@@ -217,7 +248,7 @@ fn nested_structs_delegate_to_their_own_codecs() {
     expected.push(0x00);
     round_trip(
         &Nested {
-            outer: VarInt(9),
+            outer: 9,
             inner,
             list: vec![inner],
             id: None,

--- a/crates/hyperion-minecraft-proto/tests/live_server.rs
+++ b/crates/hyperion-minecraft-proto/tests/live_server.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use hyperion_minecraft_proto::{
-    Decode, Encode, PROTOCOL_VERSION, Reader, VarInt, Writer,
+    Decode, Encode, PROTOCOL_VERSION, Reader, Writer,
     packets::{
         handshake::serverbound::Intention,
         status::{
@@ -88,7 +88,7 @@ fn status_ping_against_real_server() {
 
     // Handshake, then status request, in one write the way a real client does.
     let handshake = Intention {
-        protocol_version: VarInt(PROTOCOL_VERSION),
+        protocol_version: PROTOCOL_VERSION,
         host_name: host,
         port,
         intention: ClientIntent::Status,

--- a/crates/hyperion-minecraft-proto/tests/wire.rs
+++ b/crates/hyperion-minecraft-proto/tests/wire.rs
@@ -6,7 +6,7 @@
 //! handing bytes to a real 26.2 server and reading back what it sends.
 
 use hyperion_minecraft_proto::{
-    Decode, Encode, Error, Identifier, PROTOCOL_VERSION, Reader, Uuid, VarInt, Writer,
+    Decode, Encode, Error, Identifier, PROTOCOL_VERSION, Reader, Uuid, Writer,
     packets::{
         common::serverbound::{CookieResponse, PingRequest},
         configuration::clientbound::SelectKnownPacks,
@@ -148,7 +148,7 @@ fn truncated_input_is_an_error_not_a_default() {
 #[test]
 fn intention_round_trips() {
     let packet = Intention {
-        protocol_version: VarInt(PROTOCOL_VERSION),
+        protocol_version: PROTOCOL_VERSION,
         host_name: "localhost",
         port: 25565,
         intention: ClientIntent::Login,
@@ -254,11 +254,9 @@ fn login_hello_request_round_trips() {
 
 #[test]
 fn login_compression_round_trips() {
-    round_trip(&LoginCompression(VarInt(256)), &[0x80, 0x02]);
+    round_trip(&LoginCompression(256), &[0x80, 0x02]);
     // A negative threshold disables compression and needs the full five bytes.
-    round_trip(&LoginCompression(VarInt(-1)), &[
-        0xFF, 0xFF, 0xFF, 0xFF, 0x0F,
-    ]);
+    round_trip(&LoginCompression(-1), &[0xFF, 0xFF, 0xFF, 0xFF, 0x0F]);
 }
 
 #[test]

--- a/crates/hyperion/src/net/protocol/pre_play.rs
+++ b/crates/hyperion/src/net/protocol/pre_play.rs
@@ -38,7 +38,7 @@ use hyperion_minecraft_proto::{
         status::clientbound::{PongResponse, StatusResponse},
     },
     types::{
-        ClientIntent, GameProfile, Identifier, Uuid as ProtoUuid, VarInt,
+        ClientIntent, GameProfile, Identifier, Uuid as ProtoUuid,
         registry_synchronization::PackedRegistryEntry,
     },
 };
@@ -137,11 +137,11 @@ fn handshake(world: &World) {
                 // path. A client on any version may ping, and answering the
                 // ping is how it learns which version to be.
                 if intention.intention != ClientIntent::Status
-                    && intention.protocol_version.0 != PROTOCOL_VERSION
+                    && intention.protocol_version != PROTOCOL_VERSION
                 {
                     warn!(
                         "client speaks protocol {} but this server speaks {PROTOCOL_VERSION}",
-                        intention.protocol_version.0
+                        intention.protocol_version
                     );
                 }
 
@@ -343,7 +343,7 @@ fn login_hello(
         compose,
         connection_id,
         packet_id::login::clientbound::PacketId::LoginCompression.to_raw(),
-        &LoginCompression(VarInt(threshold.0)),
+        &LoginCompression(threshold.0),
     )?;
     decoder.set_compression(threshold);
 


### PR DESCRIPTION
A packet field is now the integer itself, and `#[proto(varint)]` says how it
goes out.

```rust
// before
pub struct UpdateAttributes<'a> {
    pub entity_id: VarInt,
    #[proto(max_count = 128)]
    pub values: Vec<update_attributes::AttributeSnapshot<'a>>,
}

// after
pub struct UpdateAttributes<'a> {
    #[proto(varint)]
    pub entity_id: i32,
    #[proto(max_count = 128)]
    pub values: Vec<update_attributes::AttributeSnapshot<'a>>,
}
```

How many bytes a number costs is the wire's business, not the caller's, so it
belongs in an attribute the derive reads rather than in a wrapper every call
site has to spell. `entity_id: 42` is right; `entity_id: VarInt(42)` was
ceremony.

## What the derive gained

`varint` and `varlong` thread through `Option<_>` and `Vec<_>` to the integer
they describe, exactly as `max_len` and `max_count` already reach the string
and the collection they constrain. `#[proto(varint)] passengers: Vec<i32>`
writes each id as a `VarInt` while the count keeps its own encoding.

Reaching the bottom of a field with an option still unapplied is now a compile
error rather than a silent drop. That hole was real: `#[proto(max_count = 32)]`
landing on an `Either` produced a codec that looked limited and was not. The
generator refuses the same shapes rather than emitting them, so coverage stays
honest at **177 layouts generated and 3 declined**.

## What did not change

The wire format. Every byte-level assertion in the suite passes untouched, and
the generated diff is exactly the type-and-attribute swap plus two rewrapped
`use` lines.

`VarInt` and `VarLong` still exist for the positions no attribute reaches. The
only one in the generated surface is `Either<VarInt, nbt::Tag>` in
`ServerLinks$UntrustedEntry`, because `Either` has two branches and an
attribute cannot say which it means.

## Single-field tuple structs

Kept as tuples: `TickingStep(#[proto(varint)] pub i32)`. Mojang has a field
name for that value, but the extracted layout does not carry it -- these
packets are `ByteBufCodecs.VAR_INT` with no `composite` call, so
`protocol.json` records `{"kind": "varint"}` and nothing else. Naming the field
would mean inventing the name here. Recovering it belongs in
`nix/extract-protocol.py`, which another branch owns.

## Call-site changes

Three sites in `pre_play.rs`, all mechanical: `intention.protocol_version.0` is
now `intention.protocol_version`, and `LoginCompression(VarInt(n))` is
`LoginCompression(n)`.

## Gates

`nix run .#fmt -- --check`, `nix run .#lint` and `nix run .#test` all pass;
375 tests run, 375 passed, 1 skipped.
