### PR TITLE
feat(net): the last thirteen valence 1.20.1 packet sends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,7 +1939,6 @@ dependencies = [
  "valence_protocol",
  "valence_registry",
  "valence_server",
- "valence_text",
 ]
 
 [[package]]

--- a/crates/hyperion-clap/src/lib.rs
+++ b/crates/hyperion-clap/src/lib.rs
@@ -6,7 +6,11 @@ use flecs_ecs::{
     prelude::{Component, Module},
 };
 use hyperion::{
-    net::{Compose, ConnectionId, DataBundle, agnostic},
+    hyperion_minecraft_proto::{
+        generated::packet_id::play::clientbound::PacketId,
+        packets::play::clientbound::{CommandSuggestions, command_suggestions},
+    },
+    net::{Compose, ConnectionId, DataBundle, agnostic, protocol::Clientbound},
     simulation::{IgnMap, command::get_root_command_entity, handlers::PacketSwitchQuery},
     storage::CommandCompletionRequest,
 };
@@ -14,13 +18,7 @@ pub use hyperion_clap_macros::CommandPermission;
 pub use hyperion_command;
 use hyperion_command::{CommandHandler, CommandRegistry};
 use hyperion_permission::Group;
-use valence_protocol::{
-    VarInt,
-    packets::{
-        play,
-        play::{command_suggestions_s2c::CommandSuggestionsMatch, command_tree_s2c::StringArg},
-    },
-};
+use valence_protocol::packets::play::command_tree_s2c::StringArg;
 
 pub trait MinecraftCommand: Parser + CommandPermission {
     fn execute(self, system: EntityView<'_>, caller: Entity);
@@ -155,10 +153,10 @@ pub trait MinecraftCommand: Parser + CommandPermission {
                         return;
                     }
 
-                    let matches = substring_matches
+                    let suggestions = substring_matches
                         .map(clap::builder::PossibleValue::get_name)
-                        .map(|name| CommandSuggestionsMatch {
-                            suggested_match: name.into(),
+                        .map(|name| command_suggestions::Entry {
+                            text: name,
                             tooltip: None,
                         })
                         .collect();
@@ -169,16 +167,19 @@ pub trait MinecraftCommand: Parser + CommandPermission {
                     let start = i32::try_from(start).unwrap();
                     let len = i32::try_from(len).unwrap();
 
-                    let packet = play::CommandSuggestionsS2c {
-                        id: VarInt(id),
-                        start: VarInt(start),
-                        length: VarInt(len),
-                        matches,
+                    let packet = CommandSuggestions {
+                        id,
+                        start,
+                        length: len,
+                        suggestions,
                     };
 
                     packet_switch_query
                         .compose
-                        .unicast(&packet, packet_switch_query.io_ref)
+                        .unicast(
+                            Clientbound::new(PacketId::CommandSuggestions.to_raw(), &packet),
+                            packet_switch_query.io_ref,
+                        )
                         .unwrap();
 
                     // todo: send possible matches to player
@@ -196,10 +197,10 @@ pub trait MinecraftCommand: Parser + CommandPermission {
                     .iter()
                     .map(clap::builder::PossibleValue::get_name);
 
-                let matches = names
+                let suggestions = names
                     .into_iter()
-                    .map(|name| CommandSuggestionsMatch {
-                        suggested_match: name.into(),
+                    .map(|name| command_suggestions::Entry {
+                        text: name,
                         tooltip: None,
                     })
                     .collect();
@@ -207,16 +208,19 @@ pub trait MinecraftCommand: Parser + CommandPermission {
                 let start = full_query.len();
                 let start = i32::try_from(start).unwrap();
 
-                let packet = play::CommandSuggestionsS2c {
-                    id: VarInt(id),
-                    start: VarInt(start),
-                    length: VarInt(0),
-                    matches,
+                let packet = CommandSuggestions {
+                    id,
+                    start,
+                    length: 0,
+                    suggestions,
                 };
 
                 packet_switch_query
                     .compose
-                    .unicast(&packet, packet_switch_query.io_ref)
+                    .unicast(
+                        Clientbound::new(PacketId::CommandSuggestions.to_raw(), &packet),
+                        packet_switch_query.io_ref,
+                    )
                     .unwrap();
             },
         );

--- a/crates/hyperion-minecraft-proto/src/packets/play/chunk.rs
+++ b/crates/hyperion-minecraft-proto/src/packets/play/chunk.rs
@@ -1,11 +1,12 @@
-//! Terrain: the chunks a client renders, and the block changes inside them.
+//! The level: the chunks a client renders, the block changes inside them, and
+//! the particles spawned in them.
 //!
 //! Five packets carry terrain, and only two of them need writing by hand.
 //! `forget_level_chunk`, `chunk_batch_start`, `chunk_batch_finished` and
 //! `block_update` are plain field sequences, so the generator produced them
 //! into [`super::clientbound`] and they should be used from there.
 //!
-//! What is left is the two whose codecs branch on a runtime value:
+//! What is left is the three whose codecs branch on a runtime value:
 //!
 //! * `level_chunk_with_light` writes a length-prefixed blob whose length only
 //!   the sections themselves know. It lives in [`crate::world::chunk`] because
@@ -204,11 +205,184 @@ impl Decode<'_> for SectionBlocksUpdate {
     }
 }
 
+// --- particles ------------------------------------------------------------
+
+/// A particle, together with whatever its own codec writes after the type id
+/// (`ParticleTypes.STREAM_CODEC`).
+///
+/// That codec is `ByteBufCodecs.registry(Registries.PARTICLE_TYPE)
+/// .dispatch(ParticleOptions::getType, ParticleType::streamCodec)`: a `VarInt`
+/// id into `minecraft:particle_type`, then the body the dispatched type's own
+/// codec writes. 103 of the 125 types are a `SimpleParticleType`, whose
+/// `StreamCodec.unit` writes nothing at all; the other 22 carry options of
+/// eleven different shapes.
+///
+/// Only the types hyperion sends have a variant here. Nothing after the
+/// particle is length-prefixed, so a variant added without reading its Java
+/// codec first would not lose one field, it would shift every byte of the rest
+/// of the frame.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Particle {
+    /// `minecraft:cloud`, a `SimpleParticleType`.
+    Cloud,
+    /// `minecraft:crit`, a `SimpleParticleType`.
+    Crit,
+    /// `minecraft:dragon_breath`, a `PowerParticleOption`.
+    DragonBreath {
+        /// `PowerParticleOption.power`, which scales the puff. Vanilla's
+        /// `Codec` default is `1.0`, but the stream codec is a bare
+        /// `ByteBufCodecs.FLOAT` and always writes it.
+        power: f32,
+    },
+    /// `minecraft:explosion`, a `SimpleParticleType`.
+    Explosion,
+    /// `minecraft:portal`, a `SimpleParticleType`.
+    Portal,
+}
+
+impl Particle {
+    /// The type's `minecraft:particle_type` network id.
+    ///
+    /// Registry ids are positional, so these are indices into
+    /// [`crate::generated::registry::PARTICLE_TYPE`] and move whenever Mojang
+    /// inserts a particle. `particle_ids_match_the_registry` pins each one.
+    #[must_use]
+    pub const fn id(self) -> i32 {
+        match self {
+            Self::Cloud => 11,
+            Self::Crit => 13,
+            Self::DragonBreath { .. } => 15,
+            Self::Explosion => 30,
+            Self::Portal => 67,
+        }
+    }
+
+    /// The type's registry name.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Cloud => "minecraft:cloud",
+            Self::Crit => "minecraft:crit",
+            Self::DragonBreath { .. } => "minecraft:dragon_breath",
+            Self::Explosion => "minecraft:explosion",
+            Self::Portal => "minecraft:portal",
+        }
+    }
+}
+
+impl Encode for Particle {
+    fn encode(&self, writer: &mut Writer) -> Result<()> {
+        writer.var_int(self.id());
+        match self {
+            Self::Cloud | Self::Crit | Self::Explosion | Self::Portal => {}
+            Self::DragonBreath { power } => writer.f32(*power),
+        }
+        Ok(())
+    }
+}
+
+impl Decode<'_> for Particle {
+    fn decode(reader: &mut Reader<'_>) -> Result<Self> {
+        let id = reader.var_int()?;
+        match id {
+            11 => Ok(Self::Cloud),
+            13 => Ok(Self::Crit),
+            15 => Ok(Self::DragonBreath {
+                power: reader.f32()?,
+            }),
+            30 => Ok(Self::Explosion),
+            67 => Ok(Self::Portal),
+            // A type this server never sends is also a type whose body length
+            // is unknown, so there is nothing to skip past and the read has to
+            // stop here.
+            value => Err(Error::InvalidEnum {
+                name: "Particle",
+                value,
+            }),
+        }
+    }
+}
+
+/// `minecraft:level_particles`, clientbound
+/// (`ClientboundLevelParticlesPacket`).
+///
+/// Layout from
+/// `net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket#STREAM_CODEC`.
+/// The generator declined it because the [`Particle`] at the end is a registry
+/// dispatch: how many bytes follow is decided by the type id itself.
+///
+/// One packet spawns [`count`](Self::count) particles scattered through a box
+/// centred on the position, so a caller wanting a single particle at an exact
+/// point sends a count of one with zero distances.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LevelParticles {
+    /// `ClientboundLevelParticlesPacket.overrideLimiter`: show the particle
+    /// past the radius the client normally culls at.
+    pub override_limiter: bool,
+    /// `ClientboundLevelParticlesPacket.alwaysShow`, added in 1.21.4. The
+    /// client class that reads it is not in the decompiled subset, so what
+    /// exactly it overrides is taken from the name rather than from source;
+    /// vanilla passes false for ordinary effects.
+    pub always_show: bool,
+    /// Centre x of the spawn box.
+    pub x: f64,
+    /// Centre y of the spawn box.
+    pub y: f64,
+    /// Centre z of the spawn box.
+    pub z: f64,
+    /// Half-width of the spawn box on x, in blocks.
+    pub x_dist: f32,
+    /// Half-width of the spawn box on y, in blocks.
+    pub y_dist: f32,
+    /// Half-width of the spawn box on z, in blocks.
+    pub z_dist: f32,
+    /// Scale applied to each particle's starting velocity.
+    pub max_speed: f32,
+    /// How many particles to spawn. A fixed-width `int`, not a `VarInt`.
+    pub count: i32,
+    /// Which particle, and its options.
+    pub particle: Particle,
+}
+
+impl Encode for LevelParticles {
+    fn encode(&self, writer: &mut Writer) -> Result<()> {
+        writer.bool(self.override_limiter);
+        writer.bool(self.always_show);
+        writer.f64(self.x);
+        writer.f64(self.y);
+        writer.f64(self.z);
+        writer.f32(self.x_dist);
+        writer.f32(self.y_dist);
+        writer.f32(self.z_dist);
+        writer.f32(self.max_speed);
+        writer.i32(self.count);
+        self.particle.encode(writer)
+    }
+}
+
+impl Decode<'_> for LevelParticles {
+    fn decode(reader: &mut Reader<'_>) -> Result<Self> {
+        Ok(Self {
+            override_limiter: reader.bool()?,
+            always_show: reader.bool()?,
+            x: reader.f64()?,
+            y: reader.f64()?,
+            z: reader.f64()?,
+            x_dist: reader.f32()?,
+            y_dist: reader.f32()?,
+            z_dist: reader.f32()?,
+            max_speed: reader.f32()?,
+            count: reader.i32()?,
+            particle: Particle::decode(reader)?,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         BlockChange, ChunkData, ChunkSection, Heightmap, HeightmapKind, LevelChunkWithLight,
-        LightData, SectionBlocksUpdate, SectionPos,
+        LevelParticles, LightData, Particle, SectionBlocksUpdate, SectionPos,
     };
     use crate::{
         Decode, Encode, Reader, Writer,
@@ -321,5 +495,105 @@ mod tests {
         let mut reader = Reader::new(&bytes);
         assert_eq!(SectionBlocksUpdate::decode(&mut reader).unwrap(), packet);
         reader.finish().unwrap();
+    }
+
+    /// The ids in [`Particle::id`] are positions in the generated registry, so
+    /// a Mojang insertion moves them and this is what notices.
+    #[test]
+    fn particle_ids_match_the_registry() {
+        for particle in [
+            Particle::Cloud,
+            Particle::Crit,
+            Particle::DragonBreath { power: 1.0 },
+            Particle::Explosion,
+            Particle::Portal,
+        ] {
+            let expected = crate::generated::registry::PARTICLE_TYPE
+                .id_of(particle.name())
+                .unwrap_or_else(|| panic!("{} is a vanilla particle", particle.name()));
+            assert_eq!(
+                i32::try_from(expected).unwrap(),
+                particle.id(),
+                "{}",
+                particle.name()
+            );
+        }
+    }
+
+    /// A `SimpleParticleType` is the id and nothing else, which is what makes
+    /// the count before it the last field a reader can find unaided.
+    #[test]
+    fn a_simple_particle_is_the_bare_type_id() {
+        let packet = LevelParticles {
+            override_limiter: true,
+            always_show: false,
+            x: 1.0,
+            y: 2.0,
+            z: 3.0,
+            x_dist: 0.5,
+            y_dist: 0.5,
+            z_dist: 0.5,
+            max_speed: 0.5,
+            count: 100,
+            particle: Particle::Crit,
+        };
+
+        assert_eq!(encoded(&packet), [
+            0x01, // override_limiter
+            0x00, // always_show
+            0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // x = 1.0
+            0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // y = 2.0
+            0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // z = 3.0
+            0x3F, 0x00, 0x00, 0x00, // x_dist = 0.5
+            0x3F, 0x00, 0x00, 0x00, // y_dist = 0.5
+            0x3F, 0x00, 0x00, 0x00, // z_dist = 0.5
+            0x3F, 0x00, 0x00, 0x00, // max_speed = 0.5
+            0x00, 0x00, 0x00, 0x64, // count = 100, a fixed-width int
+            0x0D, // minecraft:crit, with no options after it
+        ]);
+
+        let bytes = encoded(&packet);
+        let mut reader = Reader::new(&bytes);
+        assert_eq!(LevelParticles::decode(&mut reader).unwrap(), packet);
+        reader.finish().unwrap();
+    }
+
+    /// `dragon_breath` is a `PowerParticleOption`, so four more bytes follow
+    /// the id that a `SimpleParticleType` would not have written.
+    #[test]
+    fn a_power_particle_writes_its_float_after_the_id() {
+        let packet = LevelParticles {
+            override_limiter: false,
+            always_show: false,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            x_dist: 0.0,
+            y_dist: 0.0,
+            z_dist: 0.0,
+            max_speed: 0.0,
+            count: 1,
+            particle: Particle::DragonBreath { power: 1.0 },
+        };
+
+        let bytes = encoded(&packet);
+        assert_eq!(
+            &bytes[bytes.len() - 5..],
+            // minecraft:dragon_breath, then power = 1.0
+            [0x0F, 0x3F, 0x80, 0x00, 0x00]
+        );
+
+        let mut reader = Reader::new(&bytes);
+        assert_eq!(LevelParticles::decode(&mut reader).unwrap(), packet);
+        reader.finish().unwrap();
+    }
+
+    /// A type with no variant has no known body length, so decoding refuses
+    /// rather than returning a particle it would then mis-skip.
+    #[test]
+    fn an_unmodelled_particle_fails_to_decode() {
+        // minecraft:angry_villager, id 0, which nothing here models.
+        let mut reader = Reader::new(&[0x00]);
+        assert!(Particle::decode(&mut reader).is_err());
     }
 }

--- a/crates/hyperion/Cargo.toml
+++ b/crates/hyperion/Cargo.toml
@@ -69,7 +69,6 @@ valence_nbt = { workspace = true }
 valence_protocol = { workspace = true }
 valence_registry = { workspace = true }
 valence_server = { workspace = true }
-valence_text = { workspace = true }
 ordered-float = { workspace = true }
 
 [dev-dependencies]

--- a/crates/hyperion/src/egress/channel.rs
+++ b/crates/hyperion/src/egress/channel.rs
@@ -1,11 +1,11 @@
 use flecs_ecs::prelude::*;
 use hyperion_minecraft_proto::{
-    generated::packet_id::play::clientbound::PacketId, packets::play::entity::SetEntityData,
+    generated::packet_id::play::clientbound::PacketId,
+    packets::play::{clientbound::RemoveEntities, entity::SetEntityData},
 };
 use hyperion_proto::UpdateChannelPosition;
 use hyperion_utils::EntityExt;
 use tracing::error;
-use valence_protocol::{VarInt, packets::play};
 
 use crate::{
     egress::metadata::show_all,
@@ -32,12 +32,16 @@ impl Module for ChannelModule {
             .observer::<flecs::OnAdd, ()>()
             .with(id::<Channel>())
             .each_entity(|entity, ()| {
-                let packet = play::EntitiesDestroyS2c {
-                    entity_ids: vec![VarInt(entity.minecraft_id())].into(),
-                };
+                let packet = RemoveEntities(vec![entity.minecraft_id()]);
 
                 entity.world().get::<&Compose>(|compose| {
-                    let packet_buf = compose.io_buf().encode_packet(&packet, compose).unwrap();
+                    let packet_buf = compose
+                        .io_buf()
+                        .encode_packet(
+                            Clientbound::new(PacketId::RemoveEntities.to_raw(), &packet),
+                            compose,
+                        )
+                        .unwrap();
 
                     compose
                         .io_buf()

--- a/crates/hyperion/src/egress/mod.rs
+++ b/crates/hyperion/src/egress/mod.rs
@@ -1,11 +1,14 @@
 use flecs_ecs::prelude::*;
+use hyperion_minecraft_proto::{
+    generated::packet_id::play::clientbound::PacketId, packets::play::clientbound::BlockChangedAck,
+};
 use tracing::{error, info_span};
-use valence_protocol::{VarInt, packets::play};
 
 use crate::{
     net::{
         Compose, ConnectionId,
         intermediate::{IntermediateServerToProxyMessage, UpdatePlayerPositions},
+        protocol::send,
     },
     simulation::{Position, blocks::Blocks},
 };
@@ -60,12 +63,12 @@ impl Module for EgressModule {
                 for to_confirm in mc.to_confirm.drain(..) {
                     let entity = world.entity_from_id(to_confirm.entity);
 
-                    let pkt = play::PlayerActionResponseS2c {
-                        sequence: VarInt(to_confirm.sequence),
-                    };
+                    let pkt = BlockChangedAck(to_confirm.sequence);
 
                     entity.get::<&ConnectionId>(|stream| {
-                        if let Err(e) = compose.unicast(&pkt, *stream) {
+                        if let Err(e) =
+                            send(compose, *stream, PacketId::BlockChangedAck.to_raw(), &pkt)
+                        {
                             error!("failed to send player action response: {e}");
                         }
                     });

--- a/crates/hyperion/src/ingress/mod.rs
+++ b/crates/hyperion/src/ingress/mod.rs
@@ -1,14 +1,12 @@
-use std::borrow::Cow;
-
 use flecs_ecs::prelude::*;
 use hyperion_minecraft_proto::{
-    Uuid as ProtoUuid, generated::packet_id::play::clientbound::PacketId,
-    packets::play::clientbound::PlayerInfoRemove,
+    Uuid as ProtoUuid,
+    generated::packet_id::play::clientbound::PacketId,
+    packets::play::clientbound::{PlayerInfoRemove, RemoveEntities},
 };
 use hyperion_utils::EntityExt;
 use sha2::Digest;
 use tracing::{error, info, info_span};
-use valence_protocol::{VarInt, packets::play::EntitiesDestroyS2c};
 
 use crate::{
     Shutdown,
@@ -67,14 +65,13 @@ fn remove_player_from_visibility(world: &World) {
             };
 
             world.get::<&Compose>(|compose| {
-                let entity_ids = [VarInt(entity.id().minecraft_id())];
-
                 // destroy
-                let pkt = EntitiesDestroyS2c {
-                    entity_ids: Cow::Borrowed(&entity_ids),
-                };
+                let pkt = RemoveEntities(vec![entity.id().minecraft_id()]);
 
-                if let Err(e) = compose.broadcast(&pkt).send() {
+                if let Err(e) = compose
+                    .broadcast(Clientbound::new(PacketId::RemoveEntities.to_raw(), &pkt))
+                    .send()
+                {
                     error!("failed to send player remove packet: {e}");
                     return;
                 }

--- a/crates/hyperion/src/net/protocol/join.rs
+++ b/crates/hyperion/src/net/protocol/join.rs
@@ -35,35 +35,21 @@ const LEVEL: &str = "minecraft:overworld";
 /// at 63; the client uses it for fog and water ambience before it has a chunk.
 const SEA_LEVEL: i32 = 63;
 
-/// Send the join sequence and leave the client in play.
+/// The level description both [`Login`] and a later respawn carry.
+///
+/// Shared rather than written out twice: a respawn whose spawn info disagrees
+/// with the one the client joined on is how a client ends up rendering the
+/// wrong horizon or the wrong water level, and neither is an error anywhere.
 ///
 /// # Errors
-/// Returns an error when a packet fails to encode or when the world has no
-/// `minecraft:overworld` dimension type, which would mean [`registries`] and
-/// the level key here have drifted apart.
-pub fn enter_world(
-    world: &WorldRef<'_>,
-    entity: EntityView<'_>,
-    compose: &Compose,
-    connection_id: ConnectionId,
-) -> anyhow::Result<()> {
+/// Returns an error when the world has no `minecraft:overworld` dimension
+/// type, which would mean [`registries`] and [`LEVEL`] have drifted apart.
+pub fn spawn_info() -> anyhow::Result<CommonPlayerSpawnInfo<'static>> {
     let dimension_type = registries::DIMENSION_TYPE
         .id_of(LEVEL)
         .ok_or_else(|| anyhow::anyhow!("no dimension type named {LEVEL}"))?;
 
-    let (position, yaw, pitch) = entity
-        .try_get::<(&Position, &Yaw, &Pitch)>(|(position, yaw, pitch)| (**position, **yaw, **pitch))
-        .ok_or_else(|| anyhow::anyhow!("player finished configuration without a spawn position"))?;
-
-    let (max_players, chunk_radius, simulation_distance) = world.get::<&Config>(|config| {
-        (
-            config.max_players,
-            i32::from(config.view_distance),
-            config.simulation_distance,
-        )
-    });
-
-    let spawn_info = CommonPlayerSpawnInfo {
+    Ok(CommonPlayerSpawnInfo {
         dimension_type,
         dimension: LEVEL,
         // The client only uses this to seed its own biome noise, and this
@@ -76,7 +62,32 @@ pub fn enter_world(
         last_death_location: None,
         portal_cooldown: 0,
         sea_level: SEA_LEVEL,
-    };
+    })
+}
+
+/// Send the join sequence and leave the client in play.
+///
+/// # Errors
+/// Returns an error when a packet fails to encode or when the world has no
+/// `minecraft:overworld` dimension type, which would mean [`registries`] and
+/// the level key here have drifted apart.
+pub fn enter_world(
+    world: &WorldRef<'_>,
+    entity: EntityView<'_>,
+    compose: &Compose,
+    connection_id: ConnectionId,
+) -> anyhow::Result<()> {
+    let (position, yaw, pitch) = entity
+        .try_get::<(&Position, &Yaw, &Pitch)>(|(position, yaw, pitch)| (**position, **yaw, **pitch))
+        .ok_or_else(|| anyhow::anyhow!("player finished configuration without a spawn position"))?;
+
+    let (max_players, chunk_radius, simulation_distance) = world.get::<&Config>(|config| {
+        (
+            config.max_players,
+            i32::from(config.view_distance),
+            config.simulation_distance,
+        )
+    });
 
     send(compose, connection_id, PacketId::Login.to_raw(), &Login {
         player_id: entity.minecraft_id(),
@@ -88,7 +99,7 @@ pub fn enter_world(
         reduced_debug_info: false,
         show_death_screen: false,
         do_limited_crafting: false,
-        spawn_info,
+        spawn_info: spawn_info()?,
         online_mode: false,
         enforces_secure_chat: false,
     })?;

--- a/crates/hyperion/src/simulation/handlers.rs
+++ b/crates/hyperion/src/simulation/handlers.rs
@@ -19,8 +19,13 @@ use flecs_ecs::core::{Entity, EntityView, EntityViewGet, World, id};
 use geometry::aabb::Aabb;
 use glam::{DVec3, IVec3, Vec3};
 use hyperion_minecraft_proto::{
-    generated::packet_id::play::serverbound::PacketId,
-    packets::play::serverbound::{self as c2s, client_command, player_action, player_command},
+    generated::packet_id::play::{
+        clientbound::PacketId as ClientboundPacketId, serverbound::PacketId,
+    },
+    packets::play::{
+        clientbound::OpenBook,
+        serverbound::{self as c2s, client_command, player_action, player_command},
+    },
     types::{Direction, HumanoidArm, InteractionHand},
 };
 use hyperion_utils::EntityExt;
@@ -30,7 +35,6 @@ use valence_generated::{
     item::ItemKind,
 };
 use valence_protocol::{Hand, packets::play};
-use valence_text::IntoText;
 
 use super::{
     ConfirmBlockSequences, EntitySize, Flight, MovementTracking, PendingTeleportation, Position,
@@ -42,9 +46,9 @@ use super::{
 };
 use crate::{
     net::{
-        Compose, ConnectionId, PROTOCOL_VERSION,
+        Compose, ConnectionId, PROTOCOL_VERSION, agnostic,
         decoder::BorrowedPacketFrame,
-        protocol::{decode_body, frame_body},
+        protocol::{decode_body, frame_body, send},
     },
     simulation::{
         Pitch, Yaw, aabb, event,
@@ -541,9 +545,12 @@ fn use_item(body: &[u8], query: &mut PacketSwitchQuery<'_>) -> anyhow::Result<()
 
     if !cursor.is_empty() {
         if cursor.item == ItemKind::WrittenBook {
-            query
-                .compose
-                .unicast(&play::OpenWrittenBookS2c { hand }, query.io_ref)?;
+            send(
+                query.compose,
+                query.io_ref,
+                ClientboundPacketId::OpenBook.to_raw(),
+                &OpenBook(packet.hand),
+            )?;
         }
 
         query.events.push(
@@ -651,7 +658,7 @@ const fn offset(direction: Direction) -> IVec3 {
 }
 
 /// The proto crate's hand and valence's are the same two values in the same
-/// order; the events and the clientbound packets still speak valence's.
+/// order; the simulation events still speak valence's.
 const fn hand(hand: InteractionHand) -> Hand {
     match hand {
         InteractionHand::MainHand => Hand::Main,
@@ -669,11 +676,7 @@ fn change_position_or_correct_client(
 
     if let Err(e) = try_change_position(proposed, pose, *query.size, query.blocks) {
         // Send error message to player
-        let msg = format!("§c{e}");
-        let pkt = play::GameMessageS2c {
-            chat: msg.into_cow_text(),
-            overlay: false,
-        };
+        let pkt = agnostic::chat(format!("§c{e}"));
 
         if let Err(e) = query.compose.unicast(&pkt, query.io_ref) {
             warn!("Failed to send error message to player: {e}");

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -8,7 +8,13 @@ use glam::{DVec3, I16Vec2, IVec3, Quat, Vec3};
 use hyperion_minecraft_proto::{
     Uuid as ProtoUuid,
     generated::packet_id::play::clientbound::PacketId,
-    packets::play::entity::{AddEntity, pack_degrees},
+    packets::{
+        play::{
+            entity::{AddEntity, pack_degrees},
+            player::{AbilityFlags, PlayerAbilities},
+        },
+        play_login::{PlayerPosition, PositionMoveRotation, Relative, Vec3 as LoginVec3},
+    },
     types::Vec3 as ProtoVec3,
 };
 use hyperion_utils::EntityExt;
@@ -18,17 +24,14 @@ use skin::PlayerSkin;
 use tracing::{debug, error};
 use uuid;
 use valence_generated::block::BlockState;
-use valence_protocol::{
-    VarInt,
-    packets::play::{
-        self, PlayerAbilitiesS2c, player_abilities_s2c::PlayerAbilitiesFlags,
-        player_position_look_s2c::PlayerPositionLookFlags,
-    },
-};
+use valence_protocol::VarInt;
 
 use crate::{
     Global,
-    net::{Compose, ConnectionId, DataBundle, protocol::Clientbound},
+    net::{
+        Compose, ConnectionId, DataBundle,
+        protocol::{Clientbound, send},
+    },
     simulation::{
         command::Command,
         entity_kind::EntityKind,
@@ -845,15 +848,35 @@ impl Module for SimModule {
             &ConnectionId
         )
         .each(|(pending_teleportation, compose, yaw, pitch, connection)| {
-            let pkt = play::PlayerPositionLookS2c {
-                position: pending_teleportation.destination.as_dvec3(),
-                yaw: **yaw,
-                pitch: **pitch,
-                flags: PlayerPositionLookFlags::default(),
-                teleport_id: VarInt(pending_teleportation.teleport_id),
+            let destination = pending_teleportation.destination.as_dvec3();
+            let pkt = PlayerPosition {
+                id: pending_teleportation.teleport_id,
+                change: PositionMoveRotation {
+                    position: LoginVec3 {
+                        x: destination.x,
+                        y: destination.y,
+                        z: destination.z,
+                    },
+                    // A correction teleport stops the player rather than
+                    // carrying their velocity into the new position.
+                    delta_movement: LoginVec3 {
+                        x: 0.0,
+                        y: 0.0,
+                        z: 0.0,
+                    },
+                    y_rot: **yaw,
+                    x_rot: **pitch,
+                },
+                relatives: Relative::NONE,
             };
 
-            compose.unicast(&pkt, *connection).unwrap();
+            send(
+                compose,
+                *connection,
+                PacketId::PlayerPosition.to_raw(),
+                &pkt,
+            )
+            .unwrap();
         });
 
         observer!(
@@ -865,15 +888,13 @@ impl Module for SimModule {
             &Flight
         )
         .each(|(flying_speed, compose, connection, flight)| {
-            let pkt = PlayerAbilitiesS2c {
-                flags: PlayerAbilitiesFlags::default()
-                    .with_allow_flying(flight.allow)
-                    .with_flying(flight.is_flying),
-                flying_speed: flying_speed.speed,
-                fov_modifier: 0.0,
-            };
-
-            compose.unicast(&pkt, *connection).unwrap();
+            send(
+                compose,
+                *connection,
+                PacketId::PlayerAbilities.to_raw(),
+                &abilities(*flight, *flying_speed),
+            )
+            .unwrap();
         });
 
         observer!(
@@ -885,16 +906,39 @@ impl Module for SimModule {
             &FlyingSpeed
         )
         .each(|(flight, compose, connection, flying_speed)| {
-            let pkt = play::PlayerAbilitiesS2c {
-                flags: PlayerAbilitiesFlags::default()
-                    .with_allow_flying(flight.allow)
-                    .with_flying(flight.is_flying),
-                flying_speed: flying_speed.speed,
-                fov_modifier: 0.,
-            };
-
-            compose.unicast(&pkt, *connection).unwrap();
+            send(
+                compose,
+                *connection,
+                PacketId::PlayerAbilities.to_raw(),
+                &abilities(*flight, *flying_speed),
+            )
+            .unwrap();
         });
+    }
+}
+
+/// What the client should be told it may do, given the two components that say
+/// so.
+///
+/// Flight permission and flying speed live in separate components that are set
+/// independently, and the packet carries both, so either one changing has to
+/// resend the pair.
+const fn abilities(flight: Flight, flying_speed: FlyingSpeed) -> PlayerAbilities {
+    let mut flags = AbilityFlags::NONE;
+    if flight.allow {
+        flags = flags.union(AbilityFlags::CAN_FLY);
+    }
+    if flight.is_flying {
+        flags = flags.union(AbilityFlags::FLYING);
+    }
+
+    PlayerAbilities {
+        flags,
+        flying_speed: flying_speed.speed,
+        // Zero is what hyperion has always put in this slot, back when valence
+        // called it `fov_modifier`. Vanilla sends 0.1. ENG-10456 tracks
+        // whether that difference is visible.
+        walking_speed: 0.0,
     }
 }
 

--- a/events/bedwars/src/module/attack.rs
+++ b/events/bedwars/src/module/attack.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::LazyLock};
+use std::sync::LazyLock;
 
 use flecs_ecs::{
     core::{
@@ -15,6 +15,7 @@ use hyperion::{
         RegistryId,
         generated::{packet_id::play::clientbound::PacketId, registry::ATTRIBUTE},
         packets::play::{
+            chunk::{LevelParticles, Particle},
             clientbound::{
                 PlayerCombatKill, UpdateAttributes, update_attributes::AttributeSnapshot,
             },
@@ -37,10 +38,8 @@ use hyperion::{
     },
     storage::EventQueue,
     valence_protocol::{
-        ItemKind, ItemStack, Particle, ident,
+        ItemKind, ItemStack, ident,
         math::{DVec3, Vec3},
-        packets::play,
-        text::IntoText,
     },
 };
 use hyperion_inventory::PlayerInventory;
@@ -74,6 +73,35 @@ static ARMOR: LazyLock<RegistryId> = LazyLock::new(|| {
         .expect("minecraft:armor is a vanilla attribute");
     RegistryId(i32::try_from(id).expect("a registry index fits in an i32"))
 });
+
+/// A burst of `count` particles scattered through a box centred on `at`.
+///
+/// `override_limiter` is set on every one of these: a kill or a critical hit
+/// is exactly the thing a spectator further out still wants to see, and the
+/// client would otherwise cull it at its normal particle radius.
+const fn particles(
+    at: DVec3,
+    spread: Vec3,
+    max_speed: f32,
+    count: i32,
+    particle: Particle,
+) -> LevelParticles {
+    LevelParticles {
+        override_limiter: true,
+        // The client's particle setting is the player's own choice, so a
+        // combat effect does not override it.
+        always_show: false,
+        x: at.x,
+        y: at.y,
+        z: at.z,
+        x_dist: spread.x,
+        y_dist: spread.y,
+        z_dist: spread.z,
+        max_speed,
+        count,
+        particle,
+    }
+}
 
 #[derive(Component)]
 pub struct AttackModule;
@@ -162,12 +190,7 @@ impl Module for AttackModule {
                                     }
 
                                     if target_team == origin_team {
-                                        let msg = "§cCannot attack teammates";
-                                        let pkt_msg = play::GameMessageS2c {
-                                            chat: msg.into_cow_text(),
-                                            overlay: false,
-                                        };
-
+                                        let pkt_msg = agnostic::chat("§cCannot attack teammates");
                                         compose.unicast(&pkt_msg, *origin_connection).unwrap();
                                         return;
                                     }
@@ -213,18 +236,21 @@ impl Module for AttackModule {
                                     send(compose, *target_connection, PacketId::HurtAnimation.to_raw(), &pkt_hurt).unwrap();
 
                                     if critical_hit {
-                                    let particle_pkt = play::ParticleS2c {
-                                            particle: Cow::Owned(Particle::Crit),
-                                            long_distance: true,
-                                            position: target_position.as_dvec3() + DVec3::new(0.0, 1.0, 0.0),
-                                            max_speed: 0.5,
-                                            count: 100,
-                                            offset: Vec3::new(0.5, 0.5, 0.5),
-                                        };
+                                        let particle_pkt = particles(
+                                            target_position.as_dvec3() + DVec3::new(0.0, 1.0, 0.0),
+                                            Vec3::new(0.5, 0.5, 0.5),
+                                            0.5,
+                                            100,
+                                            Particle::Crit,
+                                        );
 
                                         // origin is excluded because the crit particles are
                                         // already generated on the client side of the attacker
-                                        compose.broadcast(&particle_pkt).exclude(*origin_connection).send().unwrap();
+                                        compose
+                                            .broadcast(Clientbound::new(PacketId::LevelParticles.to_raw(), &particle_pkt))
+                                            .exclude(*origin_connection)
+                                            .send()
+                                            .unwrap();
                                     }
 
                                     if health.is_dead() {
@@ -244,24 +270,24 @@ impl Module for AttackModule {
 
                                     if health.is_dead() {
                                         // Create particle effect at the attacker's position
-                                        let particle_pkt = play::ParticleS2c {
-                                            particle: Cow::Owned(Particle::Explosion),
-                                            long_distance: true,
-                                            position: target_position.as_dvec3() + DVec3::new(0.0, 1.0, 0.0),
-                                            max_speed: 0.5,
-                                            count: 100,
-                                            offset: Vec3::new(0.5, 0.5, 0.5),
-                                        };
+                                        let particle_pkt = particles(
+                                            target_position.as_dvec3() + DVec3::new(0.0, 1.0, 0.0),
+                                            Vec3::new(0.5, 0.5, 0.5),
+                                            0.5,
+                                            100,
+                                            Particle::Explosion,
+                                        );
 
                                         // Add a second particle effect for more visual impact
-                                        let particle_pkt2 = play::ParticleS2c {
-                                            particle: Cow::Owned(Particle::DragonBreath),
-                                            long_distance: true,
-                                            position: target_position.as_dvec3() + DVec3::new(0.0, 1.5, 0.0),
-                                            max_speed: 0.2,
-                                            count: 75,
-                                            offset: Vec3::new(0.3, 0.3, 0.3),
-                                        };
+                                        let particle_pkt2 = particles(
+                                            target_position.as_dvec3() + DVec3::new(0.0, 1.5, 0.0),
+                                            Vec3::new(0.3, 0.3, 0.3),
+                                            0.2,
+                                            75,
+                                            // `PowerParticleOption.power`, at the default the
+                                            // datapack codec would have supplied.
+                                            Particle::DragonBreath { power: 1.0 },
+                                        );
                                         // `EntityEvent` 3 is `Entity.DEATH`, which starts the
                                         // death animation on every client that can see the body.
                                         let pkt_entity_status = EntityEvent {
@@ -288,8 +314,8 @@ impl Module for AttackModule {
                                         *target_pose = Pose::Dying;
                                         target.modified(id::<Pose>());
                                         compose.broadcast(Clientbound::new(PacketId::UpdateAttributes.to_raw(), &pkt)).send().unwrap();
-                                        compose.broadcast(&particle_pkt).send().unwrap();
-                                        compose.broadcast(&particle_pkt2).send().unwrap();
+                                        compose.broadcast(Clientbound::new(PacketId::LevelParticles.to_raw(), &particle_pkt)).send().unwrap();
+                                        compose.broadcast(Clientbound::new(PacketId::LevelParticles.to_raw(), &particle_pkt2)).send().unwrap();
                                         compose.broadcast(Clientbound::new(PacketId::EntityEvent.to_raw(), &pkt_entity_status)).send().unwrap();
                                         compose.broadcast(Clientbound::new(PacketId::RemoveEntities.to_raw(), &pkt_remove_entities)).send().unwrap();
 

--- a/events/bedwars/src/module/block.rs
+++ b/events/bedwars/src/module/block.rs
@@ -5,17 +5,19 @@ use flecs_ecs::{
 };
 use hyperion::{
     chat,
-    net::{Compose, ConnectionId},
+    hyperion_minecraft_proto::{
+        BlockPos, generated::packet_id::play::clientbound::PacketId,
+        packets::play::clientbound::BlockUpdate,
+    },
+    net::{Compose, ConnectionId, protocol::send},
     simulation::{
-        blocks::{Blocks, EntityAndSequence},
+        blocks::{Blocks, EntityAndSequence, translate},
         event,
     },
     storage::EventQueue,
     valence_protocol::{
-        BlockPos,
         block::{PropName, PropValue},
         math::IVec3,
-        packets::play,
     },
 };
 use tracing::{error, info_span};
@@ -46,16 +48,28 @@ impl Module for BlockModule {
                 let current = blocks.get_block(event.position).unwrap();
 
                 // make sure the player knows the block was placed back
-                let pkt = play::BlockUpdateS2c {
-                    position: BlockPos::new(event.position.x, event.position.y, event.position.z),
-                    block_id: current,
+                let pkt = BlockUpdate {
+                    pos: BlockPos {
+                        x: event.position.x,
+                        y: event.position.y,
+                        z: event.position.z,
+                    },
+                    // The world is stored as 1.20.1 states and 776 numbers
+                    // them differently, so this cannot be `current` raw.
+                    block_state: i32::try_from(translate::block_state(current)).unwrap(),
                 };
 
                 event
                     .from
                     .entity_view(world)
                     .get::<&ConnectionId>(|connection_id| {
-                        compose.unicast(&pkt, *connection_id).unwrap();
+                        send(
+                            compose,
+                            *connection_id,
+                            PacketId::BlockUpdate.to_raw(),
+                            &pkt,
+                        )
+                        .unwrap();
                     });
             }
         });

--- a/events/bedwars/src/skin.rs
+++ b/events/bedwars/src/skin.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use flecs_ecs::{
     core::{Entity, EntityViewGet, SystemAPI, World},
     macros::{Component, system},
@@ -7,16 +5,21 @@ use flecs_ecs::{
 };
 use hyperion::{
     egress::player_join::{PlayerInfoActions, PlayerList, PlayerListEntry, SkinProperty},
-    net::{Compose, ConnectionId, DataBundle},
+    hyperion_minecraft_proto::{
+        Uuid as ProtoUuid,
+        generated::packet_id::play::clientbound::PacketId,
+        packets::{
+            play::clientbound::{PlayerInfoRemove, RemoveEntities},
+            play_login::Respawn,
+        },
+    },
+    net::{
+        Compose, ConnectionId, DataBundle,
+        protocol::{Clientbound, join},
+    },
     simulation::{event, skin::PlayerSkin},
     storage::EventQueue,
     uuid::Uuid,
-    valence_ident::ident,
-    valence_protocol::{
-        GameMode, VarInt,
-        game_mode::OptGameMode,
-        packets::play::{EntitiesDestroyS2c, PlayerRemoveS2c, PlayerRespawnS2c},
-    },
 };
 use hyperion_utils::EntityExt;
 use tracing::debug;
@@ -35,7 +38,7 @@ impl Module for SkinModule {
                         .by
                         .entity_view(world)
                         .get::<(&ConnectionId, &hyperion::simulation::Uuid)>(|(io, uuid)| {
-                            on_set_skin(event.by, compose, uuid.0, event.skin, *io);
+                            on_set_skin(event.by, compose, uuid.0, event.skin, *io).unwrap();
                         });
                 }
             },
@@ -43,56 +46,63 @@ impl Module for SkinModule {
     }
 }
 
-fn on_set_skin(id: Entity, compose: &Compose, uuid: Uuid, skin: PlayerSkin, io: ConnectionId) {
-    let minecraft_id = id.minecraft_id();
+/// Re-send the player to every client so a new skin takes effect.
+///
+/// A skin lives in the profile the tab list carries, and a client only reads
+/// it when the profile arrives, so changing it means removing the entry and
+/// the entity and adding both back.
+///
+/// # Errors
+/// Returns an error when a packet fails to encode or when the registries carry
+/// no overworld dimension type.
+fn on_set_skin(
+    id: Entity,
+    compose: &Compose,
+    uuid: Uuid,
+    skin: PlayerSkin,
+    io: ConnectionId,
+) -> anyhow::Result<()> {
     let mut bundle = DataBundle::new(compose);
+
     // Remove player info
-    bundle
-        .add_packet(&PlayerRemoveS2c {
-            uuids: Cow::Borrowed(&[uuid]),
-        })
-        .unwrap();
+    let remove_info = PlayerInfoRemove(vec![ProtoUuid(uuid.as_u128())]);
+    bundle.add_packet(Clientbound::new(
+        PacketId::PlayerInfoRemove.to_raw(),
+        &remove_info,
+    ))?;
 
     // Destroy player entity
-    bundle
-        .add_packet(&EntitiesDestroyS2c {
-            entity_ids: Cow::Borrowed(&[VarInt(minecraft_id)]),
-        })
-        .unwrap();
+    let remove_entity = RemoveEntities(vec![id.minecraft_id()]);
+    bundle.add_packet(Clientbound::new(
+        PacketId::RemoveEntities.to_raw(),
+        &remove_entity,
+    ))?;
 
     // Add player back with new skin. Only `ADD_PLAYER` is set, so the entry's
     // other fields are not on the wire and are left at their defaults.
-    bundle
-        .add_packet(&PlayerList {
-            actions: PlayerInfoActions::ADD_PLAYER,
-            entries: vec![PlayerListEntry {
-                uuid,
-                username: "Player".to_owned(),
-                properties: vec![SkinProperty {
-                    name: "textures".to_owned(),
-                    value: skin.textures,
-                    signature: Some(skin.signature),
-                }],
-                ..PlayerListEntry::default()
+    bundle.add_packet(&PlayerList {
+        actions: PlayerInfoActions::ADD_PLAYER,
+        entries: vec![PlayerListEntry {
+            uuid,
+            username: "Player".to_owned(),
+            properties: vec![SkinProperty {
+                name: "textures".to_owned(),
+                value: skin.textures,
+                signature: Some(skin.signature),
             }],
-        })
-        .unwrap();
+            ..PlayerListEntry::default()
+        }],
+    })?;
 
-    // // Respawn player
-    bundle
-        .add_packet(&PlayerRespawnS2c {
-            dimension_type_name: ident!("minecraft:overworld"),
-            dimension_name: ident!("minecraft:overworld"),
-            hashed_seed: 0,
-            game_mode: GameMode::Survival,
-            previous_game_mode: OptGameMode::default(),
-            is_debug: false,
-            is_flat: false,
-            copy_metadata: false,
-            last_death_location: None,
-            portal_cooldown: VarInt::default(),
-        })
-        .unwrap();
+    // Respawn player
+    let respawn = Respawn {
+        spawn_info: join::spawn_info()?,
+        // Zero is what the 1.20.1 `copy_metadata: false` this replaces meant.
+        // Keeping attributes or entity data across a cosmetic respawn is a
+        // behaviour change, not a port, so it is not made here.
+        data_to_keep: 0,
+    };
+    bundle.add_packet(Clientbound::new(PacketId::Respawn.to_raw(), &respawn))?;
 
-    bundle.unicast(io).unwrap();
+    bundle.unicast(io)
 }

--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -18,18 +18,21 @@ use glam::Vec3;
 use hyperion::{
     hyperion_minecraft_proto::{
         generated::packet_id::play::clientbound::PacketId,
-        packets::play::{
-            clientbound::{SetActionBarText, SetDisplayObjective, SetHealth, SetTitleText},
-            player::{DisplaySlot, ObjectiveDisplay, ObjectiveRenderType, SetObjective, SetScore},
+        packets::{
+            play::{
+                chunk::{LevelParticles, Particle},
+                clientbound::{SetActionBarText, SetDisplayObjective, SetHealth, SetTitleText},
+                player::{
+                    DisplaySlot, ObjectiveDisplay, ObjectiveRenderType, SetObjective, SetScore,
+                },
+            },
+            play_login::{GameEvent, GameType},
         },
         text::Component,
     },
     net::{Compose, ConnectionId, agnostic, protocol, protocol::Clientbound},
     simulation::{PendingTeleportation, Velocity, metadata::living_entity::Health},
-    valence_protocol::{
-        ItemKind, ItemStack, Particle,
-        packets::play::{self, game_state_change_s2c::GameEventKind},
-    },
+    valence_protocol::{ItemKind, ItemStack},
 };
 use hyperion_inventory::PlayerInventory;
 use hyperion_utils::EntityExt;
@@ -305,11 +308,19 @@ fn apply(world: WorldRef<'_>, compose: &Compose, op: Op) {
             let Some(connection) = entity.try_get::<&ConnectionId>(|id| *id) else {
                 return;
             };
-            let packet = play::GameStateChangeS2c {
-                kind: GameEventKind::ChangeGameMode,
-                value: if spectating { 3.0 } else { 0.0 },
+            let mode = if spectating {
+                GameType::Spectator
+            } else {
+                GameType::Survival
             };
-            let _unused = compose.unicast(&packet, connection);
+            let packet = GameEvent {
+                event: GameEvent::CHANGE_GAME_MODE,
+                param: f32::from(mode.to_id()),
+            };
+            let _unused = compose.unicast(
+                Clientbound::new(PacketId::GameEvent.to_raw(), &packet),
+                connection,
+            );
         }
         Op::Play { at, cue } => play_cue(compose, at, cue),
     }
@@ -427,6 +438,9 @@ fn sidebar(compose: &Compose, to: ConnectionId, title: &str, lines: &[String]) {
 ///
 /// `[INFERRED]` throughout: Mineplex's own choices are not in the leaked source,
 /// which loaded them from the same spreadsheet as everything else.
+/// Half-width of the box a cue's particles are scattered through, in blocks.
+const CUE_SPREAD: f32 = 0.4;
+
 fn play_cue(compose: &Compose, at: Vec3, cue: Cue) {
     let sound = match cue {
         Cue::Explosion => "minecraft:entity.generic.explode",
@@ -453,15 +467,26 @@ fn play_cue(compose: &Compose, at: Vec3, cue: Cue) {
     let Some(particle) = particle else {
         return;
     };
-    let packet = play::ParticleS2c {
-        particle: std::borrow::Cow::Owned(particle),
-        long_distance: true,
-        position: at.as_dvec3(),
+    let packet = LevelParticles {
+        // A cue marks something that just happened to a player, so it is worth
+        // seeing from further out than the client's normal particle radius.
+        override_limiter: true,
+        // The client's particle setting is the player's own choice.
+        always_show: false,
+        x: f64::from(at.x),
+        y: f64::from(at.y),
+        z: f64::from(at.z),
+        x_dist: CUE_SPREAD,
+        y_dist: CUE_SPREAD,
+        z_dist: CUE_SPREAD,
         max_speed: 0.5,
         count: 40,
-        offset: Vec3::splat(0.4),
+        particle,
     };
-    if let Err(error) = compose.broadcast(&packet).send() {
+    if let Err(error) = compose
+        .broadcast(Clientbound::new(PacketId::LevelParticles.to_raw(), &packet))
+        .send()
+    {
         tracing::warn!("dropping a smash particle: {error}");
     }
 }


### PR DESCRIPTION
No packet leaves this server under a 1.20.1 id any more.

```
$ rg -n 'play::[A-Za-z0-9_]+S2c' crates events -g '*.rs'
$ echo $?
1
```

Thirteen sites, across the proxy, the ingress and egress paths, the simulation, and both events. Twelve resolved to bodies that already existed; one needed writing.

## The one that needed writing: LevelParticles

`ParticleTypes.STREAM_CODEC` is `ByteBufCodecs.registry(Registries.PARTICLE_TYPE).dispatch(ParticleOptions::getType, ParticleType::streamCodec)`: a VarInt type id, then whatever that type's own codec writes. 103 of the 125 types write nothing; 22 carry options in eleven different shapes.

Only the five this server sends are modelled. An unmodelled id fails to decode rather than being skipped, because its body length is exactly the thing that is unknown. One of the four tests checks the five hardcoded registry ids against the generated registry, so a Mojang insertion breaks the build rather than the wire.

## Two bugs the port surfaced

`join::enter_world` built its `CommonPlayerSpawnInfo` inline and `skin.rs` built a second one for respawn. They are now one function. Two copies would let a respawn's level description drift from the join's, which renders wrong and errors nowhere.

bedwars sent `BlockUpdate` with a raw 1.20.1 block state id. It goes through the translation table now.

## Not changed, deliberately

`player_abilities` sends `walking_speed: 0.0`. Hyperion has always sent zero there, back to when valence called the field `fov_modifier`; vanilla sends 0.1. Preserving the byte rather than changing behaviour inside a port, with ENG-10456 filed to check it against a real client.

## Verified

```
cargo check --workspace --all-targets   rc=0
nix run .#lint                          rc=0
nix run .#test                          rc=0
nix run .#unused-deps                   rc=0
nix run .#fmt -- --check                rc=0
nix run .#e2e -- --seconds 12           rc=0   3729 LevelChunkWithLight, play state reached
```

`.#fmt --check` is not part of `.#lint`, only of `.#ci`, and it found real drift after clippy was already green. Worth running separately.

## Still valence

The types, not the packets: `BlockState`, `ItemStack`, `Ident`, `Hand` and the anvil region reader. Those do not go on the wire in valence's shape any more, they get translated at the edge. Replacing them is a separate change.

(sent by an AI agent via Claude Code, model claude-opus-4-6)
