### PR TITLE
chore: bump index, for the cargo-unit fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -259,11 +259,11 @@
         "tests": "tests"
       },
       "locked": {
-        "lastModified": 1785144006,
-        "narHash": "sha256-rDYx8+THQQqodP3r7Re5KkwtjwqqXToEjYbPnQ2ji3k=",
+        "lastModified": 1785167710,
+        "narHash": "sha256-+GibfstVTRaWmGaVUYTUr+ZxcZ5Ytz3QF0cSQNUJDow=",
         "owner": "indexable-inc",
         "repo": "index",
-        "rev": "d817f9d340ad9594311ed1bb2ea188be6776dac4",
+        "rev": "3225f70fca2bc3a442e703ce09582c9d418e7221",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`nix flake check` could not build the unit graph at all, on any platform:

```
local unit bedwars 0.1.0 source root /nix/store/<a>-<b>-source/events/bedwars
is outside workspace root /nix/store/<b>-source
```

Note the doubled store hash. cargo-unit's render derivation spelled its `src` argument two different ways in one builder script, interpolated in a `sed` and stringified in the `--workspace-root` argument. Those agree only when `src` is a derivation, which is what every other caller and every existing test passed. For a path value, which is what this flake passes, the interpolated form picks up a second store hash.

Fixed upstream in [indexable-inc/index#4242](https://github.com/indexable-inc/index/pull/4242) for [#4239](https://github.com/indexable-inc/index/issues/4239). This is the pin bump.

## What this unblocks

`nix flake check` now reaches the build phase and 12 of its 13 checks pass. It also makes `nix build .#packages.x86_64-linux.bedwars` evaluate, which is a prerequisite for deploying to a Linux host.

## What is still red

`minecraft-encoder-fixtures`. The vanilla encoder harness throws `Components not bound yet` from `ItemStack`'s constructor in `setEntityData`: `Bootstrap.bootStrap()` runs, but item data component prototypes are not bound after it in 26.2. Being tracked separately; naming it rather than working around it.

(sent by an AI agent via Claude Code, model claude-opus-4-6)
