### PR TITLE
feat(nix): NixOS modules for the game server and the proxy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -462,6 +462,19 @@
                 "sha256-rpuJSz8KxEwG5qeT4HYVtTxHJ24nrYZJwDurv+mjPxM=";
             };
           };
+          # cargoUnit names a binary derivation after its cargo target, but
+          # does not set `meta.mainProgram`, so `lib.getExe` guesses the
+          # derivation name and misses. The NixOS modules below read
+          # `meta.mainProgram` to build their ExecStart, so this is what makes
+          # them work rather than a nicety.
+          named =
+            name: drv:
+            drv.overrideAttrs (previous: {
+              meta = (previous.meta or { }) // {
+                mainProgram = name;
+              };
+            });
+
         in
         {
           devShells.default = pkgs.mkShell {
@@ -489,8 +502,10 @@
             });
 
           packages = {
-            default = workspace.binaries.bedwars;
-            inherit (workspace.binaries) bedwars hyperion-proxy rust-mc-bot;
+            default = named "bedwars" workspace.binaries.bedwars;
+            bedwars = named "bedwars" workspace.binaries.bedwars;
+            hyperion-proxy = named "hyperion-proxy" workspace.binaries.hyperion-proxy;
+            rust-mc-bot = named "rust-mc-bot" workspace.binaries.rust-mc-bot;
 
             minecraft-server-jar = minecraft.serverJar;
             minecraft-data = minecraft.generatedData;
@@ -521,8 +536,110 @@
         };
     in
     {
+      # A NixOS system that imports both modules and nothing else, built by
+      # `nix flake check`. Without it the modules are only ever exercised by
+      # whoever deploys them, and a typo in an option name is discovered on a
+      # host rather than here.
+      nixosConfigurations.module-smoke-test = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          self.nixosModules.game-server
+          self.nixosModules.proxy
+          (
+            { lib, ... }:
+            {
+              boot.loader.grub.enable = false;
+              fileSystems."/" = {
+                device = "/dev/disk/by-label/nixos";
+                fsType = "ext4";
+              };
+              system.stateVersion = "25.05";
+              nixpkgs.hostPlatform = "x86_64-linux";
+
+              # Paths that do not exist, which is the point: the modules must
+              # not read them at evaluation time. A module that did would work
+              # on the machine that has the certificates and fail everywhere
+              # else.
+              services.hyperion-game-server = {
+                enable = true;
+                pki = {
+                  rootCaCert = "/var/lib/hyperion-pki/root_ca.crt";
+                  cert = "/var/lib/hyperion-pki/game.crt";
+                  privateKey = "/var/lib/hyperion-pki/game_private_key.pem";
+                };
+              };
+
+              services.hyperion-proxy = {
+                enable = true;
+                gameServer = "hyperion-game.internal:35565";
+                pki = {
+                  rootCaCert = "/var/lib/hyperion-pki/root_ca.crt";
+                  cert = "/var/lib/hyperion-pki/proxy.crt";
+                  privateKey = "/var/lib/hyperion-pki/proxy_private_key.pem";
+                };
+              };
+            }
+          )
+        ];
+      };
+
+      # NixOS modules for the two services, so a deployment imports them
+      # rather than reimplementing a systemd unit per host. Not per system:
+      # a module reads the host platform off the machine it lands on.
+      nixosModules = {
+        game-server = import ./nix/modules/game-server.nix {
+          hyperionPackages = self.packages;
+        };
+        proxy = import ./nix/modules/proxy.nix {
+          hyperionPackages = self.packages;
+        };
+      };
+
       apps = forAllSystems (system: (mkSystem system).apps);
-      checks = forAllSystems (system: (mkSystem system).checks);
+      checks = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        (mkSystem system).checks
+        // {
+          # Pins the command line the two modules build, so a renamed option
+          # or a reordered argument is caught here rather than on a host.
+          #
+          # The store paths are context-stripped on purpose. Keeping the
+          # context would make this check depend on the binaries, and a module
+          # check should run everywhere in seconds rather than compile a
+          # server. What a module gets wrong is the spelling of a flag or the
+          # order of the arguments, and that is what this reads.
+          nixos-modules =
+            let
+              units = self.nixosConfigurations.module-smoke-test.config.systemd.services;
+              argv = unit: builtins.unsafeDiscardStringContext units.${unit}.serviceConfig.ExecStart;
+            in
+            pkgs.runCommand "hyperion-nixos-modules" { } ''
+              cat > argv <<'ARGV'
+              ${argv "hyperion-game-server"}
+              ${argv "hyperion-proxy"}
+              ARGV
+
+              expect() {
+                grep -qF -- "$1" argv || {
+                  echo "hyperion NixOS module argv lost: $1" >&2
+                  echo "what the modules built:" >&2
+                  cat argv >&2
+                  exit 1
+                }
+              }
+
+              expect "/bin/bedwars --ip :: --port 35565"
+              expect "/bin/hyperion-proxy '[::]:25565' --server hyperion-game.internal:35565"
+              expect "--root-ca-cert /var/lib/hyperion-pki/root_ca.crt --cert /var/lib/hyperion-pki/game.crt --private-key /var/lib/hyperion-pki/game_private_key.pem"
+              expect "--root-ca-cert /var/lib/hyperion-pki/root_ca.crt --cert /var/lib/hyperion-pki/proxy.crt --private-key /var/lib/hyperion-pki/proxy_private_key.pem"
+
+              touch $out
+            '';
+        }
+      );
       devShells = forAllSystems (system: (mkSystem system).devShells);
       packages = forAllSystems (system: (mkSystem system).packages);
     };

--- a/nix/modules/common.nix
+++ b/nix/modules/common.nix
@@ -1,0 +1,65 @@
+# Shared option shapes for the two hyperion services.
+#
+# The game server and the proxy authenticate to each other with mutual TLS,
+# and both refuse to start without all three files, so the paths are options
+# with no defaults rather than guesses. Where the files come from is the
+# deployment's problem: a secret manager, a provisioning unit, or for local
+# experiments `nix run .#certs`.
+{ lib }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  pkiOptions = {
+    rootCaCert = mkOption {
+      type = types.path;
+      description = ''
+        The certificate authority both sides trust. A peer presenting a
+        certificate this does not sign is refused, which is the whole point:
+        the game server accepts commands from its proxies and from nothing
+        else.
+      '';
+      example = "/var/lib/hyperion-pki/root_ca.crt";
+    };
+
+    cert = mkOption {
+      type = types.path;
+      description = "This node's certificate, signed by `rootCaCert`.";
+      example = "/var/lib/hyperion-pki/node.crt";
+    };
+
+    privateKey = mkOption {
+      type = types.path;
+      description = ''
+        The private key for `cert`. Readable only by this service's user, so
+        it belongs in a secret store or a `systemd` credential rather than in
+        the nix store, which is world readable.
+      '';
+      example = "/var/lib/hyperion-pki/node_private_key.pem";
+    };
+  };
+
+  # Everything a long-lived network service can give up and still run. Written
+  # once here because the two units want the same answer and a copy would drift.
+  hardening = {
+    DynamicUser = true;
+    NoNewPrivileges = true;
+    PrivateDevices = true;
+    PrivateTmp = true;
+    ProtectClock = true;
+    ProtectControlGroups = true;
+    ProtectHome = true;
+    ProtectHostname = true;
+    ProtectKernelLogs = true;
+    ProtectKernelModules = true;
+    ProtectKernelTunables = true;
+    ProtectProc = "invisible";
+    ProtectSystem = "strict";
+    RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+    RestrictNamespaces = true;
+    RestrictRealtime = true;
+    RestrictSUIDSGID = true;
+    SystemCallArchitectures = "native";
+    SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
+  };
+}

--- a/nix/modules/game-server.nix
+++ b/nix/modules/game-server.nix
@@ -1,0 +1,85 @@
+# The hyperion game server: one process holding the world, which proxies dial
+# into. It never faces the internet.
+#
+# Traffic direction is what makes the topology simple. Proxies connect to the
+# game server, not the other way round, so this node needs one address its
+# proxies can reach and nothing else. Put it on a private network and give the
+# proxies the public ones.
+{ hyperionPackages }:
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.hyperion-game-server;
+  common = import ./common.nix { inherit lib; };
+  inherit (lib) mkOption mkEnableOption mkIf types escapeShellArgs;
+in
+{
+  options.services.hyperion-game-server = {
+    enable = mkEnableOption "the hyperion game server";
+
+    package = mkOption {
+      type = types.package;
+      default = hyperionPackages.${pkgs.stdenv.hostPlatform.system}.bedwars;
+      defaultText = "the bedwars binary for this system";
+      description = ''
+        The event to run. One binary is one game: `bedwars` and `smash` are
+        separate packages rather than a flag, because an event is compiled in.
+      '';
+    };
+
+    address = mkOption {
+      type = types.str;
+      default = "::";
+      description = ''
+        What to bind. The default takes every address, which is safe only
+        because this port is not routed from the internet. Narrow it to the
+        private interface if that assumption does not hold in your deployment.
+      '';
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 35565;
+      description = "The port proxies dial.";
+    };
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Arguments appended verbatim after the ones this module builds.";
+    };
+
+    pki = common.pkiOptions;
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.hyperion-game-server = {
+      description = "hyperion game server";
+      # network-online rather than network: the bind fails outright if the
+      # address is not up yet, and a restart loop is a worse diagnostic than
+      # waiting.
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = common.hardening // {
+        Type = "simple";
+        ExecStart = escapeShellArgs ([
+          "${cfg.package}/bin/${cfg.package.meta.mainProgram}"
+          "--ip" cfg.address
+          "--port" (toString cfg.port)
+          "--root-ca-cert" (toString cfg.pki.rootCaCert)
+          "--cert" (toString cfg.pki.cert)
+          "--private-key" (toString cfg.pki.privateKey)
+        ] ++ cfg.extraArgs);
+        Restart = "on-failure";
+        RestartSec = "2s";
+        StateDirectory = "hyperion-game-server";
+
+        # The world is memory mapped and a full server holds thousands of
+        # connections' worth of buffers, so the default 1024 descriptors runs
+        # out long before anything else does.
+        LimitNOFILE = 1048576;
+      };
+    };
+  };
+}

--- a/nix/modules/proxy.nix
+++ b/nix/modules/proxy.nix
@@ -1,0 +1,99 @@
+# The hyperion proxy: the process players connect to. It terminates the
+# Minecraft connection, forwards bytes to the game server without reading them,
+# and is the only part of the system that faces the internet.
+#
+# Several proxies share one game server. Each holds its own player connections
+# and multiplexes them onto a single link, so adding one is adding a node here
+# rather than changing anything on the game server.
+{ hyperionPackages }:
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.hyperion-proxy;
+  common = import ./common.nix { inherit lib; };
+  inherit (lib) mkOption mkEnableOption mkIf types escapeShellArgs;
+in
+{
+  options.services.hyperion-proxy = {
+    enable = mkEnableOption "the hyperion proxy";
+
+    package = mkOption {
+      type = types.package;
+      default = hyperionPackages.${pkgs.stdenv.hostPlatform.system}.hyperion-proxy;
+      defaultText = "the hyperion-proxy binary for this system";
+      description = "The proxy binary.";
+    };
+
+    listen = mkOption {
+      type = types.str;
+      default = "[::]:25565";
+      description = ''
+        Where players connect. 25565 is the port a Minecraft client tries when
+        the address carries no port, so moving it means every player has to
+        type one.
+      '';
+    };
+
+    gameServer = mkOption {
+      type = types.str;
+      example = "hyperion-game.internal:35565";
+      description = ''
+        The game server, as `host:port`.
+
+        This must be a name, not an address. The host part becomes the TLS
+        server name the proxy expects on the game server's certificate, so an
+        address here fails the handshake against a certificate issued for a
+        name, and the failure reads as a connection problem rather than a
+        naming one.
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Open the listen port. A proxy nobody can reach is not one.";
+    };
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Arguments appended verbatim after the ones this module builds.";
+    };
+
+    pki = common.pkiOptions;
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.hyperion-proxy = {
+      description = "hyperion proxy";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = common.hardening // {
+        Type = "simple";
+        ExecStart = escapeShellArgs ([
+          "${cfg.package}/bin/${cfg.package.meta.mainProgram}"
+          cfg.listen
+          "--server" cfg.gameServer
+          "--root-ca-cert" (toString cfg.pki.rootCaCert)
+          "--cert" (toString cfg.pki.cert)
+          "--private-key" (toString cfg.pki.privateKey)
+        ] ++ cfg.extraArgs);
+        # The proxy retries the game server itself, so a restart here means the
+        # proxy died rather than that the server is down.
+        Restart = "on-failure";
+        RestartSec = "2s";
+        StateDirectory = "hyperion-proxy";
+
+        # One descriptor per player, plus the link to the game server. The
+        # default 1024 caps the server at a few hundred players, which is two
+        # orders of magnitude below what this is for.
+        LimitNOFILE = 1048576;
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [
+      (lib.toInt (lib.last (lib.splitString ":" cfg.listen)))
+    ];
+  };
+}


### PR DESCRIPTION
A deployment currently reimplements two systemd units by hand, which means each one rediscovers the same three things: both binaries refuse to start without all three TLS paths, the proxy's `--server` host becomes the TLS server name so it cannot be an address, and 1024 file descriptors caps a 10k player server at a few hundred.

`services.hyperion-game-server` and `services.hyperion-proxy` carry those.

- The game server binds a private address, because proxies dial it and not the reverse. It opens no firewall port.
- The proxy is the only part that faces the internet, so it is the only one that does.
- Both take the three PKI paths as options with no defaults. A default would be a guess at someone else's secret store.

## meta.mainProgram

cargoUnit names a binary derivation after its cargo target but sets no `meta.mainProgram`, so `lib.getExe` guessed the derivation name and missed. The modules read `mainProgram` to build their `ExecStart`, so this is what makes them work rather than a nicety.

## The check

A NixOS system that imports both modules, with certificate paths that do not exist, and an assertion on the argv both units produce.

Store path context is stripped deliberately. Keeping it would make a module check compile a server; a module check should run everywhere in seconds. What a module gets wrong is the spelling of a flag or the order of the arguments, and that is what this reads.

Watched it fail before trusting it, by pointing `--server` at a constant:

```
hyperion NixOS module argv lost: /bin/hyperion-proxy '[::]:25565' --server hyperion-game.internal:35565
what the modules built:
...
```

## Verified

```
nix build .#checks.aarch64-darwin.nixos-modules   rc=0
nix run .#fmt                                     rc=0
```

(sent by an AI agent via Claude Code, model claude-opus-4-6)
