### PR TITLE
fix(simulation): give a player the movement state its own handler asserts on

### DIFF
--- a/crates/hyperion/src/net/protocol/join.rs
+++ b/crates/hyperion/src/net/protocol/join.rs
@@ -24,7 +24,7 @@ use crate::{
         Channel, Compose, ConnectionId,
         protocol::{registries, send},
     },
-    simulation::{Comms, Pitch, Position, Yaw},
+    simulation::{Comms, MovementTracking, Pitch, Position, Yaw},
 };
 
 /// The level this server serves. Only one, so the dimension list in [`Login`]
@@ -178,6 +178,18 @@ pub fn enter_world(
             param: 0.0,
         },
     )?;
+
+    // The movement handler reads this on every position packet and does not
+    // check for it first, so a player without it aborts the process the moment
+    // they walk. It is seeded with the position the client was just told to
+    // spawn at, not with `default()`: the handler treats a large step from
+    // `last_tick_position` as a cheat and teleports the player back to it, so a
+    // zeroed tracker drags a joining player to the origin one tick later.
+    entity.set(MovementTracking {
+        last_tick_position: position,
+        was_on_ground: true,
+        ..MovementTracking::default()
+    });
 
     // The player is now visible to other players through its own packet
     // channel, and may receive broadcasts.

--- a/events/smash/src/input.rs
+++ b/events/smash/src/input.rs
@@ -6,9 +6,7 @@
 
 use flecs_ecs::prelude::*;
 use hyperion::{
-    simulation::{
-        MovementTracking, Name, event, metadata::living_entity::Health as HyperionHealth,
-    },
+    simulation::{Name, event, metadata::living_entity::Health as HyperionHealth},
     storage::EventQueue,
 };
 use hyperion_inventory::PlayerInventory;
@@ -52,32 +50,6 @@ impl Module for InputModule {
             .with_enum(hyperion::simulation::PacketState::Play)
             .each_entity(|entity, ()| {
                 entity.set(player_id(entity.id())).add(Player::id());
-            });
-
-        // hyperion registers `MovementTracking` but never adds it to a player.
-        // Two things break as a result, and both look like something else:
-        // hyperion's own movement handler does a hard `get` on it and aborts the
-        // process on the first position packet, and `mirror.rs` names it as a
-        // query term, so the mirror matches nobody and every mirrored position
-        // stays at the origin.
-        //
-        // It has to be seeded with the player's real position, not `default()`.
-        // The movement handler treats a large step from `last_tick_position` as
-        // a cheat and teleports the player back to it, so a zeroed tracker drags
-        // everyone to (0, 0, 0) a tick after they join -- under the kill plane,
-        // which then reads as "fell out of bounds" the moment a match starts.
-        //
-        // This is a workaround for a hyperion bug, not a smash concern. The fix
-        // belongs in hyperion's join path; the diff is in the report.
-        world
-            .observer::<flecs::OnSet, &hyperion::simulation::Position>()
-            .without(id::<MovementTracking>())
-            .each_entity(|entity, position| {
-                entity.set(MovementTracking {
-                    last_tick_position: **position,
-                    was_on_ground: true,
-                    ..MovementTracking::default()
-                });
             });
 
         // The scoreboard and the death messages are built from `EntityView::name`,

--- a/flake.nix
+++ b/flake.nix
@@ -380,6 +380,7 @@
                 # Killing the process group, not the pid: process-compose forks
                 # cargo, which forks the server, and killing only $stack orphans
                 # both so the next run dies on "address already in use".
+                # shellcheck disable=SC2329  # run by the EXIT trap below
                 cleanup() {
                   kill -- "-$stack" >> "$log" 2>&1 || kill "$stack" >> "$log" 2>&1 || true
                   wait "$stack" >> "$log" 2>&1 || true
@@ -422,7 +423,27 @@
                 # Not `exec`: replacing this shell would skip the EXIT trap and
                 # orphan the stack, and the next run would die on "address
                 # already in use".
-                python3 "''${client[@]}" --host 127.0.0.1 --port "$player_port" "$@"
+                rc=0
+                python3 "''${client[@]}" --host 127.0.0.1 --port "$player_port" "$@" || rc=$?
+
+                # A client that finished its checks proves nothing if the server
+                # died while it was reading. It has: the movement handler
+                # aborted the process on the first step a player took
+                # (hyperion#987), and the client saw only its own read timeout,
+                # which it treats as a clean end of session. So ask the game
+                # server directly whether it is still listening.
+                if ! python3 -c "
+                import socket, sys
+                s = socket.socket()
+                s.settimeout(2)
+                sys.exit(0 if s.connect_ex(('127.0.0.1', $server_port)) == 0 else 1)
+                "; then
+                  echo "the game server stopped listening during the session; tail of $log:" >&2
+                  tail -60 "$log" >&2
+                  exit 1
+                fi
+
+                exit "$rc"
               '';
             };
 

--- a/tools/client-26.2.py
+++ b/tools/client-26.2.py
@@ -38,6 +38,7 @@ C2S_CONFIG_KEEP_ALIVE = 0x04
 C2S_CONFIG_SELECT_KNOWN_PACKS = 0x07
 C2S_PLAY_ACCEPT_TELEPORTATION = 0x00
 C2S_PLAY_KEEP_ALIVE = 0x1C
+C2S_PLAY_MOVE_PLAYER_POS = 0x1E
 
 # Clientbound ids, same source.
 S2C_STATUS_RESPONSE = 0x00
@@ -630,6 +631,8 @@ def main():
     started = time.time()
     deadline = started + args.seconds
     seen = {}
+    moved = False
+    lost_after_move = False
 
     while time.time() < deadline:
         try:
@@ -638,6 +641,7 @@ def main():
             break
         except ConnectionError as error:
             log("connection lost: %s" % error)
+            lost_after_move = moved
             break
 
         seen[packet_id] = seen.get(packet_id, 0) + 1
@@ -658,6 +662,18 @@ def main():
                 % (x, y, z, teleport_id)
             )
             client.send(C2S_PLAY_ACCEPT_TELEPORTATION, var_int(teleport_id))
+
+            # Walk. A client that only reads is a client that never exercises
+            # the movement handler, and that handler is where a player missing
+            # a component the server never added aborts the whole process
+            # (hyperion#987). One step is enough to reach it: the check is
+            # that the server is still there afterwards.
+            client.send(
+                C2S_PLAY_MOVE_PLAYER_POS,
+                struct.pack(">dddb", x + 0.2, y, z, 1),
+            )
+            moved = True
+            log("-> MovePlayerPos (%.1f, %.1f, %.1f)" % (x + 0.2, y, z))
         elif packet_id == S2C_PLAY_SET_DEFAULT_SPAWN:
             log("<- SetDefaultSpawnPosition")
         elif packet_id == S2C_PLAY_KEEP_ALIVE:
@@ -700,6 +716,17 @@ def main():
 
     if not client.joined:
         log("RESULT: never reached play state (client would sit on 'Joining world...')")
+        return 1
+
+    if not moved:
+        log("RESULT: never sent a movement packet, so the movement handler is untested")
+        return 1
+
+    if lost_after_move:
+        log(
+            "RESULT: the server dropped the connection after one step. A crash "
+            "here is what a real player hits the moment they walk."
+        )
         return 1
 
     # Reaching play is necessary but not sufficient. A vanilla client shows the


### PR DESCRIPTION
A real 26.2 client that joins and walks kills the game server. #986 let a real
client reach the world for the first time; one second later, moving crashed it:

```
thread 'main' panicked at flecs_ecs/src/core/get_tuple.rs:422:21:
ECS_OPERATION_FAILED: Component `hyperion::simulation::MovementTracking` not
found on `EntityView::get` operation
```

The handler reads `MovementTracking` with a hard `get`, which aborts the
process when the component is absent, and nothing ever added it to a player.
Every player was one step away from taking the server down.

## The fix

hyperion registered the component and never set it. `events/smash` carried its
own observer to add it, with a comment saying the fix belonged in the join
path, so this was known and worked around a layer up rather than fixed.

It is now set in `join.rs` where the player becomes visible, and the smash
observer is deleted. It is seeded with the position the client was just told to
spawn at, not `default()`: the handler treats a large step from
`last_tick_position` as a cheat and teleports the player back to it, so a
zeroed tracker drags a joining player to the origin one tick after they join.

## Why no gate caught it

`tools/client-26.2.py` joined, read packets and left. It never sent a movement
packet, so nothing in CI ever entered the handler. `smash-e2e` does move, and
passed, because smash added the component itself.

Two checks close that, and both were watched failing against the code without
this fix.

The client now takes one step after acknowledging the teleport:

```
[e2e] -> MovePlayerPos (15.7, 8.0, 10.5)
[e2e] RESULT: the server dropped the connection after one step. A crash here is
      what a real player hits the moment they walk.
```

And the e2e app asks the game server afterwards whether it is still listening:

```
the game server stopped listening during the session; tail of /tmp/hyperion-e2e.QLKi3c:
```

That second check is not redundant. On the first attempt the crash slipped
through the client-side check entirely: the client had finished its reads and
treated its own timeout as a clean end of session, and the run passed with
`rc=0` while the server was already dead. A client that has stopped reading
cannot tell a quiet server from a dead one.

## Gates

```
nix run .#e2e         rc=0   (rc=1 without the join.rs change)
nix run .#smash-e2e   rc=0   175.33s  RESULT: a whole match ran at protocol 776
nix run .#fmt --check rc=0
nix run .#lint        rc=0
nix run .#test        rc=0
```

`smash-e2e` matters here beyond being a gate: it is the proof that deleting
smash's own observer did not regress the thing that observer was protecting.

Closes #987.
