### PR TITLE
test: a gate that joins with the real game, because the scripted one cannot

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ Every command is a flake app, so nix is the only thing you need installed.
 | `nix run .#deny` | `cargo deny check` |
 | `nix run .#unused-deps` | `cargo machete` |
 | `nix run .#doc` | Workspace documentation |
+| `nix run .#e2e` | Boots the stack and drives a scripted 26.2 client through it |
+| `nix run .#smash-e2e` | The same on smash: four clients, a whole match |
+| `nix run .#real-client -- <host:port>` | Joins with the actual game and says whether a player reached the world |
 
 `nix build .#bedwars` builds a release binary, and `nix flake check` builds every
 app. If you would rather use cargo directly, `nix develop` gives you a shell with

--- a/flake.nix
+++ b/flake.nix
@@ -339,6 +339,21 @@
               '';
             };
 
+            # Joins a running server with the real Minecraft client and says
+            # whether a player reached the world.
+            #
+            # Everything else in this file reads the wire; this reads the game.
+            # The distance between the two is not theoretical: the scripted
+            # client passed for a week while every real client was dropped
+            # during registry loading, because the scripted one does not load
+            # registries. It cannot run in CI, since it needs a launcher, an
+            # account and a GPU, so it is a command a person runs before saying
+            # an address works.
+            real-client = {
+              deps = [ pkgs.bash ];
+              text = ''exec ./tools/real-client-join.sh "$@"'';
+            };
+
             # Boots the whole stack, drives a scripted 26.2 client through it,
             # and exits with that client's verdict.
             #

--- a/tools/real-client-join.sh
+++ b/tools/real-client-join.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Join a server with the real Minecraft client and report whether the player
+# reached the world. A scripted client proves packets parse; only this proves
+# a real client can use them.
+#
+#   real-client-join.sh <host:port> [instance] [dwell_s] [server_log]
+#
+# Verdict rules. The client logs a failure loudly and a success not at all, so
+# failure is read from the client and success is read from both sides: no
+# failure line, the client still running after the dwell, and, when a server
+# log is given, a join recorded on it during the run.
+set -euo pipefail
+
+addr="${1:?usage: real-client-join.sh <host:port> [instance] [dwell_s] [server_log]}"
+instance="${2:-26.2}"
+dwell="${3:-60}"
+server_log="${4:-}"
+
+prism="/Applications/Prism Launcher.app/Contents/MacOS/prismlauncher"
+log="$HOME/Library/Application Support/PrismLauncher/instances/$instance/minecraft/logs/latest.log"
+
+server_before=0
+if [ -n "$server_log" ]; then
+  server_before=$(grep -c "joined the world" "$server_log" || true)
+fi
+
+rm -f "$log"
+"$prism" -l "$instance" -s "$addr" -o AgentBot >"/tmp/prism-$instance.out" 2>&1 &
+launcher=$!
+
+failed=""
+for _ in $(seq 1 "$dwell"); do
+  if [ -f "$log" ] && grep -qE 'Client disconnected with reason|Missing tag|Registry Loading' "$log"; then
+    failed=yes
+    break
+  fi
+  sleep 1
+done
+
+alive=no
+pgrep -f "Prism Launcher: $instance\"" >/dev/null && alive=yes
+
+server_after=$server_before
+if [ -n "$server_log" ]; then
+  server_after=$(grep -c "joined the world" "$server_log" || true)
+fi
+
+# Match the instance exactly. A bare KnotClient pattern also matches a client
+# the operator is playing in, and killing that has already been one keystroke away.
+# The launcher hands off to the game and exits, so by the time we get here it
+# is usually already gone; its "no such process" goes to the launcher log
+# rather than to the operator reading the verdict.
+kill "$launcher" >>"/tmp/prism-$instance.out" 2>&1 || true
+pkill -f "Prism Launcher: $instance\"" >>"/tmp/prism-$instance.out" 2>&1 || true
+
+if [ -n "$failed" ]; then
+  echo "FAILED $addr"
+  grep -m3 -E 'disconnected with reason|Missing tag|Caused by' "$log" || true
+  exit 1
+fi
+if [ "$alive" != yes ]; then
+  echo "FAILED $addr: the client exited during the session"
+  exit 1
+fi
+if [ -n "$server_log" ] && [ "$server_after" -le "$server_before" ]; then
+  echo "FAILED $addr: no join recorded on the server during the session"
+  exit 1
+fi
+echo "JOINED $addr, still in the world after ${dwell}s"
+[ -n "$server_log" ] && echo "server recorded $((server_after - server_before)) join(s)"
+exit 0


### PR DESCRIPTION
Every check in this repo reads the wire. None of them read the game, and the
distance between those two is where today's two bugs lived: the scripted client
passed for a week while every real client was dropped during registry loading,
because the scripted client does not load registries. The second bug, the
movement crash in #988, was found the same way: by a real client, one second
after a real client could join for the first time.

```
nix run .#real-client -- <host:port> [instance] [dwell_s] [server_log]
```

It launches the actual Minecraft client at an address and reports whether a
player reached the world.

## The verdict rule

A client that fails says so loudly and a client that succeeds says nothing at
all, so the two are read differently. Failure is any of `Client disconnected
with reason`, `Missing tag`, `Registry Loading` in the client log. Success is
the absence of those, plus the client still running after the dwell, plus a
join recorded on the server log when one is passed.

That last term matters. An earlier version of this script guessed at a
success marker in the client log, found none, and reported `TIMEOUT` on a
session where the client had in fact joined and was sitting in the world.

## What it cannot do

Run in CI. It needs a launcher, an account and a GPU. It is a command a person
runs before saying an address works, which is exactly the claim that was wrong
twice today.

## Verified

Against the live server, on `origin/main` with #986 and #988 in it:

```
$ nix run .#real-client -- 100.115.233.43:25565 26.2 30 /tmp/live-stack.log
JOINED 100.115.233.43:25565, still in the world after 30s
server recorded 1 join(s)
```

And against the same server before #986, where it reports the failure the
client's own log names:

```
FAILED 100.115.233.43:25565
Caused by: java.lang.IllegalStateException: Missing tag: 'minecraft:sulfur_cube_archetype/sticky' in 'minecraft:item'
```

Gates: `nix run .#fmt -- --check` rc=0, `nix flake check` rc=0.
