### PR TITLE
fix(events): one launcher, so the IPv6 listen address stops being unspellable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,14 +245,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "dotenvy",
- "envy",
  "fastrand 2.5.0",
  "flecs_ecs",
  "geometry",
  "glam",
  "hyperion",
  "hyperion-clap",
+ "hyperion-event-runner",
  "hyperion-genmap",
  "hyperion-gui",
  "hyperion-inventory",
@@ -262,10 +261,8 @@ dependencies = [
  "rayon",
  "roaring",
  "rustc-hash 2.1.3",
- "serde",
  "tikv-jemallocator",
  "tracing",
- "tracing-subscriber",
  "uuid",
  "valence_protocol",
  "valence_server",
@@ -1992,6 +1989,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "hyperion-event-runner"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "dotenvy",
+ "envy",
+ "hyperion",
+ "serde",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3911,23 +3922,21 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 name = "smash"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
- "dotenvy",
- "envy",
  "flecs_ecs",
  "glam",
  "hyperion",
  "hyperion-clap",
+ "hyperion-event-runner",
  "hyperion-inventory",
  "hyperion-item",
  "hyperion-permission",
  "hyperion-utils",
  "proptest",
  "rayon",
- "serde",
  "tikv-jemallocator",
  "tracing",
- "tracing-subscriber",
  "valence_nbt",
  "valence_protocol",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     'crates/hyperion-command',
     'crates/hyperion-crafting',
     'crates/hyperion-event-macros',
+    'crates/hyperion-event-runner',
     'crates/hyperion-genmap',
     'crates/hyperion-gui',
     'crates/hyperion-hot-reload',
@@ -194,6 +195,9 @@ path = 'crates/hyperion-crafting'
 
 [workspace.dependencies.hyperion-event-macros]
 path = 'crates/hyperion-event-macros'
+
+[workspace.dependencies.hyperion-event-runner]
+path = 'crates/hyperion-event-runner'
 
 [workspace.dependencies.hyperion-genmap]
 path = 'crates/hyperion-genmap'

--- a/crates/hyperion-event-runner/Cargo.toml
+++ b/crates/hyperion-event-runner/Cargo.toml
@@ -1,0 +1,18 @@
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+dotenvy = { workspace = true }
+envy = "0.4"
+hyperion = { workspace = true }
+serde = { version = "1.0", features = ["derive"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[lints]
+workspace = true
+
+[package]
+edition.workspace = true
+name = "hyperion-event-runner"
+publish = false
+version.workspace = true

--- a/crates/hyperion-event-runner/src/lib.rs
+++ b/crates/hyperion-event-runner/src/lib.rs
@@ -1,0 +1,160 @@
+//! The command line every event binary shares.
+//!
+//! An event is a world plus an `init_game`. Everything around that call is the
+//! same for all of them: the same five arguments, the same environment
+//! override, the same logging. It used to be the same ninety lines copied into
+//! each event's `main.rs`, and the copies had drifted: the listen address was
+//! built by joining the IP and the port with a colon and parsing the result, so
+//! the documented IPv6 default `::` became `::35565` and every IPv6 launch
+//! panicked on `AddrParseError`. Both copies. One of them is the default this
+//! server ships, so that default had never started.
+//!
+//! Here the address is a [`SocketAddr`] built from an [`IpAddr`] and a `u16`,
+//! which cannot be spelled wrong.
+
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::PathBuf,
+};
+
+use clap::Parser;
+use hyperion::Crypto;
+use serde::Deserialize;
+use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt};
+
+/// What every event binary takes.
+#[derive(Parser, Deserialize, Debug)]
+pub struct Args {
+    /// The address the server listens on.
+    #[clap(short, long, default_value = "0.0.0.0")]
+    #[serde(default = "default_ip")]
+    pub ip: IpAddr,
+
+    /// The port the server listens on.
+    #[clap(short, long, default_value = "35565")]
+    #[serde(default = "default_port")]
+    pub port: u16,
+
+    /// The file path to the root certificate authority's certificate.
+    #[clap(long)]
+    pub root_ca_cert: PathBuf,
+
+    /// The file path to the game server's certificate.
+    #[clap(long)]
+    pub cert: PathBuf,
+
+    /// The file path to the game server's private key.
+    #[clap(long)]
+    pub private_key: PathBuf,
+}
+
+impl Args {
+    /// Where the server listens.
+    #[must_use]
+    pub const fn address(&self) -> SocketAddr {
+        SocketAddr::new(self.ip, self.port)
+    }
+}
+
+const fn default_ip() -> IpAddr {
+    IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+}
+
+const fn default_port() -> u16 {
+    35565
+}
+
+fn setup_logging() {
+    tracing::subscriber::set_global_default(
+        Registry::default()
+            .with(EnvFilter::from_default_env())
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_target(false)
+                    .with_thread_ids(false)
+                    .with_file(true)
+                    .with_line_number(true),
+            ),
+    )
+    .expect("setup tracing subscribers");
+}
+
+/// Read the arguments, set up logging, and hand the event its world.
+///
+/// `env_prefix` is the prefix of the environment variables that stand in for
+/// the arguments, so `bedwars` reads `BEDWARS_PORT` and smash reads
+/// `SMASH_PORT`. The environment wins when it carries a complete set, and the
+/// command line is used otherwise.
+///
+/// # Errors
+/// Returns whatever `init_game` returns, or an error reading the TLS material.
+pub fn run(
+    env_prefix: &str,
+    init_game: impl FnOnce(SocketAddr, Crypto) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    dotenvy::dotenv().ok();
+
+    setup_logging();
+
+    let args = match envy::prefixed(env_prefix).from_env::<Args>() {
+        Ok(args) => {
+            tracing::info!("loaded configuration from environment variables");
+            args
+        }
+        Err(error) => {
+            tracing::info!("reading the command line instead of the environment: {error}");
+            Args::parse()
+        }
+    };
+
+    let crypto = Crypto::new(&args.root_ca_cert, &args.cert, &args.private_key)?;
+
+    init_game(args.address(), crypto)
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::Args;
+
+    fn args_from(ip: &str) -> Args {
+        Args::parse_from([
+            "event",
+            "--ip",
+            ip,
+            "--root-ca-cert",
+            "/dev/null",
+            "--cert",
+            "/dev/null",
+            "--private-key",
+            "/dev/null",
+        ])
+    }
+
+    /// The bug this crate exists to make unspellable. Both events used to join
+    /// the IP and the port with a colon and parse the result, so `::` became
+    /// `::35565` and every IPv6 launch died on `AddrParseError`.
+    #[test]
+    fn an_ipv6_listen_address_survives_reaching_the_socket() {
+        assert_eq!(args_from("::").address().to_string(), "[::]:35565");
+    }
+
+    #[test]
+    fn the_default_is_every_ipv4_address() {
+        assert_eq!(
+            Args::parse_from([
+                "event",
+                "--root-ca-cert",
+                "/dev/null",
+                "--cert",
+                "/dev/null",
+                "--private-key",
+                "/dev/null",
+            ])
+            .address()
+            .to_string(),
+            "0.0.0.0:35565"
+        );
+    }
+}

--- a/events/bedwars/Cargo.toml
+++ b/events/bedwars/Cargo.toml
@@ -1,13 +1,12 @@
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-dotenvy = { workspace = true }
-envy = "0.4"
 fastrand = { workspace = true }
 flecs_ecs = { workspace = true }
 geometry = { workspace = true }
 glam = { workspace = true }
 hyperion = { workspace = true }
+hyperion-event-runner = { workspace = true }
 hyperion-clap = { workspace = true }
 hyperion-genmap = { workspace = true }
 hyperion-gui = { workspace = true }
@@ -18,9 +17,7 @@ hyperion-utils = { workspace = true }
 rayon = { workspace = true }
 roaring = { workspace = true }
 rustc-hash = { workspace = true }
-serde = { version = "1.0", features = ["derive"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 valence_protocol = { workspace = true }
 valence_server = { workspace = true }

--- a/events/bedwars/src/main.rs
+++ b/events/bedwars/src/main.rs
@@ -1,89 +1,9 @@
-use std::{net::SocketAddr, path::PathBuf};
-
 use bedwars::init_game;
-use clap::Parser;
-use hyperion::Crypto;
-use serde::Deserialize;
-use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt};
-// use tracing_tracy::TracyLayer;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-/// The arguments to run the server
-#[derive(Parser, Deserialize, Debug)]
-struct Args {
-    /// The IP address the server should listen on. Defaults to 0.0.0.0
-    #[clap(short, long, default_value = "0.0.0.0")]
-    #[serde(default = "default_ip")]
-    ip: String,
-
-    /// The port the server should listen on. Defaults to 25565
-    #[clap(short, long, default_value = "35565")]
-    #[serde(default = "default_port")]
-    port: u16,
-
-    /// The file path to the root certificate authority's certificate
-    #[clap(long)]
-    root_ca_cert: PathBuf,
-
-    /// The file path to the game server's certificate
-    #[clap(long)]
-    cert: PathBuf,
-
-    /// The file path to the game server's private key
-    #[clap(long)]
-    private_key: PathBuf,
-}
-
-fn default_ip() -> String {
-    "0.0.0.0".to_string()
-}
-
-const fn default_port() -> u16 {
-    35565
-}
-
-fn setup_logging() {
-    tracing::subscriber::set_global_default(
-        Registry::default()
-            .with(EnvFilter::from_default_env())
-            // .with(TracyLayer::default())
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .with_target(false)
-                    .with_thread_ids(false)
-                    .with_file(true)
-                    .with_line_number(true),
-            ),
-    )
-    .expect("setup tracing subscribers");
-}
-
-fn main() {
-    dotenvy::dotenv().ok();
-
-    setup_logging();
-
-    // Try to load config from environment variables
-    let args = match envy::prefixed("BEDWARS_").from_env::<Args>() {
-        Ok(args) => {
-            tracing::info!("Loaded configuration from environment variables");
-            args
-        }
-        Err(e) => {
-            tracing::info!(
-                "Failed to load from environment: {}, falling back to command line arguments",
-                e
-            );
-            Args::parse()
-        }
-    };
-
-    let address = format!("{ip}:{port}", ip = args.ip, port = args.port);
-    let address = address.parse::<SocketAddr>().unwrap();
-    let crypto = Crypto::new(&args.root_ca_cert, &args.cert, &args.private_key).unwrap();
-
-    init_game(address, crypto).unwrap();
+fn main() -> anyhow::Result<()> {
+    hyperion_event_runner::run("BEDWARS_", init_game)
 }

--- a/events/smash/Cargo.toml
+++ b/events/smash/Cargo.toml
@@ -7,21 +7,19 @@ readme = "README.md"
 version.workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 clap = { workspace = true }
-dotenvy = { workspace = true }
-envy = "0.4"
 flecs_ecs = { workspace = true }
 glam = { workspace = true }
 hyperion = { workspace = true }
+hyperion-event-runner = { workspace = true }
 hyperion-clap = { workspace = true }
 hyperion-inventory = { workspace = true }
 hyperion-item = { workspace = true }
 hyperion-permission = { workspace = true }
 hyperion-utils = { workspace = true }
 rayon = { workspace = true }
-serde = { version = "1.0", features = ["derive"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 valence_nbt = { workspace = true }
 valence_protocol = { workspace = true }
 

--- a/events/smash/src/lib.rs
+++ b/events/smash/src/lib.rs
@@ -99,7 +99,7 @@ impl Module for SmashHost {
 ///
 /// # Errors
 /// If the thread count does not fit in the `i32` flecs wants.
-pub fn init_game(address: SocketAddr, crypto: Crypto) -> Result<(), std::num::TryFromIntError> {
+pub fn init_game(address: SocketAddr, crypto: Crypto) -> anyhow::Result<()> {
     let world = World::new();
 
     world.import::<HyperionCore>();

--- a/events/smash/src/main.rs
+++ b/events/smash/src/main.rs
@@ -1,86 +1,9 @@
-use std::{net::SocketAddr, path::PathBuf};
-
-use clap::Parser;
-use hyperion::Crypto;
-use serde::Deserialize;
 use smash::init_game;
-use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt};
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-/// The arguments to run the server
-#[derive(Parser, Deserialize, Debug)]
-struct Args {
-    /// The IP address the server should listen on. Defaults to 0.0.0.0
-    #[clap(short, long, default_value = "0.0.0.0")]
-    #[serde(default = "default_ip")]
-    ip: String,
-
-    /// The port the server should listen on. Defaults to 35565
-    #[clap(short, long, default_value = "35565")]
-    #[serde(default = "default_port")]
-    port: u16,
-
-    /// The file path to the root certificate authority's certificate
-    #[clap(long)]
-    root_ca_cert: PathBuf,
-
-    /// The file path to the game server's certificate
-    #[clap(long)]
-    cert: PathBuf,
-
-    /// The file path to the game server's private key
-    #[clap(long)]
-    private_key: PathBuf,
-}
-
-fn default_ip() -> String {
-    "0.0.0.0".to_string()
-}
-
-const fn default_port() -> u16 {
-    35565
-}
-
-fn setup_logging() {
-    tracing::subscriber::set_global_default(
-        Registry::default()
-            .with(EnvFilter::from_default_env())
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .with_target(false)
-                    .with_thread_ids(false)
-                    .with_file(true)
-                    .with_line_number(true),
-            ),
-    )
-    .expect("setup tracing subscribers");
-}
-
-fn main() {
-    dotenvy::dotenv().ok();
-
-    setup_logging();
-
-    let args = match envy::prefixed("SMASH_").from_env::<Args>() {
-        Ok(args) => {
-            tracing::info!("Loaded configuration from environment variables");
-            args
-        }
-        Err(e) => {
-            tracing::info!(
-                "Failed to load from environment: {}, falling back to command line arguments",
-                e
-            );
-            Args::parse()
-        }
-    };
-
-    let address = format!("{ip}:{port}", ip = args.ip, port = args.port);
-    let address = address.parse::<SocketAddr>().unwrap();
-    let crypto = Crypto::new(&args.root_ca_cert, &args.cert, &args.private_key).unwrap();
-
-    init_game(address, crypto).unwrap();
+fn main() -> anyhow::Result<()> {
+    hyperion_event_runner::run("SMASH_", init_game)
 }


### PR DESCRIPTION
The documented default listen address has never worked.

Both events built the address by joining the IP and the port with a colon and
parsing the result, so the IPv6 unspecified address became `::35565` and the
process died before anything started:

```
$ bedwars --ip :: --port 39999 --root-ca-cert ... --cert ... --private-key ...
thread 'main' panicked at events/bedwars/src/main.rs:85:49:
called `Result::unwrap()` on an `Err` value: AddrParseError(Socket)
```

Found deploying hyperion to a VM, where the module's own IPv6 default is what
it passes. Filed as ENG-10494 with `--ip "[::]"` as the deployment-side
workaround; this removes the need for it.

## One launcher instead of two copies

The two mains were the same ninety lines with the event name changed: same five
arguments, same environment override, same logging, same address bug. Fixing
the bug twice leaves the next person two places to drift, so
`crates/hyperion-event-runner` owns that command line and each event main is
three lines.

The address is now a `SocketAddr` built from an `IpAddr` and a `u16`. There is
no string to get wrong.

`smash::init_game` returned `Result<(), TryFromIntError>`, which is the error of
one conversion somewhere inside it rather than the error of starting a game
server. It returns `anyhow::Result<()>` like bedwars now.

## Watched failing first

Same command, before and after, is the whole test:

```
before: thread 'main' panicked at AddrParseError(Socket)
after:  INFO reading the command line instead of the environment
        Error: no items found       <- the fake certificate it was handed
```

Two unit tests pin it, one named after the bug:
`an_ipv6_listen_address_survives_reaching_the_socket`.

## Gates

```
nix run .#fmt -- --check   rc=0
nix run .#lint             rc=0
nix run .#test             rc=0
nix run .#unused-deps      rc=0   (four dependencies moved out of each event)
nix run .#e2e              rc=0
cargo check --workspace --all-targets  rc=0
```
