### PR TITLE
feat(smash): prove the maps on a real client, and test the format that builds them

### DIFF
--- a/events/smash/README.md
+++ b/events/smash/README.md
@@ -18,6 +18,8 @@ src/
   server.rs          the seam to the host Minecraft server: nine write methods
   server/mock.rs     a recording test double, so the game runs headless
   flecs_ext.rs       fixes to the flecs_ecs API, carried until they land upstream
+  map.rs             the map file format, its parser, and the list of maps
+  terrain.rs         map files into the world's blocks; the region layout
   module/
     player.rs        mirrored position/velocity/facing, health, energy, jumps
     damage.rs        armour, the Damaged event, kill attribution
@@ -25,12 +27,13 @@ src/
     ability.rs       abilities as entities; one dispatcher for the whole game
     kit.rs           kits as prefabs, and the builder a kit file uses
     projectile.rs    arrows, hooks, thrown blocks: one component set, one system
-    arena.rs         platforms, the kill plane
+    arena.rs         the live arena singleton, and the death checks
     lives.rs         four lives, death, respawn, elimination
     lobby.rs         hub to countdown to match to results, as a pure function
     scoreboard.rs    the sidebar, and spectating on elimination
     kits.rs          the list of kits, which is only ever imports
     kits/            skeleton, iron_golem, enderman, slime
+maps/              one file per arena, plus the waiting lobby
 ```
 
 ## Adding a kit
@@ -67,6 +70,83 @@ impl Module for Wolf {
 then `world.import::<Wolf>()`. `tests/modularity.rs` proves the claim by
 defining a kit from outside the crate and asserting no file under `src/`
 mentions it.
+
+## Adding a map
+
+One file under [`maps/`](maps) and one line in `map::ARENAS`. No Rust
+otherwise: a map is data, the way Mineplex's were, so a wrong island is fixed by
+editing a text file rather than by knowing Rust.
+
+A map file is one directive per line, `#` to end of line for comments. Every
+coordinate is local to the map, and every range is inclusive, which is how a
+builder thinks about a platform ("y 63 to 66"):
+
+```
+name Sky Fortress            # runs to the end of the line; no quotes needed
+author whoever built it
+
+kill_y 20                    # below this Y a player is dead
+
+box      -6 65 -2  -4 67 2   minecraft:stone      # two inclusive corners
+cylinder  0 64  0  16 1      minecraft:grass_block  # centre, radius, height up
+sphere   -8 71 -8  3         minecraft:oak_leaves   # centre, radius
+cone      0 61  0  15 12     minecraft:stone        # centre, radius, depth down
+
+spawn   -10 65 -10           # where the scatter and respawns put players
+crystal   0 68 0             # where a Smash Crystal may land
+```
+
+Brushes are stamped in the order they appear and a later one overwrites an
+earlier one, which is how the lobby carves the inside out of its glass ring with
+a cylinder of air. `cone` tapers downwards from its centre to a point, which is
+the underside every floating island has.
+
+`parse` refuses a file rather than degrading it: an unknown directive, a block
+id without its `minecraft:` prefix, no `name`, no `spawn`, no `kill_y`, or a
+kill plane at or above the lowest spawn. That last one is not hypothetical --
+it is the shape of the bug that made the old downloaded world unplayable, where
+everyone died on the tick they were placed.
+
+Two more checks run over the shipped maps and will fail the build or the tests
+rather than the match:
+
+- every spawn point has a solid block under it. hyperion reads `ceil(y) - 1` to
+  decide a player is standing, so a spawn one block too high leaves them
+  airborne forever and every grounded ability silently refuses to fire.
+- the kill plane is below every block the map places, so nobody dies standing on
+  real terrain.
+
+[`tests/maps.rs`](tests/maps.rs) has both, plus one test per rejection above.
+
+### Where the maps live in the world
+
+There is one world and no world switching, because hyperion serves exactly one
+set of chunks. Each map gets its own slot along +X, `terrain::REGION_STRIDE`
+apart, far enough that no view distance reaches from one to the next. The lobby
+is region 0 and the arenas follow in `map::ARENAS` order. Choosing a map for the
+next match is therefore a teleport, not a world load, and the x coordinate of
+where a player lands says which map they are on.
+
+`MapRotation` picks the next one when a match ends rather than when the next one
+starts, because `Lobby::scatter` reads the `Arena` singleton on the way into
+`Preparing` and would otherwise use the previous map. The order is the order of
+`map::ARENAS`, so it is deterministic and a test can predict it.
+
+### Checking a map on a real client
+
+`nix run .#smash-map-e2e` brings the stack up and drives
+[`tools/smash-map-check.py`](../../tools/smash-map-check.py) at it: a protocol
+776 client that decodes the world off the wire and compares it, block for block,
+against the files in `maps/`. It then walks a player off the edge, hovers five
+blocks above the declared kill plane long enough to prove that height is
+survivable, and drops through to prove it is not.
+
+Reading the world takes two packets and not one. `terrain.rs` builds on
+`Blocks::empty`, so every column is encoded as air before a single block is
+stamped into it and that encoding is never rebuilt; a joining player gets the
+empty chunk followed by `section_blocks_update` carrying every change since the
+column loaded. A client that decodes only `level_chunk_with_light` sees a world
+with no floor in it.
 
 ## Running it
 

--- a/events/smash/src/map.rs
+++ b/events/smash/src/map.rs
@@ -72,6 +72,36 @@ pub struct MapSpec {
     pub brushes: Vec<Brush>,
 }
 
+/// The waiting lobby, as a map file. It is an arena as far as the builder is
+/// concerned; it just never gets played on.
+pub const HUB: &str = include_str!("../maps/hub.map");
+
+/// Every arena this server ships, in rotation order.
+///
+/// A `const` list rather than a directory scan: `include_str!` needs the name
+/// at compile time anyway, and a map that exists but was never added to a list
+/// is a worse failure than a compile error. Adding a map is a file under
+/// `maps/` and a line here, and nothing else.
+///
+/// The list lives beside the parser rather than beside the world builder so
+/// that reading a map costs nothing but this module. `terrain.rs` pulls in the
+/// whole of hyperion to turn a [`MapSpec`] into blocks, and a caller who only
+/// wants to know what the arenas are should not have to.
+pub const ARENAS: &[&str] = &[
+    include_str!("../maps/skylands.map"),
+    include_str!("../maps/mushroom_islands.map"),
+    include_str!("../maps/glacier.map"),
+    include_str!("../maps/desert.map"),
+];
+
+/// Parse every shipped arena, in rotation order.
+///
+/// # Errors
+/// As [`parse`], for the first arena that does not parse.
+pub fn arenas() -> Result<Vec<MapSpec>, ParseError> {
+    ARENAS.iter().copied().map(parse).collect()
+}
+
 /// Where a map file went wrong, with the line that did it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseError {

--- a/events/smash/src/module/arena.rs
+++ b/events/smash/src/module/arena.rs
@@ -30,18 +30,28 @@ pub struct Arena {
 }
 
 impl Default for Arena {
+    /// The first committed arena, in its own local coordinates.
+    ///
+    /// This used to be six hand-written coordinates and a kill plane at y 0,
+    /// and they described no terrain that has ever existed: nothing placed a
+    /// block at any of them, and a player put there would have fallen through
+    /// empty air past a death plane thirty blocks below. Reading a real map
+    /// file instead is what stops the fallback drifting away from the game
+    /// again, because there is no second copy of the numbers to drift.
+    ///
+    /// `terrain.rs` overwrites this with the same map offset into its region
+    /// before anyone connects, so on a running server the default is only ever
+    /// the value between two `world.set` calls. It matters for the tests under
+    /// `tests/`, which import the game without a host and get their arena from
+    /// here.
     fn default() -> Self {
+        let spec = crate::map::parse(crate::map::ARENAS[0]).expect(
+            "the first committed arena parses; `tests/maps.rs` proves every one of them does",
+        );
         Self {
-            name: "Skylands",
-            kill_y: 0.0,
-            spawns: vec![
-                Vec3::new(-12.0, 34.0, 0.0),
-                Vec3::new(12.0, 34.0, 0.0),
-                Vec3::new(0.0, 34.0, -12.0),
-                Vec3::new(0.0, 34.0, 12.0),
-                Vec3::new(-8.0, 40.0, -8.0),
-                Vec3::new(8.0, 40.0, 8.0),
-            ],
+            name: spec.name,
+            kill_y: spec.kill_y,
+            spawns: spec.spawns,
         }
     }
 }

--- a/events/smash/src/terrain.rs
+++ b/events/smash/src/terrain.rs
@@ -23,7 +23,7 @@ use hyperion::{
 };
 
 use crate::{
-    map::{MapSpec, parse},
+    map::{self, MapSpec, parse},
     module::{
         arena::Arena,
         lobby::{Lobby, Phase, PhaseChanged},
@@ -111,22 +111,6 @@ impl Hub {
     }
 }
 
-/// The hub, as a map file. It is an arena as far as the builder is concerned;
-/// it just never gets played on.
-const HUB_SOURCE: &str = include_str!("../maps/hub.map");
-
-/// Every arena, in rotation order.
-///
-/// A `const` list rather than a directory scan: `include_str!` needs the name
-/// at compile time anyway, and a map that exists but was never added to a list
-/// is a worse failure than a compile error.
-const ARENA_SOURCES: &[&str] = &[
-    include_str!("../maps/skylands.map"),
-    include_str!("../maps/mushroom_islands.map"),
-    include_str!("../maps/glacier.map"),
-    include_str!("../maps/desert.map"),
-];
-
 #[derive(Component)]
 pub struct MapModule;
 
@@ -139,10 +123,10 @@ impl Module for MapModule {
             .add_trait::<flecs::Singleton>();
         world.component::<Hub>().add_trait::<flecs::Singleton>();
 
-        let hub = parse(HUB_SOURCE).unwrap_or_else(|error| {
+        let hub = parse(map::HUB).unwrap_or_else(|error| {
             panic!("the hub map does not parse: {error}");
         });
-        let arenas: Vec<Loaded> = ARENA_SOURCES
+        let arenas: Vec<Loaded> = map::ARENAS
             .iter()
             .enumerate()
             .map(|(index, source)| {

--- a/events/smash/tests/maps.rs
+++ b/events/smash/tests/maps.rs
@@ -1,0 +1,321 @@
+//! What a map file has to be true for, checked without a server.
+//!
+//! `terrain.rs` asserts most of this at boot, which means a bad map is a server
+//! that panics on start rather than a test that fails. Boot is also the only
+//! place it was ever checked, so a map could be broken for as long as nobody
+//! started the game. These run in `cargo test`, need no world, no chunks and no
+//! network, and fail on the map that is wrong rather than on the first one.
+
+use std::collections::HashSet;
+
+use smash::map::{ARENAS, Brush, HUB, MapSpec, parse};
+
+/// Every shipped map, hub included, with a label for the failure message.
+fn shipped() -> Vec<(String, MapSpec)> {
+    let mut out = Vec::new();
+    for (index, source) in core::iter::once(&HUB).chain(ARENAS).enumerate() {
+        let spec =
+            parse(source).unwrap_or_else(|error| panic!("map {index} does not parse: {error}"));
+        out.push((format!("map {index} ({:?})", spec.name), spec));
+    }
+    out
+}
+
+/// Every block position a map's brushes cover.
+///
+/// The same rasterisation `terrain.rs` feeds to `set_block`, collected instead
+/// of written, so a test can ask what a map is solid at without a world.
+fn solid(spec: &MapSpec) -> HashSet<[i32; 3]> {
+    let mut out = HashSet::new();
+    for brush in &spec.brushes {
+        brush.each_block(|at, _| {
+            out.insert(at);
+        });
+    }
+    out
+}
+
+#[test]
+fn every_shipped_map_parses() {
+    let maps = shipped();
+    assert_eq!(
+        maps.len(),
+        ARENAS.len() + 1,
+        "the hub and every arena should have parsed"
+    );
+    for (label, spec) in &maps {
+        assert!(!spec.brushes.is_empty(), "{label} places no blocks at all");
+    }
+}
+
+/// The three arenas the game asks a match to choose between.
+#[test]
+fn there_are_several_arenas_to_choose_between() {
+    assert!(
+        ARENAS.len() >= 3,
+        "a rotation of fewer than three arenas is not a rotation"
+    );
+}
+
+/// Two maps with one name would make selection by name ambiguous, and a
+/// scoreboard that names the map would be lying on one of them.
+#[test]
+fn map_names_are_distinct() {
+    let mut seen = HashSet::new();
+    for (label, spec) in shipped() {
+        assert!(
+            seen.insert(spec.name),
+            "{label} reuses the name {:?}",
+            spec.name
+        );
+    }
+}
+
+/// The check `terrain.rs::stand_on_something` makes at boot, made here instead.
+///
+/// hyperion decides whether a player is on the ground by reading the block at
+/// `ceil(y) - 1`, so a spawn one block too high leaves a player airborne from
+/// the moment they arrive and every grounded ability silently refuses to fire.
+#[test]
+fn every_spawn_stands_on_geometry() {
+    for (label, spec) in shipped() {
+        let solid = solid(&spec);
+        for spawn in &spec.spawns {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "a spawn is within a few hundred blocks of its map origin"
+            )]
+            let below = [
+                spawn.x.floor() as i32,
+                spawn.y.ceil() as i32 - 1,
+                spawn.z.floor() as i32,
+            ];
+            assert!(
+                solid.contains(&below),
+                "{label} spawns a player at {spawn} with nothing under them at {below:?}"
+            );
+        }
+    }
+}
+
+/// A spawn at or below the kill plane kills whoever is put there, immediately.
+/// `parse` refuses it; this is the shipped maps having a margin rather than
+/// merely clearing it by a hair.
+#[test]
+fn every_spawn_clears_the_kill_plane() {
+    for (label, spec) in shipped() {
+        for spawn in &spec.spawns {
+            assert!(
+                spawn.y > spec.kill_y + 1.0,
+                "{label} spawns at {spawn}, which is {:.1} above its kill plane {}",
+                spawn.y - spec.kill_y,
+                spec.kill_y
+            );
+        }
+    }
+}
+
+/// The kill plane has to be under the map, not through it. A plane cutting the
+/// geometry means a player standing on a real block dies for no visible reason.
+#[test]
+fn the_kill_plane_is_below_every_block() {
+    for (label, spec) in shipped() {
+        let lowest = solid(&spec)
+            .iter()
+            .map(|at| at[1])
+            .min()
+            .expect("a shipped map places blocks");
+        assert!(
+            (lowest as f32) > spec.kill_y,
+            "{label} has a block at y {lowest}, at or below its kill plane {}",
+            spec.kill_y
+        );
+    }
+}
+
+// --- the guards in `parse`, each watched to fire ---------------------------
+
+fn rejected(source: &'static str) -> String {
+    match parse(source) {
+        Ok(spec) => panic!("expected a rejection, got the map {:?}", spec.name),
+        Err(error) => error.to_string(),
+    }
+}
+
+#[test]
+fn a_map_with_no_name_is_refused() {
+    assert!(rejected("kill_y 0\nspawn 0 1 0\nbox 0 0 0 0 0 0 minecraft:stone\n").contains("name"));
+}
+
+#[test]
+fn a_map_with_no_spawn_is_refused() {
+    let reason = rejected("name Nowhere\nkill_y 0\nbox 0 0 0 0 0 0 minecraft:stone\n");
+    assert!(reason.contains("spawn"), "{reason}");
+}
+
+#[test]
+fn a_map_with_no_kill_plane_is_refused() {
+    let reason = rejected("name Endless\nspawn 0 1 0\n");
+    assert!(reason.contains("kill_y"), "{reason}");
+}
+
+/// The bug the downloaded world shipped with: everyone died the instant they
+/// were placed.
+#[test]
+fn a_kill_plane_above_the_spawns_is_refused() {
+    let reason = rejected("name Fatal\nkill_y 70\nspawn 0 65 0\n");
+    assert!(reason.contains("kill_y 70"), "{reason}");
+    assert!(reason.contains("65"), "{reason}");
+}
+
+#[test]
+fn an_unknown_directive_names_itself_and_its_line() {
+    let reason = rejected("name Typo\nkill_y 0\nspawn 0 1 0\nsphre 0 0 0 1 minecraft:stone\n");
+    assert!(reason.contains("line 4"), "{reason}");
+    assert!(reason.contains("sphre"), "{reason}");
+}
+
+/// A bare `stone` is a block id in no namespace, and the block table would
+/// reject it far from the file that wrote it.
+#[test]
+fn a_block_without_its_namespace_is_refused() {
+    let reason = rejected("name Bare\nkill_y 0\nspawn 0 1 0\nbox 0 0 0 1 1 1 stone\n");
+    assert!(reason.contains("minecraft:"), "{reason}");
+}
+
+#[test]
+fn a_malformed_number_names_the_word_that_was_not_one() {
+    let reason = rejected("name Fuzzy\nkill_y 0\nspawn 0 1 0\nsphere 0 0 0 big minecraft:stone\n");
+    assert!(reason.contains("big"), "{reason}");
+}
+
+#[test]
+fn trailing_junk_is_refused_rather_than_ignored() {
+    let reason = rejected("name Extra\nkill_y 0\nspawn 0 1 0 sideways\n");
+    assert!(reason.contains("sideways"), "{reason}");
+}
+
+#[test]
+fn comments_and_blank_lines_are_skipped() {
+    let spec = parse(
+        "# a comment\n\nname Quiet\n\nkill_y 0  # trailing comment\nspawn 0 1 0\nbox 0 0 0 0 0 0 \
+         minecraft:stone\n",
+    )
+    .expect("comments should not be directives");
+    assert_eq!(spec.name, "Quiet");
+    assert_eq!(spec.spawns.len(), 1);
+}
+
+/// A name runs to the end of the line, so a map can be called "Sky Fortress"
+/// without quoting.
+#[test]
+fn a_name_may_contain_spaces() {
+    let spec = parse("name Sky Fortress\nkill_y 0\nspawn 0 1 0\n").expect("a two-word name parses");
+    assert_eq!(spec.name, "Sky Fortress");
+}
+
+// --- the brushes -----------------------------------------------------------
+
+fn covered(brush: Brush) -> HashSet<[i32; 3]> {
+    let mut out = HashSet::new();
+    brush.each_block(|at, _| {
+        out.insert(at);
+    });
+    out
+}
+
+/// Both corners inclusive, which is how the map files are written.
+#[test]
+fn a_box_covers_both_corners() {
+    let blocks = covered(Brush::Box {
+        min: [0, 0, 0],
+        max: [1, 2, 3],
+        block: "minecraft:stone",
+    });
+    assert_eq!(blocks.len(), 2 * 3 * 4);
+    assert!(blocks.contains(&[0, 0, 0]));
+    assert!(blocks.contains(&[1, 2, 3]));
+}
+
+/// Corners in either order, because a builder writing a box backwards should
+/// get a box rather than nothing.
+#[test]
+fn a_box_does_not_care_which_corner_comes_first() {
+    let forwards = covered(Brush::Box {
+        min: [0, 0, 0],
+        max: [2, 2, 2],
+        block: "minecraft:stone",
+    });
+    let backwards = covered(Brush::Box {
+        min: [2, 2, 2],
+        max: [0, 0, 0],
+        block: "minecraft:stone",
+    });
+    assert_eq!(forwards, backwards);
+}
+
+#[test]
+fn a_cylinder_is_round_and_starts_at_its_centre() {
+    let blocks = covered(Brush::Cylinder {
+        centre: [0, 64, 0],
+        radius: 4,
+        height: 2,
+        block: "minecraft:stone",
+    });
+    // The base is at the centre's own y and the height grows upwards.
+    assert!(blocks.contains(&[0, 64, 0]));
+    assert!(blocks.contains(&[0, 65, 0]));
+    assert!(!blocks.contains(&[0, 63, 0]));
+    // Round, not square: the corner of the bounding box is outside it.
+    assert!(blocks.contains(&[4, 64, 0]));
+    assert!(!blocks.contains(&[4, 64, 4]));
+    assert!(!blocks.contains(&[5, 64, 0]));
+}
+
+#[test]
+fn a_sphere_is_centred_on_its_centre() {
+    let blocks = covered(Brush::Sphere {
+        centre: [0, 0, 0],
+        radius: 2,
+        block: "minecraft:stone",
+    });
+    assert!(blocks.contains(&[0, 0, 0]));
+    for axis in 0..3 {
+        let mut at = [0, 0, 0];
+        at[axis] = 2;
+        assert!(blocks.contains(&at), "sphere should reach {at:?}");
+        at[axis] = -2;
+        assert!(blocks.contains(&at), "sphere should reach {at:?}");
+    }
+    assert!(!blocks.contains(&[2, 2, 2]));
+}
+
+/// A cone tapers downwards from the centre, which is what puts an underside on
+/// a floating island rather than a flat slab.
+#[test]
+fn a_cone_tapers_downwards_to_a_point() {
+    let depth = 8;
+    let blocks = covered(Brush::Cone {
+        centre: [0, 64, 0],
+        radius: 6,
+        depth,
+        block: "minecraft:stone",
+    });
+    let width = |y: i32| {
+        blocks
+            .iter()
+            .filter(|at| at[1] == y)
+            .map(|at| at[0])
+            .max()
+            .unwrap_or(-1)
+    };
+    assert_eq!(width(64), 6, "the top level should be the full radius");
+    assert!(
+        width(64 - depth + 1) < width(64),
+        "the bottom level should be narrower than the top"
+    );
+    // Downwards only: nothing above the centre.
+    assert!(!blocks.iter().any(|at| at[1] > 64));
+    // And nothing below the depth it was given.
+    assert!(!blocks.iter().any(|at| at[1] <= 64 - depth));
+}

--- a/events/smash/tests/maps.rs
+++ b/events/smash/tests/maps.rs
@@ -8,7 +8,7 @@
 
 use std::collections::HashSet;
 
-use smash::map::{ARENAS, Brush, HUB, MapSpec, parse};
+use smash::map::{ARENAS, Brush, HUB, MapSpec, arenas, parse};
 
 /// Every shipped map, hub included, with a label for the failure message.
 fn shipped() -> Vec<(String, MapSpec)> {
@@ -54,6 +54,20 @@ fn there_are_several_arenas_to_choose_between() {
     assert!(
         ARENAS.len() >= 3,
         "a rotation of fewer than three arenas is not a rotation"
+    );
+}
+
+/// The whole list in one call, which is what a caller outside this crate wants
+/// and what `Arena::default` and `terrain.rs` are both a longhand for.
+#[test]
+fn arenas_parses_the_whole_rotation_in_order() {
+    let parsed = arenas().expect("every committed arena parses");
+    assert_eq!(parsed.len(), ARENAS.len());
+    let names: Vec<&str> = parsed.iter().map(|spec| spec.name).collect();
+    assert_eq!(
+        names.first().copied(),
+        Some("Skylands"),
+        "the rotation should start where `map::ARENAS` does, got {names:?}"
     );
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -484,6 +484,31 @@
               '';
             };
 
+            # The same gate again, driving a client that reads blocks rather
+            # than positions.
+            #
+            # Separate from `smash-e2e` rather than folded into it because the
+            # two answer different questions and fail for different reasons.
+            # `smash-e2e` asks whether a match happens; this asks whether the
+            # world the match happens in is the one the map files describe, and
+            # whether the kill plane each of them declares is the height the
+            # game actually kills at. Its ports default off `smash-e2e`'s again
+            # so all three gates can run at once.
+            smash-map-e2e = {
+              deps = [
+                pkgs.process-compose
+                pkgs.git
+                pkgs.python3
+              ];
+              text = ''
+                export HYPERION_EVENT=smash
+                export HYPERION_E2E_CLIENT=tools/smash-map-check.py
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + 3000)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + 3000)}}"
+                exec "${lib.getExe runners.e2e}" "$@"
+              '';
+            };
+
             # `nix run .#dev` runs bedwars; this runs the same stack on smash.
             smash-dev = {
               deps = [ pkgs.process-compose pkgs.git ];

--- a/tools/smash-map-check.py
+++ b/tools/smash-map-check.py
@@ -1,0 +1,1150 @@
+#!/usr/bin/env python3
+"""Check a Super Smash Mobs map against the blocks a real client is sent.
+
+`smash-match.py` proves a match happens. It says so itself: its clients
+"teleport rather than walk, so nothing here says the platforms have collision
+from a real client's point of view". It decides which map a player landed on
+from the x coordinate of a teleport, which is arithmetic over a region stride
+and not a block. Nothing in the repository has ever read a block off the wire.
+
+This does. It joins on protocol 776, decodes the world into block state ids,
+turns those into block names, and compares them against the map files under
+`events/smash/maps/`. Then it walks a player off the edge and descends a block
+at a time to find the height the server kills at, and checks that height
+against the `kill_y` the map file declares.
+
+Reading the world takes two packets, not one, and this is the part that is easy
+to get wrong: `level_chunk_with_light` carries nothing but air. `terrain.rs`
+builds on `Blocks::empty`, so every column was encoded before a single block
+was stamped into it, and the cached encoding is never rebuilt. What a joining
+player gets is that empty chunk followed by `section_blocks_update` for every
+change the column has seen since it loaded. A checker that decodes only the
+chunk packet reports a world with no floor in it, which is how this one spent
+its first three runs.
+
+Three claims, in the order the run makes them:
+
+  * **the map file's blocks are in the world** -- every block a map places, in
+    every chunk this client was sent, arrives with the name the file gives it,
+    and the gaps between the islands arrive as air.
+  * **a player stands on them** -- the block under a spawn point is solid on
+    the wire, and a client that claims to be standing there is not corrected.
+  * **the kill plane is where the map says** -- descending through open air
+    below an island, the server kills within a block of `kill_y` and not
+    before.
+
+The map format is re-implemented here rather than imported, for the same
+reason the knockback constants are restated in `smash-match.py`: a checker that
+asks the server's own parser what a file means cannot catch the parser being
+wrong. This one reads the bytes and the text and has to agree with neither.
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import importlib.util
+import math
+import pathlib
+import re
+import struct
+import sys
+import time
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+ROOT = TOOLS.parent
+MAPS = ROOT / "events/smash/maps"
+
+
+def _load_client():
+    """Import `client-26.2.py`, whose file name is not a Python identifier."""
+    path = TOOLS / "client-26.2.py"
+    spec = importlib.util.spec_from_file_location("client_26_2", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+base = _load_client()
+var_int = base.var_int
+take_var_int = base.take_var_int
+PROTOCOL = base.PROTOCOL
+
+# Serverbound play ids, from
+# crates/hyperion-minecraft-proto/src/generated/packet_id.rs.
+C2S_ACCEPT_TELEPORTATION = 0x00
+C2S_KEEP_ALIVE = 0x1C
+C2S_MOVE_PLAYER_POS = 0x1E
+
+# Clientbound play ids this file decodes.
+S2C_DISCONNECT = 0x20
+S2C_LEVEL_CHUNK_WITH_LIGHT = 0x2D
+S2C_SECTION_BLOCKS_UPDATE = 0x54
+S2C_KEEP_ALIVE = 0x2C
+S2C_LOGIN = 0x31
+S2C_PLAYER_POSITION = 0x48
+S2C_SET_HEALTH = 0x68
+
+# `ServerboundMovePlayerPacket` packs the ground flag into a bitfield; bit 0 is
+# `ON_GROUND`, the only bit hyperion reads.
+ON_GROUND = 1
+
+# crates/hyperion/src/simulation/blocks/chunk.rs and crates/hyperion/src/lib.rs:
+# the overworld spans 384 blocks from y -64, which is 24 sections of 16.
+WORLD_MIN_Y = -64
+SECTION_COUNT = 24
+
+# events/smash/src/terrain.rs: the hub is region 0 and each arena sits a whole
+# stride further along +X.
+REGION_STRIDE = 512
+
+POSITION_INTERVAL = 0.05
+
+
+# --- the map format, restated -----------------------------------------------
+
+
+class MapSpec:
+    def __init__(self, name, kill_y, spawns, brushes):
+        self.name = name
+        self.kill_y = kill_y
+        self.spawns = spawns
+        self.brushes = brushes
+        self._blocks = None
+
+    @property
+    def blocks(self):
+        """Every block the file places, brushes applied in order.
+
+        Later brushes overwrite earlier ones because `set_block` does, which is
+        how the hub carves the inside out of its glass ring with a cylinder of
+        air. A rasteriser that unioned instead would expect glass across the
+        whole floor.
+        """
+        if self._blocks is None:
+            out = {}
+            for brush in self.brushes:
+                for at, block in brush:
+                    out[at] = block
+            self._blocks = out
+        return self._blocks
+
+
+def _box(min_xyz, max_xyz, block):
+    lo = [min(a, b) for a, b in zip(min_xyz, max_xyz)]
+    hi = [max(a, b) for a, b in zip(min_xyz, max_xyz)]
+    for x in range(lo[0], hi[0] + 1):
+        for y in range(lo[1], hi[1] + 1):
+            for z in range(lo[2], hi[2] + 1):
+                yield (x, y, z), block
+
+
+def _cylinder(centre, radius, height, block):
+    squared = radius * radius
+    for dx in range(-radius, radius + 1):
+        for dz in range(-radius, radius + 1):
+            if dx * dx + dz * dz > squared:
+                continue
+            for dy in range(height):
+                yield (centre[0] + dx, centre[1] + dy, centre[2] + dz), block
+
+
+def _sphere(centre, radius, block):
+    squared = radius * radius
+    for dx in range(-radius, radius + 1):
+        for dy in range(-radius, radius + 1):
+            for dz in range(-radius, radius + 1):
+                if dx * dx + dy * dy + dz * dz > squared:
+                    continue
+                yield (centre[0] + dx, centre[1] + dy, centre[2] + dz), block
+
+
+def _cone(centre, radius, depth, block):
+    for level in range(depth):
+        # Rust: `radius - (radius * level) / depth.max(1)`, truncating.
+        shrunk = radius - (radius * level) // max(depth, 1)
+        squared = shrunk * shrunk
+        for dx in range(-shrunk, shrunk + 1):
+            for dz in range(-shrunk, shrunk + 1):
+                if dx * dx + dz * dz > squared:
+                    continue
+                yield (centre[0] + dx, centre[1] - level, centre[2] + dz), block
+
+
+def parse_map(text):
+    """events/smash/src/map.rs, in Python."""
+    name = None
+    kill_y = None
+    spawns = []
+    brushes = []
+    for number, raw in enumerate(text.splitlines(), start=1):
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        words = line.split()
+        directive, rest = words[0], words[1:]
+        if directive == "name":
+            name = line[len(directive) :].strip()
+        elif directive == "author":
+            pass
+        elif directive == "kill_y":
+            kill_y = float(rest[0])
+        elif directive == "spawn":
+            spawns.append(tuple(float(v) for v in rest[:3]))
+        elif directive == "crystal":
+            pass
+        elif directive == "box":
+            nums = [int(v) for v in rest[:6]]
+            brushes.append(list(_box(nums[:3], nums[3:6], rest[6])))
+        elif directive == "cylinder":
+            nums = [int(v) for v in rest[:5]]
+            brushes.append(list(_cylinder(nums[:3], nums[3], nums[4], rest[5])))
+        elif directive == "sphere":
+            nums = [int(v) for v in rest[:4]]
+            brushes.append(list(_sphere(nums[:3], nums[3], rest[4])))
+        elif directive == "cone":
+            nums = [int(v) for v in rest[:5]]
+            brushes.append(list(_cone(nums[:3], nums[3], nums[4], rest[5])))
+        else:
+            raise SystemExit("line %d: unknown directive %r" % (number, directive))
+    if name is None or kill_y is None or not spawns:
+        raise SystemExit("map is missing a name, a kill_y or a spawn")
+    return MapSpec(name, kill_y, spawns, brushes)
+
+
+# events/smash/src/map.rs: `HUB` then `ARENAS`, which is the order
+# `terrain.rs` assigns regions in.
+MAP_ORDER = ["hub", "skylands", "mushroom_islands", "glacier", "desert"]
+
+
+def load_maps():
+    """The hub and every arena, keyed by the region they are stamped into."""
+    return {
+        index: parse_map((MAPS / ("%s.map" % stem)).read_text())
+        for index, stem in enumerate(MAP_ORDER)
+    }
+
+
+# --- block state ids --------------------------------------------------------
+
+BLOCK_STATES = ROOT / "crates/hyperion-minecraft-proto/src/block_state.rs"
+
+
+def load_block_runs():
+    """Every block's run of state ids, from the generated table.
+
+    A block state on the wire is one number out of 32366, and the numbering is
+    arbitrary. The table is generated from the same Mojang data the server's
+    ids come from, which is why it is read rather than restated.
+    """
+    source = BLOCK_STATES.read_text()
+    pattern = re.compile(
+        r'name: "([^"]+)",\s*base_id: (\d+),\s*default_id: (\d+),\s*state_count: (\d+),'
+    )
+    runs = []
+    for name, base_id, _default, count in pattern.findall(source):
+        base_id = int(base_id)
+        runs.append((base_id, base_id + int(count), name))
+    if not runs:
+        raise SystemExit("no blocks found in %s" % BLOCK_STATES)
+    runs.sort()
+    return runs
+
+
+class BlockNames:
+    def __init__(self):
+        self.runs = load_block_runs()
+        self.starts = [run[0] for run in self.runs]
+
+    def name(self, state_id):
+        index = bisect.bisect_right(self.starts, state_id) - 1
+        if index < 0:
+            return "<state %d>" % state_id
+        start, end, name = self.runs[index]
+        if start <= state_id < end:
+            return name
+        return "<state %d>" % state_id
+
+
+# --- chunk decoding ---------------------------------------------------------
+#
+# Transcribed from crates/hyperion-minecraft-proto/src/world/chunk.rs and
+# .../world/palette.rs. Two things about 26.2 that most write-ups get wrong and
+# that a decoder silently desynchronises on:
+#
+#   * a section carries `nonEmptyBlockCount` *and* `fluidCount`, two shorts;
+#   * a paletted container's storage has no length prefix. The reader works the
+#     long count out from the bit width and the entry count.
+
+
+def storage_len(bits, count):
+    """`SimpleBitStorage`: values never straddle a long, so this is not
+    `count * bits / 64`."""
+    if bits == 0:
+        return 0
+    per_long = 64 // bits
+    return -(-count // per_long)
+
+
+class Reader:
+    def __init__(self, buf, offset=0):
+        self.buf = buf
+        self.offset = offset
+
+    def var_int(self):
+        value, used = take_var_int(self.buf, self.offset)
+        self.offset = used
+        return value
+
+    def u8(self):
+        value = self.buf[self.offset]
+        self.offset += 1
+        return value
+
+    def var_long(self):
+        out = 0
+        for index in range(10):
+            byte = self.u8()
+            out |= (byte & 0x7F) << (index * 7)
+            if not byte & 0x80:
+                return out
+        raise SystemExit("var long too long")
+
+    def i16(self):
+        value = struct.unpack_from(">h", self.buf, self.offset)[0]
+        self.offset += 2
+        return value
+
+    def i32(self):
+        value = struct.unpack_from(">i", self.buf, self.offset)[0]
+        self.offset += 4
+        return value
+
+    def u64s(self, count):
+        if count == 0:
+            return ()
+        values = struct.unpack_from(">%dQ" % count, self.buf, self.offset)
+        self.offset += count * 8
+        return values
+
+
+def decode_container(reader, entry_count, global_above):
+    """One paletted container: a palette and its bit-packed indices.
+
+    `global_above` is the bit width past which the palette is dropped and the
+    storage holds registry ids directly: 8 for block states, 3 for biomes.
+    Which palette a container uses is not on the wire; the reader picks it from
+    the bit width using the same table the writer did.
+    """
+    bits = reader.u8()
+    if bits == 0:
+        palette = [reader.var_int()]
+    elif bits > global_above:
+        palette = None
+    else:
+        palette = [reader.var_int() for _ in range(reader.var_int())]
+    storage = reader.u64s(storage_len(bits, entry_count))
+    return bits, palette, storage
+
+
+def container_value(bits, palette, storage, index):
+    if bits == 0:
+        return palette[0]
+    per_long = 64 // bits
+    word = storage[index // per_long]
+    shift = (index % per_long) * bits
+    raw = (word >> shift) & ((1 << bits) - 1)
+    return raw if palette is None else palette[raw]
+
+
+def decode_chunk(payload, keep_y):
+    """Block state ids from one `level_chunk_with_light`.
+
+    `keep_y` is a `(low, high)` band; blocks outside it are decoded and thrown
+    away. Every section has to be read whether or not it is wanted, because the
+    blob is a concatenation with no per-section offset, but a smash map occupies
+    forty of the overworld's three hundred and eighty-four levels and keeping
+    the rest would be most of a million entries per chunk for nothing.
+    """
+    reader = Reader(payload)
+    chunk_x = reader.i32()
+    chunk_z = reader.i32()
+
+    for _ in range(reader.var_int()):
+        reader.var_int()
+        reader.u64s(reader.var_int())
+
+    blob_len = reader.var_int()
+    blob = Reader(payload, reader.offset)
+    end = reader.offset + blob_len
+
+    low, high = keep_y
+    blocks = {}
+    for section in range(SECTION_COUNT):
+        blob.i16()
+        blob.i16()
+        bits, palette, storage = decode_container(blob, 4096, 8)
+        decode_container(blob, 64, 3)
+
+        base_y = WORLD_MIN_Y + section * 16
+        if base_y + 15 < low or base_y > high:
+            continue
+        for y in range(16):
+            world_y = base_y + y
+            if not low <= world_y <= high:
+                continue
+            for z in range(16):
+                # `Strategy.getIndex`: ((y << 4 | z) << 4) | x.
+                row = ((y << 4) | z) << 4
+                for x in range(16):
+                    state = container_value(bits, palette, storage, row | x)
+                    if state == 0:
+                        continue
+                    blocks[(chunk_x * 16 + x, world_y, chunk_z * 16 + z)] = state
+
+    if blob.offset != end:
+        raise SystemExit(
+            "section blob desynchronised: read %d of %d bytes"
+            % (blob.offset - (end - blob_len), blob_len)
+        )
+    return (chunk_x, chunk_z), blocks
+
+
+# `SectionPos.asLong`: x in the top 22 bits, z in the next 22, y in the low 20.
+SECTION_HORIZONTAL_BITS = 22
+SECTION_Y_BITS = 64 - 2 * SECTION_HORIZONTAL_BITS
+
+
+def _sign_extend(value, bits):
+    value &= (1 << bits) - 1
+    if value >> (bits - 1):
+        value -= 1 << bits
+    return value
+
+
+def decode_section_blocks_update(payload):
+    """`section_blocks_update`, which is how a map's blocks actually arrive.
+
+    This is the packet the whole check turned on and the reason a decoder that
+    reads only `level_chunk_with_light` sees an empty world. `terrain.rs` starts
+    from `Blocks::empty` and stamps the maps in afterwards, so every column was
+    already encoded as air by the time a block was placed in it. The cached
+    encoding is never rebuilt; instead `sync_chunks.rs` sends a joining player
+    the empty base chunk and then `original_delta_packets`, every change the
+    column has seen since it loaded. So the platform arrives as seventy-six
+    thousand block changes layered on a world of air, and a client that ignores
+    them stands in a void.
+    """
+    reader = Reader(payload)
+    packed = struct.unpack_from(">q", payload, 0)[0]
+    reader.offset = 8
+    section_x = _sign_extend(packed >> (SECTION_Y_BITS + SECTION_HORIZONTAL_BITS), SECTION_HORIZONTAL_BITS)
+    section_z = _sign_extend(packed >> SECTION_Y_BITS, SECTION_HORIZONTAL_BITS)
+    section_y = _sign_extend(packed, SECTION_Y_BITS)
+
+    changes = []
+    for _ in range(reader.var_int()):
+        bits = reader.var_long()
+        # `Block.getId(state) << 12 | position`, and the position inside the
+        # section packs as x << 8 | z << 4 | y. Note the order: the chunk
+        # section container indexes y << 8 | z << 4 | x, the other way round.
+        position = bits & 0xFFF
+        state = bits >> 12
+        x = (position >> 8) & 0xF
+        z = (position >> 4) & 0xF
+        y = position & 0xF
+        changes.append(
+            ((section_x * 16 + x, section_y * 16 + y, section_z * 16 + z), state)
+        )
+    return (section_x, section_z), changes
+
+
+# --- the client -------------------------------------------------------------
+
+
+def stamp(started):
+    return "%7.2fs" % (time.time() - started)
+
+
+class MapClient(base.Client):
+    """One scripted player, with the chunks it was sent."""
+
+    def __init__(self, host, port, name, started):
+        super().__init__(host, port, name, lambda line: None)
+        self.started = started
+        self.log = self._log
+        self.buffer = b""
+        self.position = (0.0, 65.0, 0.0)
+        self.path = []
+        self.on_ground = True
+        self.health = None
+        self.alive = True
+        self.chunks = {}
+        self.blocks = {}
+        self.teleports = []
+        self.corrections = 0
+        self.last_position_sent = 0.0
+
+    def _log(self, line):
+        print("%s [%-3s] %s" % (stamp(self.started), self.name, line), flush=True)
+
+    def enter_play(self):
+        self.sock.settimeout(0.02)
+
+    def drain(self):
+        try:
+            chunk = self.sock.recv(1 << 20)
+            if not chunk:
+                raise ConnectionError("server closed the connection")
+            self.buffer += chunk
+        except (TimeoutError, BlockingIOError):
+            pass
+
+        out = []
+        while True:
+            length = 0
+            shift = 0
+            used = 0
+            complete = False
+            while used < len(self.buffer) and used < 5:
+                byte = self.buffer[used]
+                used += 1
+                length |= (byte & 0x7F) << shift
+                shift += 7
+                if not byte & 0x80:
+                    complete = True
+                    break
+            if not complete or len(self.buffer) < used + length:
+                return out
+            body = self.buffer[used : used + length]
+            self.buffer = self.buffer[used + length :]
+            out.append(self.decode_body(body))
+
+    def decode_body(self, body):
+        if self.threshold >= 0:
+            import zlib
+
+            size, offset = take_var_int(body)
+            body = zlib.decompress(body[offset:]) if size else body[offset:]
+        packet_id, offset = take_var_int(body)
+        return packet_id, body[offset:]
+
+    def step_towards(self):
+        """Re-assert where we are, the way a real client does every tick.
+
+        Without it hyperion's mirrored position goes stale and the arena's
+        bounds check keeps reading wherever we last claimed to be. Steps are
+        small because hyperion treats a step it cannot account for as a cheat
+        and teleports the player back, which is also the only way a descent
+        reads as falling rather than as a correction.
+        """
+        now = time.time()
+        if now - self.last_position_sent < POSITION_INTERVAL:
+            return
+        self.last_position_sent = now
+
+        if self.path:
+            x, y, z = self.position
+            tx, ty, tz = self.path[0]
+            dx, dy, dz = tx - x, ty - y, tz - z
+            distance = (dx * dx + dy * dy + dz * dz) ** 0.5
+            if distance <= 3.0:
+                self.position = self.path.pop(0)
+            else:
+                scale = 3.0 / distance
+                self.position = (x + dx * scale, y + dy * scale, z + dz * scale)
+
+        x, y, z = self.position
+        self.send(
+            C2S_MOVE_PLAYER_POS,
+            struct.pack(">dddb", x, y, z, ON_GROUND if self.on_ground else 0),
+        )
+
+
+# --- walking off the edge ---------------------------------------------------
+
+# The height to leave over an island on the way out. Every map's tallest block
+# is at y 77, and hyperion refuses a step that ends inside a block, so a route
+# that clips the far side of an island reads as a cheat and gets teleported
+# back rather than falling.
+ESCAPE_Y = 100.0
+
+# Blocks from a region's centre to open air. The widest thing any committed map
+# puts down reaches a radius of about 52, so 70 clears all of them.
+OFF_MAP_RADIUS = 70.0
+
+# Far enough out to clear the tree whose leaves hang over two of the main
+# island's opening spawn points.
+RIM_HOP = 6.0
+
+# Blocks per position packet on the way down: 20 a second, well under
+# Minecraft's terminal velocity and slow enough to bracket the kill plane to
+# within a couple of blocks.
+DESCEND_STEP = 2.0
+
+# How far below the kill plane to keep descending before levelling off.
+DESCEND_MARGIN = 40.0
+
+# Seconds to keep claiming a position below the plane before calling it not
+# lethal. A fall is not instantaneous from the server's point of view: the
+# arena's death check only runs while the lobby is in `Preparing` or `Playing`,
+# and the scatter that puts a player on an arena happens at the top of a nine
+# second `Preparing`, so a client that dives immediately can outrun the phase
+# it needs. Holding is also simply what falling looks like.
+HOLD_SECONDS = 60.0
+
+# Where to hover before dropping through, and for how long.
+#
+# Diving straight past the plane and dying proves only that something below is
+# lethal; it does not rule out the plane being higher than the map says, because
+# a dive from y 100 to y -20 takes five seconds and the server has no chance to
+# object on the way. So the descent stops just above the declared plane and sits
+# there, in open air well off the edge of the island, long enough for the match
+# to reach `Playing` and for the death check to have run over this player many
+# times. Surviving that and then dying a few blocks lower is the two-sided
+# claim: the plane is not above the number, and it is not missing below it.
+ABOVE_PLANE_MARGIN = 5.0
+ABOVE_PLANE_HOVER = 15.0
+
+
+class Descent:
+    """Walk a player off the edge and find the height the server kills at.
+
+    This is the only check in the repository that reads the kill plane as
+    anything but a number. `kill_y` has always been a field a map file sets and
+    `is_out_of_bounds` compares against, and nothing has ever confirmed that
+    the height it names is below the terrain, above the terrain, or anywhere a
+    falling player would ever reach. A descent from well above the islands to
+    well below the plane answers all three at once: the player must survive
+    every block down to the plane, and must die within a few of crossing it.
+    """
+
+    def __init__(self, client, spec, region, check):
+        self.client = client
+        self.spec = spec
+        self.check = check
+        self.origin_x = region * REGION_STRIDE
+
+        x, y, z = client.position
+        dx, dz = x - self.origin_x, z
+        length = math.hypot(dx, dz)
+        if length < 1.0:
+            ux, uz = 1.0, 0.0
+        else:
+            ux, uz = dx / length, dz / length
+
+        # Out over the rim, up over the tallest block, then out to open air.
+        # Straight up from a spawn would clip the leaves above two of them.
+        client.on_ground = False
+        client.path = [
+            (x + ux * RIM_HOP, y, z + uz * RIM_HOP),
+            (x + ux * RIM_HOP, ESCAPE_Y, z + uz * RIM_HOP),
+            (self.origin_x + ux * OFF_MAP_RADIUS, ESCAPE_Y, uz * OFF_MAP_RADIUS),
+        ]
+        check.log(
+            "%s heads off the edge of %s, out to radius %.0f at y %.0f"
+            % (client.name, spec.name, OFF_MAP_RADIUS, ESCAPE_Y)
+        )
+
+        self.stage = "out"
+        self.teleports_seen = len(client.teleports)
+        self.alive_floor = ESCAPE_Y
+        self.deaths_above_the_plane = []
+        self.hold_until = None
+        self.announced_hold = False
+        self.hover_until = None
+        self.hovered_for = 0.0
+        self.world_spawns = [
+            (spawn[0] + self.origin_x, spawn[1], spawn[2]) for spawn in spec.spawns
+        ]
+
+    def _descend_to(self, target, stage):
+        x, y, z = self.client.position
+        steps = max(int((y - target) / DESCEND_STEP), 1)
+        self.client.path = [
+            (x, y - DESCEND_STEP * step, z) for step in range(1, steps + 1)
+        ] + [(x, target, z)]
+        self.stage = stage
+
+    def _start_descending(self):
+        ledge = self.spec.kill_y + ABOVE_PLANE_MARGIN
+        self._descend_to(ledge, "to the ledge")
+        self.check.log(
+            "%s falls from y %.0f to y %.0f, %.0f blocks above %s's kill plane y=%g"
+            % (
+                self.client.name,
+                self.client.position[1],
+                ledge,
+                ABOVE_PLANE_MARGIN,
+                self.spec.name,
+                self.spec.kill_y,
+            )
+        )
+
+    def _respawned(self):
+        """A teleport onto one of this map's spawn points.
+
+        Not merely "a teleport upwards". hyperion answers a position it will not
+        account for with a teleport back to where the player was last tick, and
+        those corrections arrive constantly while a client is walking. Reading
+        any upward teleport as a respawn turns the first correction into a
+        reported death at y 100, which is exactly the false positive this check
+        would otherwise be famous for. `lives.rs` puts a respawning player on
+        `Arena::spawn`, so the signal is landing on a spawn point and nothing
+        else.
+        """
+        for teleport in self.client.teleports[self.teleports_seen :]:
+            for spawn in self.world_spawns:
+                if (
+                    abs(teleport[0] - spawn[0]) < 1.5
+                    and abs(teleport[1] - spawn[1]) < 1.5
+                    and abs(teleport[2] - spawn[2]) < 1.5
+                ):
+                    return True
+        self.teleports_seen = len(self.client.teleports)
+        return False
+
+    def tick(self):
+        """One step. True once the run has an answer."""
+        client = self.client
+
+        if self.stage == "out":
+            if not client.path:
+                self._start_descending()
+            return False
+
+        y = client.position[1]
+
+        if self.stage == "to the ledge":
+            if self._respawned() or (client.health is not None and client.health <= 0.0):
+                raise SystemExit(
+                    "%s died at y %.1f on the way down, which is above %s's declared "
+                    "kill plane y=%g: the game kills higher than the map says"
+                    % (client.name, y, self.spec.name, self.spec.kill_y)
+                )
+            if client.path:
+                return False
+            if self.hover_until is None:
+                self.hover_until = time.time() + ABOVE_PLANE_HOVER
+                self.check.log(
+                    "%s hovers at y %.1f, %.0f blocks above the plane, for %.0fs"
+                    % (client.name, y, ABOVE_PLANE_MARGIN, ABOVE_PLANE_HOVER)
+                )
+            if time.time() < self.hover_until:
+                return False
+            self.hovered_for = ABOVE_PLANE_HOVER
+            self._descend_to(self.spec.kill_y - DESCEND_MARGIN, "down")
+            self.check.log(
+                "%s survived %.0fs above the plane; now dropping through it"
+                % (client.name, ABOVE_PLANE_HOVER)
+            )
+            return False
+
+        if self._respawned():
+            return self._finish(y)
+
+        if y > self.spec.kill_y:
+            # Still above the plane. A death here would be the bug this check
+            # exists to catch, and it is recorded rather than asserted so the
+            # report can say how far above.
+            if client.health is not None and client.health <= 0.0:
+                self.deaths_above_the_plane.append(y)
+        self.alive_floor = min(self.alive_floor, y)
+
+        if client.path:
+            return False
+
+        # Out of waypoints: hold here, well under the plane, and keep saying so.
+        if self.hold_until is None:
+            self.hold_until = time.time() + HOLD_SECONDS
+        if not self.announced_hold:
+            self.announced_hold = True
+            self.check.log(
+                "%s holds at y %.1f, %.1f blocks below %s's kill plane, waiting to die"
+                % (client.name, y, self.spec.kill_y - y, self.spec.name)
+            )
+        if time.time() < self.hold_until:
+            return False
+        raise SystemExit(
+            "%s claimed to be at y %.1f, which is %.1f blocks below %s's kill plane "
+            "y=%g, for %.0f seconds and was never killed: the map declares a death "
+            "plane the game does not enforce"
+            % (
+                client.name,
+                y,
+                self.spec.kill_y - y,
+                self.spec.name,
+                self.spec.kill_y,
+                HOLD_SECONDS,
+            )
+        )
+
+    def _finish(self, y):
+        plane = self.spec.kill_y
+        if self.deaths_above_the_plane:
+            highest = max(self.deaths_above_the_plane)
+            raise SystemExit(
+                "%s died at y %.1f, which is %.1f blocks ABOVE %s's kill plane y=%g: "
+                "the game kills higher than the map says"
+                % (self.client.name, highest, highest - plane, self.spec.name, plane)
+            )
+        if self.alive_floor > plane:
+            raise SystemExit(
+                "%s was killed at y %.1f without ever crossing %s's kill plane y=%g"
+                % (self.client.name, self.alive_floor, self.spec.name, plane)
+            )
+        self.check.prove(
+            "the kill plane is where the map says",
+            "%s fell from y %.0f to y %g, %.0f blocks above %s's declared kill plane "
+            "y=%g, and hovered there in open air for %.0fs without dying; it then "
+            "dropped through the plane, reached y %.1f and was killed and respawned. "
+            "No death was reported at any height above the plane"
+            % (
+                self.client.name,
+                ESCAPE_Y,
+                plane + ABOVE_PLANE_MARGIN,
+                ABOVE_PLANE_MARGIN,
+                self.spec.name,
+                plane,
+                self.hovered_for,
+                self.alive_floor,
+            ),
+        )
+        return True
+
+
+# --- the run ----------------------------------------------------------------
+
+
+class Check:
+    """The claims this run makes, and the evidence for each."""
+
+    ORDER = [
+        "the map file's blocks are in the world",
+        "a player stands on the geometry",
+        "the arena's blocks are in the world",
+        "the kill plane is where the map says",
+    ]
+
+    def __init__(self, started):
+        self.started = started
+        self.proof = {claim: None for claim in self.ORDER}
+
+    def log(self, line):
+        print("%s %-5s %s" % (stamp(self.started), "", line), flush=True)
+
+    def prove(self, claim, evidence):
+        if self.proof[claim] is None:
+            self.proof[claim] = evidence
+            self.log("PROVED %s: %s" % (claim, evidence))
+
+    def report(self):
+        print("")
+        print("=" * 78)
+        unproved = [claim for claim, evidence in self.proof.items() if evidence is None]
+        for claim in self.ORDER:
+            evidence = self.proof[claim]
+            print("  %-4s %s" % ("ok" if evidence else "MISS", claim))
+            if evidence:
+                print("       %s" % evidence)
+        print("=" * 78)
+        return 1 if unproved else 0
+
+
+# The share of a map's chunk columns that has to have arrived before its
+# geometry is compared.
+COVERAGE = 0.95
+
+
+def occupied_columns(maps):
+    """The chunk columns the maps put blocks in, in world coordinates.
+
+    Everything else is skipped without decoding its sections. hyperion sends
+    thousands of columns of pure air around a player and decoding them costs
+    tens of millions of Python iterations, which is enough to stall this
+    client's own position packets and get it teleported back as a cheat. The
+    maps together occupy about two hundred columns.
+    """
+    wanted = set()
+    for region, spec in maps.items():
+        origin_x = region * REGION_STRIDE
+        for x, _y, z in spec.blocks:
+            wanted.add(((x + origin_x) >> 4, z >> 4))
+    return wanted
+
+
+def region_of(x):
+    """Which map region a world x lies in. `terrain.rs` spaces them by stride."""
+    return int(round(x / REGION_STRIDE))
+
+
+def compare_geometry(spec, region, client, names, check, claim):
+    """Every block the map places, in every chunk this client was sent.
+
+    Positives and negatives both, because a server that filled the world with
+    stone would pass a check that only asked whether the platform blocks are
+    present. The negatives are the air between the islands, which is the part
+    of a Super Smash Mobs map that does the killing.
+    """
+    origin_x = region * REGION_STRIDE
+
+    # Wait until nearly the whole map has arrived. Comparing the moment the
+    # first column lands would pass on a fraction of the geometry and read, in
+    # the report, exactly like comparing all of it.
+    columns = {((at[0] + origin_x) >> 4, at[2] >> 4) for at in spec.blocks}
+    arrived = columns & set(client.chunks)
+    if len(arrived) < len(columns) * COVERAGE:
+        return False
+
+    low = min(at[1] for at in spec.blocks)
+    high = max(at[1] for at in spec.blocks)
+
+    matched = 0
+    mismatched = []
+    for (x, y, z), block in spec.blocks.items():
+        world = (x + origin_x, y, z)
+        if (world[0] >> 4, world[2] >> 4) not in client.chunks:
+            continue
+        state = client.blocks.get(world, 0)
+        got = names.name(state)
+        if got == block:
+            matched += 1
+        elif len(mismatched) < 5:
+            mismatched.append((world, block, got))
+
+    if mismatched:
+        for world, want, got in mismatched:
+            check.log("MISMATCH at %s: map says %s, server sent %s" % (world, want, got))
+        raise SystemExit(
+            "%s: %d blocks disagree with %s"
+            % (spec.name, len(mismatched), spec.name)
+        )
+    if matched == 0:
+        return False
+
+    # The air. Every position inside the map's own bounding box that the file
+    # leaves empty has to arrive empty.
+    empty = 0
+    filled = []
+    xs = [at[0] for at in spec.blocks]
+    zs = [at[2] for at in spec.blocks]
+    for x in range(min(xs), max(xs) + 1, 3):
+        for z in range(min(zs), max(zs) + 1, 3):
+            for y in range(low, high + 1, 3):
+                if (x, y, z) in spec.blocks:
+                    continue
+                world = (x + origin_x, y, z)
+                if (world[0] >> 4, world[2] >> 4) not in client.chunks:
+                    continue
+                if client.blocks.get(world, 0) == 0:
+                    empty += 1
+                elif len(filled) < 5:
+                    filled.append((world, names.name(client.blocks[world])))
+    if filled:
+        for world, got in filled:
+            check.log("MISMATCH at %s: map says air, server sent %s" % (world, got))
+        raise SystemExit("%s: %d gaps are not empty" % (spec.name, len(filled)))
+
+    check.prove(
+        claim,
+        "%s: %d of the %d blocks the map file places arrived, across %d of its %d "
+        "chunk columns, every one of them with the name the file gives it; and %d "
+        "sampled gaps between the islands arrived as air"
+        % (spec.name, matched, len(spec.blocks), len(arrived), len(columns), empty),
+    )
+    return True
+
+
+# --- the schedule -----------------------------------------------------------
+
+
+def solid_under(client, names, at):
+    """The block hyperion reads to decide a player is standing.
+
+    `ceil(y) - 1`, which is the check `terrain.rs::stand_on_something` makes
+    against its own `Blocks` and this makes against the wire instead.
+    """
+    below = (int(math.floor(at[0])), int(math.ceil(at[1])) - 1, int(math.floor(at[2])))
+    state = client.blocks.get(below, 0)
+    return below, state, names.name(state)
+
+
+def run(args):
+    started = time.time()
+    check = Check(started)
+    names = BlockNames()
+    maps = load_maps()
+
+    band_low = min(min(at[1] for at in spec.blocks) for spec in maps.values())
+    band_high = max(max(at[1] for at in spec.blocks) for spec in maps.values())
+    check.log(
+        "maps: %s"
+        % ", ".join("%d=%s" % (index, spec.name) for index, spec in sorted(maps.items()))
+    )
+    wanted = occupied_columns(maps)
+    check.log(
+        "decoding y %d to y %d in the %d chunk columns the maps occupy"
+        % (band_low, band_high, len(wanted))
+    )
+
+    clients = []
+    for index in range(args.clients):
+        client = MapClient(args.host, args.port, "P%d" % (index + 1), started)
+        client.handshake(args.host, args.port, 2)
+        client.login()
+        client.configuration()
+        client.enter_play()
+        clients.append(client)
+        client.log("configuration acknowledged")
+
+    subject = clients[0]
+    phase = "hub"
+    phase_since = time.time()
+    arena_region = None
+    descent = None
+    deadline = time.time() + args.timeout
+
+    def handle(client, packet_id, payload):
+        nonlocal phase, phase_since
+        if packet_id == S2C_LOGIN:
+            client.entity_id = struct.unpack(">i", payload[:4])[0]
+            client.joined = True
+        elif packet_id == S2C_PLAYER_POSITION:
+            teleport_id, offset = take_var_int(payload)
+            x, y, z = struct.unpack(">ddd", payload[offset : offset + 24])
+            client.send(C2S_ACCEPT_TELEPORTATION, var_int(teleport_id))
+            client.teleports.append((x, y, z))
+            moved = (
+                abs(x - client.position[0]) > 1.0
+                or abs(y - client.position[1]) > 1.0
+                or abs(z - client.position[2]) > 1.0
+            )
+            client.position = (x, y, z)
+            if moved:
+                client.log("<- teleported to (%.1f, %.1f, %.1f)" % (x, y, z))
+        elif packet_id == S2C_KEEP_ALIVE:
+            client.send(C2S_KEEP_ALIVE, payload[:8])
+        elif packet_id == S2C_SET_HEALTH:
+            health = struct.unpack(">f", payload[:4])[0]
+            if client.health != health:
+                client.log("<- health %.2f/20" % health)
+            client.health = health
+        elif packet_id == S2C_LEVEL_CHUNK_WITH_LIGHT:
+            where = struct.unpack_from(">ii", payload, 0)
+            if where not in wanted:
+                return
+            _, blocks = decode_chunk(payload, (band_low, band_high))
+            client.chunks[where] = client.chunks.get(where, 0) + len(blocks)
+            client.blocks.update(blocks)
+        elif packet_id == S2C_SECTION_BLOCKS_UPDATE:
+            where, changes = decode_section_blocks_update(payload)
+            if where not in wanted:
+                return
+            client.chunks.setdefault(where, 0)
+            for at, state in changes:
+                if not band_low <= at[1] <= band_high:
+                    continue
+                if state == 0:
+                    client.blocks.pop(at, None)
+                else:
+                    client.blocks[at] = state
+                    client.chunks[where] += 1
+        elif packet_id == S2C_DISCONNECT:
+            client.alive = False
+            raise SystemExit("%s was disconnected" % client.name)
+
+    while time.time() < deadline:
+        for client in clients:
+            for packet_id, payload in client.drain():
+                handle(client, packet_id, payload)
+            client.step_towards()
+
+        region = region_of(subject.position[0])
+
+        if phase == "hub":
+            if region == 0:
+                if compare_geometry(
+                    maps[0], 0, subject, names, check,
+                    "the map file's blocks are in the world",
+                ):
+                    below, state, block = solid_under(subject, names, subject.position)
+                    if state == 0:
+                        raise SystemExit(
+                            "%s stands at %s with air under them at %s"
+                            % (subject.name, subject.position, below)
+                        )
+                    check.prove(
+                        "a player stands on the geometry",
+                        "%s claimed to be on the ground at (%.1f, %.1f, %.1f) for %.0fs "
+                        "and was never corrected; the block under them at %s is %s, "
+                        "which the map file puts there"
+                        % (
+                            subject.name,
+                            subject.position[0],
+                            subject.position[1],
+                            subject.position[2],
+                            time.time() - phase_since,
+                            below,
+                            block,
+                        ),
+                    )
+                    phase = "waiting for the match"
+                    phase_since = time.time()
+                    check.log("waiting for the scatter onto an arena")
+
+        elif phase == "waiting for the match":
+            if region >= 1:
+                phase = "arena"
+                phase_since = time.time()
+                # Fixed here rather than re-read each pass: once the descent
+                # starts the subject is a long way off the island and a later
+                # correction would be read against the wrong map.
+                arena_region = region
+                check.log(
+                    "%s was scattered into region %d (%s)"
+                    % (subject.name, region, maps[region].name)
+                )
+
+        elif phase == "arena":
+            spec = maps[arena_region]
+            if compare_geometry(
+                spec, arena_region, subject, names, check,
+                "the arena's blocks are in the world",
+            ):
+                below, state, block = solid_under(subject, names, subject.position)
+                check.log(
+                    "%s stands on %s at %s, %.0f blocks above %s's kill plane y=%g"
+                    % (subject.name, block, below, subject.position[1] - spec.kill_y,
+                       spec.name, spec.kill_y)
+                )
+                descent = Descent(subject, spec, arena_region, check)
+                phase = "descending"
+                phase_since = time.time()
+
+        elif phase == "descending":
+            if descent.tick():
+                return check.report()
+
+        time.sleep(0.005)
+
+    check.log("timed out in phase %r" % phase)
+    return check.report()
+
+
+# --- entry point ------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=25565)
+    # Eight, because `LobbyConfig::countdown_for` gives a full lobby a ten
+    # second countdown and a merely sufficient one sixty.
+    parser.add_argument("--clients", type=int, default=8)
+    parser.add_argument("--timeout", type=float, default=240.0)
+    args = parser.parse_args()
+    sys.exit(run(args))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The map format, the four arenas and the per-match rotation landed in #983. What
did not land was any check that a client sees any of it, and that turned out to
be the interesting half.

## What was missing

`tools/smash-match.py` is candid about its own limits in its docstring: its
clients "teleport rather than walk, so nothing here says the platforms have
collision from a real client's point of view". Its proof that a match is on a
committed map is `abs(x) >= REGION_STRIDE / 2` -- arithmetic over a region
stride, not a block. Nothing in the repository had ever decoded a block off the
wire, and `kill_y` was a number in a file that had never been compared against
the terrain it was supposed to sit under.

## The new client

`tools/smash-map-check.py`, driven by `nix run .#smash-map-e2e`. It joins on
protocol 776 and proves four things in order:

| claim | how |
| --- | --- |
| the map file's blocks are in the world | decode the world, resolve state ids to names through `block_state.rs`, compare against `events/smash/maps/*.map` |
| a player stands on the geometry | the block at `ceil(y) - 1` under a spawn is the block the file puts there, and the client is never corrected |
| the arena's blocks are in the world | the same comparison against whichever arena the match chose |
| the kill plane is where the map says | hover five blocks above it for fifteen seconds without dying, then drop through and die |

The last one is two-sided on purpose. Diving straight past the plane and dying
proves only that something below is lethal; a dive from y 100 takes five
seconds and the server has no chance to object on the way down. Hovering just
above it first, in open air well off the island, is what rules out the plane
being higher than the file says.

Output from a run on a fresh server:

```
0.11s  decoding y 46 to y 76 in the 132 chunk columns the maps occupy
2.17s  PROVED the map file's blocks are in the world: Lobby: 11729 of the 11729
       blocks the map file places arrived, across 12 of its 12 chunk columns,
       every one of them with the name the file gives it; and 831 sampled gaps
       between the islands arrived as air
2.17s  PROVED a player stands on the geometry: P1 claimed to be on the ground at
       (4.0, 65.0, 4.0) and was never corrected; the block under them at
       (4, 64, 4) is minecraft:quartz_block, which the map file puts there
11.99s P1 was scattered into region 1 (Skylands)
12.29s PROVED the arena's blocks are in the world: Skylands: 15301 of the 15301
       blocks the map file places arrived, across 30 of its 30 chunk columns,
       every one of them with the name the file gives it; and 6802 sampled gaps
       between the islands arrived as air
17.59s P1 hovers at y 25.0, 5 blocks above the plane, for 15s
32.60s P1 survived 15s above the plane; now dropping through it
36.82s PROVED the kill plane is where the map says: P1 fell from y 100 to y 25,
       5 blocks above Skylands's declared kill plane y=20, and hovered there in
       open air for 15s without dying; it then dropped through the plane,
       reached y -20.0 and was killed and respawned. No death was reported at
       any height above the plane
```

Rotation is visible across consecutive runs against one server: Skylands,
Mushroom Islands, Glacier, Desert.

## Reading the world takes two packets, not one

This is what made the first three runs report a world with no floor, and it is
worth writing down. `terrain.rs` builds on `Blocks::empty`, so every column is
encoded as air before a single block is stamped into it, and that cached
encoding is never rebuilt. `sync_chunks.rs` sends a joining player the empty
`level_chunk_with_light` and then `original_delta_packets`: every change the
column has seen since it loaded, as `section_blocks_update`. A decoder that
reads only the chunk packet sees 24 sections of pure air, a 192-byte blob, in
every one of 3072 columns. That is also a performance question for another
change; filed separately.

## The format's own tests

`map.rs` had no tests at all. `events/smash/tests/maps.rs` adds 21:

- each of `parse`'s five rejections watched to fire, with the message it gives
- the brush rasterisers against their documented shapes: inclusive box corners
  either way round, a round cylinder starting at its centre, a centred sphere,
  a cone that tapers downwards only and stops at its depth
- every shipped map parses, places blocks, and has a distinct name
- **every spawn point has a solid block under it**, and **the kill plane is
  below every block the map places**

Those last two were previously asserted only at boot, which means a bad map was
a server that panicked on start rather than a test that failed, and only if
somebody started it. Both were confirmed to fail before being kept:

```
map 1 ("Skylands") spawns a player at [-10, 66, -10] with nothing under them at [-10, 65, -10]
map 1 ("Skylands") has a block at y 46, at or below its kill plane 50
```

## Smaller things

- `map.rs` now owns `HUB` and `ARENAS`, so the module that owns the format also
  owns what exists in it, and reading a map costs nothing but that module.
  `terrain.rs` pulls in the whole of hyperion to turn a `MapSpec` into blocks
  and a caller who only wants the arena list should not pay for it.
- `Arena::default` reads the first committed arena instead of six hand-written
  coordinates and a kill plane at y 0. Those numbers described no terrain that
  has ever existed: nothing placed a block at any of them, and a player put
  there would have fallen through empty air past a death plane thirty blocks
  below. It is only reachable from the tests under `tests/` now, but a fallback
  that is a second copy of the numbers is a fallback that drifts.
- The README gains "Adding a map": the directives, what `parse` refuses and
  why, the region layout, how rotation picks the next map, and how to check one
  on a real client.

## The download

Untouched. smash has not used `hyperion-genmap` since #983; bedwars still does,
and `crates/hyperion/tests/collision.rs` still does. Everything added here
parses from `include_str!` and needs no network.

## Gates

```
nix run .#fmt -- --check   ok
nix run .#lint             ok
nix run .#test             ok   483 tests run: 483 passed, 1 skipped
nix run .#e2e              ok   4096 LevelChunkWithLight, reached play state
nix run .#smash-e2e        ok   all seven claims proved, a whole match at 776
nix run .#smash-map-e2e    ok   all four claims proved (new)
nix flake check            ok   all checks passed
```

Expect the `Flake` CI job to fail for an unrelated reason (ENG-10485).
