### PR TITLE
feat(smash): every kit's abilities, declared as data and proved by real clients

### DIFF
--- a/events/smash/README.md
+++ b/events/smash/README.md
@@ -59,6 +59,7 @@ impl Module for Wolf {
             item: "minecraft:iron_shovel",
             slot: 1,
             cooldown: 6.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: wolf_strike,
             ..AbilitySpec::DEFAULT
         })
@@ -70,6 +71,66 @@ impl Module for Wolf {
 then `world.import::<Wolf>()`. `tests/modularity.rs` proves the claim by
 defining a kit from outside the crate and asserting no file under `src/`
 mentions it.
+
+### An ability says what a player will see
+
+`proves` is the one field on [`AbilitySpec`](src/module/kit.rs) with no useful
+default. Everything else describes the ability; that field is the ability's own
+claim about what a client would observe, and it is what turns "adding a kit
+means adding data" into "adding a kit means saying what the data does".
+
+The vocabulary is deliberately short, and every variant names a packet, because
+an effect nothing on the far side of the seam can see is not a proof:
+
+| `Observable` | what has to reach a client |
+| --- | --- |
+| `HurtsTarget` | somebody in front of the caster loses health (`ClientboundSetHealth`) |
+| `LaunchesTarget` | somebody in front of the caster gains velocity (`ClientboundSetEntityMotion`) |
+| `LaunchesCaster` | the caster gains velocity |
+| `TeleportsCaster` | the caster is moved (`ClientboundPlayerPosition`) |
+| `HealsCaster` | the caster's own health bar goes up |
+| `BuffsMelee` | the caster's next melee swing takes off more than the last one did |
+
+Two further flags exist for abilities that legitimately break a shared rule.
+`requires_ground` gates activation on standing still, and `refunds_on_hit` says
+a landed hit clears the cooldown, which is Chicken Missile's whole selling point
+and would otherwise read as a broken cooldown.
+
+The declaration is exhaustive for movement, not a lower bound: an ability that
+launches somebody without saying so fails the gate as surely as one that says it
+launches and does not. That is where the quiet bugs turned out to live.
+
+### What reads the declaration
+
+Nothing hard-codes a kit. [`ability::manifest`](src/module/ability.rs) is a query
+over the ability entities themselves and is the single source of truth:
+
+```rust
+for entry in ability::manifest(&world) {
+    println!("{} / {} in slot {}: {:?}", entry.kit, entry.name, entry.slot, entry.proves);
+}
+```
+
+Three things consume it, and a kit added tomorrow is covered by all three
+without any of them being edited:
+
+- `tests/abilities.rs` fires every ability through the mock seam and holds it to
+  its declaration, refuses a declaration that is empty, refuses a movement it
+  did not declare, and checks every cooldown by asking for a second use.
+- `/abilities` publishes it as one JSON object per chat line, which is how it
+  crosses to a client at all.
+- `nix run .#smash-e2e` reads that and drives every entry with a real 776
+  client, in the hub, one client short of the lobby's minimum so nothing starts
+  a match underneath it.
+
+### The Smash Crystal
+
+An ultimate is declared with `.ultimate(..)` and is not granted at spawn.
+[`kit::grant_ultimate`](src/module/kit.rs) hands it out for a window, and
+`ability::GrantedFor` counts that window down and takes it back. What is missing
+is the pickup: nothing spawns a crystal in the arena for somebody to walk into,
+which is arena work. Until it exists, `/crystal` is the entry point to the same
+mechanic and is what the gate uses.
 
 ## Adding a map
 

--- a/events/smash/src/command.rs
+++ b/events/smash/src/command.rs
@@ -11,6 +11,7 @@ use hyperion::net::{Compose, ConnectionId, agnostic};
 use hyperion_clap::{CommandPermission, MinecraftCommand, hyperion_command::CommandRegistry};
 
 use crate::module::{
+    ability,
     kit::{self, KitBlurb, KitName},
     lobby,
 };
@@ -18,6 +19,8 @@ use crate::module::{
 pub fn register(registry: &mut CommandRegistry, world: &World) {
     KitCommand::register(registry, world);
     KitsCommand::register(registry, world);
+    AbilitiesCommand::register(registry, world);
+    CrystalCommand::register(registry, world);
 }
 
 #[derive(Parser, CommandPermission, Debug)]
@@ -96,6 +99,129 @@ impl MinecraftCommand for KitsCommand {
         }
 
         tell(world, caller, &listing);
+    }
+}
+
+/// The line `/abilities` prefixes each ability with.
+///
+/// A marker rather than a bare object per line because chat is a shared
+/// channel: a reader has to be able to tell the manifest apart from a death
+/// message that happens to start with a brace.
+pub const MANIFEST_PREFIX: &str = "smash-ability ";
+
+/// The line that closes the manifest, with the count that should have preceded
+/// it. A reader that sees fewer has lost some to a truncated chat packet, and
+/// silently testing a short roster is exactly the failure this whole mechanism
+/// exists to prevent.
+pub const MANIFEST_END_PREFIX: &str = "smash-abilities-end ";
+
+/// Dump the ability registry, one JSON object per chat line.
+///
+/// The registry lives in the world as components on ability prefabs, and this is
+/// its only view over the wire. The end to end gate reads it and drives every
+/// ability it names, so an ability that exists is an ability the gate tests: no
+/// list of kits is written down anywhere on the client side, and nothing has to
+/// be edited when a kit is added.
+#[derive(Parser, CommandPermission, Debug)]
+#[command(name = "abilities")]
+#[command_permission(group = "Normal")]
+pub struct AbilitiesCommand;
+
+impl MinecraftCommand for AbilitiesCommand {
+    fn execute(self, system: EntityView<'_>, caller: Entity) {
+        let world = system.world();
+        let declared = ability::manifest(&world);
+        for entry in &declared {
+            tell(world, caller, &format!("{MANIFEST_PREFIX}{}", json(entry)));
+        }
+        tell(
+            world,
+            caller,
+            &format!("{MANIFEST_END_PREFIX}{}", declared.len()),
+        );
+    }
+}
+
+/// One ability as a JSON object.
+///
+/// Hand-rolled rather than pulled in behind serde: this is four scalar kinds and
+/// a string list, the crate has no JSON dependency, and a schema a reader has to
+/// match exactly is easier to check when it is written out in one place.
+fn json(entry: &ability::Declared) -> String {
+    let mut out = String::new();
+    let _unused = write!(
+        out,
+        r#"{{"kit":"{}","name":"{}","slot":{},"item":"{}","cooldown":{},"#,
+        escape(entry.kit),
+        escape(entry.name),
+        entry.slot,
+        escape(entry.item),
+        entry.cooldown,
+    );
+    match entry.charge_time {
+        Some(seconds) => {
+            let _unused = write!(out, r#""charge_time":{seconds},"#);
+        }
+        None => out.push_str(r#""charge_time":null,"#),
+    }
+    match entry.energy_cost {
+        Some(cost) => {
+            let _unused = write!(out, r#""energy_cost":{cost},"#);
+        }
+        None => out.push_str(r#""energy_cost":null,"#),
+    }
+    let _unused = write!(
+        out,
+        r#""requires_ground":{},"refunds_on_hit":{},"ultimate":{},"proves":["#,
+        entry.requires_ground, entry.refunds_on_hit, entry.ultimate,
+    );
+    for (index, observable) in entry.proves.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        let _unused = write!(out, r#""{}""#, observable.as_str());
+    }
+    out.push_str("]}");
+    out
+}
+
+fn escape(text: &str) -> String {
+    text.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Pick up a Smash Crystal.
+///
+/// Mineplex spawned the crystal in the arena and you walked into it. Nothing
+/// spawns one here yet -- that is arena work, and the arena is somebody else's
+/// file -- so this is the entry point to the same mechanic: the ultimate is
+/// granted for [`ability::ULTIMATE_SECONDS`] and taken back when it lapses,
+/// through exactly the code path a real pickup would use.
+#[derive(Parser, CommandPermission, Debug)]
+#[command(name = "crystal")]
+#[command_permission(group = "Normal")]
+pub struct CrystalCommand;
+
+impl MinecraftCommand for CrystalCommand {
+    fn execute(self, system: EntityView<'_>, caller: Entity) {
+        let world = system.world();
+        let player = caller.entity_view(world);
+
+        let Some(name) = kit::ultimate_name(player) else {
+            tell(world, caller, "§cPick a kit first. Try /kits.");
+            return;
+        };
+        if kit::grant_ultimate(&world, player, ability::ULTIMATE_SECONDS) {
+            tell(
+                world,
+                caller,
+                &format!(
+                    "§bSmash Crystal: {name} for {:.0} seconds.",
+                    ability::ULTIMATE_SECONDS
+                ),
+            );
+        } else {
+            tell(world, caller, "§cYou are already holding one.");
+        }
     }
 }
 

--- a/events/smash/src/input.rs
+++ b/events/smash/src/input.rs
@@ -133,6 +133,30 @@ impl Module for InputModule {
                 player.add(HotbarStale::id());
             });
 
+        // The same deferral applies to abilities arriving and leaving one at a
+        // time rather than a whole kit at once, which is what the Smash Crystal
+        // does: without this a granted ultimate never reaches slot 8 and an
+        // expired one stays there forever.
+        //
+        // One term, and the `Player` check moved into the body. A second filter
+        // term turns this into a query-match observer, which fires on any table
+        // transition that keeps the query satisfied -- so every ability use,
+        // which adds and removes an invulnerability marker, rewrote the whole
+        // inventory in the same tick.
+        let mark_stale = |entity: EntityView<'_>, ()| {
+            if entity.has(Player::id()) {
+                entity.add(HotbarStale::id());
+            }
+        };
+        world
+            .observer::<flecs::OnAdd, ()>()
+            .with((ability::Grants, id::<flecs::Wildcard>()))
+            .each_entity(mark_stale);
+        world
+            .observer::<flecs::OnRemove, ()>()
+            .with((ability::Grants, id::<flecs::Wildcard>()))
+            .each_entity(mark_stale);
+
         world
             .system_named::<&PlayerId>("smash::push_stale_hotbars")
             .kind(id::<flecs::pipeline::PostUpdate>())
@@ -144,6 +168,9 @@ impl Module for InputModule {
                     return;
                 }
                 let id = *id;
+                // Deliberately a full replace and not a diff: the seam's only
+                // hotbar verb is "here is the whole bar", and a kit change, a
+                // respawn and a crystal expiring all want the same answer.
                 player
                     .world()
                     .get::<&crate::server::ServerHandle>(|server| server.set_hotbar(id, &hotbar));

--- a/events/smash/src/module/ability.rs
+++ b/events/smash/src/module/ability.rs
@@ -51,6 +51,69 @@ pub struct Named(pub &'static str);
 #[derive(Component, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Description(pub &'static str);
 
+/// One thing a client can see when an ability fires.
+///
+/// This is the half of an ability declaration that the gates read. A kit says
+/// what its ability does in terms a player could point at, and both
+/// `tests/abilities.rs` and the scripted-client gate `nix run .#smash-e2e`
+/// enumerate [`manifest`] and hold every ability to what it declared. An
+/// ability that declares nothing fails the first test in `tests/abilities.rs`;
+/// an ability that declares something it does not do fails both gates.
+///
+/// The list is deliberately short and stated in wire terms, because an
+/// observation nothing on the far side of the seam can see is not a proof. Each
+/// variant names the packet that carries it:
+///
+/// - [`Self::HurtsTarget`] and [`Self::HealsCaster`] are `ClientboundSetHealth`
+/// - [`Self::LaunchesTarget`] and [`Self::LaunchesCaster`] are
+///   `ClientboundSetEntityMotion`
+/// - [`Self::TeleportsCaster`] is `ClientboundPlayerPosition`
+/// - [`Self::BuffsMelee`] is the same melee swing hurting more than it did
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Observable {
+    /// A player in front of the caster loses health.
+    HurtsTarget,
+    /// A player in front of the caster gains velocity.
+    LaunchesTarget,
+    /// The caster gains velocity.
+    LaunchesCaster,
+    /// The caster ends up somewhere they were not.
+    TeleportsCaster,
+    /// The caster's own health bar goes up.
+    HealsCaster,
+    /// The caster's melee swing hurts more than it did before.
+    BuffsMelee,
+}
+
+impl Observable {
+    /// The name this observation goes over the wire under, in `/abilities`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::HurtsTarget => "hurts_target",
+            Self::LaunchesTarget => "launches_target",
+            Self::LaunchesCaster => "launches_caster",
+            Self::TeleportsCaster => "teleports_caster",
+            Self::HealsCaster => "heals_caster",
+            Self::BuffsMelee => "buffs_melee",
+        }
+    }
+}
+
+/// What an ability promises a client will see. Declared by the kit.
+#[derive(Component, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Proves(pub &'static [Observable]);
+
+/// Seconds left on a grant that expires on its own.
+///
+/// The Smash Crystal is the only thing that makes one: an ultimate is granted
+/// for a fixed time and taken back, and the ability entity carrying the
+/// countdown is the whole of that bookkeeping.
+#[derive(Component, Debug, Copy, Clone, PartialEq)]
+pub struct GrantedFor {
+    pub remaining: f32,
+}
+
 /// How long after use before the ability is available again, in seconds.
 #[derive(Component, Debug, Copy, Clone, PartialEq)]
 pub struct CooldownSpec(pub f32);
@@ -69,6 +132,15 @@ pub struct EnergyCost(pub f32);
 /// and Seismic Slam.
 #[derive(Component, Debug)]
 pub struct RequiresGround;
+
+/// This ability's cooldown is cleared by landing a hit rather than by waiting.
+///
+/// A tag on the ability, not a behaviour: clearing the cooldown is the kit's own
+/// `on_hit` payload. What this says is that the ability is *allowed* to come
+/// back early, which is what stops the shared cooldown check in
+/// `tests/abilities.rs` from reading a deliberate refund as a broken cooldown.
+#[derive(Component, Debug)]
+pub struct RefundsOnHit;
 
 /// Everything an ability gets to see and touch when it fires.
 pub struct Cast<'a> {
@@ -225,6 +297,111 @@ pub fn activate(player: EntityView<'_>, slot: u8, charge: f32) -> Result<(), Ref
     Ok(())
 }
 
+/// Seconds a Smash Crystal's ultimate lasts before it is taken back.
+///
+/// Mineplex's crystal spawned in the arena, was picked up, and gave the holder
+/// their kit's ultimate for a fixed window. The window is the ability layer's
+/// business and lives here; spawning the crystal is the arena's, and until it
+/// does, [`crate::module::kit::grant_ultimate`] is how one is handed out.
+pub const ULTIMATE_SECONDS: f32 = 20.0;
+
+/// One ability, exactly as its kit declared it.
+///
+/// The registry is the ability entities themselves; this is a flat read of them
+/// for anything that wants the whole roster at once. `/abilities` serialises it
+/// for the end to end gate, and `tests/abilities.rs` walks it to drive every
+/// ability in the game through the mock seam.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Declared {
+    pub kit: &'static str,
+    pub name: &'static str,
+    pub slot: u8,
+    pub item: &'static str,
+    pub description: &'static str,
+    pub cooldown: f32,
+    /// `Some` for a hold-and-release ability, in seconds to full charge.
+    pub charge_time: Option<f32>,
+    pub energy_cost: Option<f32>,
+    pub requires_ground: bool,
+    /// A hit clears the cooldown, so a second use may legitimately be allowed
+    /// straight away.
+    pub refunds_on_hit: bool,
+    /// Granted by the Smash Crystal rather than at spawn.
+    pub ultimate: bool,
+    pub proves: &'static [Observable],
+}
+
+/// Every ability every registered kit declares, kit registration order first
+/// and hotbar slot order within a kit.
+///
+/// A query over the world, not a list anybody maintains: a kit imported from
+/// outside the crate appears here the moment its module runs, which is what
+/// makes this the single source of truth the gates enumerate.
+#[must_use]
+pub fn manifest(world: &World) -> Vec<Declared> {
+    use crate::module::kit::{KitName, Ultimate, registry};
+
+    let mut out = Vec::new();
+    for kit in registry(world) {
+        let kit = world.entity_from_id(kit);
+        let Some(kit_name) = kit.try_get::<&KitName>(|name| name.0) else {
+            continue;
+        };
+        let mut abilities = Vec::new();
+        kit.each_target_view(Grants, |ability| {
+            let (Some(name), Some(slot)) = (
+                ability.try_get::<&Named>(|n| n.0),
+                ability.try_get::<&Slot>(|s| s.0),
+            ) else {
+                return;
+            };
+            abilities.push(Declared {
+                kit: kit_name,
+                name,
+                slot,
+                item: ability.try_get::<&Item>(|i| i.0).unwrap_or(""),
+                description: ability.try_get::<&Description>(|d| d.0).unwrap_or(""),
+                cooldown: ability.try_get::<&CooldownSpec>(|c| c.0).unwrap_or(0.0),
+                charge_time: ability.try_get::<&ChargeTime>(|c| c.0),
+                energy_cost: ability.try_get::<&EnergyCost>(|c| c.0),
+                requires_ground: ability.has(RequiresGround::id()),
+                refunds_on_hit: ability.has(RefundsOnHit::id()),
+                ultimate: ability.has(Ultimate::id()),
+                proves: ability.try_get::<&Proves>(|p| p.0).unwrap_or(&[]),
+            });
+        });
+        abilities.sort_by_key(|ability| ability.slot);
+        out.append(&mut abilities);
+    }
+    out
+}
+
+/// Take back a grant that has run out: unlink it from whoever holds it and
+/// destroy the instance.
+fn expire(world: WorldRef<'_>, expired: &[Entity]) {
+    let mut edges = Vec::new();
+    world
+        .query::<()>()
+        .with(Player::id())
+        .build()
+        .each_entity(|player, ()| {
+            player.each_target_view(Grants, |ability| {
+                if expired.contains(&ability.id()) {
+                    edges.push((player.id(), ability.id()));
+                }
+            });
+        });
+    for (player, ability) in edges {
+        world.entity_at(player).remove((Grants, ability));
+    }
+    for ability in expired {
+        let ability = world.entity_at(*ability);
+        if ability.is_alive() {
+            ability.destruct();
+        }
+    }
+}
+
 #[derive(Component)]
 pub struct AbilityModule;
 
@@ -241,6 +418,7 @@ impl Module for AbilityModule {
         world.component::<Cooldown>();
         world.component::<EnergyCost>();
         world.component::<RequiresGround>();
+        world.component::<RefundsOnHit>();
         world.component::<OnActivate>();
         world.component::<OnRelease>();
         world.component::<ChargeTime>();
@@ -248,6 +426,8 @@ impl Module for AbilityModule {
         world.component::<UseSlot>();
         world.component::<ReleaseSlot>();
         world.component::<Grants>();
+        world.component::<Proves>();
+        world.component::<GrantedFor>();
 
         world
             .system_named::<&mut Cooldown>("smash::tick_cooldowns")
@@ -261,6 +441,31 @@ impl Module for AbilityModule {
             .system_named::<&mut Charging>("smash::tick_charge")
             .each_iter(|it, _, charging| {
                 charging.held += it.delta_time();
+            });
+
+        // Grants that expire. Written as one `run` rather than as a per-entity
+        // system because taking the grant back edits the holder's type, and
+        // flecs refuses that from inside the query that found it.
+        world
+            .system_named::<()>("smash::expire_grants")
+            .run(|mut it| {
+                while it.next() {
+                    let world = it.world();
+                    let dt = it.delta_time();
+                    let mut expired = Vec::new();
+                    world
+                        .query::<&mut GrantedFor>()
+                        .build()
+                        .each_entity(|ability, granted| {
+                            granted.remaining -= dt;
+                            if granted.remaining <= 0.0 {
+                                expired.push(ability.id());
+                            }
+                        });
+                    if !expired.is_empty() {
+                        expire(world, &expired);
+                    }
+                }
             });
 
         // A single dispatcher for every ability in the game. Adding a kit
@@ -279,6 +484,15 @@ impl Module for AbilityModule {
                 if let Some(ability) = granted_in_slot(player, slot)
                     && ability.has(ChargeTime::id())
                 {
+                    // Checked here and not only on release: a charge that is
+                    // going to be refused should be refused while the player
+                    // can still do something else, and a hold that silently
+                    // banked a use is how a cooldown looks like it does not
+                    // exist from a client's point of view.
+                    if let Err(refusal) = check(ability, player) {
+                        report(player, Err(refusal));
+                        return;
+                    }
                     ability.set(Charging { held: 0.0 });
                     return;
                 }
@@ -320,12 +534,27 @@ fn report(player: EntityView<'_>, outcome: Result<(), Refusal>) {
     });
 }
 
-/// Hurt everything within `radius` of `at`, except the caster.
+/// Hurt everything within `radius` of `at`, except the caster, launching it away
+/// from `origin`.
 ///
 /// The one geometric primitive the kits share. Collecting the victims before
 /// hurting any of them is deliberate: the damage observers mutate components
 /// the query is reading, and flecs will catch that at runtime if you nest them.
-pub fn splash_at(cast: &Cast<'_>, at: Vec3, radius: f32, damage: f32, multiplier: f32) {
+///
+/// `origin` is separate from `at` because knockback is horizontal-only and a
+/// launch away from a point a victim is standing on has no direction: it
+/// normalises to zero and the victim does not move. An ability centred on its
+/// own victims -- Storm Squid calls down a bolt on each player where they stand
+/// -- has to name the caster as the origin or it silently deals damage and no
+/// knockback at all.
+pub fn splash_from(
+    cast: &Cast<'_>,
+    origin: Vec3,
+    at: Vec3,
+    radius: f32,
+    damage: f32,
+    multiplier: f32,
+) {
     use crate::module::{
         damage::{DamageKind, Damaged},
         knockback::Knockback,
@@ -335,6 +564,7 @@ pub fn splash_at(cast: &Cast<'_>, at: Vec3, radius: f32, damage: f32, multiplier
     let mut victims = Vec::new();
     cast.world
         .query::<(&Position, &Health)>()
+        .with(Player::id())
         .build()
         .each_entity(|entity, (position, health)| {
             if entity.id() != caster && !health.is_dead() && position.0.distance(at) <= radius {
@@ -346,10 +576,16 @@ pub fn splash_at(cast: &Cast<'_>, at: Vec3, radius: f32, damage: f32, multiplier
         crate::module::damage::hurt(cast.world.entity_at(victim), Damaged {
             attacker: Some(caster),
             amount: damage,
-            knockback: Knockback::from(at).times(multiplier),
+            knockback: Knockback::from(origin).times(multiplier),
             kind: DamageKind::Ability,
         });
     }
+}
+
+/// [`splash_from`] with the blast's own centre as the origin, which is what an
+/// explosion somewhere other than on top of a victim wants.
+pub fn splash_at(cast: &Cast<'_>, at: Vec3, radius: f32, damage: f32, multiplier: f32) {
+    splash_from(cast, at, at, radius, damage, multiplier);
 }
 
 /// Turn a 0..=1 charge fraction into a whole number of steps.

--- a/events/smash/src/module/kit.rs
+++ b/events/smash/src/module/kit.rs
@@ -15,8 +15,9 @@ use crate::{
     flecs_ext::EntityViewExt,
     module::{
         ability::{
-            Ability, Cast, ChargeTime, Cooldown, CooldownSpec, Description, EnergyCost, Grants,
-            Item, Named, OnActivate, OnRelease, RequiresGround, Slot,
+            Ability, Cast, ChargeTime, Cooldown, CooldownSpec, Description, EnergyCost, GrantedFor,
+            Grants, Item, Named, Observable, OnActivate, OnRelease, Proves, RefundsOnHit,
+            RequiresGround, Slot,
         },
         damage::Armor,
         knockback::KnockbackTaken,
@@ -112,10 +113,17 @@ const fn noop(_: &Cast<'_>) {}
 ///     item: "minecraft:iron_axe",
 ///     slot: 1,
 ///     cooldown: 7.0,
+///     proves: &[Observable::TeleportsCaster],
 ///     activate: blink,
 ///     ..AbilitySpec::DEFAULT
 /// }
 /// ```
+///
+/// `proves` is the one field with no sensible default. Everything else
+/// describes the ability; that field is the ability's own claim about what a
+/// player will see, and it is what the two gates enumerate. Leaving it empty is
+/// caught by `tests/abilities.rs`, so a kit cannot be added without saying what
+/// its abilities do.
 #[derive(Debug, Copy, Clone)]
 pub struct AbilitySpec {
     pub name: &'static str,
@@ -129,6 +137,16 @@ pub struct AbilitySpec {
     pub charge_time: Option<f32>,
     pub energy_cost: Option<f32>,
     pub requires_ground: bool,
+    /// Landing a hit clears the cooldown instead of the clock doing it.
+    ///
+    /// Chicken Missile is the only ability in the roster built this way, and the
+    /// wiki calls it the kit's strongest point. It is declared rather than left
+    /// implicit because "a cooldown refuses the next use" is otherwise a rule
+    /// every ability is held to, and one that is meant to be broken has to say
+    /// so where the gates can read it.
+    pub refunds_on_hit: bool,
+    /// What a client sees when this fires. Must not be empty.
+    pub proves: &'static [Observable],
     pub activate: fn(&Cast<'_>),
 }
 
@@ -142,6 +160,8 @@ impl AbilitySpec {
         charge_time: None,
         energy_cost: None,
         requires_ground: false,
+        refunds_on_hit: false,
+        proves: &[],
         activate: noop,
     };
 }
@@ -193,8 +213,7 @@ impl<'w> KitBuilder<'w> {
     /// it and its expiry takes it back.
     #[must_use]
     pub fn ultimate(self, spec: AbilitySpec) -> Self {
-        let ability = self.build_ability(spec, true);
-        ability.add(Ultimate::id());
+        self.build_ability(spec, true);
         self
     }
 
@@ -217,6 +236,7 @@ impl<'w> KitBuilder<'w> {
             .set(Slot(spec.slot))
             .set(Description(spec.description))
             .set(CooldownSpec(spec.cooldown))
+            .set(Proves(spec.proves))
             .set(Cooldown::default());
 
         if let Some(charge) = spec.charge_time {
@@ -231,9 +251,18 @@ impl<'w> KitBuilder<'w> {
         if spec.requires_ground {
             ability.add(RequiresGround::id());
         }
-        if !ultimate {
-            self.kit.add((Grants, ability));
+        if spec.refunds_on_hit {
+            ability.add(RefundsOnHit::id());
         }
+        if ultimate {
+            ability.add(Ultimate::id());
+        }
+        // Every ability the kit has, ultimate included, hangs off the same
+        // relationship, so one traversal enumerates the whole kit. What
+        // separates them is the `Ultimate` tag, which `apply` filters on: an
+        // ultimate that was reachable only through its flecs scope path was an
+        // ability no registry could see and therefore no gate could test.
+        self.kit.add((Grants, ability));
         ability
     }
 }
@@ -265,11 +294,58 @@ pub fn apply(world: &World, player: EntityView<'_>, kit: EntityView<'_>) {
     }
 
     let mut prefabs = Vec::new();
-    kit.each_target_view(Grants, |ability| prefabs.push(ability.id()));
+    kit.each_target_view(Grants, |ability| {
+        // The ultimate is the Smash Crystal's to hand out, so it is on the kit
+        // and not on the player until one is picked up.
+        if !ability.has(Ultimate::id()) {
+            prefabs.push(ability.id());
+        }
+    });
     for prefab in prefabs {
         let instance = world.entity().is_a(prefab).child_of(player);
         player.add((Grants, instance));
     }
+}
+
+/// Hand `player` their kit's Smash Crystal ability for `seconds`.
+///
+/// The window is the ability layer's ([`crate::module::ability::GrantedFor`]
+/// counts it down and takes the ability back); what spawns a crystal in the
+/// arena for somebody to walk into is the arena's, and does not exist yet. Until
+/// it does this is the whole of the mechanic, and `/crystal` is the way a player
+/// or a test reaches it.
+///
+/// Returns `false` when the player has no kit, the kit declares no ultimate, or
+/// they are already holding one.
+#[must_use]
+pub fn grant_ultimate(world: &World, player: EntityView<'_>, seconds: f32) -> bool {
+    let Some(kit) = player.find_target(Playing, |_| true) else {
+        return false;
+    };
+    let Some(prefab) = kit.find_target(Grants, |ability| ability.has(Ultimate::id())) else {
+        return false;
+    };
+    if player
+        .find_target(Grants, |ability| ability.has(Ultimate::id()))
+        .is_some()
+    {
+        return false;
+    }
+
+    let instance = world.entity().is_a(prefab).child_of(player);
+    instance.set(GrantedFor { remaining: seconds });
+    player.add((Grants, instance));
+    true
+}
+
+/// The name of the ultimate `player`'s kit declares, whether or not they hold
+/// it. `None` for a player with no kit.
+#[must_use]
+pub fn ultimate_name(player: EntityView<'_>) -> Option<&'static str> {
+    player
+        .find_target(Playing, |_| true)?
+        .find_target(Grants, |ability| ability.has(Ultimate::id()))?
+        .try_get::<&Named>(|name| name.0)
 }
 
 /// Strip whatever kit a player is currently carrying.

--- a/events/smash/src/module/kits/blaze.rs
+++ b/events/smash/src/module/kits/blaze.rs
@@ -13,7 +13,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, splash_at},
+        ability::{Cast, Observable, splash_at},
         damage::{DamageKind, Damaged, hurt},
         kit::{self, AbilitySpec, KitStats},
         knockback::Knockback,
@@ -53,6 +53,7 @@ impl Module for Blaze {
             description: "Spew flame. No knockback, and armour does not reduce it.",
             cooldown: 0.5,
             energy_cost: Some(12.0),
+            proves: &[Observable::HurtsTarget],
             activate: inferno,
             ..AbilitySpec::DEFAULT
         })
@@ -64,6 +65,11 @@ impl Module for Blaze {
                           cancels it.",
             cooldown: 9.0,
             charge_time: Some(1.5),
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::LaunchesCaster,
+            ],
             activate: firefly,
             ..AbilitySpec::DEFAULT
         })
@@ -73,6 +79,11 @@ impl Module for Blaze {
             slot: 8,
             description: "Twenty seconds of Firefly with no charge and free flight.",
             cooldown: 1.0,
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::LaunchesCaster,
+            ],
             activate: phoenix,
             ..AbilitySpec::DEFAULT
         })

--- a/events/smash/src/module/kits/chicken.rs
+++ b/events/smash/src/module/kits/chicken.rs
@@ -13,7 +13,7 @@ use glam::Vec3;
 use crate::{
     flecs_ext::EntityViewExt,
     module::{
-        ability::{Cast, Cooldown, Grants, Named},
+        ability::{Cast, Cooldown, Grants, Named, Observable},
         kit::{self, AbilitySpec, KitStats},
         projectile::{Flight, Impact, Payload, fire},
     },
@@ -53,6 +53,7 @@ impl Module for Chicken {
             // of 2 seconds."
             cooldown: 2.0,
             charge_time: Some(0.8),
+            proves: &[Observable::HurtsTarget],
             activate: egg_blaster,
             ..AbilitySpec::DEFAULT
         })
@@ -62,6 +63,8 @@ impl Module for Chicken {
             slot: 2,
             description: "A chick that explodes. Recharges the instant it hits something.",
             cooldown: 8.0,
+            refunds_on_hit: true,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: chicken_missile,
             ..AbilitySpec::DEFAULT
         })
@@ -71,6 +74,7 @@ impl Module for Chicken {
             slot: 8,
             description: "Unlimited flight and eggs, for twenty seconds.",
             cooldown: 1.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesCaster],
             activate: aerial_gunner,
             ..AbilitySpec::DEFAULT
         })

--- a/events/smash/src/module/kits/cow.rs
+++ b/events/smash/src/module/kits/cow.rs
@@ -13,7 +13,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, splash_at},
+        ability::{Cast, Observable, splash_at},
         kit::{self, AbilitySpec, KitStats},
         projectile::{Flight, Payload, fire},
     },
@@ -46,6 +46,7 @@ impl Module for Cow {
             description: "Five cows in a line. Each one can hit you.",
             // `[VERIFIED]` "(Cooldown: 13 seconds)".
             cooldown: 13.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: angry_herd,
             ..AbilitySpec::DEFAULT
         })
@@ -56,6 +57,11 @@ impl Module for Cow {
             description: "A helix of milk that carries you with it. Hits at most two people.",
             // `[VERIFIED]` "(Cooldown: 11 seconds)".
             cooldown: 11.0,
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::LaunchesCaster,
+            ],
             activate: milk_spiral,
             ..AbilitySpec::DEFAULT
         })
@@ -65,6 +71,7 @@ impl Module for Cow {
             slot: 8,
             description: "Become a mooshroom: more damage, five more hearts, faster abilities.",
             cooldown: 20.0,
+            proves: &[Observable::HealsCaster],
             activate: mooshroom_madness,
             ..AbilitySpec::DEFAULT
         })
@@ -110,18 +117,34 @@ fn milk_spiral(cast: &Cast<'_>) {
     cast.server.cue(cast.position.0, Cue::Charge);
 }
 
+/// `[VERIFIED]` "5 more hearts".
+pub const MOOSHROOM_BONUS_HEALTH: f32 = 10.0;
+
 /// `[VERIFIED]` "+1 Damage ... 5 more hearts"; the transformation itself needs
 /// the host's entity type machinery, so what lands is the heal.
 fn mooshroom_madness(cast: &Cast<'_>) {
-    use crate::module::player::Health;
+    use crate::{
+        flecs_ext::EntityViewExt,
+        module::{
+            kit::{KitStats, Playing},
+            player::Health,
+        },
+    };
 
-    cast.caster.get::<&mut Health>(|health| {
-        health.max += 10.0;
-        health.current = health.max;
-    });
-    let (current, max) = cast
+    // Set against the kit's own maximum rather than added to whatever the
+    // player currently has. Adding compounds: the crystal can be picked up more
+    // than once in a match, and two Mooshroom Madnesses used to leave a Cow on
+    // forty hearts and a third on fifty.
+    let base = cast
         .caster
-        .try_get::<&Health>(|h| (h.current, h.max))
-        .unwrap_or((20.0, 20.0));
+        .find_target(Playing, |_| true)
+        .and_then(|kit| kit.try_get::<&KitStats>(|stats| stats.max_health))
+        .unwrap_or(20.0);
+
+    let (current, max) = cast.caster.get::<&mut Health>(|health| {
+        health.max = base + MOOSHROOM_BONUS_HEALTH;
+        health.current = health.max;
+        (health.current, health.max)
+    });
     cast.server.set_health(cast.player, current, max);
 }

--- a/events/smash/src/module/kits/creeper.rs
+++ b/events/smash/src/module/kits/creeper.rs
@@ -11,7 +11,7 @@ use flecs_ecs::prelude::*;
 
 use crate::{
     module::{
-        ability::{Cast, splash},
+        ability::{Cast, Observable, splash},
         damage::DamageKind,
         kit::{self, AbilitySpec, KitStats},
         player::Player,
@@ -51,6 +51,7 @@ impl Module for Creeper {
             slot: 1,
             description: "Throw coal. It goes off on whatever it touches.",
             cooldown: 6.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: sulphur_bomb,
             ..AbilitySpec::DEFAULT
         })
@@ -63,6 +64,7 @@ impl Module for Creeper {
             description: "Charge for a second and a half, then take everything nearby with you.",
             cooldown: 10.0,
             charge_time: Some(1.5),
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: explosion,
             ..AbilitySpec::DEFAULT
         })
@@ -72,6 +74,7 @@ impl Module for Creeper {
             slot: 8,
             description: "The same idea, without the restraint.",
             cooldown: 20.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: atomic_blast,
             ..AbilitySpec::DEFAULT
         })

--- a/events/smash/src/module/kits/enderman.rs
+++ b/events/smash/src/module/kits/enderman.rs
@@ -13,7 +13,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::Cast,
+        ability::{Cast, Observable},
         kit::{self, AbilitySpec, KitStats},
         player::Position,
         projectile::{Flight, Payload, fire},
@@ -53,6 +53,7 @@ impl Module for Enderman {
             description: "Pick up a block and hurl it. Charge it for the extra point.",
             cooldown: 2.0,
             charge_time: Some(1.2),
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: block_toss,
             ..AbilitySpec::DEFAULT
         })
@@ -62,6 +63,7 @@ impl Module for Enderman {
             slot: 1,
             description: "Instantly cross sixteen blocks in the direction you are looking.",
             cooldown: 7.0,
+            proves: &[Observable::TeleportsCaster],
             activate: blink,
             ..AbilitySpec::DEFAULT
         })
@@ -72,6 +74,7 @@ impl Module for Enderman {
             description: "Charge, then go wherever you are looking. Getting hit cancels it.",
             cooldown: 5.0,
             charge_time: Some(1.0),
+            proves: &[Observable::TeleportsCaster],
             activate: long_teleport,
             ..AbilitySpec::DEFAULT
         })
@@ -81,6 +84,7 @@ impl Module for Enderman {
             slot: 8,
             description: "Ride a dragon through everyone.",
             cooldown: 30.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: dragon_rider,
             ..AbilitySpec::DEFAULT
         })

--- a/events/smash/src/module/kits/guardian.rs
+++ b/events/smash/src/module/kits/guardian.rs
@@ -14,7 +14,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, splash_at},
+        ability::{Cast, Observable, splash_at},
         damage::MatchClock,
         kit::{self, AbilitySpec, KitStats},
         player::{Player, Position},
@@ -62,6 +62,7 @@ impl Module for Guardian {
             description: "A shard that pulls, like a weaker hook on a shorter cooldown.",
             // `[VERIFIED]` "its low recharge time of 5 seconds".
             cooldown: 5.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: whirlpool_axe,
             ..AbilitySpec::DEFAULT
         })
@@ -72,6 +73,11 @@ impl Module for Guardian {
             description: "Bounce up, dragging everyone within five blocks with you.",
             // `[VERIFIED]` "Due to its cooldown of 12 seconds".
             cooldown: 12.0,
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::LaunchesCaster,
+            ],
             activate: water_splash,
             ..AbilitySpec::DEFAULT
         })
@@ -83,6 +89,7 @@ impl Module for Guardian {
                           seconds.",
             cooldown: 15.0,
             requires_ground: true,
+            proves: &[Observable::BuffsMelee],
             activate: target_laser,
             ..AbilitySpec::DEFAULT
         })
@@ -92,6 +99,7 @@ impl Module for Guardian {
             slot: 8,
             description: "Everything in the water goes where the water goes.",
             cooldown: 20.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: tidal_wave,
             ..AbilitySpec::DEFAULT
         })

--- a/events/smash/src/module/kits/iron_golem.rs
+++ b/events/smash/src/module/kits/iron_golem.rs
@@ -12,7 +12,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, splash, splash_at},
+        ability::{Cast, Observable, splash, splash_at},
         kit::{self, AbilitySpec, KitStats},
         player::Position,
         projectile::{Flight, Impact, Payload, fire},
@@ -48,6 +48,7 @@ impl Module for IronGolem {
             description: "Split the ground in a line, launching whoever it reaches.",
             cooldown: 8.0,
             requires_ground: true,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: fissure,
             ..AbilitySpec::DEFAULT
         })
@@ -57,6 +58,7 @@ impl Module for IronGolem {
             slot: 2,
             description: "Throw a hook. On a hit it drags them to you.",
             cooldown: 8.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: iron_hook,
             ..AbilitySpec::DEFAULT
         })
@@ -67,6 +69,7 @@ impl Module for IronGolem {
             description: "Leap, then land hard. Everything nearby goes flying.",
             cooldown: 7.0,
             requires_ground: true,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: seismic_slam,
             ..AbilitySpec::DEFAULT
         })
@@ -76,6 +79,7 @@ impl Module for IronGolem {
             slot: 8,
             description: "Shake the whole map. Anyone touching the ground pays.",
             cooldown: 16.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: earthquake,
             ..AbilitySpec::DEFAULT
         })
@@ -145,22 +149,42 @@ fn seismic_slam(cast: &Cast<'_>) {
 }
 
 /// Hits every grounded player on the map, wherever they are.
+///
+/// Each victim is hurt once, by id. Splashing at each of their positions in
+/// turn double-hit anyone standing near somebody else, which made the ultimate
+/// swing between three damage and twelve depending on how bunched up the arena
+/// happened to be.
 fn earthquake(cast: &Cast<'_>) {
-    use crate::module::player::OnGround;
+    use crate::module::{
+        damage::{DamageKind, Damaged, hurt},
+        knockback::Knockback,
+        player::{Health, OnGround, Player},
+    };
+
+    const DAMAGE: f32 = 3.0;
 
     let caster = cast.caster.id();
     let mut victims = Vec::new();
     cast.world
-        .query::<(&Position, &OnGround)>()
+        .query::<(&OnGround, &Health)>()
+        .with(Player::id())
         .build()
-        .each_entity(|entity, (position, ground)| {
-            if entity.id() != caster && ground.0 {
-                victims.push((entity.id(), position.0));
+        .each_entity(|entity, (ground, health)| {
+            if entity.id() != caster && ground.0 && !health.is_dead() {
+                victims.push(entity.id());
             }
         });
 
-    for (victim, at) in victims {
-        splash_at(cast, at, 2.0, 3.0, 1.0);
-        let _ = victim;
+    for victim in victims {
+        hurt(cast.world.entity_from_id(victim), Damaged {
+            attacker: Some(caster),
+            amount: DAMAGE,
+            // Away from the golem. A shockwave centred on each victim in turn
+            // is what the previous version computed, and knockback away from
+            // the point you are standing on normalises to nothing.
+            knockback: Knockback::from(cast.position.0),
+            kind: DamageKind::Ability,
+        });
     }
+    cast.server.cue(cast.position.0, Cue::Explosion);
 }

--- a/events/smash/src/module/kits/skeleton.rs
+++ b/events/smash/src/module/kits/skeleton.rs
@@ -13,7 +13,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, charge_steps, splash},
+        ability::{Cast, Observable, charge_steps, splash},
         kit::{self, AbilitySpec, KitStats},
         player::Position,
         projectile::{Flight, Impact, Payload, fire},
@@ -57,6 +57,7 @@ impl Module for Skeleton {
             // 1000 ms to the first arrow, 300 ms per arrow after: five arrows
             // is 2.2 seconds of standing still.
             charge_time: Some(2.2),
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: barrage,
             ..AbilitySpec::DEFAULT
         })
@@ -66,6 +67,7 @@ impl Module for Skeleton {
             slot: 1,
             description: "Scatter your bones. Little damage, enormous knockback.",
             cooldown: 10.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: bone_explosion,
             ..AbilitySpec::DEFAULT
         })
@@ -75,6 +77,11 @@ impl Module for Skeleton {
             slot: 2,
             description: "Fire an arrow and be dragged after it. Your way back onto the map.",
             cooldown: 5.0,
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::LaunchesCaster,
+            ],
             activate: roped_arrow,
             ..AbilitySpec::DEFAULT
         })
@@ -84,6 +91,7 @@ impl Module for Skeleton {
             slot: 8,
             description: "Fire without ever reloading.",
             cooldown: 8.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: arrow_storm,
             ..AbilitySpec::DEFAULT
         })

--- a/events/smash/src/module/kits/sky_squid.rs
+++ b/events/smash/src/module/kits/sky_squid.rs
@@ -12,7 +12,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, splash_at},
+        ability::{Cast, Observable, splash_at},
         kit::{self, AbilitySpec, KitStats},
         projectile::{Flight, Payload, fire},
     },
@@ -46,6 +46,7 @@ impl Module for SkySquid {
             slot: 1,
             description: "One second of flight, and nothing can touch you during it.",
             cooldown: 9.0,
+            proves: &[Observable::LaunchesCaster],
             activate: super_squid,
             ..AbilitySpec::DEFAULT
         })
@@ -55,6 +56,7 @@ impl Module for SkySquid {
             slot: 2,
             description: "Seven ink sacs at once. All seven is 12 damage and almost never happens.",
             cooldown: 5.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: ink_shotgun,
             ..AbilitySpec::DEFAULT
         })
@@ -65,6 +67,7 @@ impl Module for SkySquid {
             description: "Fish erupt from the ground for four seconds. Hard to walk out of.",
             // `[VERIFIED]`: "a ridiculous 16 seconds cooldown to balance it".
             cooldown: 16.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: fish_flurry,
             ..AbilitySpec::DEFAULT
         })
@@ -74,6 +77,7 @@ impl Module for SkySquid {
             slot: 8,
             description: "Fly, and call lightning down once a second.",
             cooldown: 1.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: storm_squid,
             ..AbilitySpec::DEFAULT
         })
@@ -128,7 +132,7 @@ fn fish_flurry(cast: &Cast<'_>) {
 /// `[APPROXIMATED]`: a lightning bolt a second for the crystal's duration needs
 /// a repeating effect the ability layer does not have. One strike stands in.
 fn storm_squid(cast: &Cast<'_>) {
-    use crate::module::{ability::splash_at as splash_there, player::Position};
+    use crate::module::{ability::splash_from, player::Position};
 
     let caster = cast.caster.id();
     let mut targets = Vec::new();
@@ -142,7 +146,9 @@ fn storm_squid(cast: &Cast<'_>) {
             }
         });
     for at in targets {
-        splash_there(cast, at, 2.0, 6.0, 1.2);
+        // The bolt lands on the victim, so the launch has to be measured from
+        // the squid: away from the point you are standing on is not a direction.
+        splash_from(cast, cast.position.0, at, 2.0, 6.0, 1.2);
         cast.server.cue(at, Cue::Explosion);
     }
 }

--- a/events/smash/src/module/kits/slime.rs
+++ b/events/smash/src/module/kits/slime.rs
@@ -14,7 +14,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, splash_at},
+        ability::{Cast, Observable, splash_at},
         damage::{DamageKind, Damaged, hurt},
         kit::{self, AbilitySpec, KitStats},
         knockback::Knockback,
@@ -59,6 +59,7 @@ impl Module for Slime {
             charge_time: Some(MAX_CHARGE_SECONDS),
             // A third of the bar minimum; a full charge costs the lot.
             energy_cost: Some(0.33),
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: slime_rocket,
             ..AbilitySpec::DEFAULT
         })
@@ -68,6 +69,14 @@ impl Module for Slime {
             slot: 1,
             description: "Throw yourself at someone. You take a quarter of it back.",
             cooldown: 6.0,
+            // The recoil is a real launch on the caster, not a rounding
+            // artefact: a quarter of the hit comes back the other way, which is
+            // what makes the ability a commitment.
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::LaunchesCaster,
+            ],
             activate: slime_slam,
             ..AbilitySpec::DEFAULT
         })
@@ -77,6 +86,7 @@ impl Module for Slime {
             slot: 8,
             description: "Become enormous and untouchable. Everything near you dies.",
             cooldown: 19.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: giga_slime,
             ..AbilitySpec::DEFAULT
         })

--- a/events/smash/src/module/kits/snowman.rs
+++ b/events/smash/src/module/kits/snowman.rs
@@ -11,7 +11,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, splash_at},
+        ability::{Cast, Observable, splash_at},
         kit::{self, AbilitySpec, KitStats},
         projectile::{Flight, Payload, fire},
     },
@@ -46,6 +46,7 @@ impl Module for Snowman {
             description: "Snowballs, endlessly. Low damage, good knockback, best at an edge.",
             cooldown: 0.4,
             energy_cost: Some(8.0),
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: blizzard,
             ..AbilitySpec::DEFAULT
         })
@@ -55,6 +56,7 @@ impl Module for Snowman {
             slot: 2,
             description: "A path of ice wherever you point, and a hop so you do not fall through.",
             cooldown: 8.0,
+            proves: &[Observable::LaunchesCaster],
             activate: ice_path,
             ..AbilitySpec::DEFAULT
         })
@@ -65,6 +67,7 @@ impl Module for Snowman {
             description: "Snow around you. Slows them, and you hit a point harder on it.",
             cooldown: 2.0,
             energy_cost: Some(20.0),
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: arctic_aura,
             ..AbilitySpec::DEFAULT
         })
@@ -74,6 +77,7 @@ impl Module for Snowman {
             slot: 8,
             description: "A snowman that shoots for you. Twenty seconds, three of them.",
             cooldown: 1.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: snow_turret,
             ..AbilitySpec::DEFAULT
         })
@@ -113,10 +117,26 @@ fn arctic_aura(cast: &Cast<'_>) {
     splash_at(cast, cast.position.0, 5.0, AURA_BONUS_DAMAGE, 0.2);
 }
 
+/// Six snowballs in a ring, the first one down the barrel.
+///
+/// The ring is turned to face the caster: it used to be laid out in absolute
+/// world directions, so the ultimate hit whatever happened to be east of the
+/// snowman and a target dead ahead was in the gap between two of the six unless
+/// the fight happened to be lined up with +X. Nobody would have noticed from the
+/// inside, because the ability does fire and does hit *something*.
 fn snow_turret(cast: &Cast<'_>) {
+    let flat = Vec3::new(cast.facing.0.x, 0.0, cast.facing.0.z).normalize_or_zero();
+    // Looking straight down leaves no bearing to build a ring on.
+    let forward = if flat == Vec3::ZERO { Vec3::Z } else { flat };
+
     for step in 0..6 {
         let angle = std::f32::consts::TAU * (step as f32) / 6.0;
-        let direction = Vec3::new(angle.cos(), 0.0, angle.sin());
+        let (sin, cos) = angle.sin_cos();
+        let direction = Vec3::new(
+            forward.x.mul_add(cos, -(forward.z * sin)),
+            0.0,
+            forward.x.mul_add(sin, forward.z * cos),
+        );
         fire(
             cast.world,
             cast.caster,

--- a/events/smash/src/module/kits/spider.rs
+++ b/events/smash/src/module/kits/spider.rs
@@ -14,7 +14,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, splash},
+        ability::{Cast, Observable, splash},
         kit::{self, AbilitySpec, KitStats},
         projectile::{Flight, Payload, fire},
     },
@@ -48,6 +48,7 @@ impl Module for Spider {
             description: "Spray six needles. They poison, which armour does not stop.",
             cooldown: 6.0,
             charge_time: Some(1.0),
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: needler,
             ..AbilitySpec::DEFAULT
         })
@@ -57,6 +58,7 @@ impl Module for Spider {
             slot: 2,
             description: "Launch forward, trailing web. Mostly a way back onto the map.",
             cooldown: 8.0,
+            proves: &[Observable::LaunchesCaster],
             activate: spin_web,
             ..AbilitySpec::DEFAULT
         })
@@ -66,6 +68,7 @@ impl Module for Spider {
             slot: 8,
             description: "A dome of web. Everything you hit heals you.",
             cooldown: 1.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: spiders_nest,
             ..AbilitySpec::DEFAULT
         })

--- a/events/smash/src/module/kits/wither_skeleton.rs
+++ b/events/smash/src/module/kits/wither_skeleton.rs
@@ -14,7 +14,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, splash_at},
+        ability::{Cast, Observable, splash_at},
         damage::MatchClock,
         kit::{self, AbilitySpec, KitStats},
         projectile::{Flight, Impact, Payload, fire},
@@ -56,6 +56,7 @@ impl Module for WitherSkeleton {
             description: "A skull with a wide blast. Hold to steer it.",
             cooldown: 7.0,
             charge_time: Some(0.6),
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: guided_wither_skull,
             ..AbilitySpec::DEFAULT
         })
@@ -65,6 +66,7 @@ impl Module for WitherSkeleton {
             slot: 2,
             description: "Drop a copy of yourself. Use it again to swap places with it.",
             cooldown: 10.0,
+            proves: &[Observable::TeleportsCaster],
             activate: wither_image,
             ..AbilitySpec::DEFAULT
         })
@@ -74,6 +76,7 @@ impl Module for WitherSkeleton {
             slot: 8,
             description: "Every image at once.",
             cooldown: 20.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: wither_swap,
             ..AbilitySpec::DEFAULT
         })

--- a/events/smash/src/module/kits/wolf.rs
+++ b/events/smash/src/module/kits/wolf.rs
@@ -14,7 +14,7 @@ use flecs_ecs::prelude::*;
 use crate::{
     flecs_ext::EntityViewExt,
     module::{
-        ability::Cast,
+        ability::{Cast, Observable},
         damage::{DamageKind, Damaged, MeleeBonus},
         kit::{self, AbilitySpec, KitName, KitStats, Playing},
         player::Player,
@@ -62,6 +62,7 @@ impl Module for Wolf {
             slot: 1,
             description: "Throw a cub. Whoever it lands on can barely move for five seconds.",
             cooldown: 8.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: cub_tackle,
             ..AbilitySpec::DEFAULT
         })
@@ -71,6 +72,11 @@ impl Module for Wolf {
             slot: 2,
             description: "Launch at what you are looking at. Triple knockback on a tackled target.",
             cooldown: 7.0,
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::LaunchesCaster,
+            ],
             activate: wolf_strike,
             ..AbilitySpec::DEFAULT
         })
@@ -80,6 +86,7 @@ impl Module for Wolf {
             slot: 8,
             description: "Twenty seconds of everything at once.",
             cooldown: 20.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: frenzy,
             ..AbilitySpec::DEFAULT
         })

--- a/events/smash/src/module/kits/zombie.rs
+++ b/events/smash/src/module/kits/zombie.rs
@@ -9,7 +9,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, splash_at},
+        ability::{Cast, Observable, splash_at},
         kit::{self, AbilitySpec, KitStats},
         player::Position,
         projectile::{Flight, Impact, Payload, fire},
@@ -39,6 +39,7 @@ impl Module for Zombie {
             slot: 1,
             description: "Spray bile. It lands where you point and hurts what it lands on.",
             cooldown: 7.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: bile_blaster,
             ..AbilitySpec::DEFAULT
         })
@@ -49,6 +50,7 @@ impl Module for Zombie {
             description: "An arrow that drags whoever it hits back to you.",
             cooldown: 9.0,
             charge_time: Some(1.0),
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: deaths_grasp,
             ..AbilitySpec::DEFAULT
         })
@@ -58,6 +60,7 @@ impl Module for Zombie {
             slot: 8,
             description: "The dead get up around you.",
             cooldown: 20.0,
+            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
             activate: night_of_the_living_dead,
             ..AbilitySpec::DEFAULT
         })

--- a/events/smash/src/module/knockback.rs
+++ b/events/smash/src/module/knockback.rs
@@ -152,6 +152,14 @@ pub fn resolve(
     if away == Vec3::ZERO {
         return Vec3::ZERO;
     }
+    // `speed_base` and `ground_boost` are floors under a launch, not a launch of
+    // their own. Without this a hit that asked for no knockback at all still
+    // moved the victim 0.2 blocks a tick sideways and 0.2 up, which is most of
+    // a jump: Blaze's Inferno is documented as having none and was quietly
+    // repositioning everyone it touched.
+    if strength <= 0.0 {
+        return Vec3::ZERO;
+    }
 
     let trajectory_length = model.trajectory_scale * strength;
     let speed = model

--- a/events/smash/src/module/projectile.rs
+++ b/events/smash/src/module/projectile.rs
@@ -111,6 +111,7 @@ impl Module for ProjectileModule {
             .each_iter(|it, index, (flight, payload)| {
                 let dt = it.delta_time();
                 let projectile = it.entity(index);
+                let from = flight.position;
                 flight.velocity.y = flight.gravity.mul_add(-dt, flight.velocity.y);
                 flight.position += flight.velocity * dt;
                 flight.seconds_left -= dt;
@@ -121,9 +122,13 @@ impl Module for ProjectileModule {
                 }
 
                 let shooter = projectile.target(FiredBy, 0).map(|e| e.id());
-                let Some(victim) =
-                    nearest_target(projectile.world(), flight.position, flight.radius, shooter)
-                else {
+                let Some((victim, at)) = nearest_target(
+                    projectile.world(),
+                    from,
+                    flight.position,
+                    flight.radius,
+                    shooter,
+                ) else {
                     return;
                 };
 
@@ -132,7 +137,7 @@ impl Module for ProjectileModule {
                 hurt(victim, Damaged {
                     attacker: shooter,
                     amount: payload.damage,
-                    knockback: Knockback::from(flight.position).times(payload.knockback),
+                    knockback: Knockback::from(at).times(payload.knockback),
                     kind: DamageKind::Projectile,
                 });
 
@@ -141,23 +146,42 @@ impl Module for ProjectileModule {
                     projectile,
                     shooter: shooter.map(|s| world.entity_at(s)),
                     victim,
-                    at: flight.position,
+                    at,
                 });
 
-                world.get::<&ServerHandle>(|server| server.cue(flight.position, Cue::Hurt));
+                world.get::<&ServerHandle>(|server| server.cue(at, Cue::Hurt));
                 projectile.destruct();
             });
     }
 }
 
-/// Closest living player within `radius`, excluding the shooter.
+/// The point on the segment `from`..`to` nearest `point`.
+fn closest_on_segment(from: Vec3, to: Vec3, point: Vec3) -> Vec3 {
+    let along = to - from;
+    let length_squared = along.length_squared();
+    if length_squared <= f32::EPSILON {
+        return from;
+    }
+    from + along * ((point - from).dot(along) / length_squared).clamp(0.0, 1.0)
+}
+
+/// Closest living player within `radius` of the segment this tick swept,
+/// excluding the shooter, and the point on that segment where it connected.
+///
+/// A segment and not a point. Integration moves a projectile a whole tick's
+/// travel at once, and Barrage's arrows travel at 60 blocks per second, which
+/// at 20 ticks is three blocks a step against a hit radius of 0.4: sampling
+/// only the endpoint means seven eighths of the flight path is a hole a player
+/// can stand in. Every arrow ability in the game was decided by whether a
+/// victim happened to be standing on a sample point.
 fn nearest_target(
     world: WorldRef<'_>,
-    at: Vec3,
+    from: Vec3,
+    to: Vec3,
     radius: f32,
     exclude: Option<Entity>,
-) -> Option<Entity> {
-    let mut best: Option<(f32, Entity)> = None;
+) -> Option<(Entity, Vec3)> {
+    let mut best: Option<(f32, Entity, Vec3)> = None;
     world
         .query::<(&Position, &Health)>()
         .with(Player::id())
@@ -166,13 +190,14 @@ fn nearest_target(
             if health.is_dead() || Some(entity.id()) == exclude {
                 return;
             }
+            let at = closest_on_segment(from, to, position.0);
             let distance = position.0.distance(at);
             if distance > radius {
                 return;
             }
-            if best.is_none_or(|(closest, _)| distance < closest) {
-                best = Some((distance, entity.id()));
+            if best.is_none_or(|(closest, ..)| distance < closest) {
+                best = Some((distance, entity.id(), at));
             }
         });
-    best.map(|(_, entity)| entity)
+    best.map(|(_, entity, at)| (entity, at))
 }

--- a/events/smash/tests/abilities.rs
+++ b/events/smash/tests/abilities.rs
@@ -1,0 +1,535 @@
+//! Every ability in the game, driven through the mock seam and held to what its
+//! kit declared it does.
+//!
+//! This file names no kit and no ability. It walks [`ability::manifest`], which
+//! is a query over the world rather than a list, so a kit imported from outside
+//! the crate is covered the moment its module runs and a kit added tomorrow
+//! fails here rather than passing quietly.
+//!
+//! What this proves and what it does not: this is the game half, so what it
+//! reads is the call log of a [`MockServer`] -- the same calls the adapter turns
+//! into packets. It says an ability computed the effect it promised. It does not
+//! say the packet carrying that effect reaches a client, which is what
+//! `nix run .#smash-e2e` is for, and which drives the same manifest.
+
+mod harness;
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use harness::Game;
+use smash::{
+    module::{
+        ability::{self, Declared, Observable},
+        damage::{DamageKind, Damaged, MatchClock, hurt},
+        kit::{self, Playing},
+        knockback::Knockback,
+        player::{Energy, Health, OnGround, Position},
+    },
+    server::{PlayerId, mock::Call},
+};
+
+/// How far in front of the caster the near victim stands.
+///
+/// Not a whole number, and not the distance any ability centres its blast on.
+/// A victim standing exactly on a splash centre is launched away from the point
+/// they occupy, which normalises to no direction and no launch, so a round
+/// number would make several abilities look like they deal no knockback when
+/// the arrangement is what has no answer.
+const NEAR: f32 = 3.5;
+
+/// The far victim, for the projectiles that need room to arm.
+const FAR: f32 = 8.5;
+
+struct Bench {
+    game: Game,
+    caster: Entity,
+    near: Entity,
+    far: Entity,
+}
+
+impl Bench {
+    fn new() -> Self {
+        let mut game = Game::new();
+        let caster = game.player("caster", Vec3::ZERO);
+        let near = game.player("near", Vec3::new(NEAR, 0.0, 0.0));
+        let far = game.player("far", Vec3::new(FAR, 0.0, 0.0));
+        Self {
+            game,
+            caster,
+            near,
+            far,
+        }
+    }
+
+    fn caster(&self) -> EntityView<'_> {
+        self.game.world.entity_from_id(self.caster)
+    }
+
+    /// Put the caster on `kit`, stand everybody back up and clear the log.
+    fn reset(&self, kit_name: &str) {
+        let world = &self.game.world;
+        let chosen =
+            kit::by_name(world, kit_name).unwrap_or_else(|| panic!("the registry lost {kit_name}"));
+
+        for entity in [self.caster, self.near, self.far] {
+            kit::apply(world, world.entity_from_id(entity), chosen);
+        }
+        self.place(Vec3::ZERO);
+        self.game.world.set(MatchClock(1.0));
+        self.game.server.take();
+    }
+
+    /// Give the caster the Smash Crystal ability, if this entry needs one.
+    fn arm(&self, entry: &Declared) {
+        if !entry.ultimate || ability::granted_in_slot(self.caster(), entry.slot).is_some() {
+            return;
+        }
+        assert!(
+            kit::grant_ultimate(&self.game.world, self.caster(), 600.0),
+            "{} / {}: the Smash Crystal granted nothing",
+            entry.kit,
+            entry.name
+        );
+    }
+
+    /// Fire `entry` the way a player would: hold a charge ability for its full
+    /// charge time, tap everything else. Does not wait afterwards.
+    fn press(&self, entry: &Declared) {
+        match entry.charge_time {
+            Some(seconds) => {
+                ability::use_slot(self.caster(), entry.slot);
+                self.game.advance(seconds, 8);
+                ability::release_slot(self.caster(), entry.slot);
+            }
+            None => ability::use_slot(self.caster(), entry.slot),
+        }
+    }
+
+    /// Long enough for the slowest projectile in the game to cross the far
+    /// victim.
+    fn settle(&self) {
+        self.game.advance(1.5, 30);
+    }
+
+    /// Wait out `entry`'s cooldown and set the three of them up again, `attempt`
+    /// steps further along the aim axis.
+    ///
+    /// The whole arrangement moves rather than the caster alone, so every
+    /// distance and direction an ability cares about is identical to the first
+    /// press and only the absolute position differs. That difference is what
+    /// Wither Image needs: it drops a decoy on one press and swaps you to it on
+    /// the next, and a swap back to the spot you never left is not a teleport
+    /// anybody could see.
+    fn recover(&self, entry: &Declared, attempt: u32) {
+        self.game.advance(entry.cooldown + 0.5, 30);
+        self.place(Vec3::new(
+            f32::from(u16::try_from(attempt).unwrap_or(0)) * -4.0,
+            0.0,
+            0.0,
+        ));
+    }
+
+    /// Stand all three up, healthy and grounded, `base` blocks from the origin.
+    fn place(&self, base: Vec3) {
+        let world = &self.game.world;
+        for (entity, offset) in [
+            (self.caster, Vec3::ZERO),
+            (self.near, Vec3::new(NEAR, 0.0, 0.0)),
+            (self.far, Vec3::new(FAR, 0.0, 0.0)),
+        ] {
+            let player = world.entity_from_id(entity);
+            player.set(Position(base + offset));
+            player.set(OnGround(true));
+            player.get::<&mut Health>(|health| health.current = health.max);
+        }
+        // Every ability that costs energy is used once, so a full bar is the
+        // condition under test rather than a coincidence of the previous one.
+        if let Some(mut energy) = self.caster().try_get::<&Energy>(|e| *e) {
+            energy.current = energy.max;
+            self.caster().set(energy);
+        }
+    }
+
+    fn health_of(&self, entity: Entity) -> Health {
+        self.game.world.entity_from_id(entity).cloned::<&Health>()
+    }
+
+    fn id_of(&self, entity: Entity) -> PlayerId {
+        self.game.world.entity_from_id(entity).cloned::<&PlayerId>()
+    }
+}
+
+/// Whether the log shows `observable` happening to the right party.
+fn observed(bench: &Bench, observable: Observable, before: &Snapshot) -> bool {
+    let calls = bench.game.server.calls();
+    match observable {
+        Observable::HurtsTarget => {
+            bench.health_of(bench.near).current < before.near_health
+                || bench.health_of(bench.far).current < before.far_health
+        }
+        Observable::LaunchesTarget => [bench.near, bench.far].iter().any(|victim| {
+            bench
+                .game
+                .server
+                .total_velocity(bench.id_of(*victim))
+                .length()
+                > 1e-4
+        }),
+        Observable::LaunchesCaster => {
+            bench
+                .game
+                .server
+                .total_velocity(bench.id_of(bench.caster))
+                .length()
+                > 1e-4
+        }
+        Observable::TeleportsCaster => {
+            let caster = bench.id_of(bench.caster);
+            calls.iter().any(|call| {
+                matches!(call, Call::Teleport(id, to) if *id == caster && to.distance(before.caster_at) > 1.0)
+            })
+        }
+        Observable::HealsCaster => bench.health_of(bench.caster).current > before.caster_health,
+        // Measured rather than read off a component: what a player experiences
+        // is the next swing hurting more, and a bonus that never reaches the
+        // melee path is a bonus that does not exist.
+        Observable::BuffsMelee => {
+            let clock = bench.game.world.cloned::<&MatchClock>().0;
+            let boosted = melee_damage(bench, clock);
+            boosted > before.baseline_melee + 1e-3
+        }
+    }
+}
+
+/// What one melee swing at the near victim takes off, right now.
+fn melee_damage(bench: &Bench, now: f32) -> f32 {
+    use smash::module::{damage::MeleeBonus, kit::KitStats};
+
+    let caster = bench.caster();
+    let base = caster
+        .target(Playing, 0)
+        .and_then(|kit| kit.try_get::<&KitStats>(|stats| stats.melee_damage))
+        .unwrap_or(1.0);
+    let bonus = caster
+        .try_get::<&MeleeBonus>(|bonus| bonus.applies_to(bench.near, now))
+        .unwrap_or(0.0);
+
+    let victim = bench.game.world.entity_from_id(bench.near);
+    let before = victim.cloned::<&Health>().current;
+    hurt(victim, Damaged {
+        attacker: Some(bench.caster),
+        amount: base + bonus,
+        knockback: Knockback::from(Vec3::ZERO),
+        kind: DamageKind::Melee,
+    });
+    before - victim.cloned::<&Health>().current
+}
+
+struct Snapshot {
+    near_health: f32,
+    far_health: f32,
+    caster_health: f32,
+    caster_at: Vec3,
+    baseline_melee: f32,
+}
+
+/// Everything the checks below compare against, taken immediately before a
+/// press.
+///
+/// The caster is deliberately left short of full health. `SetHealth` is scaled
+/// to twenty on the wire, so a heal that also raises the maximum -- which is
+/// what Mooshroom Madness is -- lands on exactly the same number a full-health
+/// player was already showing, and would read as nothing happening at all.
+fn snapshot(bench: &Bench) -> Snapshot {
+    bench
+        .game
+        .world
+        .entity_from_id(bench.caster)
+        .get::<&mut Health>(|health| health.current = health.max * 0.5);
+
+    let clock = bench.game.world.cloned::<&MatchClock>().0;
+    let baseline_melee = melee_damage(bench, clock);
+    // Undo the probe swing so the ability under test sees a full-health victim.
+    let victim = bench.game.world.entity_from_id(bench.near);
+    victim.get::<&mut Health>(|health| health.current = health.max);
+    bench.game.server.take();
+
+    Snapshot {
+        near_health: bench.health_of(bench.near).current,
+        far_health: bench.health_of(bench.far).current,
+        caster_health: bench.health_of(bench.caster).current,
+        caster_at: bench
+            .game
+            .world
+            .entity_from_id(bench.caster)
+            .cloned::<&Position>()
+            .0,
+        baseline_melee,
+    }
+}
+
+/// The guard that makes the rest of this file mandatory rather than optional.
+///
+/// An ability with an empty declaration would sail through every check below,
+/// because there would be nothing to check. Refusing it here is what turns
+/// "adding a kit means adding data" into "adding a kit means saying what the
+/// data does".
+#[test]
+fn every_ability_declares_what_a_client_would_see() {
+    let game = Game::new();
+    let manifest = ability::manifest(&game.world);
+
+    assert!(
+        manifest.len() >= 50,
+        "the registry only found {} abilities, which is fewer than the roster has; something is \
+         not being discovered",
+        manifest.len()
+    );
+
+    let silent: Vec<_> = manifest
+        .iter()
+        .filter(|entry| entry.proves.is_empty())
+        .map(|entry| format!("{} / {}", entry.kit, entry.name))
+        .collect();
+    assert!(
+        silent.is_empty(),
+        "these abilities declare no observable effect, so no gate can test them: {silent:?}"
+    );
+}
+
+/// Two kits must not put two abilities on one hotbar slot, or one of them is
+/// unreachable and the gate below would silently fire the other.
+#[test]
+fn no_kit_binds_two_abilities_to_one_slot() {
+    let game = Game::new();
+    let mut clashes = Vec::new();
+    for kit_name in kit_names(&game) {
+        let mut slots = Vec::new();
+        for entry in ability::manifest(&game.world) {
+            if entry.kit == kit_name {
+                if slots.contains(&entry.slot) {
+                    clashes.push(format!("{kit_name} slot {}", entry.slot));
+                }
+                slots.push(entry.slot);
+            }
+        }
+    }
+    assert!(
+        clashes.is_empty(),
+        "abilities share a hotbar slot: {clashes:?}"
+    );
+}
+
+fn kit_names(game: &Game) -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = ability::manifest(&game.world)
+        .into_iter()
+        .map(|entry| entry.kit)
+        .collect();
+    names.dedup();
+    names
+}
+
+/// How many times an ability may be pressed before it has to have done what it
+/// said.
+///
+/// More than one because two abilities in the roster are stateful across uses:
+/// Wither Image drops a decoy on the first press and swaps you to it on the
+/// second, and that is the ability, not a workaround. A press that never
+/// achieves anything still fails, however many it gets.
+const ATTEMPTS: u32 = 3;
+
+/// The sweep: every declared ability, fired, and every observation it declared,
+/// checked.
+#[test]
+fn every_declared_effect_actually_happens() {
+    let manifest = ability::manifest(&Game::new().world);
+    let mut failures = Vec::new();
+
+    for entry in manifest {
+        let bench = Bench::new();
+        bench.reset(entry.kit);
+        let mut outstanding: Vec<Observable> = entry.proves.to_vec();
+
+        for attempt in 0..ATTEMPTS {
+            if outstanding.is_empty() {
+                break;
+            }
+            if attempt > 0 {
+                // Wait the cooldown out and stand everybody back up, so the
+                // next press starts from the same conditions as the first.
+                bench.recover(&entry, attempt);
+            }
+            bench.arm(&entry);
+            let before = snapshot(&bench);
+            bench.press(&entry);
+            bench.settle();
+            outstanding.retain(|observable| !observed(&bench, *observable, &before));
+        }
+
+        for observable in outstanding {
+            failures.push(format!(
+                "{} / {} declares {} and did not do it",
+                entry.kit,
+                entry.name,
+                observable.as_str()
+            ));
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// The declaration is exhaustive for movement, not just a lower bound.
+///
+/// An ability that launches somebody without saying so is the same defect as one
+/// that says it launches and does not: the registry stops describing the game.
+/// It is also where the quiet bugs live. Blaze's Inferno is documented as having
+/// no knockback and was moving everyone it touched a fifth of a block a tick,
+/// because the horizontal floor in the knockback model applied even to a hit
+/// whose multiplier was zero.
+///
+/// Damage is deliberately not checked this way: several abilities cost the
+/// caster health on purpose, and "hurts somebody" has no single subject.
+#[test]
+fn nothing_moves_that_did_not_say_it_would() {
+    let manifest = ability::manifest(&Game::new().world);
+    let mut failures = Vec::new();
+
+    for entry in manifest {
+        let bench = Bench::new();
+        bench.reset(entry.kit);
+        bench.arm(&entry);
+        let before = snapshot(&bench);
+        bench.press(&entry);
+        bench.settle();
+
+        for observable in [
+            Observable::LaunchesTarget,
+            Observable::LaunchesCaster,
+            Observable::TeleportsCaster,
+        ] {
+            if !entry.proves.contains(&observable) && observed(&bench, observable, &before) {
+                failures.push(format!(
+                    "{} / {} does not declare {} and did it anyway",
+                    entry.kit,
+                    entry.name,
+                    observable.as_str()
+                ));
+            }
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// A cooldown that does not refuse the next use is a cooldown a player cannot
+/// feel, and an ability that says it refunds on a hit and does not is a kit
+/// whose whole selling point is missing. Both come from the registry.
+#[test]
+fn a_cooldown_does_what_the_registry_says_it_does() {
+    let manifest = ability::manifest(&Game::new().world);
+    let mut failures = Vec::new();
+
+    for entry in manifest {
+        // Barrage deliberately has none at all.
+        if entry.cooldown <= 0.0 {
+            continue;
+        }
+        let bench = Bench::new();
+        bench.reset(entry.kit);
+        bench.arm(&entry);
+        bench.press(&entry);
+
+        let immediately = ability::activate(bench.caster(), entry.slot, 1.0);
+        if immediately != Err(ability::Refusal::OnCooldown) {
+            failures.push(format!(
+                "{} / {} has a {}s cooldown and answered {immediately:?} to a second use in the \
+                 same tick",
+                entry.kit, entry.name, entry.cooldown
+            ));
+            continue;
+        }
+
+        // The refund is a claim in the registry, so it is checked rather than
+        // excused: fly the projectile into the victim and the cooldown should
+        // be gone.
+        if entry.refunds_on_hit {
+            bench.settle();
+            let after_hit = ability::activate(bench.caster(), entry.slot, 1.0);
+            if after_hit != Ok(()) {
+                failures.push(format!(
+                    "{} / {} says it refunds on a hit; after one landed it answered {after_hit:?}",
+                    entry.kit, entry.name
+                ));
+            }
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Changing kit while holding a crystal must not cost you the new kit's
+/// abilities.
+///
+/// The expiry sweep takes a grant back by unlinking it from whoever holds it. A
+/// kit change destroys the granted instance first, and flecs recycles entity
+/// ids, so an expiry that fires afterwards and trusts a stale id can unlink an
+/// ability that merely inherited the number. The symptom is the worst kind:
+/// right-clicking the slot does nothing at all and says nothing at all, because
+/// an empty slot is not an error.
+#[test]
+fn a_crystal_left_over_from_a_previous_kit_does_not_eat_the_next_one() {
+    let bench = Bench::new();
+    bench.reset("Guardian");
+    assert!(kit::grant_ultimate(&bench.game.world, bench.caster(), 5.0));
+
+    bench.reset("Iron Golem");
+    // Past when the old grant would have lapsed.
+    bench.game.advance(8.0, 80);
+
+    let slots: Vec<u8> = ability::manifest(&bench.game.world)
+        .into_iter()
+        .filter(|entry| entry.kit == "Iron Golem" && !entry.ultimate)
+        .map(|entry| entry.slot)
+        .collect();
+    for slot in slots {
+        assert!(
+            ability::granted_in_slot(bench.caster(), slot).is_some(),
+            "slot {slot} lost its ability when a previous kit's crystal lapsed"
+        );
+    }
+}
+
+/// The Smash Crystal's window, from the outside: granted, in the hotbar, gone
+/// again when it lapses.
+#[test]
+fn an_ultimate_is_granted_for_a_window_and_then_taken_back() {
+    let bench = Bench::new();
+    bench.reset("Iron Golem");
+
+    let ultimate = kit::ultimate_name(bench.caster()).expect("Iron Golem declares an ultimate");
+    assert!(kit::grant_ultimate(&bench.game.world, bench.caster(), 5.0));
+    assert!(
+        kit::hotbar(bench.caster())
+            .iter()
+            .any(|item| item.name == ultimate),
+        "the granted ultimate never reached the hotbar"
+    );
+    assert!(
+        !kit::grant_ultimate(&bench.game.world, bench.caster(), 5.0),
+        "a second crystal should not stack"
+    );
+
+    bench.game.advance(6.0, 60);
+    assert!(
+        !kit::hotbar(bench.caster())
+            .iter()
+            .any(|item| item.name == ultimate),
+        "the ultimate outlived its window"
+    );
+    assert_eq!(
+        ability::activate(bench.caster(), 8, 1.0),
+        Ok(()),
+        "an expired ultimate should be nothing at all in that slot, not a refusal"
+    );
+}

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -15,13 +15,27 @@ there is one place where "how do you get into this server" is written down.
 What this file adds is the play state: the serverbound ids a player uses, the
 clientbound ids a match is visible through, and the schedule.
 
+It also drives every ability in the game, and it does not know what those are.
+The server answers `/abilities` with its own registry -- one JSON object per
+ability, built by walking the ability entities themselves -- and this file fires
+each one and holds it to the effects that entry declares. Nothing here lists a
+kit or an ability, so a kit added tomorrow is a kit this gate tests tomorrow,
+and one whose ability does nothing fails here rather than passing quietly.
+
+The sweep runs in the hub with one client short of `min_players`, which is what
+keeps the lobby in `Waiting` for as long as it takes: there is no countdown to
+race, no kill plane under the lobby, and kits can still be changed. The last
+client joins when the sweep is done and the match runs after it.
+
 What this proves and what it does not
 -------------------------------------
 It proves the server's own state machine, on the wire, at 776 ids: the lobby
 count, the countdown, the scatter onto a committed map's spawn points, the kit
 hotbar arriving as real item stacks, knockback matching the model in
 `events/smash/src/module/knockback.rs`, the life counter, the respawn, and the
-return to the hub.
+return to the hub. It proves each declared ability by its effect -- health
+lost, a velocity packet, a teleport, a heal, a melee swing that got stronger --
+and never by the fact that a right-click was sent.
 
 It does not prove the game is playable by a human. These clients do not render,
 do not simulate physics and never disagree with the server. They teleport
@@ -36,6 +50,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import json
 import math
 import pathlib
 import re
@@ -79,9 +94,15 @@ C2S_CHAT_COMMAND = 0x07
 C2S_KEEP_ALIVE = 0x1C
 C2S_MOVE_PLAYER_POS = 0x1E
 C2S_MOVE_PLAYER_POS_ROT = 0x1F
+C2S_PLAYER_ACTION = 0x29
 C2S_SET_CARRIED_ITEM = 0x35
 C2S_SWING = 0x3F
 C2S_USE_ITEM = 0x43
+
+# `ServerboundPlayerActionPacket$Action#RELEASE_USE_ITEM`. Letting go of a held
+# item is a player action and not its own packet, which is why a client that
+# only ever sends `use_item` can start a charge and never finish one.
+ACTION_RELEASE_USE_ITEM = 5
 
 # Clientbound play ids this file decodes. Everything else is counted by id and
 # reported in the census.
@@ -90,6 +111,7 @@ S2C_DISCONNECT = 0x20
 S2C_KEEP_ALIVE = 0x2C
 S2C_LOGIN = 0x31
 S2C_PLAYER_POSITION = 0x48
+S2C_SET_ACTION_BAR_TEXT = 0x57
 S2C_SET_ENTITY_MOTION = 0x65
 S2C_SET_HEALTH = 0x68
 S2C_SET_TITLE_TEXT = 0x72
@@ -201,6 +223,71 @@ MAIN_ISLAND_RADIUS = 16.0
 # air after it.
 RIM_HOP = 6.0
 
+# events/smash/src/command.rs. The markers `/abilities` puts on each line, so a
+# reader can tell the registry apart from the rest of the chat channel.
+MANIFEST_PREFIX = "smash-ability "
+MANIFEST_END_PREFIX = "smash-abilities-end "
+
+# events/smash/src/module/ability.rs: the refusal an ability on cooldown sends to
+# the action bar. Restated here so the check below is a check.
+COOLDOWN_REFUSAL = "That ability is recharging."
+
+# Where the sweep stands everyone, in events/smash/maps/hub.map's coordinates.
+#
+# A clear line at x = 6: outside the raised centre (a disc of radius 4 at y 65,
+# which a player standing at the origin is inside rather than on), inside the
+# glass rim at radius 19, and clear of all twelve pillars, none of which is at
+# that x. The attacker looks along +Z, which is yaw 0.
+SWEEP_X = 6.0
+SWEEP_Y = 65.0
+SWEEP_Z = -11.0
+SWEEP_YAW = 0.0
+
+# How far in front of the attacker the two victims stand.
+#
+# Neither is a whole number, and neither is a distance an ability centres its
+# blast on. Knockback is horizontal and points away from the blast, so a victim
+# standing exactly on a splash centre has no direction to be launched in and does
+# not move: a round number would make several abilities look like they deal no
+# knockback when it is the arrangement that has no answer.
+NEAR_VICTIM = 3.5
+FAR_VICTIM = 8.5
+
+# How far the whole arrangement shifts along the aim axis between attempts.
+#
+# The three of them move together, so every distance and bearing an ability cares
+# about is identical and only the absolute position differs. Wither Image needs
+# exactly that: it drops a decoy on one press and swaps you to it on the next,
+# and a swap back to the spot you never left is not a teleport anybody can see.
+ATTEMPT_STRIDE = 4.0
+
+# `PlayerInventory::HOTBAR_START_SLOT`: where the nine hotbar slots begin in the
+# inventory numbering `ClientboundContainerSetSlot` uses.
+HOTBAR_START_SLOT = 36
+
+# The height the sweep travels at between marks.
+#
+# Above everything the hub puts down -- the pillars stop at 68 and their lanterns
+# at 69 -- so a route that goes up, across and down never ends a step inside a
+# block, which is the one move hyperion refuses outright. Going in a straight
+# line at head height does not work: half the hub's spawn ring is on the far side
+# of the raised centre.
+#
+# The route is walked at `STEP_BLOCKS` a step and not claimed in one packet:
+# hyperion teleports a player back when a tick's movement exceeds about ten
+# blocks against one movement packet, which is `sync_entity_state`'s speed check
+# rather than the collision one, so it reports nothing at all and simply undoes
+# the move.
+HUB_CLEAR_Y = 72.0
+
+# How many presses an ability gets before it has to have done what it declared.
+SWEEP_ATTEMPTS = 3
+
+# Seconds to wait for an ability's effects after the press. Two hundred server
+# ticks, which is far longer than the slowest projectile in the game takes to
+# cross the far victim.
+SWEEP_WINDOW = 2.0
+
 ITEM_REGISTRY = ROOT / "crates/hyperion-minecraft-proto/src/generated/registry.rs"
 
 
@@ -222,6 +309,10 @@ def stamp(started):
     return "%7.2fs" % (time.time() - started)
 
 
+def distance(one, other):
+    return math.sqrt(sum((a - b) ** 2 for a, b in zip(one, other)))
+
+
 class MatchClient(base.Client):
     """One scripted player.
 
@@ -240,9 +331,18 @@ class MatchClient(base.Client):
         self.position = (0.0, 65.0, 0.0)
         self.path = []
         self.on_ground = True
+        # A scripted client that never sends a rotation looks along +Z forever,
+        # which is what every ability that fires "where you look" would have
+        # read. Carrying yaw and pitch and sending pos-rot rather than pos is
+        # what lets the sweep aim.
+        self.yaw = 0.0
+        self.pitch = 0.0
         self.health = None
+        self.kit = None
         self.hotbar = {}
         self.seen = {}
+        self.action_bar = []
+        self.teleported_to = []
         self.last_position_sent = 0.0
         self.alive = True
 
@@ -340,11 +440,33 @@ class MatchClient(base.Client):
                 scale = STEP_BLOCKS / distance
                 self.position = (x + dx * scale, y + dy * scale, z + dz * scale)
 
+        self.send_position()
+
+    def send_position(self):
         x, y, z = self.position
         self.send(
-            C2S_MOVE_PLAYER_POS,
-            struct.pack(">dddb", x, y, z, ON_GROUND if self.on_ground else 0),
+            C2S_MOVE_PLAYER_POS_ROT,
+            struct.pack(
+                ">dddffb",
+                x,
+                y,
+                z,
+                self.yaw,
+                self.pitch,
+                ON_GROUND if self.on_ground else 0,
+            ),
         )
+
+    def aim(self, yaw, pitch=0.0):
+        self.yaw = yaw
+        self.pitch = pitch
+
+    def look_at(self, other):
+        """Face `other`, in Minecraft's yaw, which is clockwise from +Z."""
+        dx = other.position[0] - self.position[0]
+        dz = other.position[2] - self.position[2]
+        self.aim(math.degrees(math.atan2(-dx, dz)))
+        self.send_position()
 
     def attack(self, target):
         self.log("-> attack %s (entity %d)" % (target.name, target.entity_id))
@@ -359,6 +481,21 @@ class MatchClient(base.Client):
         self.send(C2S_USE_ITEM, var_int(0) + var_int(0) + struct.pack(">ff", 0.0, 0.0))
         self.send(C2S_SWING, var_int(0))
 
+    def release_slot(self, slot, note=""):
+        """Let go of a held item, which is how a charge ability fires.
+
+        `ServerboundPlayerActionPacket` with `RELEASE_USE_ITEM`: the block
+        position and face are what a dig would have filled in and are ignored for
+        this action.
+        """
+        self.log("-> release hotbar slot %d %s" % (slot, note))
+        self.send(
+            C2S_PLAYER_ACTION,
+            var_int(ACTION_RELEASE_USE_ITEM)
+            + struct.pack(">qb", 0, 0)
+            + var_int(0),
+        )
+
 
 class Match:
     """The run: four clients, one transcript, and what it proved."""
@@ -371,7 +508,12 @@ class Match:
         self.by_entity = {}
         # Every claim the report at the end makes, in the order a match makes
         # them. A step is proved by a packet, never by a timer expiring.
-        self.proof = {
+        self.proof = {}
+        if args.abilities:
+            self.proof["the server published its ability registry"] = None
+            self.proof["every declared ability did what it declared"] = None
+            self.proof["cooldowns refused a second use"] = None
+        self.proof.update({
             "four in play": None,
             "lobby started a match": None,
             "kits equipped": None,
@@ -379,7 +521,20 @@ class Match:
             "knockback from an ability": None,
             "life lost and respawned": None,
             "match ended, back in the hub": None,
-        }
+        })
+        # The registry, as the server describes it. Nothing in this file adds to
+        # it or filters it.
+        self.manifest = []
+        self.manifest_expected = None
+        # What the sweep found, one line per ability, for the report.
+        self.sweep_results = []
+        self.sweep_failures = []
+        self.cooldown_results = []
+        self.cooldown_failures = []
+        # Velocity packets seen this window, keyed by entity id. Collected from
+        # every client rather than one, because a player is not always in their
+        # own broadcast channel and the caster's own launch has to be visible.
+        self.window_motions = {}
         self.motions = []
         self.deaths = []
         self.respawns = []
@@ -400,9 +555,9 @@ class Match:
 
     # --- setup ---------------------------------------------------------
 
-    def connect(self):
-        for index in range(self.args.clients):
-            name = "P%d" % (index + 1)
+    def connect(self, count):
+        for _ in range(count):
+            name = "P%d" % (len(self.clients) + 1)
             client = MatchClient(self.args.host, self.args.port, name, self.started)
             client.handshake(self.args.host, self.args.port, 2)
             client.login()
@@ -410,6 +565,26 @@ class Match:
             client.enter_play()
             self.clients.append(client)
             client.log("configuration acknowledged")
+
+    def pump_all(self):
+        for client in self.clients:
+            if client.alive:
+                self.pump(client)
+                if client.joined:
+                    client.repeat_position()
+
+    def wait_until(self, predicate, seconds):
+        """Pump every socket until `predicate` holds. Returns whether it did."""
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            self.pump_all()
+            if predicate():
+                return True
+            time.sleep(0.01)
+        return False
+
+    def wait(self, seconds):
+        self.wait_until(lambda: False, seconds)
 
     # --- reading -------------------------------------------------------
 
@@ -440,6 +615,7 @@ class Match:
             x, y, z = struct.unpack(">ddd", payload[offset : offset + 24])
             client.position = (x, y, z)
             client.send(C2S_ACCEPT_TELEPORTATION, var_int(teleport_id))
+            client.teleported_to.append((x, y, z))
             client.log("<- teleported to (%.1f, %.1f, %.1f)" % (x, y, z))
             self.on_teleport(client, x, y, z)
         elif packet_id == S2C_KEEP_ALIVE:
@@ -457,9 +633,16 @@ class Match:
         elif packet_id == S2C_SET_TITLE_TEXT:
             text, _ = take_nbt_string(payload, 0)
             client.log("<- title: %s" % text)
+        elif packet_id == S2C_SET_ACTION_BAR_TEXT:
+            text, _ = take_nbt_string(payload, 0)
+            client.action_bar.append(text)
+            client.log("<- action bar: %s" % text)
         elif packet_id == S2C_SET_ENTITY_MOTION:
             entity, offset = take_var_int(payload)
             motion, _ = take_lp_vec3(payload, offset)
+            speed = math.sqrt(sum(component * component for component in motion))
+            if speed > 1e-4:
+                self.window_motions[entity] = motion
             self.on_motion(client, entity, motion)
         elif packet_id == S2C_CONTAINER_SET_SLOT:
             self.on_slot(client, payload)
@@ -473,6 +656,13 @@ class Match:
         _state, offset = take_var_int(payload, offset)
         (slot,) = struct.unpack(">h", payload[offset : offset + 2])
         offset += 2
+        # `ClientboundContainerSetSlot` numbers the whole inventory, and the
+        # hotbar starts at 36. Everything else in this file talks about the nine
+        # slots a player sees, which is also what the ability registry means by
+        # a slot.
+        slot -= HOTBAR_START_SLOT
+        if not 0 <= slot < 9:
+            return
         count, offset = take_var_int(payload, offset)
         if count <= 0:
             client.hotbar.pop(slot, None)
@@ -502,6 +692,18 @@ class Match:
             )
 
     def on_chat(self, client, text):
+        # Both of these are unicast to whoever asked, so they arrive before the
+        # narrator check below and would otherwise be discarded.
+        if text.startswith("Kit set to "):
+            client.kit = text[len("Kit set to ") :].rstrip(".")
+            return
+        if text.startswith(MANIFEST_PREFIX):
+            self.manifest.append(json.loads(text[len(MANIFEST_PREFIX) :]))
+            return
+        if text.startswith(MANIFEST_END_PREFIX):
+            self.manifest_expected = int(text[len(MANIFEST_END_PREFIX) :])
+            return
+
         # Every announcement is a broadcast, so one client narrates the match
         # and the rest are only proof it reached them too.
         if client is not self.clients[0]:
@@ -585,21 +787,352 @@ class Match:
         )
         self.motions.append((entity, motion))
 
+    # --- the ability sweep ---------------------------------------------
+
+    def fetch_manifest(self):
+        """Ask the server what every kit can do, and believe only the answer."""
+        self.clients[0].command("abilities")
+        done = lambda: (
+            self.manifest_expected is not None
+            and len(self.manifest) >= self.manifest_expected
+        )
+        if not self.wait_until(done, 30.0):
+            self.sweep_failures.append(
+                "the server answered /abilities with %d of %s lines"
+                % (len(self.manifest), self.manifest_expected)
+            )
+            return False
+
+        # An ability that declares nothing is one no gate can check, so the
+        # roster is refused rather than swept: this is the property that makes
+        # everything below mandatory instead of optional.
+        silent = [
+            "%s / %s" % (entry["kit"], entry["name"])
+            for entry in self.manifest
+            if not entry["proves"]
+        ]
+        if silent:
+            self.sweep_failures.append(
+                "these abilities declare no observable effect, so nothing can "
+                "test them: %s" % ", ".join(silent)
+            )
+            return False
+
+        kits = sorted({entry["kit"] for entry in self.manifest})
+        self.prove(
+            "the server published its ability registry",
+            "%d abilities across %d kits (%s), every one of them declaring what "
+            "a client would see" % (len(self.manifest), len(kits), ", ".join(kits)),
+        )
+        return True
+
+    def sweep(self):
+        """Fire every ability the registry names and check what it promised."""
+        if not self.fetch_manifest():
+            return
+
+        by_kit = {}
+        for entry in self.manifest:
+            by_kit.setdefault(entry["kit"], []).append(entry)
+
+        for kit, abilities in by_kit.items():
+            self.log("== %s ==" % kit)
+            if not self.select_kit(kit):
+                self.sweep_failures.append("%s: the kit never equipped" % kit)
+                continue
+            # Starting abilities first, then the Smash Crystal's, so the
+            # crystal's twenty-second window is not spent on anything else.
+            for entry in sorted(abilities, key=lambda e: (e["ultimate"], e["slot"])):
+                self.exercise(entry)
+
+        if self.sweep_failures:
+            for line in self.sweep_failures:
+                self.log("ABILITY FAILED %s" % line)
+        else:
+            self.prove(
+                "every declared ability did what it declared",
+                "%d abilities fired by a real client, each one checked against "
+                "the effects its own registry entry names" % len(self.manifest),
+            )
+        if self.cooldown_failures:
+            for line in self.cooldown_failures:
+                self.log("COOLDOWN FAILED %s" % line)
+        elif self.cooldown_results:
+            self.prove(
+                "cooldowns refused a second use",
+                "%d abilities answered a second right-click inside their "
+                "cooldown with %r on the action bar"
+                % (len(self.cooldown_results), COOLDOWN_REFUSAL),
+            )
+
+    def select_kit(self, kit):
+        """Put every client on `kit`, which also restores them to full health."""
+        for client in self.clients:
+            client.kit = None
+            client.command("kit %s" % kit)
+        if not self.wait_until(
+            lambda: all(client.kit == kit for client in self.clients), 15.0
+        ):
+            return False
+        # The hotbar is rebuilt a tick later, in PostUpdate, and an ability
+        # cannot be used before the item backing it exists.
+        wanted = {
+            entry["slot"]
+            for entry in self.manifest
+            if entry["kit"] == kit and not entry["ultimate"]
+        }
+        attacker = self.clients[0]
+        self.wait_until(lambda: wanted <= set(attacker.hotbar), 5.0)
+        return True
+
+    def stage(self, entry, attempt):
+        """Put the three of them on their marks, at full health, the attacker
+        looking down the line at both victims.
+
+        Health first: a victim left on nothing by the last ability is a victim
+        every splash skips, and an ability would then read as doing nothing when
+        it was the arrangement that was spent. Picking the kit again is the
+        game's own way of saying "start of a life", so it is what is used.
+        """
+        for victim in self.clients[1:]:
+            victim.kit = None
+            victim.command("kit %s" % entry["kit"])
+        self.wait_until(
+            lambda: all(victim.kit == entry["kit"] for victim in self.clients[1:]), 5.0
+        )
+
+        base = SWEEP_Z + attempt * ATTEMPT_STRIDE
+        marks = [base, base + NEAR_VICTIM, base + FAR_VICTIM]
+        for client, z in zip(self.clients, marks):
+            client.aim(SWEEP_YAW)
+            self.route_in_hub(client, (SWEEP_X, SWEEP_Y, z))
+        if not self.wait_until(
+            lambda: all(client.arrived() for client in self.clients), 15.0
+        ):
+            self.log("a client never reached its mark; the arrangement may be wrong")
+        # Long enough for hyperion to mirror the last claim onto the components
+        # the abilities read.
+        self.wait(0.2)
+
+    @staticmethod
+    def route_in_hub(client, mark):
+        """Walk `client` to `mark`, over the top of everything in the way."""
+        if distance(client.position, mark) < 0.5:
+            client.path = []
+            return
+        x, y, z = client.position
+        client.walk(
+            [
+                (x, HUB_CLEAR_Y, z),
+                (mark[0], HUB_CLEAR_Y, mark[2]),
+                mark,
+            ]
+        )
+
+    def arm(self, entry):
+        """Pick up a Smash Crystal, if this ability needs one."""
+        if not entry["ultimate"]:
+            return True
+        attacker = self.clients[0]
+        if entry["slot"] in attacker.hotbar:
+            return True
+        attacker.command("crystal")
+        if self.wait_until(lambda: entry["slot"] in attacker.hotbar, 6.0):
+            return True
+        self.sweep_failures.append(
+            "%s / %s: the Smash Crystal never put anything in slot %d"
+            % (entry["kit"], entry["name"], entry["slot"])
+        )
+        return False
+
+    def wound_attacker(self):
+        """Take the attacker off full health.
+
+        `ClientboundSetHealth` is scaled to twenty, so an ability that heals to a
+        raised maximum -- Mooshroom Madness is exactly that -- lands on the same
+        number a full-health player was already showing. Somebody has to hit them
+        first or the heal is invisible on the wire.
+        """
+        attacker, victim = self.clients[0], self.clients[1]
+        before = attacker.health
+        victim.attack(attacker)
+        self.wait_until(
+            lambda: attacker.health is not None
+            and (before is None or attacker.health < before - 0.05),
+            2.0,
+        )
+
+    def measure_melee(self):
+        """What one melee swing at the near victim takes off, right now."""
+        attacker, victim = self.clients[0], self.clients[1]
+        before = victim.health
+        attacker.attack(victim)
+        self.wait_until(
+            lambda: victim.health is not None
+            and before is not None
+            and victim.health < before - 0.05,
+            2.0,
+        )
+        if before is None or victim.health is None:
+            return 0.0
+        return before - victim.health
+
+    def baseline(self, entry):
+        # The melee probe is taken before the health snapshot, or the swing it
+        # makes reads as the ability having hurt somebody.
+        melee = self.measure_melee() if "buffs_melee" in entry["proves"] else 0.0
+        self.window_motions.clear()
+        for client in self.clients:
+            client.action_bar.clear()
+            client.teleported_to.clear()
+        return {
+            "melee": melee,
+            "health": {client.name: client.health for client in self.clients},
+            "position": {client.name: client.position for client in self.clients},
+        }
+
+    def press(self, entry):
+        attacker = self.clients[0]
+        attacker.use_slot(entry["slot"], "(%s)" % entry["name"])
+        if entry["charge_time"] is not None:
+            self.wait(entry["charge_time"] + 0.2)
+            attacker.release_slot(entry["slot"], "(%s, fully charged)" % entry["name"])
+
+    def observe(self, entry, before):
+        """Everything from `entry`'s declaration that actually reached a client."""
+        attacker = self.clients[0]
+        victims = self.clients[1:]
+        found = {}
+
+        def look():
+            for victim in victims:
+                was = before["health"].get(victim.name)
+                if was is not None and victim.health is not None and victim.health < was - 0.05:
+                    found.setdefault(
+                        "hurts_target",
+                        "%s went from %.2f to %.2f health" % (victim.name, was, victim.health),
+                    )
+                motion = self.window_motions.get(victim.entity_id)
+                if motion:
+                    found.setdefault(
+                        "launches_target",
+                        "%s took (%.3f, %.3f, %.3f) blocks/tick" % ((victim.name,) + motion),
+                    )
+            motion = self.window_motions.get(attacker.entity_id)
+            if motion:
+                found.setdefault(
+                    "launches_caster",
+                    "the caster took (%.3f, %.3f, %.3f) blocks/tick" % motion,
+                )
+            for at in attacker.teleported_to:
+                moved = distance(at, before["position"][attacker.name])
+                if moved > 1.0:
+                    found.setdefault(
+                        "teleports_caster",
+                        "the caster was moved %.1f blocks, to (%.1f, %.1f, %.1f)"
+                        % ((moved,) + at),
+                    )
+            was = before["health"].get(attacker.name)
+            if was is not None and attacker.health is not None and attacker.health > was + 0.05:
+                found.setdefault(
+                    "heals_caster",
+                    "the caster went from %.2f to %.2f health" % (was, attacker.health),
+                )
+            return set(entry["proves"]) <= set(found)
+
+        self.wait_until(look, SWEEP_WINDOW)
+
+        if "buffs_melee" in entry["proves"]:
+            after = self.measure_melee()
+            if after > before["melee"] + 0.05:
+                found["buffs_melee"] = (
+                    "a melee swing took %.2f health where the same swing took "
+                    "%.2f before" % (after, before["melee"])
+                )
+        return found
+
+    def probe_cooldown(self, entry):
+        """Right-click again straight away and expect to be told no."""
+        if entry["cooldown"] < 1.0 or entry["refunds_on_hit"]:
+            return
+        # A few ticks after the press, not the same one. Releasing a held item
+        # is a separate packet from using one, and a second use that arrives in
+        # the same tick as the release is handled before it: the ability is
+        # still charging rather than on cooldown, so the press restarts the
+        # charge and there is nothing to refuse.
+        self.wait(0.25)
+        attacker = self.clients[0]
+        attacker.action_bar.clear()
+        attacker.use_slot(entry["slot"], "(again, expecting a refusal)")
+        refused = self.wait_until(
+            lambda: any(COOLDOWN_REFUSAL in line for line in attacker.action_bar), 0.8
+        )
+        label = "%s / %s" % (entry["kit"], entry["name"])
+        if refused:
+            self.cooldown_results.append(
+                "%-42s refused inside its %.1fs cooldown" % (label, entry["cooldown"])
+            )
+        else:
+            self.cooldown_failures.append(
+                "%s has a %.1fs cooldown and let a second use through"
+                % (label, entry["cooldown"])
+            )
+
+    def exercise(self, entry):
+        label = "%s / %s" % (entry["kit"], entry["name"])
+        outstanding = list(entry["proves"])
+        evidence = []
+
+        for attempt in range(SWEEP_ATTEMPTS):
+            if not outstanding:
+                break
+            self.stage(entry, attempt)
+            if not self.arm(entry):
+                return
+            if "heals_caster" in outstanding:
+                self.wound_attacker()
+
+            before = self.baseline(entry)
+            self.press(entry)
+            if attempt == 0:
+                self.probe_cooldown(entry)
+            for name, note in self.observe(entry, before).items():
+                if name in outstanding:
+                    outstanding.remove(name)
+                    evidence.append("%s: %s" % (name, note))
+            if outstanding:
+                self.wait(entry["cooldown"] + 0.5)
+
+        if outstanding:
+            self.sweep_failures.append(
+                "%s declares %s and did not do it" % (label, ", ".join(outstanding))
+            )
+        self.sweep_results.append(
+            "%-42s %s" % (label, "; ".join(evidence) or "nothing reached a client")
+        )
+
     # --- the script ----------------------------------------------------
 
     def run(self):
-        self.connect()
+        # One short of the lobby's minimum, so the sweep runs in a hub that
+        # cannot start a countdown under it, has no kill plane and still allows
+        # a kit to be changed. The last client joins once the sweep is done.
+        self.connect(max(1, self.args.clients - 1))
+        if not self.wait_until(lambda: all(c.joined for c in self.clients), 60.0):
+            self.log("clients never reached the world")
+            return self.report()
+
+        if self.args.abilities:
+            self.sweep()
+
+        self.connect(self.args.clients - len(self.clients))
         kits = [kit.strip() for kit in self.args.kits.split(",")]
         deadline = time.time() + self.args.seconds
 
         step = 0
         script = self.build_script(kits)
         while time.time() < deadline:
-            for client in self.clients:
-                if client.alive:
-                    self.pump(client)
-                    if client.joined:
-                        client.repeat_position()
+            self.pump_all()
             if step < len(script):
                 when, action = script[step]
                 if self.ready(when):
@@ -658,7 +1191,8 @@ class Match:
         )
 
         at(playing, self.gather)
-        at(gathered, self.smash)
+        at(gathered, self.take_aim)
+        at(0.3, self.smash)
         at(launched, self.check_knockback)
         at(0.5, self.melee)
         at(1.0, self.fall)
@@ -737,10 +1271,54 @@ class Match:
             )
             client.walk(self.route(client, spot), "into range of %s" % attacker.name)
 
+    def take_aim(self):
+        """Turn to face the nearest victim.
+
+        Its own step, a beat before the ability, because a rotation does not
+        take effect in the tick it arrives: hyperion decodes packets after the
+        phase that copies yaw onto the component abilities read, so an ability
+        fired in the same tick as the turn fires along the old bearing. The
+        original script hid this by using a radial ability; anything aimed does
+        not have that luxury.
+        """
+        living = self.victims()
+        if living:
+            self.clients[0].look_at(living[0])
+
     def smash(self):
-        """Seismic Slam, which launches everything within eight blocks."""
+        """The attacker's own launching ability, chosen out of the registry."""
         self.motions.clear()
-        self.clients[0].use_slot(self.args.ability_slot, "(the kit's radial ability)")
+        attacker = self.clients[0]
+        slot = self.launching_slot(attacker.kit)
+        attacker.use_slot(slot, "(the knockback check's single-impulse ability)")
+
+    def launching_slot(self, kit):
+        """The slot the knockback check fires, and the registry's opinion of it.
+
+        A fixed slot rather than the first launching ability the registry
+        offers, because the check below solves one hidden strength out of two
+        different functions of it and that only works on a single impulse. Iron
+        Golem's Fissure puts three of its fourteen columns on one victim in one
+        tick and hyperion sums them into one velocity packet, which solves to
+        nothing at all. The sweep above is what covers every ability; this step
+        is about the model.
+
+        What the registry is for here is checking the choice rather than making
+        it: a slot holding something that does not launch is a slot this check
+        cannot use, and saying so beats a silent miss.
+        """
+        slot = self.args.ability_slot
+        declared = [
+            entry
+            for entry in self.manifest
+            if entry["kit"] == kit and entry["slot"] == slot
+        ]
+        if declared and "launches_target" not in declared[0]["proves"]:
+            self.log(
+                "--ability-slot %d on %s is %s, which the registry says does "
+                "not launch anybody" % (slot, kit, declared[0]["name"])
+            )
+        return slot
 
     def melee(self):
         attacker = self.clients[0]
@@ -850,6 +1428,17 @@ class Match:
     # --- the verdict ---------------------------------------------------
 
     def report(self):
+        if self.sweep_results:
+            print("", flush=True)
+            self.log("=== every ability the server declares, and what it did ===")
+            for line in self.sweep_results:
+                self.log("    %s" % line)
+        if self.cooldown_results:
+            print("", flush=True)
+            self.log("=== cooldowns, checked by right-clicking twice ===")
+            for line in self.cooldown_results:
+                self.log("    %s" % line)
+
         print("", flush=True)
         self.log("=== packets received in play state, by id ===")
         census = {}
@@ -906,8 +1495,14 @@ def main():
         "--ability-slot",
         type=int,
         default=3,
-        help="hotbar slot the attacker right-clicks; 3 is Iron Golem's "
-        "Seismic Slam, which is radial and so does not depend on facing",
+        help="hotbar slot the match's knockback check fires; 3 is Iron Golem's "
+        "Seismic Slam, which lands one hit and so solves against the model",
+    )
+    parser.add_argument(
+        "--no-abilities",
+        dest="abilities",
+        action="store_false",
+        help="skip the registry sweep and run only the match",
     )
     parser.add_argument("--seconds", type=float, default=300.0)
     parser.add_argument(


### PR DESCRIPTION
Fifteen kits ship fifty-one abilities. Exactly one of them had ever been fired
by a client: `tools/smash-match.py` walked everyone into one radius and pressed
one hotbar slot. This makes the kit registry say what each ability does in terms
a client can see, and drives every entry of it through real 776 clients.

## The API

An ability declares what a player will see. `proves` is the one field on
`AbilitySpec` with no useful default:

```rust
.ability(AbilitySpec {
    name: "Wolf Strike",
    item: "minecraft:iron_shovel",
    slot: 2,
    cooldown: 7.0,
    proves: &[
        Observable::HurtsTarget,
        Observable::LaunchesTarget,
        Observable::LaunchesCaster,
    ],
    activate: wolf_strike,
    ..AbilitySpec::DEFAULT
})
```

The vocabulary is six variants and every one of them names a packet, because an
effect nothing on the far side of the seam can see is not a proof:
`HurtsTarget` and `HealsCaster` are `ClientboundSetHealth`, `LaunchesTarget` and
`LaunchesCaster` are `ClientboundSetEntityMotion`, `TeleportsCaster` is
`ClientboundPlayerPosition`, and `BuffsMelee` is the same swing hurting more
than it did. Two flags exist for abilities that legitimately break a shared
rule: `requires_ground`, and `refunds_on_hit` for Chicken Missile, whose selling
point is that a hit clears its cooldown and which would otherwise read as a
broken cooldown.

`ability::manifest` is a query over the ability entities themselves rather than
a list anybody maintains, and `/abilities` publishes it as one JSON object per
chat line, which is how it crosses to a client at all. Three things enumerate
it and none of them names a kit:

- `tests/abilities.rs` fires every ability through the mock seam, refuses an
  empty declaration, refuses a movement that was not declared, and checks every
  cooldown by asking for a second use.
- `nix run .#smash-e2e` reads the manifest off the wire and drives every entry
  with real clients, in the hub, one client short of the lobby's minimum so
  nothing can start a match underneath it.
- the match's knockback check asks the registry whether the slot it fires
  actually declares a launch.

## How I proved the gate refuses an unproven ability

Added a kit whose abilities do nothing and declared that they do: one ability
declaring nothing at all, one declaring `hurts_target, launches_target`, one
ultimate declaring `hurts_target`.

`nix run .#test`:

```
---- every_ability_declares_what_a_client_would_see stdout ----
these abilities declare no observable effect, so no gate can test them: ["Hoax / Says Nothing"]
---- every_declared_effect_actually_happens stdout ----
Hoax / Empty Promise declares hurts_target and did not do it
Hoax / Empty Promise declares launches_target and did not do it
Hoax / Grand Nothing declares hurts_target and did not do it
test result: FAILED. 5 passed; 2 failed
```

`nix run .#smash-e2e` refuses the whole roster before the sweep when a
declaration is empty, and with only the lying ones left:

```
 118.42s  ABILITY FAILED Hoax / Empty Promise declares hurts_target, launches_target and did not do it
 118.42s  ABILITY FAILED Hoax / Grand Nothing declares hurts_target and did not do it
 297.65s    NOT PROVED  every declared ability did what it declared
 297.65s  RESULT: 1 of 10 steps did not happen
```

Then removed it. Every fix below was confirmed the same way, by reverting it and
watching the guard fire before restoring it.

## What was broken

Fifty of fifty-one abilities were already right. Six defects, each now guarded:

**Projectiles sampled only their endpoint.** Integration moves a projectile a
whole tick's travel at once and Barrage's arrows go 60 blocks a second, which at
20 ticks is three blocks a step against a hit radius of 0.4: seven eighths of
every arrow's flight was a hole a player could stand in. Reverting the swept
collision fails Roped Arrow, Egg Blaster and Aerial Gunner outright; whether
Barrage hit anything was decided by the victim happening to stand on a sample
point.

**A hit with a knockback multiplier of zero still launched.** `speed_base` and
`ground_boost` are floors under a launch, not a launch of their own, but they
applied to a strength of zero. Blaze's Inferno is documented as having no
knockback and was moving everyone it touched 0.2 blocks a tick sideways and the
same up, which is most of a jump.

**Storm Squid and Earthquake launched nobody at all.** Both centred their blast
on each victim in turn, and knockback away from the point you are standing on
normalises to no direction. `splash_from` separates the origin from the centre.

**Snow Turret fired at the world rather than at the enemy.** Six snowballs in a
ring of absolute world directions, so a target dead ahead sat in the gap between
two of them unless the fight was lined up with +X. This one only showed up on
the real clients: the headless sweep stands its victims along +X, which is
exactly where the first snowball went.

**Mooshroom Madness compounded.** It added ten to the maximum every use rather
than setting it, so two crystals left a Cow on forty hearts and a third on
fifty.

**Starting a charge never checked the cooldown.** A hold banked a use the
refusal was meant to stop, so nine charge abilities let a second use through.

## What was missing

Every ultimate was unreachable. `.ultimate(..)` built the ability and linked it
to nothing, so no registry could see it and nothing could grant it. Ultimates
hang off the same `Grants` relationship as the rest of the kit now, separated by
the `Ultimate` tag that `kit::apply` filters on, and `kit::grant_ultimate` hands
one out for a window that `ability::GrantedFor` counts down and takes back.

What is still missing is the pickup: nothing spawns a Smash Crystal in the arena
for somebody to walk into. That is arena work and the map format already carries
the spawn points for it (`MapSpec::crystals`), so it belongs with whoever owns
that file. `/crystal` is the entry point to the same mechanic meanwhile, and is
what the gate uses. Filed as hyperion-mc/hyperion#998.

Two things are still modelled rather than implemented, both unchanged and both
already marked `[APPROXIMATED]` in the kit files: the timed status effects
(Blaze's twenty seconds of flight, Chicken's unlimited flight, Wolf's Frenzy
buffs) need a movement mode and a potion system the seam does not carry, and the
abilities that place blocks (Snowman's Ice Path, Spider's web dome) need host
block writes. In each case the damage or the impulse is what lands, and that is
what the ability declares.

## Gates

```
nix run .#fmt -- --check   rc=0
nix run .#lint             rc=0
nix run .#test             rc=0   469 tests run: 469 passed, 1 skipped
nix run .#e2e              rc=0   RESULT: reached play state (Login received)
nix run .#smash-e2e        rc=0   RESULT: a whole match ran at protocol 776
nix flake check            rc=0   all checks passed!
```

`smash-e2e`, in full:

```
proved  the server published its ability registry
        51 abilities across 15 kits (Blaze, Chicken, Cow, Creeper, Enderman,
        Guardian, Iron Golem, Skeleton, Sky Squid, Slime, Snowman, Spider,
        Wither Skeleton, Wolf, Zombie), every one of them declaring what a
        client would see
proved  every declared ability did what it declared
        51 abilities fired by a real client, each one checked against the
        effects its own registry entry names
proved  cooldowns refused a second use
        47 abilities answered a second right-click inside their cooldown with
        'That ability is recharging.' on the action bar
proved  four in play
proved  lobby started a match
proved  kits equipped
proved  arena is a committed map
proved  knockback from an ability
        P3 took (-1.348, 0.542, -1.348) blocks/tick. Horizontal 1.907 implies
        strength 3.556, vertical 0.542 implies 3.557 (airborne), which is the
        same launch the model in module/knockback.rs describes; the direction is
        100% away from P1. Vanilla would have sent 0.4 and 0.4.
proved  life lost and respawned
proved  match ended, back in the hub

RESULT: a whole match ran at protocol 776
```

The run prints one line per ability with the evidence, for example:

```
Slime / Slime Slam       hurts_target: P2 went from 20.00 to 15.24 health;
                         launches_target: P2 took (0.000, 0.740, 1.880) blocks/tick;
                         launches_caster: the caster took (0.000, 0.259, -0.341) blocks/tick
Enderman / Blink         teleports_caster: the caster was moved 16.0 blocks, to (6.0, 65.0, 5.0)
Guardian / Target Laser  buffs_melee: a melee swing took 4.48 health where the same
                         swing took 3.20 before
Cow / Mooshroom Madness  heals_caster: the caster went from 17.12 to 20.00 health
```

## Two things worth knowing about the harness

A scripted client that never sends a rotation looks along +Z forever, so
everything that fires where you look was firing due north of everybody. It sends
pos-rot now, and it aims a beat before it fires rather than in the same packet:
hyperion decodes packets after the phase that copies yaw onto the component
abilities read, so a turn and an ability in the same tick fire along the old
bearing.

The sweep cannot claim a position outright. hyperion undoes a tick's movement
over about ten blocks in `sync_entity_state`'s speed check, which reports nothing
to the player at all, so the sweep walks its clients to their marks over the top
of the hub instead. The knockback model check still fires a fixed slot rather
than the first launching ability the registry offers, because it solves one
hidden strength out of two functions of it and that only works on a single
impulse: Iron Golem's Fissure puts three of its fourteen columns on one victim in
one tick and hyperion sums them into one packet.
