### PR TITLE
test: run the end to end gates as sandboxed nix checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,18 @@
             inherit (minecraft) jdk serverClasspath pin;
           };
 
+          # One harness behind both the `nix run` gates and the sandboxed
+          # checks, so the two cannot drift.
+          e2e = import ./nix/e2e.nix {
+            inherit pkgs lib fileDescriptors;
+            sources = {
+              root = ./.;
+              tools = ./tools;
+              protoSource = ./crates/hyperion-minecraft-proto/src;
+              genmap = ./crates/hyperion-genmap/src/lib.rs;
+            };
+          };
+
           cargoTools = [
             pkgs.cargo-deny
             pkgs.cargo-machete
@@ -375,9 +387,8 @@
             # a run does not fight a `nix run .#dev` open in another terminal.
             e2e = {
               deps = [
-                pkgs.process-compose
                 pkgs.git
-                pkgs.python3
+                e2e.driver
               ];
               text = ''
                 root="$(git rev-parse --show-toplevel)"
@@ -387,86 +398,24 @@
                 # `smash-e2e` sets both and this stays the bedwars gate. Two
                 # apps rather than one with a flag, because the useful thing to
                 # type is one word.
-                export HYPERION_EVENT="''${HYPERION_EVENT:-bedwars}"
-                read -ra client <<< "''${HYPERION_E2E_CLIENT:-tools/client-26.2.py --name e2e}"
+                event="''${HYPERION_EVENT:-bedwars}"
+                profile="''${HYPERION_PROFILE:-dev}"
+
+                # cargo, not the store: what a person debugging wants is the
+                # code in their working tree, rebuilt incrementally. The check
+                # of the same name hands the same driver two store paths, and
+                # that is the only difference between them.
+                export HYPERION_E2E_GAME_SERVER="cargo run --profile $profile -p $event --"
+                export HYPERION_E2E_PROXY="cargo run --profile $profile --bin hyperion-proxy --"
+                export HYPERION_E2E_CLIENT="''${HYPERION_E2E_CLIENT:-tools/client-26.2.py --name e2e}"
+                # Certificates from the store rather than `nix run .#certs`, so
+                # a fresh clone runs this without a setup step first.
+                export HYPERION_E2E_CERTS="${e2e.certs}"
 
                 export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + 1000)}}"
                 export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + 1000)}}"
-                player_port="$HYPERION_PLAYER_PORT"
-                server_port="$HYPERION_SERVER_PORT"
 
-                log="$(mktemp -t hyperion-e2e.XXXXXX)"
-                echo "stack log: $log"
-
-                "${lib.getExe runners.dev}" --tui=false >> "$log" 2>&1 &
-                stack=$!
-                # Killing the process group, not the pid: process-compose forks
-                # cargo, which forks the server, and killing only $stack orphans
-                # both so the next run dies on "address already in use".
-                # shellcheck disable=SC2329  # run by the EXIT trap below
-                cleanup() {
-                  kill -- "-$stack" >> "$log" 2>&1 || kill "$stack" >> "$log" 2>&1 || true
-                  wait "$stack" >> "$log" 2>&1 || true
-                }
-                trap cleanup EXIT
-
-                # A cold run compiles two binaries, so the bound is generous. It
-                # is a bound rather than a sleep because a warm run is ready in
-                # seconds and should not pay for the cold one.
-                # Both ports, not just the player one. The proxy binds its
-                # listener immediately and retries the game server behind it, so
-                # a probe that only checks the player port lets the client
-                # connect while the game server is still compiling. The client
-                # then dies on a read timeout that reads exactly like a protocol
-                # bug, which cost an agent a full cycle to diagnose (ENG-10450).
-                deadline=$(( SECONDS + 900 ))
-                until python3 -c "
-                import socket, sys
-                for port in ($player_port, $server_port):
-                    s = socket.socket()
-                    s.settimeout(1)
-                    if s.connect_ex(('127.0.0.1', port)) != 0:
-                        sys.exit(1)
-                sys.exit(0)
-                "; do
-                  if [ "$SECONDS" -ge "$deadline" ]; then
-                    echo "stack never opened both 127.0.0.1:$player_port and 127.0.0.1:$server_port; tail of $log:" >&2
-                    tail -40 "$log" >&2
-                    exit 1
-                  fi
-                  if ! kill -0 "$stack" >> "$log" 2>&1; then
-                    echo "stack exited before opening a port; tail of $log:" >&2
-                    tail -40 "$log" >&2
-                    exit 1
-                  fi
-                  sleep 2
-                done
-
-                echo "stack up on 127.0.0.1:$player_port ($HYPERION_EVENT)"
-                # Not `exec`: replacing this shell would skip the EXIT trap and
-                # orphan the stack, and the next run would die on "address
-                # already in use".
-                rc=0
-                python3 "''${client[@]}" --host 127.0.0.1 --port "$player_port" "$@" || rc=$?
-
-                # A client that finished its checks proves nothing if the server
-                # died while it was reading. It has: the movement handler
-                # aborted the process on the first step a player took
-                # (hyperion#987), and the client saw only its own read timeout,
-                # which it treats as a clean end of session. So ask the game
-                # server directly whether it is still listening.
-                if ! python3 -c "
-                import socket, sys
-                s = socket.socket()
-                s.settimeout(2)
-                sys.exit(0 if s.connect_ex(('127.0.0.1', $server_port)) == 0 else 1)
-                "; then
-                  echo "the game server stopped listening during the session; tail of $log:" >&2
-                  tail -60 "$log" >&2
-                  exit 1
-                fi
-
-                exit "$rc"
+                exec hyperion-e2e-driver "$@"
               '';
             };
 
@@ -478,11 +427,7 @@
             # Ports default off the `e2e` ones rather than sharing them, so the
             # two gates can run side by side.
             smash-e2e = {
-              deps = [
-                pkgs.process-compose
-                pkgs.git
-                pkgs.python3
-              ];
+              deps = [ pkgs.git ];
               text = ''
                 export HYPERION_EVENT=smash
                 export HYPERION_E2E_CLIENT=tools/smash-match.py
@@ -576,6 +521,15 @@
               };
             });
 
+          # Named once and used by both `packages` and the sandboxed checks, so
+          # a gate runs the same binary the flake publishes rather than a second
+          # build of it.
+          gameBinaries = {
+            bedwars = named "bedwars" workspace.binaries.bedwars;
+            smash = named "smash" workspace.binaries.smash;
+            hyperion-proxy = named "hyperion-proxy" workspace.binaries.hyperion-proxy;
+          };
+
         in
         {
           devShells.default = pkgs.mkShell {
@@ -607,9 +561,8 @@
             });
 
           packages = {
-            default = named "bedwars" workspace.binaries.bedwars;
-            bedwars = named "bedwars" workspace.binaries.bedwars;
-            hyperion-proxy = named "hyperion-proxy" workspace.binaries.hyperion-proxy;
+            default = gameBinaries.bedwars;
+            inherit (gameBinaries) bedwars smash hyperion-proxy;
             rust-mc-bot = named "rust-mc-bot" workspace.binaries.rust-mc-bot;
 
             minecraft-server-jar = minecraft.serverJar;
@@ -631,6 +584,44 @@
           # `nix flake check` builds every app, which is what proves each one
           # passes shellcheck and that its tools resolve.
           checks = scripts // {
+            # The two gates that read the wire the way a player does, as
+            # derivations: nix builds the binaries, the sandbox boots them on
+            # loopback, and the scripted client's verdict is the build result.
+            # Every other check reads the source. `nix run .#test` proves a
+            # packet encodes to the bytes a test says it should, and stays
+            # green while the server sends that packet under a number from a
+            # different protocol version. A client is what notices, and until
+            # these existed nothing in `nix flake check` ran one.
+            e2e = e2e.mkCheck {
+              name = "hyperion-e2e";
+              gameServer = gameBinaries.bedwars;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "client-26.2.py";
+              clientArgs = [ "--name" "e2e" ];
+              # bedwars still downloads its world at boot, so the sandbox has
+              # to hand it one. smash below needs nothing: its arenas are
+              # `include_str!` of files this repository owns.
+              needsGenMap = true;
+            };
+
+            smash-e2e = e2e.mkCheck {
+              name = "hyperion-smash-e2e";
+              gameServer = gameBinaries.smash;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "smash-match.py";
+              # A match is four clients playing for up to five minutes, so the
+              # cap is the client's own budget plus room to boot and report.
+              timeout = 480;
+            };
+
+            # `checks.e2e` above took the names the two app wrappers used to
+            # hold, and those wrappers still have to pass shellcheck.
+            e2e-app = scripts.e2e;
+            smash-e2e-app = scripts.smash-e2e;
+
+            # The pinned world URL still has to be the one the server asks for.
+            genmap-url-pinned = e2e.genMapUrlPinned;
+
             # The committed generated sources must match what the pipeline
             # produces, or the copy cargo reads is a fiction.
             minecraft-proto-generated = minecraft.generatedUpToDate;

--- a/nix/e2e.nix
+++ b/nix/e2e.nix
@@ -1,0 +1,340 @@
+# The end to end gates, as one harness.
+#
+# `nix run .#e2e` and `checks.e2e` are the same script with different binaries
+# behind it: the app points it at what cargo just built in the working tree, the
+# check points it at what nix built in the store and runs it in the sandbox.
+# There is one derivation for the driver so the two cannot drift, which is the
+# whole reason this file exists rather than a second copy of the glue.
+{
+  pkgs,
+  lib,
+  fileDescriptors,
+  sources,
+}:
+let
+  # The world bedwars loads. `hyperion-genmap` downloads this from GitHub the
+  # first time a server boots and caches it under the user's cache directory,
+  # which a sandbox has no way to do: there is no network in there. So the
+  # tarball is pinned by hash here and the cache is seeded with it before the
+  # server starts, which turns a download into an input.
+  #
+  # When repository-owned maps land this whole binding goes away; smash already
+  # has them (`events/smash/maps/*.map`, reached by `include_str!`) and so needs
+  # nothing seeded.
+  genMapUrl = "https://github.com/andrewgazelka/maps/raw/main/GenMap.tar.gz";
+
+  genMapArchive = pkgs.fetchurl {
+    url = genMapUrl;
+    hash = "sha256-ViX+qDEBf++HwbXu1rTAi05Ju/3JAS16Ld4Uq0sStQg=";
+  };
+
+  genMap = pkgs.runCommand "hyperion-genmap-world" { } ''
+    mkdir -p "$out"
+    tar -xzf ${genMapArchive} -C "$out"
+    test -d "$out/region" || {
+      echo "GenMap.tar.gz no longer unpacks to region/, so the seeded cache" >&2
+      echo "would be a directory the server cannot read." >&2
+      exit 1
+    }
+  '';
+
+  # `hyperion_utils::cached_save` keys its cache on the sha256 of the URL text,
+  # under the `AppId` in the world when `GenMapModule` is imported. bedwars sets
+  # its own `AppId` after that import, so the one that counts is the default
+  # `HyperionUtilsModule` writes: github / hyperion-mc / generic.
+  genMapKey = builtins.hashString "sha256" genMapUrl;
+
+  # `directories` spells that identity two ways and which one is right depends
+  # on the host the check runs on. Both are seeded rather than branching on the
+  # platform, because a wrong guess is not silent: with no network in the
+  # sandbox a cache miss panics the server on its first boot.
+  seedGenMap = ''
+    for cache in \
+      "$XDG_CACHE_HOME/generic" \
+      "$HOME/Library/Caches/github.hyperion-mc.generic"; do
+      mkdir -p "$cache"
+      ln -s ${genMap} "$cache/${genMapKey}"
+    done
+  '';
+
+  # The URL above is a copy of one that lives in Rust, and a copy goes stale.
+  # If `hyperion-genmap` starts loading a different world the seeded cache
+  # quietly stops being the world under test, so this fails the build instead.
+  # It is also the first thing to delete once world loading stops downloading.
+  genMapUrlPinned = pkgs.runCommand "hyperion-genmap-url-pinned" { } ''
+    if ! grep -qF '${genMapUrl}' ${sources.genmap}; then
+      echo "nix/e2e.nix pins" >&2
+      echo "  ${genMapUrl}" >&2
+      echo "but crates/hyperion-genmap/src/lib.rs no longer names it, so the" >&2
+      echo "sandboxed checks would seed a cache the server never reads and" >&2
+      echo "then fail with no network to fall back on. Repin the URL and its" >&2
+      echo "hash, or delete both if the world now comes from the repository." >&2
+      exit 1
+    fi
+    touch "$out"
+  '';
+
+  # mTLS between the game server and the proxy, minted in a derivation rather
+  # than by `nix run .#certs` reaching into the working tree. Throwaway by
+  # construction: nothing outside these checks trusts the CA, and the CA key is
+  # deleted rather than kept.
+  certs = pkgs.runCommand "hyperion-e2e-certs" { nativeBuildInputs = [ pkgs.openssl ]; } ''
+    mkdir -p "$out"
+    cd "$out"
+
+    openssl req -new -nodes -newkey rsa:2048 -keyout root_ca.pem \
+      -x509 -out root_ca.crt -days 36500 -subj '/CN=hyperion-e2e-ca'
+
+    for who in server proxy; do
+      openssl req -nodes -newkey rsa:2048 \
+        -keyout "''${who}_private_key.pem" -out "$who.csr" \
+        -subj "/CN=hyperion-e2e-$who"
+      # The SAN must cover the address the peer dials or the handshake fails
+      # with "certificate not valid for name".
+      openssl x509 -req -in "$who.csr" -CA root_ca.crt -CAkey root_ca.pem \
+        -CAcreateserial -out "$who.crt" -days 36500 -sha256 \
+        -extfile <(printf 'subjectAltName=DNS:localhost,IP:127.0.0.1')
+      rm -f "$who.csr"
+    done
+    rm -f root_ca.srl root_ca.pem
+  '';
+
+  # The scripted clients read three things off disk: each other, the registry
+  # contents they check the server's tags against, and the generated item
+  # registry they name items from. All three are under one root because the
+  # clients reach for them by repository-relative path.
+  clients = lib.fileset.toSource {
+    root = sources.root;
+    fileset = lib.fileset.unions [
+      (lib.fileset.fileFilter (file: file.hasExt "py") sources.tools)
+      sources.protoSource
+    ];
+  };
+
+  # One script, both callers. Everything that varies is an environment
+  # variable, and the flags the two binaries take are written down exactly once
+  # -- the pair most likely to drift, because a renamed flag breaks a gate
+  # nobody runs until CI does.
+  driver = pkgs.writeShellApplication {
+    name = "hyperion-e2e-driver";
+    runtimeInputs = [ pkgs.python3 ];
+    text = ''
+      # Job control, so each background process is its own group. `cargo run`
+      # forks the binary under test, and killing only cargo would leave the
+      # server holding its port for the next run.
+      set -m
+
+      : "''${HYPERION_E2E_GAME_SERVER:?the command that starts the game server}"
+      : "''${HYPERION_E2E_PROXY:?the command that starts the proxy}"
+      : "''${HYPERION_E2E_CLIENT:?the client script and its arguments}"
+      : "''${HYPERION_E2E_CERTS:?a directory holding root_ca.crt and the two leaf pairs}"
+
+      # Unset means "find a free pair". A check has no reason to care which
+      # ports it uses and every reason not to collide: on Linux the sandbox
+      # has its own network namespace, but on darwin there is no such thing
+      # and a build shares the host's loopback with everything else on the
+      # machine. A fixed 47565 lost that race to an unrelated server the first
+      # time this ran. Both sockets are held open until both numbers are read,
+      # so the pair cannot come back equal.
+      picked_player=""
+      picked_server=""
+      if [ -z "''${HYPERION_PLAYER_PORT:-}" ] || [ -z "''${HYPERION_SERVER_PORT:-}" ]; then
+        read -r picked_player picked_server < <(python3 -c "
+      import socket
+      held = [socket.socket() for _ in range(2)]
+      for sock in held:
+          sock.bind(('127.0.0.1', 0))
+      print(' '.join(str(sock.getsockname()[1]) for sock in held))
+      ")
+      fi
+      player_port="''${HYPERION_PLAYER_PORT:-$picked_player}"
+      server_port="''${HYPERION_SERVER_PORT:-$picked_server}"
+      bind="''${HYPERION_E2E_BIND:-127.0.0.1}"
+      certs="$HYPERION_E2E_CERTS"
+      log="''${HYPERION_E2E_LOG:-$(mktemp -t hyperion-e2e.XXXXXX)}"
+      # A cold `nix run` compiles two binaries behind this; a check has them
+      # already and is ready in seconds. A deadline rather than a sleep, so the
+      # fast case does not pay for the slow one.
+      ready_timeout="''${HYPERION_E2E_TIMEOUT:-900}"
+
+      read -ra game_server <<< "$HYPERION_E2E_GAME_SERVER"
+      read -ra proxy <<< "$HYPERION_E2E_PROXY"
+      read -ra client <<< "$HYPERION_E2E_CLIENT"
+
+      echo "stack log: $log"
+
+      "''${game_server[@]}" \
+        --ip "$bind" --port "$server_port" \
+        --root-ca-cert "$certs/root_ca.crt" \
+        --cert "$certs/server.crt" \
+        --private-key "$certs/server_private_key.pem" \
+        < /dev/null >> "$log" 2>&1 &
+      game_pid=$!
+
+      # shellcheck disable=SC2329  # called below and from the EXIT trap
+      cleanup() {
+        for pid in "''${proxy_pid:-}" "$game_pid"; do
+          [ -n "$pid" ] || continue
+          kill -- "-$pid" >> "$log" 2>&1 || kill "$pid" >> "$log" 2>&1 || true
+          wait "$pid" >> "$log" 2>&1 || true
+        done
+      }
+      trap cleanup EXIT
+      # `timeout` around this script sends TERM, and bash runs an EXIT trap on
+      # a signal only when that signal is trapped too. Without this a check
+      # that hits its cap leaves the stack running.
+      trap 'exit 143' TERM INT
+
+      fail() {
+        echo "$1" >&2
+        echo "tail of $log:" >&2
+        tail -60 "$log" >&2
+        exit 1
+      }
+
+      # Waits for a port to answer, or fails the run saying which one did not.
+      # Each call gets its own deadline. Probing the game server's port costs a
+      # line of "tls handshake eof" in its log per attempt, because a probe
+      # connects and hangs up; that noise is the price of not guessing.
+      await_port() {
+        local port="$1" who="$2" pid="$3"
+        local deadline=$(( SECONDS + ready_timeout ))
+        until python3 -c "
+      import socket, sys
+      s = socket.socket()
+      s.settimeout(1)
+      sys.exit(0 if s.connect_ex(('127.0.0.1', $port)) == 0 else 1)
+      "; do
+          if [ "$SECONDS" -ge "$deadline" ]; then
+            fail "the $who never opened 127.0.0.1:$port"
+          fi
+          if ! kill -0 "$pid" >> "$log" 2>&1; then
+            fail "the $who exited before opening 127.0.0.1:$port"
+          fi
+          sleep 2
+        done
+      }
+
+      # In this order, and waiting in between, because the proxy binds its
+      # listener immediately and only then dials the game server behind it.
+      # Started together, the player port is open for as long as the game
+      # server takes to start -- 95 seconds of it on a cold `nix run`, where
+      # cargo is still compiling -- and a client that connects in that window
+      # dies on a read timeout that reads exactly like a protocol bug. That
+      # cost an agent a full cycle to diagnose once already (ENG-10450), and
+      # then cost this one another when the two were started together. The
+      # price is that a cold `nix run` compiles the two binaries in sequence
+      # rather than at once; a check has both already built.
+      await_port "$server_port" "game server" "$game_pid"
+
+      # Best effort: a sandbox can hold a hard limit below this, and these
+      # gates drive four clients rather than the few thousand bots it is for.
+      ulimit -Sn ${fileDescriptors} || true
+
+      "''${proxy[@]}" \
+        --server "127.0.0.1:$server_port" \
+        --root-ca-cert "$certs/root_ca.crt" \
+        --cert "$certs/proxy.crt" \
+        --private-key "$certs/proxy_private_key.pem" \
+        "$bind:$player_port" \
+        < /dev/null >> "$log" 2>&1 &
+      proxy_pid=$!
+
+      await_port "$player_port" "proxy" "$proxy_pid"
+
+      echo "stack up on 127.0.0.1:$player_port"
+
+      # Not `exec`: replacing this shell would skip the EXIT trap and orphan
+      # both processes, and the next run would die on "address already in use".
+      rc=0
+      client_log="$(mktemp -t hyperion-e2e-client.XXXXXX)"
+      python3 "''${client[@]}" --host 127.0.0.1 --port "$player_port" "$@" \
+        2>&1 | tee "$client_log" || rc=$?
+
+      # A client that finished its checks proves nothing if the server died
+      # while it was reading. It has: the movement handler aborted the process
+      # on the first step a player took (hyperion#987), and the client saw only
+      # its own read timeout, which it treats as a clean end of session. So ask
+      # the game server directly whether it is still listening.
+      if ! python3 -c "
+      import socket, sys
+      s = socket.socket()
+      s.settimeout(2)
+      sys.exit(0 if s.connect_ex(('127.0.0.1', $server_port)) == 0 else 1)
+      "; then
+        fail "the game server stopped listening during the session"
+      fi
+
+      if [ "$rc" -ne 0 ]; then
+        echo "tail of $log:" >&2
+        tail -40 "$log" >&2
+        # The client says why it failed in the middle of its transcript, well
+        # before the packet census it ends with, and a build failure is read
+        # through a fixed tail. Repeating the verdict last is what puts the
+        # reason in the excerpt CI prints rather than a page of packet counts.
+        echo "" >&2
+        echo "the client's verdict was failure. What it reported:" >&2
+        grep -E 'RESULT:|Traceback|Error' "$client_log" >&2 || true
+      fi
+      exit "$rc"
+    '';
+  };
+
+  # A sandboxed gate: nix builds the binaries, the sandbox boots them on
+  # loopback, the scripted client drives them, and the client's verdict is the
+  # build result.
+  #
+  # Ports are left unset so the driver picks a free pair. On Linux the sandbox
+  # has its own network namespace and any port would do; on darwin
+  # `__darwinAllowLocalNetworking` puts the build on the host's loopback, where
+  # a fixed number is a race against every other process on the machine.
+  mkCheck =
+    {
+      name,
+      gameServer,
+      proxy,
+      client,
+      clientArgs ? [ ],
+      needsGenMap ? false,
+      timeout ? 300,
+    }:
+    pkgs.runCommand name
+      {
+        nativeBuildInputs = [
+          pkgs.python3
+          driver
+        ];
+        # Without this a darwin build gets no loopback at all and the proxy
+        # cannot reach the game server. Linux ignores it and uses the sandbox's
+        # own network namespace, which already has loopback up.
+        __darwinAllowLocalNetworking = true;
+      }
+      ''
+        export HOME="$NIX_BUILD_TOP/home"
+        export XDG_CACHE_HOME="$HOME/.cache"
+        mkdir -p "$XDG_CACHE_HOME"
+        ${lib.optionalString needsGenMap seedGenMap}
+
+        export HYPERION_E2E_GAME_SERVER="${lib.getExe gameServer}"
+        export HYPERION_E2E_PROXY="${lib.getExe proxy}"
+        export HYPERION_E2E_CLIENT="${clients}/tools/${client} ${lib.escapeShellArgs clientArgs}"
+        export HYPERION_E2E_CERTS="${certs}"
+        export HYPERION_E2E_LOG="$NIX_BUILD_TOP/stack.log"
+        # The binaries are already built, so anything past this is a hang
+        # rather than a slow compile.
+        export HYPERION_E2E_TIMEOUT=120
+
+        timeout ${toString timeout} hyperion-e2e-driver
+        touch "$out"
+      '';
+in
+{
+  inherit
+    driver
+    certs
+    clients
+    genMap
+    genMapUrlPinned
+    mkCheck
+    ;
+}


### PR DESCRIPTION
## What this is

`nix run .#e2e` and `nix run .#smash-e2e` prove a great deal and neither is a
check. They shell out to process-compose, which shells out to cargo, which
builds and runs the stack in whatever environment the developer happens to
have. Nothing in `nix flake check` booted a server and drove a client, so CI
could be green while the thing a player touches was broken.

`checks.e2e` and `checks.smash-e2e` are now derivations. Nix builds the two
binaries, the sandbox boots them on loopback with no network, the scripted
client drives them, and the client's verdict is the build result.

## The harness

`nix/e2e.nix` builds one derivation, `hyperion-e2e-driver`, and both the apps
and the checks call it. It takes the game server command, the proxy command,
the client and its arguments, and a certificate directory, all from the
environment. The app hands it `cargo run` against the working tree; the check
hands it two store paths. That is the only difference between them, so the
flags the two binaries take cannot drift between the gate a person runs and the
gate CI runs.

`mkCheck` wraps the driver in a sandboxed derivation: it seeds a world if the
event needs one, points the driver at store binaries and store certificates,
and caps the run.

The apps keep working and keep printing the path of a log you can tail.
`nix run .#dev` still uses process-compose, which is what a person poking at a
running stack wants.

## What had to change to make the build hermetic

**The world.** `hyperion-genmap` downloads `GenMap.tar.gz` from GitHub the
first time a server boots and caches it under the user's cache directory. A
sandbox cannot do that. The tarball is now a fixed-output fetch, and the cache
`hyperion_utils::cached_save` reads is seeded with it before the server starts,
keyed on the same sha256 of the URL that the Rust computes. A cache miss is not
silent: with no network in the sandbox the server panics on its first boot.
`checks.genmap-url-pinned` fails the build if the URL in
`crates/hyperion-genmap/src/lib.rs` ever stops matching the pin here.

This is the interim arrangement, as the task anticipated: repository-owned maps
would delete the whole binding. smash already needs nothing seeded, because its
arenas are `include_str!` of files this repository owns.

**The certificates.** mTLS material is minted in a derivation rather than by
`nix run .#certs` reaching into the working tree, and the CA key is deleted
rather than kept. `nix run .#e2e` uses the same store certificates, so a fresh
clone runs the gate with no setup step first.

**The ports.** The driver picks a free pair when none is given. On Linux the
sandbox has its own network namespace and any port would do; on darwin
`__darwinAllowLocalNetworking` puts the build on the host's loopback, and the
first fixed port this used lost a race to an unrelated server on the machine
within an hour of being written.

## Two bugs in the existing glue, found and fixed here

**The stack raced its own compile.** It started the game server and the proxy
at once and waited for both ports. The proxy binds its listener immediately and
dials the game server behind it, so on a cold `nix run` the player port was
open for the 95 seconds cargo spent compiling the game server, and a client
connecting in that window died on a read timeout that reads exactly like a
protocol bug. Observed, not theorised: `nix run .#e2e` on a cold tree failed
this way, with the game server's own log showing the proxy connecting 95
seconds after it bound. The driver now waits for the game server before it
starts the proxy.

**A failed check hid its own reason.** A build failure is read through a fixed
tail, and the client says why it failed in the middle of its transcript, well
before the packet census it ends with. The first deliberate break produced 25
lines of packet counts and no diagnosis. The driver now repeats the verdict
last.

## Watching it fail

Break: delete the `UpdateTags` send in
`crates/hyperion/src/net/protocol/pre_play.rs`, which is the shape of the tag
bug that reached a real client.

```
error: Cannot build '/nix/store/0b0bisl8g3q0a276zzarbmy95jrlkw2a-hyperion-e2e.drv'.
       Reason: builder failed with exit code 1.
       Last 25 log lines:
       ...
       > the client's verdict was failure. What it reported:
       > [e2e] RESULT: no tags for minecraft:item, which every client needs
       > [e2e] RESULT: no tags for minecraft:block, which every client needs
       > [e2e] RESULT: no tags for minecraft:entity_type, which every client needs
       > [e2e] RESULT: 55 tag(s) the registry contents reference were never sent, so a real client fails registry loading and disconnects with Network Protocol Error: minecraft:arrows, minecraft:blocks_wind_charge_explosions, minecraft:enchantable/armor, minecraft:enchantable/bow, minecraft:enchantable/chest_armor, minecraft:enchantable/crossbow, minecraft:enchantable/durability, minecraft:enchantable/equippable
       > [e2e] RESULT: reached play state (Login received)
       > [e2e] RESULT: 3425 LevelChunkWithLight packet(s)
       > [e2e] RESULT: GameEvent(LEVEL_CHUNKS_LOAD_START) sent
```

Restored, the same check passes:

```
hyperion-e2e> [e2e] <- UpdateTags 15 registries, 697 tags, 35203 bytes
hyperion-e2e> [e2e] RESULT: every referenced tag is present in UpdateTags
hyperion-e2e> [e2e] <- Login entity_id=67109687  ** REACHED PLAY STATE **
hyperion-e2e> [e2e] RESULT: reached play state (Login received)
hyperion-e2e> [e2e] RESULT: 2795 LevelChunkWithLight packet(s)
hyperion-e2e> [e2e] RESULT: GameEvent(LEVEL_CHUNKS_LOAD_START) sent
rc=0
```

## What it costs

On an M-series mac, nothing in the store to begin with.

| | cold | warm |
| --- | --- | --- |
| the two binaries `checks.e2e` needs | 16 min | 0 |
| `checks.e2e` itself | 53 to 71 s | 53 to 71 s |
| the smash binary | about 4 min | 0 |
| `checks.smash-e2e` itself | 194 to 250 s | 194 to 250 s |
| `nix flake check`, whole | 625 s | 625 s |

Warm means the binaries are already built, which is the case CI hits on every
run that does not touch the server. The check derivations themselves are not
cached across a source change, because a source change is the thing they exist
to catch.

`checks.smash-e2e` is the expensive one at three to four minutes, and it earns
it: the match proves kit equipment, arena placement, ability knockback, death
and respawn, and the return to the hub, on four real clients. Three to four
minutes on top of a `nix flake check` that already runs ten is worth keeping in
the default set. If that changes, the thing to do is move it behind
`--all-systems` or a nightly rather than delete it.

## Also

`packages.smash` is new. The flake published bedwars and the proxy but not
smash, and the check needs the binary.

`checks.e2e-app` and `checks.smash-e2e-app` keep the two app wrappers under
shellcheck, since the sandboxed checks took the names those wrappers used to
hold.
