### PR TITLE
test: verify the game modules rather than exercise them

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,52 @@
+# Mutation testing scope and budget. `nix run .#mutants` reads this.
+#
+# A mutant is a deliberate change to the source -- a `>` flipped to `>=`, a
+# return value replaced with a default. A mutant that survives is a line the
+# test suite executes without checking, so the surviving count is the honest
+# measure of how much of this game the tests actually verify. `nix run .#test`
+# staying green while a mutant lives is exactly the failure mode this catches.
+
+# The game logic, and only the game logic.
+#
+# Excluded on purpose, each for a reason rather than to flatter the number:
+#
+# * `module/kits/**` -- 700-odd mutants of declarative kit data. A kit is a
+#   `KitStats` literal and a handful of `splash` calls, so nearly every mutant
+#   there is "this ability's radius is a different number", which is a balance
+#   question and not a correctness one. `tests/modularity.rs` already proves the
+#   kit machinery works by defining a kit from outside the crate. Including them
+#   would quadruple the gate's runtime to test constants.
+# * `map.rs`, `terrain.rs` -- world loading. Needs chunk data on disk, which the
+#   headless harness deliberately does not have.
+# * `adapter.rs`, `input.rs`, `mirror.rs`, `command.rs` -- the hyperion seam.
+#   Untestable without a running server; `nix run .#smash-e2e` is what covers
+#   these, and it covers them end to end rather than per line.
+# * `server/mock.rs` -- test infrastructure. Mutating the recorder that the
+#   assertions read is measuring the tape measure.
+examine_globs = ["events/smash/src/module/*.rs"]
+
+# Mutants no test can distinguish, excluded with the argument rather than
+# absorbed into the budget.
+exclude_re = [
+    # `smash::tick_cooldowns` guards its decrement with `remaining > 0.0`.
+    # Relaxing that to `>=` changes nothing for any reachable value: at exactly
+    # zero the body computes `(0.0 - dt).max(0.0)`, which is zero, and a
+    # cooldown is never negative because that same `max` is the only thing that
+    # writes it. There is no input on which the two versions differ, so no test
+    # can kill this and a budget that carried it would be one mutant of
+    # permanent slack.
+    "ability\\.rs.*replace > with >= in <impl Module for AbilityModule>::module",
+
+    # `nearest_target` keeps the closest candidate with `distance < closest`.
+    # Relaxing that to `<=` changes the answer only when two players stand at
+    # exactly the same distance from the projectile, and then it returns the
+    # last one the query yielded instead of the first. Both are the nearest, and
+    # the function promises the nearest rather than a particular one of them.
+    # Killing this would mean asserting a tie-break that is really flecs' table
+    # iteration order, which is not a thing the game should be able to depend
+    # on and not a thing a test should freeze.
+    "projectile\\.rs.*replace < with <= in nearest_target",
+]
+
+# `-p smash` alone would still build the whole workspace.
+additional_cargo_test_args = ["-p", "smash"]

--- a/crates/hyperion-minecraft-proto/tests/decode_allocation.rs
+++ b/crates/hyperion-minecraft-proto/tests/decode_allocation.rs
@@ -7,8 +7,13 @@
 //! single allocation is bounded.
 //!
 //! This measures it rather than reasoning about it, with a global allocator
-//! that counts. It is its own test binary with one test in it: a counter shared
-//! with concurrently running tests would measure them too.
+//! that counts. The counter is process wide, so this binary holds exactly one
+//! test: `cargo test` runs a binary's tests as threads in one process, and a
+//! second test allocating alongside this one is measured as part of it. That is
+//! not hypothetical: an earlier version of this file had two tests, and the
+//! trickle measurement read 140 KB under `cargo test` against 76 KB when it has
+//! the process to itself. It passed under nextest, which gives every test its
+//! own process, and failed in the coverage job, which does not.
 //!
 //! # What it found
 //!
@@ -141,7 +146,7 @@ fn drain(decoder: &mut FrameDecoder) {
 }
 
 #[test]
-fn a_declared_length_cannot_buy_more_than_the_documented_ceiling() {
+fn what_a_peer_can_make_the_decoder_allocate_is_bounded() {
     // Warm the allocator and the decompressor's own buffers first, so what is
     // measured is the decode and not one-off setup.
     {
@@ -151,8 +156,14 @@ fn a_declared_length_cannot_buy_more_than_the_documented_ceiling() {
         drain(&mut decoder);
     }
 
+    ceiling_holds_however_much_is_declared();
+    buffered_bytes_grow_with_what_arrived();
+}
+
+/// A declared length cannot buy more than the documented ceiling.
+fn ceiling_holds_however_much_is_declared() {
     // The declared length is what the peer controls, so it is what is swept.
-    // Every one of these frames is about seven bytes on the wire.
+    // Every one of these frames is under ten bytes on the wire.
     let ceiling = MAX_UNCOMPRESSED_LENGTH;
     for declared in [
         1_024,
@@ -192,7 +203,7 @@ fn a_declared_length_cannot_buy_more_than_the_documented_ceiling() {
         // so it never reaches the allocation at all.
         if usize::try_from(declared).is_ok_and(|declared| declared > ceiling) {
             assert!(
-                peak < 64 * 1_024,
+                peak < 1_024 * 1_024,
                 "a frame declaring {declared}, which is over the ceiling, still allocated {peak} \
                  bytes"
             );
@@ -203,15 +214,16 @@ fn a_declared_length_cannot_buy_more_than_the_documented_ceiling() {
 /// Bytes that never form a whole frame are held, not multiplied.
 ///
 /// A peer that opens a connection and dribbles bytes without ever completing a
-/// frame is the cheapest attack there is, so the decoder's buffer must grow
+/// frame is the cheapest attack there is, so the decoder's buffer has to grow
 /// with what arrived rather than with what was promised.
-#[test]
 fn buffered_bytes_grow_with_what_arrived() {
-    // A frame header promising a megabyte, followed by a trickle that never
-    // finishes it.
+    // A frame header promising nearly two megabytes, just under the 21-bit
+    // frame cap, followed by a trickle that never finishes it.
+    const PROMISED: i32 = 1_900_000;
     let mut frame = Vec::new();
-    write_var_int(&mut frame, 1_000_000);
+    write_var_int(&mut frame, PROMISED);
     let trickle = vec![0xABu8; 32 * 1_024];
+    let arrived = frame.len() + trickle.len();
 
     let peak = peak_of(|| {
         let mut decoder = FrameDecoder::new();
@@ -221,17 +233,23 @@ fn buffered_bytes_grow_with_what_arrived() {
             drain(&mut decoder);
         }
         assert!(
-            decoder.buffered_len() <= frame.len() + trickle.len(),
+            decoder.buffered_len() <= arrived,
             "the decoder is holding more than it was sent"
         );
     });
+    eprintln!("promised {PROMISED}, sent {arrived} -> {peak} bytes allocated");
 
-    // Vec growth doubles, so a factor of four over what arrived is the honest
-    // bound. A million-byte allocation from a promise of a million bytes would
-    // be thirty times this.
+    // The claim is that the promise buys nothing, so the bound is stated
+    // against the promise. A decoder that reserved what it was told to would
+    // be an order of magnitude over this.
     assert!(
-        peak <= (frame.len() + trickle.len()) * 4,
-        "{} bytes of trickle caused a peak of {peak} bytes",
-        trickle.len()
+        peak < usize::try_from(PROMISED).expect("positive") / 4,
+        "a promise of {PROMISED} bytes with only {arrived} sent caused a peak of {peak} bytes"
+    );
+    // And against what arrived, with room for a `Vec` that doubles and for
+    // whatever instrumentation the build carries.
+    assert!(
+        peak <= arrived * 8,
+        "{arrived} bytes of trickle caused a peak of {peak} bytes"
     );
 }

--- a/crates/hyperion-minecraft-proto/tests/decode_allocation.rs
+++ b/crates/hyperion-minecraft-proto/tests/decode_allocation.rs
@@ -1,0 +1,237 @@
+//! How much memory can a stranger make the decoder allocate per byte they send?
+//!
+//! "Never panics" is half of what a decoder on an unauthenticated socket owes
+//! you. The other half is that the memory it takes is a function of what
+//! arrived and not of what the sender claimed, because a peer who can ask for
+//! an allocation with a few bytes has a denial of service whether or not any
+//! single allocation is bounded.
+//!
+//! This measures it rather than reasoning about it, with a global allocator
+//! that counts. It is its own test binary with one test in it: a counter shared
+//! with concurrently running tests would measure them too.
+//!
+//! # What it found
+//!
+//! The compression layer is a genuine amplifier, and this pins the size of it.
+//! A compressed frame carries a `VarInt` saying how many bytes it inflates to,
+//! and `Decompressor::inflate` allocates and zeroes exactly that many before
+//! looking at the payload at all. Measured, on the sweep this test runs:
+//!
+//! ```text
+//! declared       1024:  7 bytes on the wire ->     44,336 bytes allocated
+//! declared  1,048,576:  8 bytes on the wire ->  1,091,888 bytes allocated
+//! declared  8,388,608:  9 bytes on the wire ->  8,431,921 bytes allocated
+//! declared  8,388,609:  9 bytes on the wire ->     43,313 bytes allocated
+//! ```
+//!
+//! So nine bytes from an unauthenticated peer buy an 8.4 MB allocation, a ratio
+//! of about 900,000 to one. The last row is the one that makes it survivable:
+//! one byte over `MAXIMUM_UNCOMPRESSED_LENGTH` and the frame is refused on its
+//! declared length alone, before anything is reserved. Roughly 43 KB is the
+//! decoder's own fixed setup and is the floor every row sits on.
+//!
+//! None of that is a bug in this crate. It is what `CompressionDecoder.inflate`
+//! does, and the 8 MiB ceiling is Mojang's own `MAXIMUM_UNCOMPRESSED_LENGTH`;
+//! faithfulness to the server is the point of this crate, so the number is
+//! pinned rather than lowered. What this test defends is that the bound is a
+//! constant rather than the declared length, which is exactly what stops being
+//! true if the check on the last row is ever removed.
+//!
+//! It is still worth knowing at the connection level: the ceiling is per
+//! packet, not per connection, so a peer that keeps sending them keeps buying
+//! 8 MB at a time. Rate limiting is the proxy's business rather than the
+//! decoder's, but nothing here makes it unnecessary.
+
+// The `VarInt` writer chops a `u32` into seven-bit pieces, so the truncation is
+// the encoding rather than an accident of it.
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "a VarInt is defined by taking the low seven bits at a time"
+)]
+
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use hyperion_minecraft_proto::framing::{FrameDecoder, MAX_UNCOMPRESSED_LENGTH};
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+// SAFETY: every method forwards to `System` with the same layout it was given,
+// so the allocator contract is whatever `System`'s is. The counters are plain
+// atomics and touch no allocation state.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: forwarded unchanged.
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() {
+            let live = LIVE.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
+            PEAK.fetch_max(live, Ordering::Relaxed);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+        // SAFETY: forwarded unchanged.
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: forwarded unchanged.
+        let out = unsafe { System.realloc(pointer, layout, new_size) };
+        if !out.is_null() {
+            let live = LIVE
+                .fetch_add(new_size.saturating_sub(layout.size()), Ordering::Relaxed)
+                .saturating_add(new_size.saturating_sub(layout.size()));
+            PEAK.fetch_max(live, Ordering::Relaxed);
+        }
+        out
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+/// Peak live bytes during `body`, over the level it was already at.
+fn peak_of(body: impl FnOnce()) -> usize {
+    let before = LIVE.load(Ordering::Relaxed);
+    PEAK.store(before, Ordering::Relaxed);
+    body();
+    PEAK.load(Ordering::Relaxed).saturating_sub(before)
+}
+
+fn write_var_int(out: &mut Vec<u8>, value: i32) {
+    let mut remaining = value as u32;
+    loop {
+        if remaining & !0x7F == 0 {
+            out.push(remaining as u8);
+            return;
+        }
+        out.push((remaining as u8 & 0x7F) | 0x80);
+        remaining >>= 7;
+    }
+}
+
+/// A compressed frame that claims to inflate to `declared` bytes and carries
+/// almost nothing.
+fn lying_frame(declared: i32) -> Vec<u8> {
+    let mut inner = Vec::new();
+    write_var_int(&mut inner, declared);
+    inner.extend_from_slice(&[0x78, 0x9C, 0x03, 0x00]);
+
+    let mut out = Vec::new();
+    write_var_int(&mut out, i32::try_from(inner.len()).unwrap_or(0));
+    out.extend_from_slice(&inner);
+    out
+}
+
+fn drain(decoder: &mut FrameDecoder) {
+    loop {
+        match decoder.next_packet() {
+            Ok(Some(_)) => {}
+            Ok(None) | Err(_) => return,
+        }
+    }
+}
+
+#[test]
+fn a_declared_length_cannot_buy_more_than_the_documented_ceiling() {
+    // Warm the allocator and the decompressor's own buffers first, so what is
+    // measured is the decode and not one-off setup.
+    {
+        let mut decoder = FrameDecoder::new();
+        decoder.set_compression_threshold(Some(256));
+        decoder.queue(&lying_frame(1024));
+        drain(&mut decoder);
+    }
+
+    // The declared length is what the peer controls, so it is what is swept.
+    // Every one of these frames is about seven bytes on the wire.
+    let ceiling = MAX_UNCOMPRESSED_LENGTH;
+    for declared in [
+        1_024,
+        64 * 1_024,
+        1_024 * 1_024,
+        i32::try_from(ceiling).expect("the ceiling fits in an i32"),
+        // Past the ceiling. This must be refused before anything is allocated,
+        // which is the check that makes the ceiling mean anything.
+        i32::try_from(ceiling).expect("the ceiling fits in an i32") + 1,
+        i32::MAX,
+    ] {
+        let frame = lying_frame(declared);
+        let wire = frame.len();
+
+        let peak = peak_of(|| {
+            let mut decoder = FrameDecoder::new();
+            decoder.set_compression_threshold(Some(256));
+            decoder.queue(&frame);
+            drain(&mut decoder);
+        });
+
+        // Printed rather than only asserted: the ratio is the finding, and a
+        // reader running this with --no-capture should be able to see it
+        // rather than take the module comment's word for it.
+        eprintln!(
+            "declared {declared:>10}: {wire} bytes on the wire -> {peak} bytes allocated ({}x)",
+            peak / wire.max(1)
+        );
+
+        assert!(
+            peak <= ceiling + 64 * 1_024,
+            "{wire} bytes on the wire declaring {declared} caused a peak of {peak} bytes, above \
+             the {ceiling}-byte ceiling"
+        );
+
+        // Anything over the ceiling is rejected on the declared length alone,
+        // so it never reaches the allocation at all.
+        if usize::try_from(declared).is_ok_and(|declared| declared > ceiling) {
+            assert!(
+                peak < 64 * 1_024,
+                "a frame declaring {declared}, which is over the ceiling, still allocated {peak} \
+                 bytes"
+            );
+        }
+    }
+}
+
+/// Bytes that never form a whole frame are held, not multiplied.
+///
+/// A peer that opens a connection and dribbles bytes without ever completing a
+/// frame is the cheapest attack there is, so the decoder's buffer must grow
+/// with what arrived rather than with what was promised.
+#[test]
+fn buffered_bytes_grow_with_what_arrived() {
+    // A frame header promising a megabyte, followed by a trickle that never
+    // finishes it.
+    let mut frame = Vec::new();
+    write_var_int(&mut frame, 1_000_000);
+    let trickle = vec![0xABu8; 32 * 1_024];
+
+    let peak = peak_of(|| {
+        let mut decoder = FrameDecoder::new();
+        decoder.queue(&frame);
+        for chunk in trickle.chunks(256) {
+            decoder.queue(chunk);
+            drain(&mut decoder);
+        }
+        assert!(
+            decoder.buffered_len() <= frame.len() + trickle.len(),
+            "the decoder is holding more than it was sent"
+        );
+    });
+
+    // Vec growth doubles, so a factor of four over what arrived is the honest
+    // bound. A million-byte allocation from a promise of a million bytes would
+    // be thirty times this.
+    assert!(
+        peak <= (frame.len() + trickle.len()) * 4,
+        "{} bytes of trickle caused a peak of {peak} bytes",
+        trickle.len()
+    );
+}

--- a/crates/hyperion-minecraft-proto/tests/decode_fuzz.rs
+++ b/crates/hyperion-minecraft-proto/tests/decode_fuzz.rs
@@ -1,0 +1,309 @@
+//! Arbitrary bytes into the decoder, which is the one surface a stranger owns.
+//!
+//! Everything else in this crate is checked against bytes the real server
+//! produced. That answers "do we agree with Mojang", and it says nothing about
+//! what happens when the peer is not Mojang. A client can send anything at all
+//! before it has authenticated, so the whole contract of [`FrameDecoder`] on
+//! hostile input is: return an error, or return a packet, and never panic,
+//! hang, or read out of bounds.
+//!
+//! This runs a fixed corpus from a seeded generator rather than a random one.
+//! A gate that fuzzes differently on every run is a gate that fails for
+//! somebody else on a case you cannot reproduce; `nix run .#fuzz` is the
+//! unbounded search, and this is the part of it that has to stay green.
+//!
+//! The generator is deliberately weighted towards *nearly* valid frames.
+//! Uniform random bytes almost always fail on the first length prefix and
+//! never reach the compression layer, which is where the interesting arithmetic
+//! is.
+
+// The corpus generator is deliberately made of wrapping and truncating
+// arithmetic: an LCG is defined by its overflow, and a `VarInt` writer is
+// defined by chopping a `u32` into seven-bit pieces. Every cast below is the
+// operation itself rather than a conversion that happens to be lossy, and a
+// checked version would be a different function.
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "the generator's arithmetic is modular by definition"
+)]
+
+use hyperion_minecraft_proto::framing::{FrameDecoder, SHARED_SECRET_LEN};
+
+/// The length prefix, written here rather than borrowed from the crate.
+///
+/// `framing::write_var_int` is private, and a fuzzer that built its inputs with
+/// the encoder it is testing would agree with the decoder about any bug they
+/// share. This is transcribed from `VarInt.write` instead.
+fn write_var_int(out: &mut Vec<u8>, value: i32) {
+    let mut remaining = value as u32;
+    loop {
+        if remaining & !0x7F == 0 {
+            out.push(remaining as u8);
+            return;
+        }
+        out.push((remaining as u8 & 0x7F) | 0x80);
+        remaining >>= 7;
+    }
+}
+
+/// Numerical Recipes' LCG. Fixed constants and fixed seeds, so the corpus is
+/// the same on every machine and a failure is reproducible from the seed alone.
+struct Rng(u64);
+
+impl Rng {
+    const fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.0 >> 11
+    }
+
+    const fn below(&mut self, bound: u64) -> u64 {
+        self.next() % bound
+    }
+
+    const fn byte(&mut self) -> u8 {
+        (self.next() & 0xFF) as u8
+    }
+
+    fn bytes(&mut self, len: usize) -> Vec<u8> {
+        (0..len).map(|_| self.byte()).collect()
+    }
+}
+
+/// How the decoder was configured when a case ran, so a failure can be
+/// reproduced.
+#[derive(Debug, Clone, Copy)]
+struct Setup {
+    threshold: Option<usize>,
+    encrypted: bool,
+    /// Bytes per `queue` call. One byte at a time exercises every partial
+    /// frame state the decoder has.
+    chunk: usize,
+}
+
+const fn setup(rng: &mut Rng) -> Setup {
+    Setup {
+        threshold: match rng.below(3) {
+            0 => None,
+            1 => Some(256),
+            _ => Some(rng.below(4096) as usize),
+        },
+        encrypted: rng.below(4) == 0,
+        chunk: 1 + rng.below(64) as usize,
+    }
+}
+
+/// One input, built to look plausible often enough to get past the framing.
+fn case(rng: &mut Rng) -> Vec<u8> {
+    match rng.below(10) {
+        // Uniform noise. Cheap, and it is what a port scanner sends.
+        0 | 1 => {
+            let len = rng.below(512) as usize;
+            rng.bytes(len)
+        }
+
+        // A well formed length prefix over a random body, which is the shape
+        // that actually reaches the id and body decode.
+        2..=4 => {
+            let len = rng.below(600) as usize;
+            let body = rng.bytes(len);
+            let mut out = Vec::new();
+            write_var_int(&mut out, i32::try_from(body.len()).unwrap_or(0));
+            out.extend_from_slice(&body);
+            out
+        }
+
+        // A length prefix that lies: it declares far more or far less than
+        // follows. Truncation and over-declaration are different bugs.
+        5 | 6 => {
+            let declared = rng.below(1 << 22) as i32;
+            let mut out = Vec::new();
+            write_var_int(&mut out, declared);
+            let len = rng.below(300) as usize;
+            out.extend_from_slice(&rng.bytes(len));
+            out
+        }
+
+        // A compressed frame whose declared uncompressed length is chosen
+        // adversarially. This is the zip-bomb shape: a handful of bytes on the
+        // wire asking the decoder to materialise megabytes.
+        7 | 8 => {
+            let declared = match rng.below(4) {
+                0 => 0,
+                1 => rng.below(64) as i32,
+                2 => 0x0080_0000,
+                _ => rng.below(0x0100_0000) as i32,
+            };
+            let mut inner = Vec::new();
+            write_var_int(&mut inner, declared);
+            let len = rng.below(200) as usize;
+            inner.extend_from_slice(&rng.bytes(len));
+
+            let mut out = Vec::new();
+            write_var_int(&mut out, i32::try_from(inner.len()).unwrap_or(0));
+            out.extend_from_slice(&inner);
+            out
+        }
+
+        // Several frames back to back, so a decoder that recovers its cursor
+        // wrongly after one bad frame is caught on the next.
+        _ => {
+            let mut out = Vec::new();
+            for _ in 0..rng.below(6) {
+                let len = rng.below(64) as usize;
+                let body = rng.bytes(len);
+                write_var_int(&mut out, i32::try_from(body.len()).unwrap_or(0));
+                out.extend_from_slice(&body);
+            }
+            out
+        }
+    }
+}
+
+/// Feed one case to a decoder configured by `setup`, draining until it stops.
+///
+/// Returns how many packets came out, which is not asserted on: the point is
+/// that this returns at all.
+fn drive(input: &[u8], setup: Setup) -> usize {
+    let mut decoder = FrameDecoder::new();
+    decoder.set_compression_threshold(setup.threshold);
+    if setup.encrypted {
+        decoder.enable_encryption(&[0x42; SHARED_SECRET_LEN]);
+    }
+
+    let mut packets = 0;
+    for chunk in input.chunks(setup.chunk) {
+        decoder.queue(chunk);
+        // A bad frame leaves the stream position unknown, so a real connection
+        // closes. Draining past the error here is deliberate: it is the
+        // cheapest way to find a decoder that leaves its cursor somewhere it
+        // cannot recover from.
+        loop {
+            match decoder.next_packet() {
+                Ok(Some(packet)) => {
+                    // Touch the body so a decoder handing back a slice it does
+                    // not own is caught here rather than silently.
+                    std::hint::black_box(packet.body.iter().fold(0u8, |a, b| a ^ b));
+                    std::hint::black_box(packet.id);
+                    packets += 1;
+                }
+                Ok(None) => break,
+                Err(error) => {
+                    std::hint::black_box(error.to_string());
+                    break;
+                }
+            }
+        }
+    }
+    packets
+}
+
+/// How much corpus to run, and from where.
+///
+/// The defaults are the gate: four thousand cases in about a second, the same
+/// four thousand on every machine and every run. `nix run .#fuzz` raises them
+/// and walks the seed base forward, which is the same generator searching
+/// rather than the same generator checking.
+///
+/// A failure prints the seed, and the generator is a pure function of it, so a
+/// case found by an hour-long run is reproduced by a one-second one.
+fn corpus() -> (u64, u64, u64) {
+    let read = |name: &str, fallback: u64| {
+        std::env::var(name)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(fallback)
+    };
+    (
+        read("HYPERION_FUZZ_SEED_BASE", 0),
+        read("HYPERION_FUZZ_SEEDS", 64),
+        read("HYPERION_FUZZ_CASES", 64),
+    )
+}
+
+#[test]
+fn arbitrary_bytes_never_panic() {
+    let (base, seeds, per_seed) = corpus();
+    let mut cases = 0u64;
+    for seed in base..base + seeds {
+        let mut rng = Rng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1));
+        for index in 0..per_seed {
+            let setup = setup(&mut rng);
+            let input = case(&mut rng);
+            // A panic here escapes with the seed already printed above it, and
+            // the seed is all that is needed to get this case back.
+            let outcome =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drive(&input, setup)));
+            assert!(
+                outcome.is_ok(),
+                "seed {seed}, case {index}: the decoder panicked on {} bytes with {setup:?}",
+                input.len()
+            );
+            cases += 1;
+        }
+    }
+    assert_eq!(cases, seeds * per_seed, "the corpus did not run");
+}
+
+/// Every prefix of a valid stream is either incomplete or an error, never a
+/// packet that is not there.
+///
+/// The partial-read path is where a decoder is most likely to read past what it
+/// has, because it is the path a test written against whole frames never
+/// exercises.
+#[test]
+fn a_truncated_stream_never_yields_a_packet_that_has_not_arrived() {
+    use hyperion_minecraft_proto::framing::FrameEncoder;
+
+    let mut encoder = FrameEncoder::new();
+    let mut whole = Vec::new();
+    for id in 0..8 {
+        encoder
+            .encode(id, &vec![id as u8; 40 + id as usize * 13], &mut whole)
+            .expect("encode");
+    }
+
+    for cut in 0..whole.len() {
+        let mut decoder = FrameDecoder::new();
+        decoder.queue(&whole[..cut]);
+
+        let mut seen = 0;
+        while let Ok(Some(packet)) = decoder.next_packet() {
+            assert_eq!(
+                packet.id, seen,
+                "packet ids came out of order from a {cut}-byte prefix"
+            );
+            seen += 1;
+        }
+
+        // Whatever came out must be a prefix of what a whole stream gives.
+        let mut reference = FrameDecoder::new();
+        reference.queue(&whole);
+        let mut total = 0;
+        while let Ok(Some(_)) = reference.next_packet() {
+            total += 1;
+        }
+        assert!(
+            seen <= total,
+            "a {cut}-byte prefix produced {seen} packets, more than the whole {total}"
+        );
+    }
+}
+
+/// A frame declaring a length wider than 21 bits is refused rather than
+/// buffered.
+///
+/// The check `Varint21FrameDecoder.copyVarint` makes, and the reason a peer
+/// cannot ask the decoder to wait for four gigabytes.
+#[test]
+fn an_over_wide_length_prefix_is_refused_immediately() {
+    let mut decoder = FrameDecoder::new();
+    decoder.queue(&[0xFF, 0xFF, 0xFF, 0xFF, 0x7F]);
+    assert!(
+        decoder.next_packet().is_err(),
+        "a four-byte length prefix should be rejected"
+    );
+}

--- a/events/smash/src/module/lobby.rs
+++ b/events/smash/src/module/lobby.rs
@@ -18,7 +18,7 @@ use crate::{
         arena::Arena,
         damage::MatchClock,
         kit,
-        lives::{Eliminated, Lives},
+        lives::{Eliminated, InvulnerableUntil, Lives, Placement, RespawnAt},
         player::{Health, Player, Position},
     },
     server::{Channel, PlayerId, ServerHandle},
@@ -321,6 +321,21 @@ fn scatter(world: &WorldRef<'_>) {
 }
 
 /// Clear the match state so the same world can host the next game.
+///
+/// Everything a match writes onto a player has to come off here, not just the
+/// two things a player can see. The three removals below are each a real bug if
+/// they are missing, and none of them shows up until the second match:
+///
+/// * A stale [`Placement`] is a finishing position from the last game sitting
+///   on somebody who has not finished this one, which is what a results screen
+///   reads.
+/// * A stale [`RespawnAt`] is measured against a clock this function has just
+///   set back to zero, so a player who died in the closing seconds of one match
+///   spends the opening of the next one dead and spectating, for however long
+///   the old clock said.
+/// * A stale [`InvulnerableUntil`] is the same arithmetic the other way: it
+///   makes them untouchable, and immune to the kill plane, for that long
+///   instead.
 fn reset(world: &WorldRef<'_>) {
     world.get::<&mut MatchClock>(|clock| clock.0 = 0.0);
     world
@@ -331,5 +346,8 @@ fn reset(world: &WorldRef<'_>) {
             *lives = Lives::default();
             health.current = health.max;
             player.remove(Eliminated::id());
+            player.remove(Placement::id());
+            player.remove(RespawnAt::id());
+            player.remove(InvulnerableUntil::id());
         });
 }

--- a/events/smash/tests/contract.rs
+++ b/events/smash/tests/contract.rs
@@ -1,0 +1,546 @@
+//! What each module needs, and what each module provides, made checkable.
+//!
+//! `tests/modularity.rs` proves that a *kit* can be added from outside the
+//! crate. This is the other half of the same claim, one level down: that the
+//! subsystems themselves are separable, so `SmashModule`'s import list is a
+//! list of choices rather than an order somebody found by trial and error.
+//!
+//! The failure it exists to catch is silent. The workspace builds flecs with
+//! `flecs_manual_registration`, so a module that reaches for a component
+//! another module owns does not get a lazily registered one -- the process
+//! aborts. In a match that is a crash. In a normal test it never happens,
+//! because every test imports the whole game and every component is therefore
+//! already there. So a dependency can be added between two modules and nothing
+//! anywhere reports it until the day somebody removes a module from the list.
+//!
+//! Here each module is imported into a world containing only what it declares
+//! it needs, and then actually exercised. A missing declaration aborts the
+//! process, which nextest reports as that one test failing. `nix run .#test`
+//! runs nextest; under plain `cargo test` the abort takes the whole binary
+//! down, which is louder but no less correct.
+
+mod harness;
+
+use std::sync::Arc;
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use smash::{
+    module::{
+        ability::AbilityModule,
+        arena::{Arena, ArenaModule},
+        damage::{Armor, DamageKind, DamageModule, Damaged, hurt},
+        kit::KitModule,
+        kits::StockKits,
+        knockback::{Knockback, KnockbackModel, KnockbackModule, KnockbackTaken, Smashed},
+        lives::{DeathCause, Lives, LivesModule, kill},
+        lobby::{Lobby, LobbyModule, Phase},
+        player::{self, Health, OnGround, Player, PlayerModule, Position},
+        projectile::ProjectileModule,
+        scoreboard::ScoreboardModule,
+    },
+    server::{PlayerId, ServerHandle, mock::MockServer},
+};
+
+/// One module's declared contract.
+struct Contract {
+    /// The module, as `SmashModule` names it.
+    name: &'static str,
+    /// Import it, and nothing else.
+    import: fn(&World),
+    /// Modules that must be imported before this one can be imported at all,
+    /// because this module's systems and observers name their components in a
+    /// query signature and flecs resolves those at registration.
+    ///
+    /// Transitive, and necessarily acyclic: `SmashModule` imports in a straight
+    /// line with no resolution step, so a cycle here would mean no order works.
+    requires: &'static [&'static str],
+    /// Further modules whose components this one touches only while ticking,
+    /// because its queries are built inside a `run` closure rather than named
+    /// in the system signature.
+    ///
+    /// These *may* point forwards, and one pair does. `Arena` needs `Lives` and
+    /// `Lobby` to run its kill plane while `Lives` needs `Arena` to import at
+    /// all, so the two are mutually dependent and only the deferred half of the
+    /// cycle makes a linear import list possible. That is worth knowing and is
+    /// why it is a separate field rather than folded into `requires`.
+    runtime_requires: &'static [&'static str],
+    /// Do the thing this module is for, in a world holding the closure of both
+    /// requirement sets. Panicking here, or aborting inside flecs, is the
+    /// failure.
+    exercise: fn(&World, EntityView<'_>),
+}
+
+/// The seam the host installs, which belongs to no module.
+///
+/// `SmashModule` registers these itself before importing anything, so they are
+/// the floor every contract below is stated against rather than a dependency
+/// any single module could declare.
+fn core(world: &World) {
+    world.component::<ServerHandle>();
+    world.component::<PlayerId>();
+    world.set(ServerHandle(Arc::new(MockServer::new())));
+}
+
+/// The contracts, in the order `SmashModule` imports them.
+///
+/// Written by hand. That is the point: a contract derived from the code cannot
+/// be violated by the code, and would pass for any import list including a
+/// wrong one.
+fn contracts() -> Vec<Contract> {
+    vec![
+        Contract {
+            name: "Player",
+            import: |world| {
+                world.import::<PlayerModule>();
+            },
+            requires: &[],
+            runtime_requires: &[],
+            exercise: |world, player| {
+                // Ground state restores the double jump, and energy regenerates.
+                player.set(OnGround(false));
+                player.set(smash::module::player::JumpsLeft(0));
+                player.set(OnGround(true));
+                world.progress_time(0.05);
+                assert_eq!(player.cloned::<&smash::module::player::JumpsLeft>().0, 1);
+            },
+        },
+        Contract {
+            name: "Knockback",
+            import: |world| {
+                world.import::<KnockbackModule>();
+            },
+            requires: &["Player"],
+            runtime_requires: &[],
+            exercise: |world, player| {
+                // The observer reads Health, KnockbackTaken, Position, OnGround
+                // and PlayerId, and writes through the server handle. If any of
+                // those is not registered, this is where flecs aborts.
+                player::notify(player, &Smashed {
+                    attacker: None,
+                    knockback: Knockback::from(Vec3::ZERO),
+                    damage: 6.0,
+                });
+                assert!(world.cloned::<&KnockbackModel>().min_damage > 0.0);
+            },
+        },
+        Contract {
+            name: "Damage",
+            import: |world| {
+                world.import::<DamageModule>();
+            },
+            // Damage emits `Smashed`, which is Knockback's event, so it cannot
+            // stand up without it. Naming that here is the contract.
+            requires: &["Player", "Knockback"],
+            // `apply_damage` asks `lives::is_invulnerable` before doing
+            // anything, so the damage pipeline reads a component `Lives` owns
+            // while `Lives` in turn cannot import without `Damage`'s
+            // `MatchClock`. A second mutual pair, found by this test rather
+            // than by reading: nothing else in the suite imports one without
+            // the other, so nothing else could have noticed.
+            runtime_requires: &["Lives"],
+            exercise: |_world, player| {
+                player.set(Armor(10.0));
+                hurt(player, Damaged {
+                    attacker: None,
+                    amount: 8.0,
+                    knockback: Knockback::from(Vec3::ZERO),
+                    kind: DamageKind::Melee,
+                });
+                let health = player.cloned::<&Health>();
+                assert!(health.current < health.max, "the hit did not land");
+            },
+        },
+        Contract {
+            name: "Ability",
+            import: |world| {
+                world.import::<AbilityModule>();
+            },
+            requires: &["Player", "Knockback", "Damage"],
+            // `activate` clears the respawn immunity, which is Lives'.
+            runtime_requires: &["Lives"],
+            exercise: |world, player| {
+                // No kit, so no ability is granted and this is the empty path
+                // through the dispatcher. That it runs at all is the claim.
+                smash::module::ability::use_slot(player, 1);
+                world.progress_time(0.05);
+            },
+        },
+        Contract {
+            name: "Kit",
+            import: |world| {
+                world.import::<KitModule>();
+            },
+            requires: &["Player", "Knockback", "Damage", "Ability"],
+            runtime_requires: &[],
+            exercise: |world, player| {
+                let kit =
+                    smash::module::kit::define(world, "Contract", smash::module::kit::KitStats {
+                        knockback_taken: 1.5,
+                        ..smash::module::kit::KitStats::default()
+                    });
+                let kit = kit.prefab();
+                smash::module::kit::apply(world, player, kit);
+                assert!((player.cloned::<&KnockbackTaken>().0 - 1.5).abs() < 1e-6);
+            },
+        },
+        Contract {
+            name: "Arena",
+            import: |world| {
+                world.import::<ArenaModule>();
+            },
+            // The kill plane's query is built inside a `run` closure, so
+            // importing Arena needs nothing of Lives or Lobby. Ticking it needs
+            // both, which is the deferred half of the Arena/Lives cycle.
+            requires: &["Player", "Knockback", "Damage"],
+            runtime_requires: &["Lives", "Lobby"],
+            exercise: |world, player| {
+                world.set(Lobby {
+                    phase: Phase::Playing,
+                    timer: 1.0,
+                });
+                let kill_y = world.cloned::<&Arena>().kill_y;
+                player.set(Position(Vec3::new(0.0, kill_y - 10.0, 0.0)));
+                world.progress_time(0.05);
+                assert!(
+                    player.cloned::<&Lives>().0 < smash::module::lives::MAX_LIVES,
+                    "the kill plane did not fire"
+                );
+            },
+        },
+        Contract {
+            name: "Lives",
+            import: |world| {
+                world.import::<LivesModule>();
+            },
+            // `smash::respawn` names `&Arena` in its signature, so Arena must
+            // be imported first. This is the hard half of the cycle.
+            requires: &["Player", "Knockback", "Damage", "Ability", "Kit", "Arena"],
+            runtime_requires: &["Lobby"],
+            exercise: |_world, player| {
+                kill(player, DeathCause::Void);
+                assert_eq!(
+                    player.cloned::<&Lives>().0,
+                    smash::module::lives::MAX_LIVES - 1
+                );
+            },
+        },
+        Contract {
+            name: "Projectile",
+            import: |world| {
+                world.import::<ProjectileModule>();
+            },
+            requires: &["Player", "Knockback", "Damage"],
+            runtime_requires: &[],
+            exercise: |world, _player| {
+                world.progress_time(0.05);
+            },
+        },
+        Contract {
+            name: "Lobby",
+            import: |world| {
+                world.import::<LobbyModule>();
+            },
+            requires: &[
+                "Player",
+                "Knockback",
+                "Damage",
+                "Ability",
+                "Kit",
+                "Arena",
+                "Lives",
+            ],
+            runtime_requires: &[],
+            exercise: |world, _player| {
+                world.progress_time(0.05);
+                assert!(world.cloned::<&Lobby>().timer >= 0.0);
+            },
+        },
+        Contract {
+            name: "Scoreboard",
+            import: |world| {
+                world.import::<ScoreboardModule>();
+            },
+            requires: &[
+                "Player",
+                "Knockback",
+                "Damage",
+                "Ability",
+                "Kit",
+                "Arena",
+                "Lives",
+                "Lobby",
+            ],
+            runtime_requires: &[],
+            exercise: |world, _player| {
+                world.progress_time(0.05);
+            },
+        },
+        Contract {
+            name: "StockKits",
+            import: |world| {
+                world.import::<StockKits>();
+            },
+            requires: &["Player", "Knockback", "Damage", "Ability", "Kit"],
+            runtime_requires: &[],
+            exercise: |world, _player| {
+                assert!(
+                    smash::module::kit::registry(world).len() >= 10,
+                    "the stock kits did not register"
+                );
+            },
+        },
+    ]
+}
+
+/// Which modules `name` needs standing, in the order to import them.
+///
+/// Membership and order are computed separately, and that split is the point.
+/// Membership is the transitive closure over whichever edge sets `runtime`
+/// selects, and the runtime edges genuinely contain a cycle, so no traversal
+/// order over them exists. Order is simply the declaration order, which is
+/// `SmashModule`'s order, and which
+/// [`import_time_requirements_never_point_forwards`] separately proves is a
+/// valid one.
+///
+/// Deriving the order from a traversal instead would be deriving it from the
+/// same edges the test is checking, and would happily produce an order that
+/// works for a module list nobody ships.
+fn closure(all: &[Contract], name: &str, runtime: bool) -> Vec<usize> {
+    let index_of = |wanted: &str| {
+        all.iter()
+            .position(|contract| contract.name == wanted)
+            .unwrap_or_else(|| panic!("no module named {wanted}"))
+    };
+
+    let mut wanted: Vec<usize> = Vec::new();
+    let mut pending = vec![index_of(name)];
+    while let Some(next) = pending.pop() {
+        if wanted.contains(&next) {
+            continue;
+        }
+        wanted.push(next);
+        pending.extend(all[next].requires.iter().map(|r| index_of(r)));
+        if runtime {
+            pending.extend(all[next].runtime_requires.iter().map(|r| index_of(r)));
+        }
+    }
+
+    wanted.sort_unstable();
+    wanted
+}
+
+/// Build a world holding exactly `name`'s closure, and one player in it.
+fn world_for(all: &[Contract], name: &str, runtime: bool) -> (World, Entity) {
+    let world = World::new();
+    core(&world);
+    for index in closure(all, name, runtime) {
+        (all[index].import)(&world);
+    }
+    let player = world
+        .entity_named("subject")
+        .set(PlayerId(1))
+        .add(Player::id())
+        .id();
+    (world, player)
+}
+
+/// Run `body` for every module, collecting the ones that fail.
+///
+/// flecs reports a missing component by panicking, so the panic is caught here
+/// and turned into a line naming the module. Without that the failure is one
+/// `ECS_INVALID_OPERATION` with no indication of which of eleven modules
+/// produced it, which is a report nobody can act on.
+fn for_every_module(what: &str, mut body: impl FnMut(&[Contract], &Contract)) {
+    let all = contracts();
+    let previous = std::panic::take_hook();
+    // The default hook prints a backtrace per module, which buries the summary.
+    std::panic::set_hook(Box::new(|_| {}));
+    let broken: Vec<String> = all
+        .iter()
+        .filter_map(|contract| {
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                body(&all, contract);
+            }));
+            outcome.err().map(|payload| {
+                let detail = payload
+                    .downcast_ref::<String>()
+                    .cloned()
+                    .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_owned()))
+                    .unwrap_or_else(|| "panicked".to_owned());
+                format!("  {}: {detail}", contract.name)
+            })
+        })
+        .collect();
+    std::panic::set_hook(previous);
+
+    assert!(
+        broken.is_empty(),
+        "{what}, but these did not:\n{}\n\nEach line is a module reaching for something no module \
+         it declares provides. Either the declaration in this file is out of date, or the module \
+         has grown a dependency it should not have.",
+        broken.join("\n")
+    );
+}
+
+/// Every module *imports* with only its declared import-time requirements.
+///
+/// Registration is where flecs resolves the components a system signature
+/// names, so a wrong declaration fails here immediately.
+#[test]
+fn every_module_imports_with_only_its_declared_requirements() {
+    for_every_module(
+        "every module imports with only what it declares",
+        |all, contract| {
+            drop(world_for(all, contract.name, false));
+        },
+    );
+}
+
+/// Every module *runs* with only its declared requirements, import-time and
+/// deferred.
+///
+/// The stronger claim, and the one that catches a module reaching into another
+/// module's components from inside a `run` closure -- which registration cannot
+/// see and which no test importing the whole game will ever notice.
+#[test]
+fn every_module_runs_with_only_its_declared_requirements() {
+    for_every_module(
+        "every module runs with only what it declares",
+        |all, contract| {
+            let (world, player) = world_for(all, contract.name, true);
+            let player = world.entity_from_id(player);
+            // Position and ground state belong to Player, so a module that requires
+            // Player gets them and one that does not never sees them.
+            if player.try_get::<&Position>(|_| ()).is_some() {
+                player.set(Position(Vec3::new(0.0, 40.0, 0.0)));
+                player.set(OnGround(true));
+            }
+            (contract.exercise)(&world, player);
+        },
+    );
+}
+
+/// Import-time requirements only ever point backwards.
+///
+/// `SmashModule` imports in a straight line with no dependency resolution, so
+/// a forward edge here would mean no single order satisfies everything and the
+/// list only works by accident. Deferred edges are exempt: one genuinely points
+/// forward, and `Contract::runtime_requires` says which and why.
+#[test]
+fn import_time_requirements_never_point_forwards() {
+    let all = contracts();
+    for (index, contract) in all.iter().enumerate() {
+        for required in contract.requires {
+            let at = all
+                .iter()
+                .position(|other| other.name == *required)
+                .unwrap_or_else(|| panic!("{} requires unknown module {required}", contract.name));
+            assert!(
+                at < index,
+                "{} needs {required} at import time, but SmashModule imports {required} after it",
+                contract.name
+            );
+        }
+    }
+}
+
+/// The modules `SmashModule` imports, in order, read out of the source.
+///
+/// Scoped to `SmashModule`'s own block: `SmashHost` in the same file imports
+/// hyperion's modules too, and those are the host's business rather than the
+/// game's.
+fn smash_module_imports() -> Vec<&'static str> {
+    let source = include_str!("../src/lib.rs");
+    let start = source
+        .find("impl Module for SmashModule")
+        .expect("SmashModule is defined in lib.rs");
+    let rest = &source[start..];
+    let end = rest[1..]
+        .find("\nimpl ")
+        .map_or(rest.len(), |offset| offset + 1);
+
+    rest[..end]
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("world.import::<"))
+        .filter_map(|line| line.split_once(">()"))
+        .map(|(name, _)| name)
+        .collect()
+}
+
+/// The contract list and the game's own import list name the same modules.
+///
+/// Without this the file rots: a module added to `SmashModule` and not here is
+/// simply never contract tested, and the suite stays green while the thing it
+/// claims to check quietly stops being true.
+#[test]
+fn the_contract_list_covers_every_module_the_game_imports() {
+    let imported = smash_module_imports();
+
+    let declared: Vec<String> = contracts()
+        .iter()
+        .map(|contract| {
+            if contract.name == "StockKits" {
+                contract.name.to_owned()
+            } else {
+                format!("{}Module", contract.name)
+            }
+        })
+        .collect();
+
+    for name in &imported {
+        assert!(
+            declared.iter().any(|held| held == name),
+            "SmashModule imports {name}, which has no contract in this file"
+        );
+    }
+    assert_eq!(
+        imported.len(),
+        declared.len(),
+        "the contract list and SmashModule's import list disagree: {imported:?} against \
+         {declared:?}"
+    );
+}
+
+/// The declared order is the order the game actually imports in.
+///
+/// The contract list claims to be `SmashModule`'s list; if the two drift, every
+/// statement above about what comes before what is about a different program.
+#[test]
+fn the_contract_list_is_in_the_games_import_order() {
+    let imported = smash_module_imports();
+
+    for (declared, actual) in contracts().iter().zip(&imported) {
+        let expected = actual.strip_suffix("Module").unwrap_or(actual);
+        assert_eq!(
+            declared.name, expected,
+            "the contract list is out of order against SmashModule"
+        );
+    }
+}
+
+/// Importing a module twice is harmless.
+///
+/// flecs makes `import` idempotent and the game relies on it: several modules
+/// name the same requirement, so resolving a closure naively imports `Player`
+/// half a dozen times.
+#[test]
+fn importing_a_module_twice_is_harmless() {
+    let all = contracts();
+    let world = World::new();
+    core(&world);
+    for contract in &all {
+        (contract.import)(&world);
+    }
+    for contract in &all {
+        (contract.import)(&world);
+    }
+    let player = world
+        .entity_named("subject")
+        .set(PlayerId(1))
+        .add(Player::id())
+        .set(Position(Vec3::new(0.0, 40.0, 0.0)))
+        .set(OnGround(true));
+    world.progress_time(0.05);
+    assert_eq!(player.cloned::<&Lives>().0, smash::module::lives::MAX_LIVES);
+}

--- a/events/smash/tests/determinism.rs
+++ b/events/smash/tests/determinism.rs
@@ -1,0 +1,203 @@
+//! Does the same input produce the same game twice?
+//!
+//! Every other generated test in this directory rests on this one. A property
+//! test that runs a script and checks an invariant is only meaningful if the
+//! script determines the run; if it does not, a failure is unreproducible, a
+//! shrunk counterexample is fiction, and the honest response to a red build is
+//! to run it again. That failure mode is worth finding on purpose.
+//!
+//! The comparison is bit exact and per tick. Floats go in by their bits rather
+//! than through a tolerance, because a tolerance would hide precisely the slow
+//! divergence this exists to catch, and the tick index is recorded so a failure
+//! names where the two runs parted rather than only that they did.
+
+// The generator's arithmetic is modular by definition: an LCG is its overflow,
+// and every `as usize` below feeds an index the driver takes modulo the number
+// of players anyway.
+#![expect(
+    clippy::cast_possible_truncation,
+    reason = "the generator's values are bounded well inside every target it is cast to"
+)]
+
+mod harness;
+
+use harness::{Action, Fingerprint, Game, Script};
+
+/// A deterministic script generator.
+///
+/// An LCG rather than proptest: a replay test wants the *same* long script
+/// every run, and wants it without a shrinker deciding to try a shorter one.
+/// The constants are Numerical Recipes'.
+struct Rng(u64);
+
+impl Rng {
+    const fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.0 >> 11
+    }
+
+    const fn below(&mut self, bound: u64) -> u64 {
+        self.next() % bound
+    }
+
+    fn unit(&mut self) -> f32 {
+        self.below(1_000_000) as f32 / 1_000_000.0
+    }
+}
+
+/// A dense script: hits, ability uses, movement and kit changes, mixed with
+/// ticks, long enough to run a whole match and start the next one.
+fn scripted(seed: u64, players: usize, actions: usize) -> Script {
+    let mut rng = Rng(seed);
+    let actions = (0..actions)
+        .map(|_| match rng.below(12) {
+            0..=5 => Action::Tick,
+            6 | 7 => Action::Hit {
+                attacker: rng.below(8) as usize,
+                victim: rng.below(8) as usize,
+                amount: rng.unit() * 30.0,
+                kind: rng.below(256) as u8,
+            },
+            8 | 9 => Action::UseSlot {
+                player: rng.below(8) as usize,
+                slot: rng.below(9) as u8,
+            },
+            10 => Action::Move {
+                player: rng.below(8) as usize,
+                to: glam::Vec3::new(
+                    rng.unit().mul_add(128.0, -64.0),
+                    rng.unit().mul_add(128.0, -32.0),
+                    rng.unit().mul_add(128.0, -64.0),
+                ),
+            },
+            _ => Action::SelectKit {
+                player: rng.below(8) as usize,
+                kit: rng.below(64) as usize,
+            },
+        })
+        .collect();
+    Script { players, actions }
+}
+
+/// Report the first tick at which two runs disagree, if any.
+fn first_divergence(left: &[Fingerprint], right: &[Fingerprint]) -> Option<String> {
+    if left.len() != right.len() {
+        return Some(format!(
+            "the two runs produced {} and {} ticks",
+            left.len(),
+            right.len()
+        ));
+    }
+    left.iter()
+        .zip(right)
+        .enumerate()
+        .find(|(_, (a, b))| a != b)
+        .map(|(tick, (a, b))| {
+            let what = match (a.world == b.world, a.calls == b.calls) {
+                (false, false) => "the world state and the calls to the server",
+                (false, true) => "the world state",
+                _ => "the calls to the server, with the world state agreeing",
+            };
+            format!("tick {tick}: {what} differ ({a:?} against {b:?})")
+        })
+}
+
+#[test]
+fn replaying_a_script_reproduces_every_tick() {
+    for seed in [1u64, 7, 99, 12_345, 0xdead_beef] {
+        let script = scripted(seed, 4, 900);
+
+        let first = Game::from_script(&script).run_recording(&script);
+        let second = Game::from_script(&script).run_recording(&script);
+
+        assert!(
+            !first.is_empty(),
+            "seed {seed} produced a script with no ticks in it"
+        );
+        assert!(
+            first_divergence(&first, &second).is_none(),
+            "seed {seed} is not reproducible: {}",
+            first_divergence(&first, &second).unwrap_or_default()
+        );
+    }
+}
+
+/// The same script run four times, not two.
+///
+/// Two runs agreeing can be luck when the source of nondeterminism is a hash
+/// seed or an allocator address that happens to land the same way. Four runs
+/// interleaved with unrelated worlds is a much less comfortable place for that
+/// kind of bug to hide.
+#[test]
+fn a_script_is_reproducible_across_several_runs_and_unrelated_worlds() {
+    let script = scripted(2_024, 5, 700);
+    let reference = Game::from_script(&script).run_recording(&script);
+
+    for attempt in 0..3 {
+        // A whole unrelated world in between, so any per-process state that
+        // leaks between worlds -- an entity id counter, a static, a cached
+        // component id -- has a chance to shift.
+        let noise = scripted(attempt + 500, 3, 200);
+        drop(Game::from_script(&noise).run_recording(&noise));
+
+        let again = Game::from_script(&script).run_recording(&script);
+        assert!(
+            first_divergence(&reference, &again).is_none(),
+            "attempt {attempt} diverged: {}",
+            first_divergence(&reference, &again).unwrap_or_default()
+        );
+    }
+}
+
+/// The exact sequence of calls that reached the server is reproduced, not just
+/// a hash of it.
+///
+/// The hash says two runs differ; this says what the first difference was,
+/// which is the part somebody debugging actually needs. It is also a stronger
+/// claim than state equality: two runs can arrive at the same world having told
+/// the clients different things on the way, and only the log notices.
+#[test]
+fn the_call_log_is_reproduced_call_for_call() {
+    let script = scripted(31_337, 4, 800);
+
+    let first = Game::from_script(&script);
+    first.run(&script);
+    let second = Game::from_script(&script);
+    second.run(&script);
+
+    let left = first.server.calls();
+    let right = second.server.calls();
+
+    for (index, (a, b)) in left.iter().zip(&right).enumerate() {
+        assert_eq!(a, b, "call {index} differs between two runs of one script");
+    }
+    assert_eq!(
+        left.len(),
+        right.len(),
+        "the two runs made different numbers of calls to the server"
+    );
+    assert!(
+        !left.is_empty(),
+        "the script never reached the server, so this proves nothing"
+    );
+}
+
+/// An empty script leaves the world exactly as it was built.
+///
+/// The base case, and the one that catches a `Game::from_script` that is itself
+/// nondeterministic -- which would make every test above pass for the wrong
+/// reason, since both sides would be equally wrong.
+#[test]
+fn two_freshly_built_worlds_are_identical() {
+    let script = Script {
+        players: 4,
+        actions: Vec::new(),
+    };
+    assert_eq!(
+        Game::from_script(&script).fingerprint(),
+        Game::from_script(&script).fingerprint()
+    );
+}

--- a/events/smash/tests/harness/mod.rs
+++ b/events/smash/tests/harness/mod.rs
@@ -1,15 +1,38 @@
 //! A whole game in a test, with no Minecraft server anywhere near it.
+//!
+//! Three things live here, and the last two are what let a generated test say
+//! anything a hand written one cannot:
+//!
+//! * [`Game`], a world with the game and a recording server in it.
+//! * [`Script`], a list of [`Action`]s a test can generate rather than write.
+//!   The same script drives a property test and a replay, so a determinism
+//!   failure and an invariant failure are found by one driver.
+//! * [`invariants`], the things that must be true of the world at the end of
+//!   every tick. [`Game::run`] checks them after each one, so a generated
+//!   script reports the *first* tick that broke a rule rather than a final
+//!   state that is wrong for reasons nobody can reconstruct.
 
 // Each test binary compiles its own copy and uses a different part of it.
 #![allow(dead_code)]
 
-use std::sync::Arc;
+use std::{
+    hash::{DefaultHasher, Hash, Hasher},
+    sync::Arc,
+};
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 use smash::{
     SmashModule,
-    module::player::{Facing, OnGround, Player, Position},
+    module::{
+        ability::{self, Cooldown, Grants, Slot},
+        damage::{DamageKind, Damaged, MatchClock, hurt},
+        kit,
+        knockback::Knockback,
+        lives::{Eliminated, InvulnerableUntil, Lives, Placement, RespawnAt},
+        lobby::{Lobby, LobbyConfig},
+        player::{Energy, Facing, Health, JumpsLeft, OnGround, Player, Position, Velocity},
+    },
     server::{PlayerId, ServerHandle, mock::MockServer},
 };
 
@@ -54,6 +77,434 @@ impl Game {
         let dt = seconds / steps as f32;
         for _ in 0..steps {
             self.world.progress_time(dt);
+        }
+    }
+
+    /// Every player, ordered by [`PlayerId`] so a caller can index them the
+    /// same way in two different worlds.
+    pub fn players(&self) -> Vec<Entity> {
+        let mut found: Vec<(u64, Entity)> = Vec::new();
+        self.world
+            .query::<&PlayerId>()
+            .with(Player::id())
+            .build()
+            .each_entity(|entity, id| found.push((id.0, entity.id())));
+        found.sort_unstable_by_key(|(id, _)| *id);
+        found.into_iter().map(|(_, entity)| entity).collect()
+    }
+}
+
+impl Default for Game {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The tick length every generated test uses. Twenty ticks a second, which is
+/// Minecraft's.
+pub const TICK: f32 = 0.05;
+
+/// One thing a script can do to the world.
+///
+/// Deliberately small and total: every variant is applicable to every world,
+/// with player and kit indices taken modulo what exists, so a generated script
+/// never has to be filtered for validity and the shrinker never produces a
+/// case that fails for being nonsense rather than for finding a bug.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Action {
+    /// Advance one tick.
+    Tick,
+    /// Deal damage from one player to another.
+    Hit {
+        attacker: usize,
+        victim: usize,
+        amount: f32,
+        kind: u8,
+    },
+    /// Right-click a hotbar slot.
+    UseSlot { player: usize, slot: u8 },
+    /// Teleport, as the host's mirror would.
+    Move { player: usize, to: Vec3 },
+    /// Land or leave the ground.
+    Ground { player: usize, on: bool },
+    /// Pick a kit, by index into the registry.
+    SelectKit { player: usize, kit: usize },
+}
+
+impl Action {
+    const fn kind(raw: u8) -> DamageKind {
+        match raw % 4 {
+            0 => DamageKind::Melee,
+            1 => DamageKind::Projectile,
+            2 => DamageKind::Ability,
+            _ => DamageKind::Environment,
+        }
+    }
+}
+
+/// A run of the game, as data.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Script {
+    /// How many players to seed the world with.
+    pub players: usize,
+    pub actions: Vec<Action>,
+}
+
+impl Game {
+    /// Build the world a script asks for.
+    ///
+    /// The lobby is left on its real state machine rather than forced into
+    /// [`Phase::Playing`], because the transitions are part of what is being
+    /// tested. The durations are shortened so a script of a few hundred ticks
+    /// reaches the end of a match instead of spending all of them in a
+    /// countdown.
+    pub fn from_script(script: &Script) -> Self {
+        let mut game = Self::new();
+        game.world.set(LobbyConfig {
+            min_players: 2,
+            full_players: 4,
+            countdown_at_min: 1.0,
+            countdown_at_three_quarters: 0.75,
+            countdown_at_full: 0.5,
+            prepare_seconds: 0.5,
+            match_timeout_seconds: 30.0,
+            results_seconds: 0.5,
+        });
+        for index in 0..script.players {
+            game.player(
+                &format!("p{index}"),
+                Vec3::new(index as f32 * 4.0, 40.0, 0.0),
+            );
+        }
+        game
+    }
+
+    /// Run a script, checking [`invariants`] after every tick.
+    ///
+    /// # Panics
+    /// On the first tick whose end state breaks an invariant, naming the tick
+    /// and the rule rather than leaving a wrong final state to be worked
+    /// backwards from.
+    pub fn run(&self, script: &Script) {
+        let players = self.players();
+        if players.is_empty() {
+            return;
+        }
+        let kits = kit::registry(&self.world);
+
+        for (index, action) in script.actions.iter().enumerate() {
+            self.apply(*action, &players, &kits);
+            if matches!(action, Action::Tick)
+                && let Err(broken) = invariants::check(&self.world)
+            {
+                panic!("invariant broken after action {index} ({action:?}): {broken}");
+            }
+        }
+    }
+
+    /// Run a script, taking a [`Fingerprint`] after every tick.
+    ///
+    /// The per-tick series rather than a final hash, so a replay that diverges
+    /// reports the tick it diverged on. A single end-of-run comparison says
+    /// only that something, somewhere, differed.
+    pub fn run_recording(&self, script: &Script) -> Vec<Fingerprint> {
+        let players = self.players();
+        let kits = kit::registry(&self.world);
+        let mut series = Vec::new();
+        if players.is_empty() {
+            return series;
+        }
+        for action in &script.actions {
+            self.apply(*action, &players, &kits);
+            if matches!(action, Action::Tick) {
+                series.push(self.fingerprint());
+            }
+        }
+        series
+    }
+
+    fn apply(&self, action: Action, players: &[Entity], kits: &[Entity]) {
+        let at = |index: usize| self.world.entity_from_id(players[index % players.len()]);
+
+        match action {
+            Action::Tick => {
+                self.world.progress_time(TICK);
+            }
+            Action::Hit {
+                attacker,
+                victim,
+                amount,
+                kind,
+            } => {
+                let attacker = at(attacker);
+                let victim = at(victim);
+                if attacker.id() == victim.id() {
+                    return;
+                }
+                hurt(victim, Damaged {
+                    attacker: Some(attacker.id()),
+                    amount,
+                    knockback: Knockback::from(
+                        attacker.try_get::<&Position>(|p| p.0).unwrap_or(Vec3::ZERO),
+                    ),
+                    kind: Action::kind(kind),
+                });
+            }
+            Action::UseSlot { player, slot } => ability::use_slot(at(player), slot % 9),
+            Action::Move { player, to } => {
+                at(player).set(Position(to));
+            }
+            Action::Ground { player, on } => {
+                at(player).set(OnGround(on));
+            }
+            Action::SelectKit { player, kit } => {
+                if kits.is_empty() {
+                    return;
+                }
+                let chosen = self.world.entity_from_id(kits[kit % kits.len()]);
+                kit::apply(&self.world, at(player), chosen);
+            }
+        }
+    }
+}
+
+/// The rules that must hold at the end of every tick.
+///
+/// Each one is a sentence about the game rather than a restatement of a line of
+/// source: "lives never go negative" is checkable against Mineplex's own copy,
+/// where "`saturating_sub` was called" is not. That distinction is the whole
+/// point -- a check that mirrors the implementation passes for any
+/// implementation, including a wrong one.
+pub mod invariants {
+    use flecs_ecs::prelude::*;
+    use smash::module::{
+        ability::Cooldown,
+        arena::Arena,
+        damage::MatchClock,
+        lives::{Eliminated, InvulnerableUntil, Lives, MAX_LIVES, Placement, RespawnAt},
+        lobby::{Lobby, Phase},
+        player::{Energy, Health, Player, Position},
+    };
+
+    use super::TICK;
+
+    /// Check every invariant, returning the first that fails.
+    ///
+    /// # Errors
+    /// A sentence naming the rule and the values that broke it.
+    pub fn check(world: &World) -> Result<(), String> {
+        let lobby = world.cloned::<&Lobby>();
+        let arena = world.cloned::<&Arena>();
+        let clock = world.cloned::<&MatchClock>().0;
+
+        if lobby.timer < 0.0 {
+            return Err(format!(
+                "the lobby timer went negative: {:?} at {}",
+                lobby.phase, lobby.timer
+            ));
+        }
+        if !clock.is_finite() || clock < 0.0 {
+            return Err(format!("the match clock is not a sane time: {clock}"));
+        }
+
+        let mut failure = None;
+        let mut fail = |message: String| {
+            if failure.is_none() {
+                failure = Some(message);
+            }
+        };
+
+        world
+            .query::<(&Lives, &Health, &Position)>()
+            .with(Player::id())
+            .build()
+            .each_entity(|player, (lives, health, position)| {
+                let name = player.name();
+
+                // Four lives, then you spectate. Never five, and never -1
+                // wrapped round to 255 by a subtraction that forgot to
+                // saturate.
+                if lives.0 > MAX_LIVES {
+                    fail(format!("{name} has {} lives, above the maximum", lives.0));
+                }
+
+                if !health.current.is_finite() || !health.max.is_finite() {
+                    fail(format!("{name} has non-finite health: {health:?}"));
+                }
+                if health.current < 0.0 {
+                    fail(format!("{name} has negative health: {}", health.current));
+                }
+                if health.current > health.max {
+                    fail(format!(
+                        "{name} has {} health out of a maximum of {}",
+                        health.current, health.max
+                    ));
+                }
+
+                if !position.0.is_finite() {
+                    fail(format!(
+                        "{name} is at a non-finite position: {}",
+                        position.0
+                    ));
+                }
+
+                let eliminated = player.has(Eliminated::id());
+                if eliminated != (lives.0 == 0) {
+                    fail(format!(
+                        "{name} has {} lives but is{} eliminated",
+                        lives.0,
+                        if eliminated { "" } else { " not" }
+                    ));
+                }
+                if eliminated && player.has(RespawnAt::id()) {
+                    fail(format!("{name} is eliminated and still queued to respawn"));
+                }
+                if eliminated != player.try_get::<&Placement>(|p| p.0).is_some() {
+                    fail(format!(
+                        "{name}'s placement disagrees with their elimination"
+                    ));
+                }
+
+                if let Some(energy) = player.try_get::<&Energy>(|e| *e)
+                    && (energy.current < 0.0 || energy.current > energy.max)
+                {
+                    fail(format!(
+                        "{name} has {} energy out of a maximum of {}",
+                        energy.current, energy.max
+                    ));
+                }
+
+                // A live player is never under the map at the end of a tick.
+                // The kill plane is only armed during a match, and a player
+                // already queued to respawn or inside their respawn immunity is
+                // exempt by design -- the mirror still holds the place they
+                // died for a tick or two after the teleport.
+                //
+                // The immunity is compared against a clock one tick behind the
+                // one this check reads. `MatchClock` is advanced by
+                // `smash::lobby_tick`, which `LobbyModule` registers after
+                // `ArenaModule` registers `smash::death_checks`, so the kill
+                // plane sees the clock as it stood at the start of the tick. A
+                // player whose immunity runs out mid-tick is therefore killed on
+                // the next one, and asserting otherwise would be asserting an
+                // ordering the game does not have. Fifty milliseconds of grace
+                // is invisible in play; the skew is worth knowing about because
+                // *every* reader of `MatchClock` has it, not just this one.
+                let armed = matches!(lobby.phase, Phase::Preparing | Phase::Playing);
+                let exempt = eliminated
+                    || player.has(RespawnAt::id())
+                    || player.try_get::<&InvulnerableUntil>(|u| clock - TICK < u.0) == Some(true);
+                if armed && !exempt && arena.is_out_of_bounds(position.0) {
+                    fail(format!(
+                        "{name} is alive at y={} with the kill plane at {}",
+                        position.0.y, arena.kill_y
+                    ));
+                }
+            });
+
+        world
+            .query::<&Cooldown>()
+            .build()
+            .each_entity(|ability, cooldown| {
+                if cooldown.remaining < 0.0 || !cooldown.remaining.is_finite() {
+                    fail(format!(
+                        "{} has a cooldown of {}",
+                        ability.name(),
+                        cooldown.remaining
+                    ));
+                }
+            });
+
+        failure.map_or(Ok(()), Err)
+    }
+}
+
+/// A fingerprint of everything the game decided.
+///
+/// Two halves, because they fail differently. The world half catches a
+/// simulation that diverged; the call half catches a simulation that reached
+/// the same state by telling the clients something different on the way, which
+/// is the bug a state comparison misses entirely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Fingerprint {
+    pub world: u64,
+    pub calls: u64,
+}
+
+impl Game {
+    /// Hash the whole observable state.
+    ///
+    /// Floats go in by their bits rather than by a rounded decimal: the
+    /// question this answers is whether two runs produced *the same* numbers,
+    /// and a tolerance would hide exactly the drift worth finding.
+    pub fn fingerprint(&self) -> Fingerprint {
+        let mut world = DefaultHasher::new();
+
+        let lobby = self.world.cloned::<&Lobby>();
+        format!("{:?}", lobby.phase).hash(&mut world);
+        lobby.timer.to_bits().hash(&mut world);
+        self.world
+            .cloned::<&MatchClock>()
+            .0
+            .to_bits()
+            .hash(&mut world);
+
+        // Sorted by PlayerId, not by entity id: flecs is free to hand out
+        // entity ids in a different order and that is not a divergence.
+        for player in self.players() {
+            let player = self.world.entity_from_id(player);
+            player.name().hash(&mut world);
+            player.try_get::<&Lives>(|l| l.0).hash(&mut world);
+            player.has(Eliminated::id()).hash(&mut world);
+            player.try_get::<&Placement>(|p| p.0).hash(&mut world);
+            player
+                .try_get::<&Health>(|h| (h.current.to_bits(), h.max.to_bits()))
+                .hash(&mut world);
+            player
+                .try_get::<&Position>(|p| p.0.to_array().map(f32::to_bits))
+                .hash(&mut world);
+            player
+                .try_get::<&Velocity>(|v| v.0.to_array().map(f32::to_bits))
+                .hash(&mut world);
+            player.try_get::<&OnGround>(|g| g.0).hash(&mut world);
+            player.try_get::<&JumpsLeft>(|j| j.0).hash(&mut world);
+            player
+                .try_get::<&Energy>(|e| (e.current.to_bits(), e.max.to_bits()))
+                .hash(&mut world);
+            player
+                .try_get::<&RespawnAt>(|r| r.0.to_bits())
+                .hash(&mut world);
+            player
+                .try_get::<&InvulnerableUntil>(|u| u.0.to_bits())
+                .hash(&mut world);
+
+            // Abilities by slot, so the order flecs stores the grants in does
+            // not count as a difference.
+            #[expect(
+                clippy::collection_is_never_read,
+                reason = "hashing it is the read; clippy does not count Hash::hash"
+            )]
+            let mut cooldowns: Vec<(u8, u32)> = Vec::new();
+            player.each_target(Grants, |granted| {
+                if let (Some(slot), Some(remaining)) = (
+                    granted.try_get::<&Slot>(|s| s.0),
+                    granted.try_get::<&Cooldown>(|c| c.remaining),
+                ) {
+                    cooldowns.push((slot, remaining.to_bits()));
+                }
+            });
+            cooldowns.sort_unstable();
+            cooldowns.hash(&mut world);
+        }
+
+        let mut calls = DefaultHasher::new();
+        for call in self.server.calls() {
+            format!("{call:?}").hash(&mut calls);
+        }
+
+        Fingerprint {
+            world: world.finish(),
+            calls: calls.finish(),
         }
     }
 }

--- a/events/smash/tests/properties.proptest-regressions
+++ b/events/smash/tests/properties.proptest-regressions
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 438bb21a773fd2487ba50ea2d011a018b8a38917dc4b35f877c1d9f8178c91f6 # shrinks to players = 4, dt = 0.01
+cc b834402bad50d873a84344b0af6e905a26eb01b0210aed3527f763a90d15f8c9 # shrinks to kit_index = 11, ticks = 1
+cc 101ea0d6c128c005f4ef3d7c8a7ed8e08d827f4c2d759fa041a23e52d9d217ed # shrinks to kit_index = 3, slot = 1, offsets = [Vec3(0.0, 0.0, 0.0)]

--- a/events/smash/tests/properties.rs
+++ b/events/smash/tests/properties.rs
@@ -1,0 +1,640 @@
+//! Properties of the game, checked over generated input.
+//!
+//! The hand written tests in this directory each pin one situation somebody
+//! thought of. These pin the rules that have to hold in *every* situation,
+//! which is where the bugs nobody thought of live: `tests/game_flow.rs` proves
+//! that four specific deaths eliminate a player, and this file proves that no
+//! sequence of any length gets a fifth life or a negative one.
+//!
+//! Two shapes here, and the split matters:
+//!
+//! * Pure properties over the formulas -- knockback, armour, the lobby state
+//!   machine. Cheap, so they run at proptest's full case count.
+//! * Whole world properties, where a generated [`Script`] drives a real flecs
+//!   world and [`harness::invariants`] is checked after every tick. A world
+//!   costs about a tenth of a second to build, so these run at a reduced case
+//!   count and lean on the shrinker rather than on volume.
+
+// Several properties here assert that a value did not change *at all*: that a
+// refused activation cost no energy, that a hit inside the immunity window took
+// no health. A tolerance would let exactly the bug being looked for through, so
+// the comparison is exact on purpose.
+#![expect(
+    clippy::float_cmp,
+    reason = "these properties are about a value being untouched, not about it being close"
+)]
+
+mod harness;
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use harness::{Action, Game, Script, TICK};
+use proptest::prelude::*;
+use smash::{
+    module::{
+        ability::charge_steps,
+        arena::Arena,
+        damage::{Armor, DamageKind, Damaged, MatchClock, MeleeBonus, hurt},
+        knockback::{Knockback, KnockbackModel, KnockbackTaken, resolve, strength},
+        lives::{InvulnerableUntil, Lives, MAX_LIVES},
+        lobby::{Lobby, LobbyConfig, Phase, step},
+        player::{Energy, Health, Position},
+    },
+    server::PlayerId,
+};
+
+/// Building a flecs world and importing every kit costs about 100ms, so a
+/// world-driving property runs tens of cases rather than hundreds. The
+/// shrinker is what earns its keep here, not the case count.
+fn world_cases() -> ProptestConfig {
+    ProptestConfig {
+        cases: 24,
+        ..ProptestConfig::default()
+    }
+}
+
+fn vec3() -> impl Strategy<Value = Vec3> {
+    (-64.0f32..64.0, -32.0f32..96.0, -64.0f32..64.0).prop_map(|(x, y, z)| Vec3::new(x, y, z))
+}
+
+fn action() -> impl Strategy<Value = Action> {
+    prop_oneof![
+        // Weighted towards ticking: a script that never advances time tests
+        // only the observers, and the systems are half the game.
+        6 => Just(Action::Tick),
+        3 => (0usize..8, 0usize..8, 0.0f32..30.0, any::<u8>()).prop_map(
+            |(attacker, victim, amount, kind)| Action::Hit { attacker, victim, amount, kind }
+        ),
+        2 => (0usize..8, 0u8..9).prop_map(|(player, slot)| Action::UseSlot { player, slot }),
+        2 => (0usize..8, vec3()).prop_map(|(player, to)| Action::Move { player, to }),
+        1 => (0usize..8, any::<bool>()).prop_map(|(player, on)| Action::Ground { player, on }),
+        1 => (0usize..8, 0usize..64).prop_map(|(player, kit)| Action::SelectKit { player, kit }),
+    ]
+}
+
+fn script() -> impl Strategy<Value = Script> {
+    (2usize..6, prop::collection::vec(action(), 0..300))
+        .prop_map(|(players, actions)| Script { players, actions })
+}
+
+// ---------------------------------------------------------------------------
+// The whole game
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(world_cases())]
+
+    /// Every rule in [`harness::invariants`], after every tick of any script.
+    ///
+    /// This is the load bearing test in the file. Everything below it is a
+    /// specific rule stated once more in a form that says what broke; this one
+    /// is the net.
+    #[test]
+    fn no_script_can_break_an_invariant(script in script()) {
+        let game = Game::from_script(&script);
+        game.run(&script);
+    }
+
+    /// Lives only ever fall, and only one at a time.
+    ///
+    /// The interesting half is the upper bound. `Lives` is a `u8` and a death
+    /// subtracts one, so the failure this is watching for is a decrement that
+    /// wrapped 0 round to 255 -- which reads as a player who cannot be
+    /// eliminated and whose scoreboard row says they have 255 lives left.
+    #[test]
+    fn lives_only_ever_fall_and_never_below_zero(script in script()) {
+        let game = Game::from_script(&script);
+        let players = game.players();
+        let mut last: Vec<u8> = vec![MAX_LIVES; players.len()];
+
+        for action in &script.actions {
+            game.run(&Script { players: script.players, actions: vec![*action] });
+
+            let lobby = game.world.cloned::<&Lobby>();
+            for (index, player) in players.iter().enumerate() {
+                let lives = game.world.entity_from_id(*player).cloned::<&Lives>().0;
+                prop_assert!(lives <= MAX_LIVES, "{lives} lives is more than the maximum");
+                // A new match hands everybody their lives back, which is the
+                // one legitimate way the count goes up.
+                if lobby.phase != Phase::Waiting {
+                    prop_assert!(
+                        lives <= last[index],
+                        "lives went from {} to {lives} without a match reset",
+                        last[index]
+                    );
+                }
+                last[index] = lives;
+            }
+        }
+    }
+
+    /// A hit inside the respawn immunity window is a no-op.
+    ///
+    /// Not "changes velocity but not health": the immunity is checked before
+    /// anything else in `apply_damage`, so `Smashed` is never emitted and no
+    /// knockback is computed either. That is the behaviour Mineplex's
+    /// `RESPAWN_INVUL` had and the behaviour this needs -- a player who could
+    /// be launched off the map while immune would be immune to the damage and
+    /// dead anyway, which is the worst of both.
+    #[test]
+    fn a_hit_inside_the_immunity_window_changes_nothing(
+        amount in 0.5f32..40.0,
+        kind in 0u8..4,
+        remaining in 0.1f32..10.0,
+    ) {
+        let mut game = Game::new();
+        let attacker = game.player("attacker", Vec3::ZERO);
+        let victim = game.player("victim", Vec3::new(4.0, 0.0, 0.0));
+        let victim = game.world.entity_from_id(victim);
+
+        let now = 5.0;
+        game.world.get::<&mut MatchClock>(|clock| clock.0 = now);
+        victim.set(InvulnerableUntil(now + remaining));
+
+        let before = victim.cloned::<&Health>();
+        hurt(victim, Damaged {
+            attacker: Some(attacker),
+            amount,
+            knockback: Knockback::from(Vec3::ZERO),
+            kind: match kind {
+                0 => DamageKind::Melee,
+                1 => DamageKind::Projectile,
+                2 => DamageKind::Ability,
+                _ => DamageKind::Environment,
+            },
+        });
+
+        let after = victim.cloned::<&Health>();
+        prop_assert_eq!(before.current, after.current, "immunity did not stop the damage");
+        prop_assert_eq!(
+            game.server.total_velocity(PlayerId(2)),
+            Vec3::ZERO,
+            "immunity did not stop the knockback"
+        );
+    }
+
+    /// The same script in two fresh worlds produces the same numbers.
+    ///
+    /// Stated here as well as in `tests/determinism.rs` because a
+    /// nondeterministic simulation makes every other property in this file
+    /// flaky, and it is worth failing on the cause rather than on a symptom
+    /// three tests later.
+    #[test]
+    fn two_runs_of_one_script_agree(script in script()) {
+        let first = Game::from_script(&script);
+        first.run(&script);
+        let second = Game::from_script(&script);
+        second.run(&script);
+        prop_assert_eq!(first.fingerprint(), second.fingerprint());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Knockback
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// Reflecting the attacker through the victim negates the horizontal
+    /// impulse and leaves the vertical alone.
+    ///
+    /// This is the reversibility that matters for a launch: two identical hits
+    /// from opposite sides cancel sideways and add upwards. It is also what
+    /// makes the formula usable at all -- a direction term that were not
+    /// antisymmetric would mean a player could be knocked *towards* whoever hit
+    /// them from one particular angle.
+    #[test]
+    fn knockback_is_antisymmetric_in_the_attacker_direction(
+        k in 0.0f32..12.0,
+        angle in 0.0f32..core::f32::consts::TAU,
+        distance in 0.5f32..40.0,
+        grounded in any::<bool>(),
+    ) {
+        let model = KnockbackModel::default();
+        let victim = Vec3::new(10.0, 3.0, -7.0);
+        let offset = Vec3::new(angle.cos(), 0.0, angle.sin()) * distance;
+
+        let one = resolve(model, k, victim - offset, victim, grounded);
+        let other = resolve(model, k, victim + offset, victim, grounded);
+
+        let tolerance = one.length().mul_add(1e-4, 1e-5);
+        prop_assert!((one.x + other.x).abs() < tolerance, "{one} and {other} do not cancel in x");
+        prop_assert!((one.z + other.z).abs() < tolerance, "{one} and {other} do not cancel in z");
+        prop_assert!((one.y - other.y).abs() < tolerance, "vertical should not depend on side");
+    }
+
+    /// Knockback depends on where the attacker is, never on how far away.
+    ///
+    /// The direction is normalised, so a hit from a metre away and the same hit
+    /// from forty metres away launch identically. Every ability that reaches
+    /// across the map relies on this; if range leaked into the impulse, a
+    /// Skeleton's arrow would hit harder the further it flew.
+    #[test]
+    fn knockback_ignores_the_distance_to_the_attacker(
+        k in 0.1f32..12.0,
+        angle in 0.0f32..core::f32::consts::TAU,
+        near in 0.5f32..5.0,
+        far in 20.0f32..200.0,
+    ) {
+        let model = KnockbackModel::default();
+        let victim = Vec3::new(-4.0, 12.0, 9.0);
+        let direction = Vec3::new(angle.cos(), 0.0, angle.sin());
+
+        let close = resolve(model, k, victim - direction * near, victim, false);
+        let distant = resolve(model, k, victim - direction * far, victim, false);
+
+        prop_assert!(
+            (close - distant).length() < 1e-4,
+            "{close} from {near} away, {distant} from {far} away"
+        );
+    }
+
+    /// Strength rises with damage and with the multipliers, and never turns
+    /// negative however the terms are combined.
+    #[test]
+    fn strength_is_monotone_and_non_negative(
+        damage in 0.0f32..100.0,
+        extra in 0.0f32..100.0,
+        current in 0.0f32..20.0,
+        taken in 0.0f32..3.0,
+        ability in 0.1f32..5.0,
+    ) {
+        let model = KnockbackModel::default();
+        let health = Health { current, max: 20.0 };
+        let base = strength(model, damage, health, KnockbackTaken(taken), ability);
+        let more = strength(model, damage + extra, health, KnockbackTaken(taken), ability);
+
+        prop_assert!(base.is_finite() && more.is_finite());
+        prop_assert!(base >= 0.0, "negative strength {base}");
+        prop_assert!(more >= base - 1e-5, "more damage gave less knockback");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Damage and armour
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// Armour reduces damage, never below zero and never by more than the cap.
+    ///
+    /// The cap is vanilla Minecraft's 80%, and it is the reason a high armour
+    /// kit is durable rather than immortal.
+    #[test]
+    fn armour_reduces_within_the_cap(points in -10.0f32..40.0, damage in 0.0f32..100.0) {
+        let armor = Armor(points);
+        let reduction = armor.reduction();
+        prop_assert!((0.0..=0.8).contains(&reduction), "reduction {reduction} is out of range");
+
+        let applied = armor.apply(damage);
+        prop_assert!(applied >= 0.0, "armour turned {damage} into healing: {applied}");
+        prop_assert!(applied <= damage + 1e-5, "armour increased the damage");
+        prop_assert!(applied >= damage.mul_add(0.2, -1e-5), "armour beat the 80% cap");
+    }
+
+    /// More armour is never worse.
+    #[test]
+    fn armour_is_monotone(points in 0.0f32..40.0, extra in 0.0f32..40.0, damage in 0.0f32..100.0) {
+        prop_assert!(Armor(points + extra).apply(damage) <= Armor(points).apply(damage) + 1e-5);
+    }
+
+    /// Health stays inside its own bar whatever it is asked to do.
+    #[test]
+    fn health_stays_between_zero_and_max(
+        max in 1.0f32..100.0,
+        operations in prop::collection::vec((any::<bool>(), 0.0f32..50.0), 0..40),
+    ) {
+        let mut health = Health::full(max);
+        for (is_damage, amount) in operations {
+            if is_damage {
+                health.damage(amount);
+            } else {
+                health.heal(amount);
+            }
+            prop_assert!(health.current >= 0.0, "health fell to {}", health.current);
+            prop_assert!(health.current <= health.max, "health rose to {}", health.current);
+            prop_assert!((0.0..=1.0).contains(&health.fraction()));
+            prop_assert_eq!(health.is_dead(), health.current <= 0.0);
+        }
+    }
+
+    /// Spending energy never overdraws, and the answer matches what was spent.
+    #[test]
+    fn energy_never_goes_negative(
+        max in 0.5f32..10.0,
+        costs in prop::collection::vec(0.0f32..5.0, 0..30),
+    ) {
+        let mut energy = Energy::full(max, 0.0);
+        for cost in costs {
+            let before = energy.current;
+            let spent = energy.try_spend(cost);
+            prop_assert!(energy.current >= 0.0, "energy fell to {}", energy.current);
+            prop_assert!(energy.current <= energy.max);
+            if spent {
+                prop_assert!((before - energy.current - cost).abs() < 1e-5);
+            } else {
+                prop_assert_eq!(before, energy.current, "a refused spend still took energy");
+            }
+        }
+    }
+
+    /// A melee bonus applies only to who it names and only while it lasts.
+    #[test]
+    fn a_melee_bonus_respects_its_target_and_its_expiry(
+        flat in 0.0f32..10.0,
+        until in 0.0f32..100.0,
+        now in 0.0f32..100.0,
+        targeted in any::<bool>(),
+    ) {
+        let marked = Entity::new(42);
+        let other = Entity::new(43);
+        let bonus = MeleeBonus { flat, against: targeted.then_some(marked), until };
+
+        if now >= until {
+            prop_assert_eq!(bonus.applies_to(marked, now), 0.0, "an expired bonus still applied");
+            prop_assert_eq!(bonus.applies_to(other, now), 0.0);
+        } else {
+            prop_assert_eq!(bonus.applies_to(marked, now), flat);
+            prop_assert_eq!(
+                bonus.applies_to(other, now),
+                if targeted { 0.0 } else { flat },
+                "a bonus aimed at one player reached another"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The lobby state machine
+// ---------------------------------------------------------------------------
+
+/// Which phases each phase may reach in one step. Written from the mode's
+/// description rather than read off `step`, so a transition the implementation
+/// invents shows up here as an illegal edge.
+const fn reachable(from: Phase) -> &'static [Phase] {
+    match from {
+        Phase::Waiting => &[Phase::Waiting, Phase::Countdown],
+        Phase::Countdown => &[Phase::Countdown, Phase::Waiting, Phase::Preparing],
+        Phase::Preparing => &[Phase::Preparing, Phase::Playing],
+        Phase::Playing => &[Phase::Playing, Phase::Ended],
+        Phase::Ended => &[Phase::Ended, Phase::Waiting],
+    }
+}
+
+fn phase() -> impl Strategy<Value = Phase> {
+    prop_oneof![
+        Just(Phase::Waiting),
+        Just(Phase::Countdown),
+        Just(Phase::Preparing),
+        Just(Phase::Playing),
+        Just(Phase::Ended),
+    ]
+}
+
+proptest! {
+    /// No step ever produces a phase that phase cannot reach, and no step ever
+    /// produces a negative timer.
+    ///
+    /// A negative timer is the specific failure worth naming: every phase but
+    /// `Playing` counts down and transitions at zero, so a timer below zero
+    /// means a transition was missed and the phase is stuck.
+    #[test]
+    fn every_step_is_a_legal_transition_with_a_sane_timer(
+        from in phase(),
+        timer in 0.0f32..120.0,
+        dt in 0.0f32..2.0,
+        players in 0u32..20,
+        alive in 0u32..20,
+    ) {
+        let config = LobbyConfig::default();
+        let next = step(&config, Lobby { phase: from, timer }, dt, players, alive.min(players));
+
+        prop_assert!(
+            reachable(from).contains(&next.phase),
+            "{from:?} reached {:?}, which is not a legal transition",
+            next.phase
+        );
+        prop_assert!(next.timer >= 0.0, "{:?} left a timer of {}", next.phase, next.timer);
+        prop_assert!(next.timer.is_finite());
+    }
+
+    /// A fuller lobby never waits longer.
+    #[test]
+    fn the_countdown_shortens_as_the_lobby_fills(players in 0u32..20, extra in 0u32..20) {
+        let config = LobbyConfig::default();
+        let (Some(fewer), Some(more)) = (
+            config.countdown_for(players),
+            config.countdown_for(players + extra),
+        ) else {
+            return Ok(());
+        };
+        prop_assert!(more <= fewer, "{} players wait {more}s, {players} wait {fewer}s", players + extra);
+    }
+
+    /// A lobby that stays full runs a whole match and then starts another.
+    ///
+    /// The cycle, not a resting state: a server that keeps its players does not
+    /// stop, so the thing to check is that every phase is reached in order and
+    /// that the machine comes back round rather than sticking. A version of
+    /// this that asserted the lobby ends in `Waiting` was wrong for exactly
+    /// that reason -- a full lobby leaves `Waiting` again on the very next
+    /// step.
+    #[test]
+    fn a_lobby_that_stays_full_runs_a_match_and_comes_back_round(
+        players in 4u32..9,
+        dt in 0.01f32..0.5,
+    ) {
+        let config = LobbyConfig::default();
+        let mut state = Lobby::default();
+        let mut visited: Vec<Phase> = vec![state.phase];
+
+        // Enough steps for the longest countdown, a whole match and the
+        // results screen, twice over.
+        for _ in 0..400_000 {
+            // One player left alive once the match is running is what ends it.
+            let alive = if state.phase == Phase::Playing { 1 } else { players };
+            state = step(&config, state, dt, players, alive);
+            prop_assert!(state.timer >= 0.0, "{:?} left a timer of {}", state.phase, state.timer);
+            if visited.last() != Some(&state.phase) {
+                visited.push(state.phase);
+            }
+        }
+
+        let wanted = [
+            Phase::Waiting,
+            Phase::Countdown,
+            Phase::Preparing,
+            Phase::Playing,
+            Phase::Ended,
+            Phase::Waiting,
+            Phase::Countdown,
+        ];
+        prop_assert!(
+            visited.starts_with(&wanted),
+            "a full lobby did not run the phases in order: {visited:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Abilities and the arena
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// Charge steps are bounded by the maximum and monotone in the charge.
+    #[test]
+    fn charge_steps_are_bounded_and_monotone(
+        charge in -1.0f32..2.0,
+        extra in 0.0f32..1.0,
+        max in 0u32..64,
+    ) {
+        let steps = charge_steps(charge, max);
+        prop_assert!(steps <= max, "{steps} steps out of a maximum of {max}");
+        prop_assert!(charge_steps(charge + extra, max) >= steps);
+        prop_assert_eq!(charge_steps(f32::NAN.max(0.0), max), 0);
+    }
+
+    /// Every spawn the arena hands out is one it declared.
+    #[test]
+    fn spawns_come_from_the_arena(index in any::<u64>()) {
+        let arena = Arena::default();
+        prop_assert!(arena.spawns.contains(&arena.spawn(index)));
+        prop_assert!(!arena.is_out_of_bounds(arena.spawn(index)), "a spawn point is below the kill plane");
+    }
+
+    /// The kill plane is exactly a comparison against y, and nothing else about
+    /// a position matters.
+    #[test]
+    fn out_of_bounds_depends_only_on_height(at in vec3(), kill_y in -32.0f32..32.0) {
+        let arena = Arena { kill_y, ..Arena::default() };
+        prop_assert_eq!(arena.is_out_of_bounds(at), at.y < kill_y);
+    }
+
+    /// Every remaining-lives count has a colour, and only a dead player is grey.
+    #[test]
+    fn every_life_count_has_a_colour(lives in any::<u8>()) {
+        let colour = Lives(lives).colour();
+        prop_assert!(!colour.is_empty());
+        prop_assert!(
+            (colour == "gray") == (lives == 0),
+            "{lives} lives is coloured {colour}"
+        );
+    }
+}
+
+proptest! {
+    #![proptest_config(world_cases())]
+
+    /// `splash` hits everything in range except the player who cast it.
+    ///
+    /// Stated over the primitive rather than over the kits. "No ability ever
+    /// hurts its caster" is the natural thing to write and it is false: Slime
+    /// Slam hands a quarter of its damage back on purpose, and the generator
+    /// found that in four cases. What is true, and what every kit relies on, is
+    /// that the shared area-of-effect helper excludes the caster -- so a kit
+    /// that wants recoil has to ask for it, and a kit that does not cannot get
+    /// it by accident.
+    ///
+    /// The radius boundary is generated too, because the whole condition is one
+    /// three-way `&&` and a mutation of it that keeps the caster out but lets
+    /// the range go would pass a test that only checked the caster.
+    #[test]
+    fn splash_hits_everything_in_range_except_the_caster(
+        radius in 1.0f32..30.0,
+        damage in 1.0f32..15.0,
+        offsets in prop::collection::vec(vec3(), 1..6),
+    ) {
+        use smash::module::{
+            ability::{Cast, splash},
+            player::Facing,
+        };
+
+        let mut game = Game::new();
+        let caster = game.player("caster", Vec3::ZERO);
+        let bystanders: Vec<_> = offsets
+            .iter()
+            .enumerate()
+            .map(|(index, offset)| (game.player(&format!("b{index}"), *offset), *offset))
+            .collect();
+        let caster = game.world.entity_from_id(caster);
+
+        let before = caster.cloned::<&Health>();
+        game.world.get::<&smash::server::ServerHandle>(|server| {
+            splash(
+                &Cast {
+                    world: caster.world(),
+                    caster,
+                    ability: caster,
+                    server: &**server,
+                    player: PlayerId(1),
+                    position: Position(Vec3::ZERO),
+                    facing: Facing(Vec3::X),
+                    charge: 1.0,
+                },
+                radius,
+                damage,
+                1.0,
+            );
+        });
+
+        prop_assert_eq!(
+            before.current,
+            caster.cloned::<&Health>().current,
+            "splash hurt the player who cast it"
+        );
+
+        for (bystander, at) in bystanders {
+            let bystander = game.world.entity_from_id(bystander);
+            let health = bystander.cloned::<&Health>();
+            let inside = at.length() <= radius;
+            prop_assert_eq!(
+                health.current < health.max,
+                inside,
+                "a bystander {} blocks away was{} hit by a splash of radius {}",
+                at.length(),
+                if inside { " not" } else { "" },
+                radius
+            );
+        }
+    }
+
+    /// A cooldown ticks down to zero and stops, never past it and never up.
+    #[test]
+    fn cooldowns_fall_to_zero_and_stay_there(
+        kit_index in 0usize..64,
+        ticks in 1u32..200,
+    ) {
+        use smash::module::ability::{Cooldown, Grants, activate, granted_in_slot};
+
+        let mut game = Game::new();
+        let player = game.player("p", Vec3::ZERO);
+        let player = game.world.entity_from_id(player);
+        let kits = smash::module::kit::registry(&game.world);
+        let chosen = game.world.entity_from_id(kits[kit_index % kits.len()]);
+        smash::module::kit::apply(&game.world, player, chosen);
+
+        let _ = activate(player, 1, 1.0);
+        let mut previous = f32::INFINITY;
+        for _ in 0..ticks {
+            game.advance(TICK, 1);
+            let mut remaining: Vec<f32> = Vec::new();
+            player.each_target(Grants, |granted| {
+                if let Some(cooldown) = granted.try_get::<&Cooldown>(|c| c.remaining) {
+                    remaining.push(cooldown);
+                }
+            });
+            let highest = remaining.into_iter().fold(0.0f32, f32::max);
+            prop_assert!(highest >= 0.0, "a cooldown went negative: {highest}");
+            prop_assert!(highest <= previous + 1e-5, "a cooldown went back up");
+            previous = highest;
+        }
+
+        // Ninety seconds, which is comfortably past the longest stock
+        // cooldown. `advance` takes seconds and a step count, and reading it as
+        // a tick count is how this first ran for one second and reported that
+        // no cooldown ever expires.
+        game.advance(90.0, 90 * 20);
+        if let Some(ability) = granted_in_slot(player, 1) {
+            let remaining = ability.try_get::<&Cooldown>(|c| c.remaining).unwrap_or(0.0);
+            prop_assert!(remaining.abs() < 1e-5, "a cooldown never expired: {remaining}");
+        }
+    }
+}

--- a/events/smash/tests/verification.rs
+++ b/events/smash/tests/verification.rs
@@ -786,6 +786,99 @@ fn an_ability_costing_the_whole_bar_is_allowed_at_a_full_bar() {
     );
 }
 
+/// The Smash Crystal's grant lasts exactly as long as it was given for.
+///
+/// `grant_ultimate` puts a countdown on the ability entity and the tick takes
+/// the grant back at zero. Both ends matter: taken back early and the crystal
+/// is worthless, taken back late and an ultimate outlives the window it was
+/// bought for. The comparison is one `<=`, and only the tick that lands exactly
+/// on the deadline tells it from `>`.
+#[test]
+fn a_temporary_ultimate_lasts_exactly_as_long_as_it_was_granted_for() {
+    use smash::{flecs_ext::EntityViewExt, module::kit::Ultimate};
+
+    let mut game = Game::new();
+    let player = game.player("p", Vec3::ZERO);
+    let player = game.world.entity_from_id(player);
+    kit::apply(
+        &game.world,
+        player,
+        kit::by_name(&game.world, "Skeleton").expect("Skeleton is a stock kit"),
+    );
+
+    let holds_ultimate = || {
+        player
+            .find_target(smash::module::ability::Grants, |ability| {
+                ability.has(Ultimate::id())
+            })
+            .is_some()
+    };
+    assert!(!holds_ultimate(), "the ultimate is not granted at spawn");
+
+    // One second, in twenty ticks of the game's own length.
+    assert!(smash::module::kit::grant_ultimate(&game.world, player, 1.0));
+    assert!(holds_ultimate(), "the grant did not take");
+
+    // Nineteen ticks in, it is still there.
+    game.advance(0.95, 19);
+    assert!(
+        holds_ultimate(),
+        "the ultimate was taken back before its second was up"
+    );
+
+    // The twentieth is the one that lands on zero.
+    game.advance(0.05, 1);
+    assert!(
+        !holds_ultimate(),
+        "the ultimate outlived the grant it was given"
+    );
+
+    // And it can be granted again afterwards, rather than the expiry leaving
+    // something behind that refuses the next one.
+    assert!(smash::module::kit::grant_ultimate(&game.world, player, 1.0));
+    assert!(holds_ultimate());
+    assert!(
+        !smash::module::kit::grant_ultimate(&game.world, player, 1.0),
+        "a second crystal stacked a second ultimate"
+    );
+}
+
+/// Every observation has the name the `/abilities` wire format uses.
+///
+/// These strings are a protocol between the server and the harness that reads
+/// them, so a typo is a check that silently never matches rather than an error
+/// anybody sees.
+#[test]
+fn every_observation_has_its_wire_name() {
+    use smash::module::ability::Observable;
+
+    for (observable, name) in [
+        (Observable::HurtsTarget, "hurts_target"),
+        (Observable::LaunchesTarget, "launches_target"),
+        (Observable::LaunchesCaster, "launches_caster"),
+        (Observable::TeleportsCaster, "teleports_caster"),
+        (Observable::HealsCaster, "heals_caster"),
+        (Observable::BuffsMelee, "buffs_melee"),
+    ] {
+        assert_eq!(observable.as_str(), name, "{observable:?}");
+    }
+
+    // All distinct, so no two observations collapse into one on the wire.
+    let names = [
+        Observable::HurtsTarget,
+        Observable::LaunchesTarget,
+        Observable::LaunchesCaster,
+        Observable::TeleportsCaster,
+        Observable::HealsCaster,
+        Observable::BuffsMelee,
+    ]
+    .map(Observable::as_str);
+    let mut sorted = names.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(sorted.len(), names.len(), "two observations share a name");
+}
+
 /// A refusal reaches the player, with the reason on it.
 ///
 /// The refusal text and the code that sends it were both dead as far as the

--- a/events/smash/tests/verification.rs
+++ b/events/smash/tests/verification.rs
@@ -1,0 +1,1861 @@
+//! The exact values and the exact boundaries.
+//!
+//! Written against a mutation testing report rather than from imagination.
+//! Every test here kills a mutant that the suite previously executed without
+//! checking: a `<` that could have been `<=`, an arithmetic operator that could
+//! have been any other one, a whole function that could have returned a
+//! constant. The distinction that matters is between a test that *runs* a line
+//! and a test that *pins* it, and these pin.
+//!
+//! Boundaries get their own tests because an off-by-one in a comparison is
+//! invisible to a test that samples either side of it generously. Where a rule
+//! says "within ten seconds", the interesting inputs are exactly ten and the
+//! smallest step either way, and nothing else.
+
+mod harness;
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use harness::Game;
+use smash::{
+    module::{
+        ability::{self, Refusal, charge_steps},
+        damage::{Armor, DamageKind, Damaged, KILL_CREDIT_WINDOW, LastHitAt, MatchClock, hurt},
+        kit::{self, AbilitySpec, KitStats},
+        knockback::{Knockback, KnockbackModel, KnockbackTaken, resolve, strength, vanilla},
+        lives::{
+            DeathCause, Eliminated, InvulnerableUntil, Lives, MAX_LIVES, Placement, RespawnAt,
+            is_invulnerable, kill, killer_of, remaining_alive,
+        },
+        lobby::{Lobby, LobbyConfig, Phase, alive_count, player_count, step},
+        player::{Energy, Health, OnGround},
+        scoreboard::{COLLAPSE_ABOVE, Row, render},
+    },
+    server::{Channel, PlayerId, mock::Call},
+};
+
+const EPS: f32 = 1e-5;
+
+// ---------------------------------------------------------------------------
+// Vanilla knockback, which nothing else touches
+// ---------------------------------------------------------------------------
+
+/// Vanilla's numbers, to the digit.
+///
+/// `vanilla` exists only to make the design document's comparison checkable, so
+/// nothing in the game calls it and nothing was pinning it. Eight separate
+/// mutations of its arithmetic went unnoticed. It is three constants and one
+/// multiply, and this is what they are.
+#[test]
+fn vanilla_knockback_is_a_flat_impulse_plus_half_a_block_per_enchantment_level() {
+    // Straight along +X, so the horizontal component is entirely in x.
+    let impulse = vanilla(Vec3::ZERO, Vec3::new(5.0, 0.0, 0.0), 0);
+    assert!(
+        (impulse.x - 0.4).abs() < EPS,
+        "horizontal was {}",
+        impulse.x
+    );
+    assert!((impulse.y - 0.4).abs() < EPS, "vertical was {}", impulse.y);
+    assert!(impulse.z.abs() < EPS);
+
+    for (levels, want) in [(0u32, 0.4f32), (1, 0.9), (2, 1.4), (3, 1.9)] {
+        let impulse = vanilla(Vec3::ZERO, Vec3::new(5.0, 0.0, 0.0), levels);
+        assert!(
+            (impulse.x - want).abs() < EPS,
+            "Knockback {levels} gave {} horizontally, expected {want}",
+            impulse.x
+        );
+        assert!(
+            (impulse.y - 0.4).abs() < EPS,
+            "the vertical impulse must not depend on the enchantment"
+        );
+    }
+}
+
+/// The push is away from where the attacker actually is.
+///
+/// Every case above puts the attacker at the origin, where `victim - origin`
+/// and `victim + origin` are the same vector, so none of them can tell a
+/// direction from its negation. This one puts the attacker somewhere.
+#[test]
+fn vanilla_knockback_pushes_away_from_the_attacker_wherever_they_stand() {
+    // Attacker to the east of the victim, so the push is west.
+    let impulse = vanilla(Vec3::new(20.0, 0.0, 0.0), Vec3::new(8.0, 0.0, 0.0), 0);
+    assert!(
+        (impulse.x + 0.4).abs() < EPS,
+        "expected a push of -0.4 in x, got {}",
+        impulse.x
+    );
+
+    // And on a diagonal, with both offsets non-zero so neither axis can hide a
+    // sign error in the other.
+    let impulse = vanilla(Vec3::new(10.0, 5.0, -30.0), Vec3::new(4.0, 5.0, -18.0), 0);
+    assert!(impulse.x < 0.0, "x was {}", impulse.x);
+    assert!(impulse.z > 0.0, "z was {}", impulse.z);
+    let horizontal = Vec3::new(impulse.x, 0.0, impulse.z);
+    assert!(
+        (horizontal.length() - 0.4).abs() < EPS,
+        "the horizontal magnitude was {}",
+        horizontal.length()
+    );
+}
+
+/// Vanilla never looks at the victim's condition, which is the whole point of
+/// the comparison.
+#[test]
+fn vanilla_knockback_ignores_health_and_distance() {
+    let near = vanilla(Vec3::ZERO, Vec3::new(0.5, 0.0, 0.0), 1);
+    let far = vanilla(Vec3::ZERO, Vec3::new(500.0, 0.0, 0.0), 1);
+    assert!((near - far).length() < EPS, "{near} against {far}");
+
+    // Co-located: no direction, so no horizontal push, but the lift stays.
+    let degenerate = vanilla(Vec3::ZERO, Vec3::ZERO, 3);
+    assert!(degenerate.x.abs() < EPS && degenerate.z.abs() < EPS);
+    assert!((degenerate.y - 0.4).abs() < EPS);
+}
+
+/// The smash formula and vanilla's agree at exactly one point, and diverge
+/// either side of it.
+#[test]
+fn the_smash_formula_and_vanilla_are_different_functions() {
+    let model = KnockbackModel::default();
+    let full = strength(model, 6.0, Health::full(20.0), KnockbackTaken(1.0), 1.0);
+    let smash = resolve(model, full, Vec3::ZERO, Vec3::X, false);
+    let flat = vanilla(Vec3::ZERO, Vec3::X, 0);
+    assert!(
+        (smash.x - flat.x).abs() > 0.01,
+        "the two formulas should not coincide at full health: {smash} against {flat}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Health and energy, to the value
+// ---------------------------------------------------------------------------
+
+/// Healing adds exactly what was asked for, up to the bar.
+#[test]
+fn healing_adds_the_amount_asked_for_and_stops_at_the_bar() {
+    let mut health = Health::full(20.0);
+    health.damage(12.0);
+    assert!((health.current - 8.0).abs() < EPS, "{}", health.current);
+
+    health.heal(3.0);
+    assert!((health.current - 11.0).abs() < EPS, "{}", health.current);
+
+    // Overhealing clamps rather than scaling, wrapping or being ignored.
+    health.heal(100.0);
+    assert!((health.current - 20.0).abs() < EPS, "{}", health.current);
+
+    // A zero heal is a no-op, not a multiply.
+    health.damage(5.0);
+    let before = health.current;
+    health.heal(0.0);
+    assert!((health.current - before).abs() < EPS);
+}
+
+/// The fraction is the ratio, not a rounding of it.
+#[test]
+fn the_health_fraction_is_current_over_max() {
+    for (current, max, want) in [
+        (20.0f32, 20.0f32, 1.0f32),
+        (10.0, 20.0, 0.5),
+        (5.0, 20.0, 0.25),
+        (0.0, 20.0, 0.0),
+        (3.0, 12.0, 0.25),
+    ] {
+        let health = Health { current, max };
+        assert!(
+            (health.fraction() - want).abs() < EPS,
+            "{current}/{max} gave {}, expected {want}",
+            health.fraction()
+        );
+    }
+
+    // A zero maximum is the degenerate case, and it is defined as dead rather
+    // than as a division by zero.
+    let broken = Health {
+        current: 5.0,
+        max: 0.0,
+    };
+    assert!((broken.fraction() - 0.0).abs() < EPS);
+    assert!(
+        Health {
+            current: 0.0,
+            max: -1.0,
+        }
+        .fraction()
+        .abs()
+            < EPS
+    );
+}
+
+/// Death is at zero and not below it.
+#[test]
+fn a_player_is_dead_at_exactly_zero_health() {
+    assert!(
+        !Health {
+            current: 0.001,
+            max: 20.0
+        }
+        .is_dead()
+    );
+    assert!(
+        Health {
+            current: 0.0,
+            max: 20.0
+        }
+        .is_dead()
+    );
+    assert!(
+        Health {
+            current: -1.0,
+            max: 20.0
+        }
+        .is_dead()
+    );
+}
+
+/// Spending exactly what is left succeeds; spending a hair more does not.
+#[test]
+fn energy_can_be_spent_down_to_exactly_empty_and_no_further() {
+    let mut energy = Energy::full(1.0, 0.2);
+
+    assert!(!energy.try_spend(1.0 + 0.01), "overdrew the bar");
+    assert!((energy.current - 1.0).abs() < EPS, "a refusal took energy");
+
+    assert!(energy.try_spend(1.0), "could not spend a full bar");
+    assert!(energy.current.abs() < EPS, "{} left over", energy.current);
+
+    assert!(!energy.try_spend(0.01), "spent from an empty bar");
+    assert!(energy.current.abs() < EPS);
+
+    // A partial spend takes exactly its cost.
+    let mut energy = Energy::full(2.0, 0.0);
+    assert!(energy.try_spend(0.75));
+    assert!((energy.current - 1.25).abs() < EPS, "{}", energy.current);
+}
+
+// ---------------------------------------------------------------------------
+// Armour, to the percentage
+// ---------------------------------------------------------------------------
+
+/// The energy gate's slack is exactly one epsilon and not a whole comparison.
+///
+/// `try_spend` reads `current + EPSILON < amount`, and the only input that
+/// tells `<` from `<=` there is a cost equal to the slack itself. Obscure, but
+/// it is the difference between a bar that can be spent to exactly empty and
+/// one that cannot, which is what an ultimate costing a full bar depends on.
+#[test]
+fn an_empty_bar_can_still_pay_a_cost_of_nothing() {
+    let mut energy = Energy::full(1.0, 0.0);
+    assert!(energy.try_spend(1.0));
+    assert!(energy.current.abs() < EPS, "{}", energy.current);
+
+    assert!(
+        energy.try_spend(0.0),
+        "an empty bar could not pay a cost of zero"
+    );
+    assert!(
+        energy.try_spend(f32::EPSILON),
+        "the slack in the comparison is not the width it is written as"
+    );
+}
+
+/// The wiki's own pairings: twelve points is 48%, sixteen is 64%.
+#[test]
+fn armour_points_convert_at_four_percent_each_up_to_eighty() {
+    for (points, want) in [
+        (0.0f32, 0.0f32),
+        (1.0, 0.04),
+        (10.0, 0.40),
+        (12.0, 0.48), // Skeleton
+        (16.0, 0.64), // Iron Golem
+        (20.0, 0.80), // exactly at the cap
+        (25.0, 0.80), // past it
+        (1000.0, 0.80),
+    ] {
+        let got = Armor(points).reduction();
+        assert!(
+            (got - want).abs() < EPS,
+            "{points} points reduced by {got}, expected {want}"
+        );
+    }
+
+    // Zero armour is the identity, which a `*` turned into a `+` is not.
+    assert!((Armor(0.0).apply(17.0) - 17.0).abs() < EPS);
+    // And the reduction is applied, not added.
+    assert!((Armor(10.0).apply(10.0) - 6.0).abs() < EPS);
+    assert!((Armor(20.0).apply(10.0) - 2.0).abs() < EPS);
+}
+
+/// Only hunger, lava and the map ignore armour.
+#[test]
+fn armour_applies_to_everything_except_the_environment() {
+    assert!(DamageKind::Melee.is_reduced_by_armor());
+    assert!(DamageKind::Projectile.is_reduced_by_armor());
+    assert!(DamageKind::Ability.is_reduced_by_armor());
+    assert!(!DamageKind::Environment.is_reduced_by_armor());
+}
+
+// ---------------------------------------------------------------------------
+// Lives, and the boundaries around a death
+// ---------------------------------------------------------------------------
+
+/// The kill plane is below, not at.
+///
+/// A player standing exactly on the configured minimum is inside the map. The
+/// generated property either side of the plane cannot reach this: the boundary
+/// is one value out of a continuum, and it is the only value at which `<` and
+/// `<=` differ.
+#[test]
+fn standing_exactly_on_the_kill_plane_is_alive() {
+    use smash::module::arena::Arena;
+
+    for kill_y in [-64.0f32, 0.0, 34.5, 128.0] {
+        let arena = Arena {
+            kill_y,
+            ..Arena::default()
+        };
+        assert!(
+            !arena.is_out_of_bounds(Vec3::new(0.0, kill_y, 0.0)),
+            "the kill plane at {kill_y} killed somebody standing on it"
+        );
+        assert!(
+            arena.is_out_of_bounds(Vec3::new(
+                0.0,
+                kill_y - f32::EPSILON.mul_add(kill_y.abs(), 1e-3),
+                0.0
+            )),
+            "the kill plane at {kill_y} did not kill somebody below it"
+        );
+        assert!(!arena.is_out_of_bounds(Vec3::new(0.0, kill_y + 1e-3, 0.0)));
+    }
+}
+
+/// The colour of every possible remaining-lives count.
+///
+/// The whole table, because the failure being guarded against is one arm going
+/// missing and falling through to the next, which no spot check notices.
+#[test]
+fn the_life_counter_has_one_colour_per_count() {
+    assert_eq!(Lives(0).colour(), "gray");
+    assert_eq!(Lives(1).colour(), "red");
+    assert_eq!(Lives(2).colour(), "gold");
+    assert_eq!(Lives(3).colour(), "yellow");
+    assert_eq!(Lives(4).colour(), "green");
+    // Four or more is green: nothing hands out a fifth, but the table is total.
+    assert_eq!(Lives(5).colour(), "green");
+    assert_eq!(Lives(u8::MAX).colour(), "green");
+}
+
+/// Kill credit expires at exactly the window, not a moment either side.
+#[test]
+fn kill_credit_expires_exactly_at_the_window() {
+    let mut game = Game::new();
+    let attacker = game.player("attacker", Vec3::ZERO);
+    let victim = game.player("victim", Vec3::new(4.0, 0.0, 0.0));
+    let victim = game.world.entity_from_id(victim);
+
+    // The clock is set well away from zero first. With a hit stamped at zero,
+    // `now - at` and `now + at` are the same number, so every arithmetic
+    // mutation of the window check reads as correct.
+    game.world.get::<&mut MatchClock>(|clock| clock.0 = 250.0);
+    hurt(victim, Damaged {
+        attacker: Some(attacker),
+        amount: 5.0,
+        knockback: Knockback::from(Vec3::ZERO),
+        kind: DamageKind::Melee,
+    });
+    let at = victim.cloned::<&LastHitAt>().0;
+    assert!((at - 250.0).abs() < EPS, "the hit was stamped at {at}");
+
+    assert_eq!(
+        killer_of(victim, at),
+        Some(attacker),
+        "credit at zero delay"
+    );
+    assert_eq!(
+        killer_of(victim, at + KILL_CREDIT_WINDOW),
+        Some(attacker),
+        "the window is inclusive of its own end"
+    );
+    assert_eq!(
+        killer_of(victim, at + KILL_CREDIT_WINDOW + 0.001),
+        None,
+        "a hit past the window is not a kill"
+    );
+    // And a victim nobody has hit has no killer at all.
+    let bystander = game.player("bystander", Vec3::new(9.0, 0.0, 0.0));
+    assert_eq!(killer_of(game.world.entity_from_id(bystander), 0.0), None);
+}
+
+/// Immunity ends at the instant it says it does.
+#[test]
+fn respawn_immunity_ends_exactly_at_its_deadline() {
+    let mut game = Game::new();
+    let player = game.player("p", Vec3::ZERO);
+    let player = game.world.entity_from_id(player);
+
+    assert!(
+        !is_invulnerable(player, 0.0),
+        "a player with no immunity component is not immune"
+    );
+
+    player.set(InvulnerableUntil(10.0));
+    assert!(is_invulnerable(player, 9.999));
+    assert!(
+        !is_invulnerable(player, 10.0),
+        "the deadline itself is not covered"
+    );
+    assert!(!is_invulnerable(player, 10.001));
+}
+
+/// Placement counts down from however many are still in.
+///
+/// The last player standing takes first place, and each earlier elimination
+/// takes the place matching how many were left when it happened. A
+/// `remaining_alive` stuck at a constant gives everybody the same place.
+#[test]
+fn placement_is_assigned_in_reverse_elimination_order() {
+    let mut game = Game::new();
+    let names = ["a", "b", "c", "d"];
+    let players: Vec<_> = names
+        .iter()
+        .enumerate()
+        .map(|(index, name)| game.player(name, Vec3::new(index as f32 * 8.0, 40.0, 0.0)))
+        .collect();
+
+    assert_eq!(remaining_alive(game.world.real_world()), 4);
+
+    let mut placements = Vec::new();
+    for (index, player) in players.iter().take(3).enumerate() {
+        let player = game.world.entity_from_id(*player);
+        for _ in 0..MAX_LIVES {
+            kill(player, DeathCause::Void);
+            player.remove(RespawnAt::id());
+            player.get::<&mut Health>(|health| health.current = health.max);
+        }
+        assert!(
+            player.has(Eliminated::id()),
+            "{} survived four deaths",
+            names[index]
+        );
+        placements.push(player.cloned::<&Placement>().0);
+        assert_eq!(
+            remaining_alive(game.world.real_world()),
+            3 - index,
+            "the alive count did not fall"
+        );
+    }
+
+    // Out first takes the worst place; each later exit takes a better one, and
+    // the survivor never gets one at all because nothing eliminates them. With
+    // four players that is fourth, third and second, which is what a results
+    // screen wants: first place belongs to whoever is still standing.
+    assert_eq!(placements, vec![4, 3, 2], "{placements:?}");
+}
+
+/// Each death says how many lives are left, and the last one says it is over.
+///
+/// The branch is one `lives.0 == 0`, and a test that only looks for "GAME OVER"
+/// somewhere in the log passes just as happily when the condition is inverted:
+/// the message still appears, on the wrong deaths. Both sides have to be
+/// pinned, in order.
+#[test]
+fn a_death_tells_the_player_what_it_cost_them() {
+    let mut game = Game::new();
+    let player = game.player("doomed", Vec3::ZERO);
+    game.player("other", Vec3::new(30.0, 0.0, 0.0));
+    let player = game.world.entity_from_id(player);
+
+    let mut said = Vec::new();
+    for _ in 0..MAX_LIVES {
+        game.server.take();
+        kill(player, DeathCause::Void);
+        player.remove(RespawnAt::id());
+        player.get::<&mut Health>(|health| health.current = health.max);
+        said.push(game.server.messages_to(PlayerId(1)));
+    }
+
+    assert_eq!(said[0], vec!["3 lives left!".to_owned()], "{:?}", said[0]);
+    assert_eq!(said[1], vec!["2 lives left!".to_owned()], "{:?}", said[1]);
+    assert_eq!(said[2], vec!["1 lives left!".to_owned()], "{:?}", said[2]);
+    assert_eq!(said[3].len(), 1, "{:?}", said[3]);
+    assert!(
+        said[3][0].contains("GAME OVER"),
+        "the last death said {:?}",
+        said[3][0]
+    );
+}
+
+/// A respawn is immune for exactly the documented window and no longer.
+#[test]
+fn a_respawn_is_immune_for_exactly_the_documented_window() {
+    use smash::module::lives::RESPAWN_INVULNERABLE_SECS;
+
+    let mut game = Game::new();
+    let player = game.player("p", Vec3::new(0.0, 40.0, 0.0));
+    let player = game.world.entity_from_id(player);
+
+    // A clock away from zero, so that multiplying by the window is not the same
+    // as adding it.
+    game.world.get::<&mut MatchClock>(|clock| clock.0 = 400.0);
+    kill(player, DeathCause::Void);
+
+    let respawn_at = player.cloned::<&RespawnAt>().0;
+    game.world
+        .get::<&mut MatchClock>(|clock| clock.0 = respawn_at);
+    game.advance(0.05, 1);
+
+    let until = player.cloned::<&InvulnerableUntil>().0;
+    assert!(
+        (until - (respawn_at + RESPAWN_INVULNERABLE_SECS)).abs() < 1e-3,
+        "immune until {until}, expected {}",
+        respawn_at + RESPAWN_INVULNERABLE_SECS
+    );
+    assert!(is_invulnerable(player, until - 0.001));
+    assert!(!is_invulnerable(player, until));
+}
+
+/// A player out of lives stays out, and a further death changes nothing.
+#[test]
+fn an_eliminated_player_absorbs_further_deaths_without_changing() {
+    let mut game = Game::new();
+    let player = game.player("doomed", Vec3::ZERO);
+    game.player("other", Vec3::new(30.0, 0.0, 0.0));
+    let player = game.world.entity_from_id(player);
+
+    for _ in 0..MAX_LIVES {
+        kill(player, DeathCause::Void);
+        player.remove(RespawnAt::id());
+        player.get::<&mut Health>(|health| health.current = health.max);
+    }
+    let placement = player.cloned::<&Placement>();
+    let before = game.server.calls().len();
+
+    kill(player, DeathCause::Void);
+    assert_eq!(player.cloned::<&Lives>().0, 0);
+    assert_eq!(player.cloned::<&Placement>(), placement);
+    assert_eq!(
+        game.server.calls().len(),
+        before,
+        "a death after elimination still talked to the server"
+    );
+}
+
+/// The respawn lands on the tick the clock reaches it, not before.
+#[test]
+fn a_respawn_waits_for_its_deadline_and_then_lands() {
+    use smash::module::lives::DEATH_SPECTATE_SECS;
+
+    let mut game = Game::new();
+    let player = game.player("p", Vec3::new(0.0, 40.0, 0.0));
+    let player = game.world.entity_from_id(player);
+
+    game.world.get::<&mut MatchClock>(|clock| clock.0 = 100.0);
+    kill(player, DeathCause::Void);
+
+    let at = player.cloned::<&RespawnAt>().0;
+    assert!(
+        (at - (100.0 + DEATH_SPECTATE_SECS)).abs() < EPS,
+        "the spectate window is {} rather than {DEATH_SPECTATE_SECS}",
+        at - 100.0
+    );
+
+    // A tick just short of the deadline changes nothing.
+    game.world
+        .get::<&mut MatchClock>(|clock| clock.0 = at - 0.001);
+    game.advance(0.05, 1);
+    assert!(
+        player.has(RespawnAt::id()),
+        "respawned before the spectate window was up"
+    );
+
+    game.world.get::<&mut MatchClock>(|clock| clock.0 = at);
+    game.advance(0.05, 1);
+    assert!(!player.has(RespawnAt::id()), "never respawned");
+    let health = player.cloned::<&Health>();
+    assert!((health.current - health.max).abs() < EPS);
+}
+
+// ---------------------------------------------------------------------------
+// Abilities
+// ---------------------------------------------------------------------------
+
+/// Charge steps round to the nearest whole step across the range.
+#[test]
+fn charge_steps_round_to_the_nearest_step() {
+    assert_eq!(charge_steps(0.0, 8), 0);
+    assert_eq!(charge_steps(0.5, 8), 4);
+    assert_eq!(charge_steps(1.0, 8), 8);
+    // Rounding, not truncation: three eighths of eight is exactly three.
+    assert_eq!(charge_steps(0.375, 8), 3);
+    assert_eq!(charge_steps(0.4, 8), 3);
+    assert_eq!(charge_steps(0.44, 8), 4);
+    // Out of range clamps rather than overflowing.
+    assert_eq!(charge_steps(-5.0, 8), 0);
+    assert_eq!(charge_steps(9.0, 8), 8);
+    assert_eq!(charge_steps(1.0, 0), 0);
+}
+
+/// Holding a slot charges it, and letting go fires it at the charge reached.
+///
+/// The hold-and-release path was entirely unexercised: nothing called
+/// `release_slot`, so the charge accumulator, the fraction it is divided into
+/// and the release dispatcher were all dead as far as the suite was concerned.
+/// Barrage, Block Toss and Slime Rocket are all this shape, and the fraction is
+/// what decides how many arrows come out.
+#[test]
+fn holding_a_slot_charges_it_and_releasing_fires_at_that_charge() {
+    /// The charge fraction the last release handed to the ability.
+    #[derive(Component, Debug, Default, Clone, Copy)]
+    struct LastCharge(f32);
+
+    /// How many times it fired, so a release that does nothing is not confused
+    /// with one that fires at zero charge.
+    #[derive(Component, Debug, Default, Clone, Copy)]
+    struct Fired(u32);
+
+    fn record(cast: &ability::Cast<'_>) {
+        cast.world
+            .get::<&mut LastCharge>(|last| last.0 = cast.charge);
+        cast.world.get::<&mut Fired>(|fired| fired.0 += 1);
+    }
+
+    #[derive(Component)]
+    struct Drawn;
+
+    impl Module for Drawn {
+        fn module(world: &World) {
+            world.module::<Self>("smash::kits::Drawn");
+            world.component::<LastCharge>();
+            world.component::<Fired>();
+            world.set(LastCharge::default());
+            world.set(Fired::default());
+
+            kit::define(world, "Drawn", KitStats::default())
+                .ability(AbilitySpec {
+                    name: "Draw",
+                    item: "minecraft:bow",
+                    slot: 1,
+                    description: "Hold to draw.",
+                    cooldown: 0.0,
+                    charge_time: Some(2.0),
+                    activate: record,
+                    ..AbilitySpec::DEFAULT
+                })
+                .register();
+        }
+    }
+
+    let mut game = Game::new();
+    game.world.import::<Drawn>();
+    let player = game.player("p", Vec3::ZERO);
+    let player = game.world.entity_from_id(player);
+    kit::apply(
+        &game.world,
+        player,
+        kit::by_name(&game.world, "Drawn").expect("just defined"),
+    );
+
+    // Pressing a charge ability starts the charge rather than firing it.
+    ability::use_slot(player, 1);
+    assert_eq!(
+        game.world.cloned::<&Fired>().0,
+        0,
+        "a charge ability fired on the press instead of the release"
+    );
+
+    // Half of the two second charge time.
+    game.advance(1.0, 20);
+    ability::release_slot(player, 1);
+
+    assert_eq!(
+        game.world.cloned::<&Fired>().0,
+        1,
+        "the release did not fire"
+    );
+    let charge = game.world.cloned::<&LastCharge>().0;
+    assert!(
+        (charge - 0.5).abs() < 1e-3,
+        "one second of a two second draw came out as {charge}, expected 0.5"
+    );
+
+    // Held past full, the fraction clamps rather than running away.
+    ability::use_slot(player, 1);
+    game.advance(10.0, 200);
+    ability::release_slot(player, 1);
+    let charge = game.world.cloned::<&LastCharge>().0;
+    assert!(
+        (charge - 1.0).abs() < 1e-6,
+        "an overdrawn bow reported a charge of {charge}"
+    );
+
+    // Tapped, it fires at nothing.
+    ability::use_slot(player, 1);
+    ability::release_slot(player, 1);
+    assert!(
+        game.world.cloned::<&LastCharge>().0.abs() < 1e-6,
+        "a tap fired at {} charge",
+        game.world.cloned::<&LastCharge>().0
+    );
+    assert_eq!(game.world.cloned::<&Fired>().0, 3);
+
+    // Releasing a slot with nothing in it is silent rather than a refusal.
+    game.server.take();
+    ability::release_slot(player, 5);
+    assert_eq!(game.world.cloned::<&Fired>().0, 3);
+    assert!(
+        game.server.messages_to(PlayerId(1)).is_empty(),
+        "releasing an empty slot said something: {:?}",
+        game.server.messages_to(PlayerId(1))
+    );
+}
+
+/// An ability costing exactly the energy in the bar is allowed.
+///
+/// The gate reads `current + EPSILON >= cost` rather than `current >= cost`,
+/// and the epsilon is the whole point: the bar is a float that has been
+/// regenerated in increments, so a player who has visibly refilled it is a few
+/// ulps short of the number the kit declared. Without the slack an ultimate
+/// costing a full bar is refused at full bar, which reads as the ability being
+/// broken.
+#[test]
+fn an_ability_costing_the_whole_bar_is_allowed_at_a_full_bar() {
+    #[derive(Component)]
+    struct Costly;
+
+    impl Module for Costly {
+        fn module(world: &World) {
+            world.module::<Self>("smash::kits::Costly");
+            kit::define(world, "Costly", KitStats {
+                energy: Some((1.0, 0.0)),
+                ..KitStats::default()
+            })
+            .ability(AbilitySpec {
+                name: "Everything",
+                item: "minecraft:stick",
+                slot: 1,
+                energy_cost: Some(1.0),
+                ..AbilitySpec::DEFAULT
+            })
+            .register();
+        }
+    }
+
+    let mut game = Game::new();
+    game.world.import::<Costly>();
+    let player = game.player("p", Vec3::ZERO);
+    let player = game.world.entity_from_id(player);
+    kit::apply(
+        &game.world,
+        player,
+        kit::by_name(&game.world, "Costly").expect("just defined"),
+    );
+
+    // Exactly full, and the cost is exactly the bar.
+    player.set(Energy {
+        current: 1.0,
+        max: 1.0,
+        regen: 0.0,
+    });
+    assert_eq!(
+        ability::activate(player, 1, 1.0),
+        Ok(()),
+        "a full bar could not pay a cost equal to it"
+    );
+    assert!(player.cloned::<&Energy>().current.abs() < EPS);
+
+    // Empty, and it is refused.
+    assert_eq!(
+        ability::activate(player, 1, 1.0),
+        Err(Refusal::NotEnoughEnergy)
+    );
+
+    // A hair under the cost is still refused: the slack is an epsilon, not a
+    // discount.
+    player.set(Energy {
+        current: 0.9,
+        max: 1.0,
+        regen: 0.0,
+    });
+    assert_eq!(
+        ability::activate(player, 1, 1.0),
+        Err(Refusal::NotEnoughEnergy),
+        "the energy gate is not a gate"
+    );
+}
+
+/// A refusal reaches the player, with the reason on it.
+///
+/// The refusal text and the code that sends it were both dead as far as the
+/// suite was concerned: an ability could be silently refused and nothing
+/// noticed. On the action bar it is the only feedback a player gets.
+#[test]
+fn a_refused_ability_tells_the_player_why() {
+    assert_eq!(Refusal::OnCooldown.message(), "That ability is recharging.");
+    assert_eq!(Refusal::NotEnoughEnergy.message(), "Not enough energy.");
+    assert_eq!(Refusal::NotGrounded.message(), "You must be on the ground.");
+
+    let mut game = Game::new();
+    let player = game.player("p", Vec3::ZERO);
+    let player = game.world.entity_from_id(player);
+    kit::apply(
+        &game.world,
+        player,
+        kit::by_name(&game.world, "Skeleton").expect("Skeleton is a stock kit"),
+    );
+
+    // First use goes through; the second is on cooldown, and that is the one
+    // the player must be told about.
+    ability::use_slot(player, 1);
+    game.server.take();
+    ability::use_slot(player, 1);
+
+    let refusals: Vec<_> = game
+        .server
+        .calls()
+        .into_iter()
+        .filter_map(|call| match call {
+            Call::Message(PlayerId(1), Channel::ActionBar, text) => Some(text),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        refusals,
+        vec![Refusal::OnCooldown.message().to_owned()],
+        "the player was not told the ability was recharging"
+    );
+}
+
+/// An ability the player does not have is not a refusal.
+#[test]
+fn using_an_empty_slot_says_nothing() {
+    let mut game = Game::new();
+    let player = game.player("p", Vec3::ZERO);
+    let player = game.world.entity_from_id(player);
+    player.set(OnGround(true));
+
+    assert_eq!(ability::activate(player, 7, 1.0), Ok(()));
+    assert!(
+        game.server.messages_to(PlayerId(1)).is_empty(),
+        "an empty hotbar slot produced chatter: {:?}",
+        game.server.messages_to(PlayerId(1))
+    );
+}
+
+/// The hotbar carries a tooltip only when there is one to carry.
+#[test]
+fn an_ability_with_no_description_has_no_lore() {
+    #[derive(Component)]
+    struct Terse;
+
+    impl Module for Terse {
+        fn module(world: &World) {
+            world.module::<Self>("smash::kits::Terse");
+            kit::define(world, "Terse", KitStats::default())
+                .ability(AbilitySpec {
+                    name: "Quiet",
+                    item: "minecraft:stick",
+                    slot: 1,
+                    description: "",
+                    ..AbilitySpec::DEFAULT
+                })
+                .ability(AbilitySpec {
+                    name: "Loud",
+                    item: "minecraft:stone",
+                    slot: 2,
+                    description: "It says something.",
+                    ..AbilitySpec::DEFAULT
+                })
+                .register();
+        }
+    }
+
+    let mut game = Game::new();
+    game.world.import::<Terse>();
+    let player = game.player("p", Vec3::ZERO);
+    let player = game.world.entity_from_id(player);
+    kit::apply(
+        &game.world,
+        player,
+        kit::by_name(&game.world, "Terse").expect("just defined"),
+    );
+
+    let hotbar = kit::hotbar(player);
+    assert_eq!(hotbar.len(), 2);
+    assert_eq!(hotbar[0].slot, 1);
+    assert!(
+        hotbar[0].lore.is_empty(),
+        "an empty description became a blank tooltip line: {:?}",
+        hotbar[0].lore
+    );
+    assert_eq!(hotbar[1].lore, vec!["It says something.".to_owned()]);
+}
+
+// ---------------------------------------------------------------------------
+// The scoreboard
+// ---------------------------------------------------------------------------
+
+/// The collapse happens above fourteen rows, not at fourteen.
+#[test]
+fn the_scoreboard_collapses_only_above_the_threshold() {
+    let rows = |count: usize| -> Vec<Row> {
+        (0..count)
+            .map(|index| Row {
+                name: format!("p{index:02}"),
+                lives: u8::try_from(index % 5).unwrap_or(0),
+                colour: "green",
+            })
+            .collect()
+    };
+
+    let at = render(Phase::Playing, rows(COLLAPSE_ABOVE));
+    assert_eq!(
+        at.len(),
+        COLLAPSE_ABOVE,
+        "exactly {COLLAPSE_ABOVE} players should still be listed one per line"
+    );
+
+    let above = render(Phase::Playing, rows(COLLAPSE_ABOVE + 1));
+    assert_eq!(above.len(), 2, "{above:?}");
+    assert!(above[0].starts_with("Players Alive: "));
+}
+
+/// A collapsed sidebar counts the living and the dead correctly.
+///
+/// The two numbers are the whole content of a big lobby's scoreboard, and the
+/// split is one comparison. A test that only checks the lines are there passes
+/// with both numbers wrong.
+#[test]
+fn a_collapsed_sidebar_splits_the_living_from_the_dead() {
+    // Eighteen rows: five with no lives left, thirteen still in.
+    let rows: Vec<Row> = (0..18)
+        .map(|index| Row {
+            name: format!("p{index:02}"),
+            lives: if index < 5 { 0 } else { 3 },
+            colour: "green",
+        })
+        .collect();
+
+    let lines = render(Phase::Playing, rows);
+    assert_eq!(lines, vec![
+        "Players Alive: 13".to_owned(),
+        "Players Dead: 5".to_owned()
+    ]);
+
+    // A player on their last life is alive, not dead.
+    let rows: Vec<Row> = (0..16)
+        .map(|index| Row {
+            name: format!("p{index:02}"),
+            lives: u8::from(index > 0),
+            colour: "red",
+        })
+        .collect();
+    let lines = render(Phase::Playing, rows);
+    assert_eq!(lines[0], "Players Alive: 15");
+    assert_eq!(lines[1], "Players Dead: 1");
+}
+
+/// The hub gets a waiting line and a match does not.
+#[test]
+fn the_sidebar_says_it_is_waiting_only_in_the_hub() {
+    let rows = vec![Row {
+        name: "solo".to_owned(),
+        lives: 4,
+        colour: "green",
+    }];
+    for phase in [Phase::Waiting, Phase::Countdown] {
+        let lines = render(phase, rows.clone());
+        assert_eq!(lines.len(), 2, "{phase:?}: {lines:?}");
+        assert_eq!(lines[1], "Waiting for players");
+    }
+    for phase in [Phase::Preparing, Phase::Playing, Phase::Ended] {
+        let lines = render(phase, rows.clone());
+        assert_eq!(lines.len(), 1, "{phase:?}: {lines:?}");
+    }
+}
+
+/// Ties are broken by name, so the sidebar does not shuffle every tick.
+#[test]
+fn equal_scores_are_ordered_by_name() {
+    let rows = vec![
+        Row {
+            name: "zoe".to_owned(),
+            lives: 2,
+            colour: "gold",
+        },
+        Row {
+            name: "amy".to_owned(),
+            lives: 2,
+            colour: "gold",
+        },
+        Row {
+            name: "bob".to_owned(),
+            lives: 4,
+            colour: "green",
+        },
+    ];
+    let lines = render(Phase::Playing, rows);
+    assert!(lines[0].contains("bob"), "{lines:?}");
+    assert!(lines[1].contains("amy"), "{lines:?}");
+    assert!(lines[2].contains("zoe"), "{lines:?}");
+}
+
+/// An unchanged sidebar is not sent again.
+///
+/// A redraw is several packets per viewer per tick, so the dedup is the
+/// difference between a few hundred packets a minute and a few hundred
+/// thousand. Nothing was checking it held.
+#[test]
+fn an_unchanged_sidebar_is_not_redrawn() {
+    let mut game = Game::new();
+    game.player("a", Vec3::new(0.0, 40.0, 0.0));
+    game.player("b", Vec3::new(8.0, 40.0, 0.0));
+
+    game.advance(0.05, 1);
+    let sidebars = |game: &Game| {
+        game.server
+            .calls()
+            .into_iter()
+            .filter(|call| matches!(call, Call::Sidebar(_, _, _)))
+            .count()
+    };
+    assert!(sidebars(&game) > 0, "the sidebar was never drawn");
+
+    game.server.take();
+    game.advance(1.0, 20);
+    assert_eq!(
+        sidebars(&game),
+        0,
+        "the sidebar was redrawn with nothing to say"
+    );
+
+    // A death changes a row, and then it is sent again.
+    let players = game.players();
+    kill(game.world.entity_from_id(players[0]), DeathCause::Void);
+    game.advance(0.05, 1);
+    assert!(
+        sidebars(&game) > 0,
+        "a changed scoreboard was not sent to anybody"
+    );
+}
+
+/// A new viewer gets the sidebar even when its text has not changed.
+///
+/// The dedup compares the lines *and* the viewers, and only the viewer half
+/// catches this: somebody who has just connected has never been sent a
+/// scoreboard, so skipping the draw because the text is the same leaves them
+/// looking at nothing. A big lobby is where it bites, because there the text is
+/// two aggregate counters that a join need not change at all.
+#[test]
+fn a_player_who_arrives_gets_the_sidebar_even_if_it_reads_the_same() {
+    let mut game = Game::new();
+    // Past the collapse threshold, so the text is two counters rather than one
+    // line per name.
+    for index in 0..16 {
+        game.player(&format!("p{index:02}"), Vec3::new(index as f32, 40.0, 0.0));
+    }
+    game.advance(0.05, 1);
+
+    let sidebars_to = |game: &Game, who: PlayerId| {
+        game.server
+            .calls()
+            .into_iter()
+            .filter(|call| matches!(call, Call::Sidebar(id, _, _) if *id == who))
+            .count()
+    };
+    assert!(sidebars_to(&game, PlayerId(1)) > 0, "nobody got a sidebar");
+
+    // Swap one player for another. The counters are identical afterwards, so
+    // the rendered text is byte for byte what it was.
+    let before: Vec<String> = game
+        .server
+        .calls()
+        .into_iter()
+        .find_map(|call| match call {
+            Call::Sidebar(_, _, lines) => Some(lines),
+            _ => None,
+        })
+        .expect("a sidebar was drawn");
+
+    game.world.entity_from_id(game.players()[0]).destruct();
+    let arrival = game.player("newcomer", Vec3::new(99.0, 40.0, 0.0));
+    let arrival = game.world.entity_from_id(arrival).cloned::<&PlayerId>();
+
+    game.server.take();
+    game.advance(0.05, 1);
+
+    let after: Vec<String> = game
+        .server
+        .calls()
+        .into_iter()
+        .find_map(|call| match call {
+            Call::Sidebar(_, _, lines) => Some(lines),
+            _ => None,
+        })
+        .expect("the sidebar was not sent to the new player at all");
+    assert_eq!(
+        before, after,
+        "the setup is only meaningful if the text is unchanged"
+    );
+    assert!(
+        sidebars_to(&game, arrival) > 0,
+        "the player who just joined was never sent a scoreboard"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The lobby's side effects
+// ---------------------------------------------------------------------------
+
+/// Counting players, and counting the ones still in.
+#[test]
+fn the_lobby_counts_players_and_survivors_separately() {
+    let mut game = Game::new();
+    for index in 0..5 {
+        game.player(
+            &format!("p{index}"),
+            Vec3::new(index as f32 * 8.0, 40.0, 0.0),
+        );
+    }
+    assert_eq!(player_count(&game.world), 5);
+    assert_eq!(alive_count(&game.world), 5);
+
+    let players = game.players();
+    for player in players.iter().take(2) {
+        game.world.entity_from_id(*player).add(Eliminated::id());
+    }
+    assert_eq!(
+        player_count(&game.world),
+        5,
+        "eliminated players are still here"
+    );
+    assert_eq!(alive_count(&game.world), 3);
+}
+
+/// Starting a match puts everybody on a distinct spawn point.
+///
+/// The scatter is what makes a match start rather than a countdown that ends
+/// with everyone standing in the hub, and its index step was unchecked: an
+/// index that fails to advance puts the whole lobby on one platform.
+#[test]
+fn preparing_scatters_everyone_onto_different_spawns() {
+    use smash::module::{arena::Arena, player::Position};
+
+    let mut game = Game::new();
+    game.world.set(LobbyConfig {
+        min_players: 2,
+        full_players: 4,
+        countdown_at_min: 0.2,
+        countdown_at_three_quarters: 0.2,
+        countdown_at_full: 0.2,
+        prepare_seconds: 5.0,
+        ..LobbyConfig::default()
+    });
+    for index in 0..4 {
+        game.player(&format!("p{index}"), Vec3::new(0.0, 100.0, 0.0));
+    }
+
+    // Waiting -> Countdown -> Preparing.
+    game.advance(1.0, 20);
+    assert_eq!(
+        game.world.cloned::<&Lobby>().phase,
+        Phase::Preparing,
+        "the countdown never committed"
+    );
+
+    let spawns = game.world.cloned::<&Arena>().spawns;
+    let mut placed: Vec<Vec3> = game
+        .players()
+        .into_iter()
+        .map(|player| game.world.entity_from_id(player).cloned::<&Position>().0)
+        .collect();
+    for at in &placed {
+        assert!(spawns.contains(at), "{at} is not a spawn point");
+    }
+    placed.sort_by(|a, b| a.to_array().partial_cmp(&b.to_array()).expect("finite"));
+    placed.dedup();
+    assert_eq!(
+        placed.len(),
+        4,
+        "four players landed on {} distinct spawn points",
+        placed.len()
+    );
+
+    assert!(
+        game.server
+            .broadcasts()
+            .iter()
+            .any(|line| line.contains("Get ready")),
+        "nobody was told the match was starting: {:?}",
+        game.server.broadcasts()
+    );
+}
+
+/// Returning to the hub hands everybody their lives and health back.
+///
+/// The reset is what makes one world able to host a second match. It was
+/// entirely unchecked, and a reset that does nothing leaves the next match
+/// starting with a lobby of corpses.
+#[test]
+fn returning_to_the_hub_restores_lives_and_health() {
+    let mut game = Game::new();
+    game.world.set(LobbyConfig {
+        min_players: 2,
+        full_players: 4,
+        countdown_at_min: 0.2,
+        countdown_at_three_quarters: 0.2,
+        countdown_at_full: 0.2,
+        prepare_seconds: 0.2,
+        match_timeout_seconds: 0.2,
+        results_seconds: 0.2,
+    });
+    for index in 0..4 {
+        game.player(
+            &format!("p{index}"),
+            Vec3::new(index as f32 * 8.0, 40.0, 0.0),
+        );
+    }
+
+    // Into the match, then hurt and kill people while it runs.
+    game.advance(0.6, 12);
+    assert_eq!(game.world.cloned::<&Lobby>().phase, Phase::Playing);
+
+    let players = game.players();
+    let casualty = game.world.entity_from_id(players[0]);
+    kill(casualty, DeathCause::Void);
+    casualty.remove(RespawnAt::id());
+    let wounded = game.world.entity_from_id(players[1]);
+    wounded.get::<&mut Health>(|health| health.current = 1.0);
+
+    assert!(casualty.cloned::<&Lives>().0 < MAX_LIVES);
+
+    // Time out the match, sit through the results, and come back to the hub.
+    //
+    // Tick by tick to the moment it arrives, not for a fixed span: a lobby that
+    // still has four players in it leaves `Waiting` again on the very next
+    // step, so a fixed advance sails straight past the state being tested and
+    // into the next match.
+    let mut reached_hub = false;
+    for _ in 0..200 {
+        game.advance(0.05, 1);
+        if game.world.cloned::<&Lobby>().phase == Phase::Waiting {
+            reached_hub = true;
+            break;
+        }
+    }
+    assert!(reached_hub, "never returned to the hub");
+
+    for player in game.players() {
+        let player = game.world.entity_from_id(player);
+        assert_eq!(
+            player.cloned::<&Lives>().0,
+            MAX_LIVES,
+            "{} did not get their lives back",
+            player.name()
+        );
+        let health = player.cloned::<&Health>();
+        assert!(
+            (health.current - health.max).abs() < EPS,
+            "{} came back on {} health",
+            player.name(),
+            health.current
+        );
+        assert!(!player.has(Eliminated::id()));
+    }
+    assert!(
+        game.world.cloned::<&MatchClock>().0.abs() < EPS,
+        "the clock was not reset"
+    );
+}
+
+/// No per-match state survives into the next match.
+///
+/// The reset restores lives and health. The question this asks is what it does
+/// *not* restore: a finishing position, a queued respawn or a respawn immunity
+/// left on a player from the previous game is state the next game reads and
+/// gets wrong. A stale `RespawnAt` in particular is measured against a clock
+/// that has just been set back to zero, which is how a player who died near the
+/// end of one match spends the opening of the next one in spectator mode.
+#[test]
+fn a_new_match_starts_with_no_leftovers_from_the_last_one() {
+    let mut game = Game::new();
+    game.world.set(LobbyConfig {
+        min_players: 2,
+        full_players: 4,
+        countdown_at_min: 0.2,
+        countdown_at_three_quarters: 0.2,
+        countdown_at_full: 0.2,
+        prepare_seconds: 0.2,
+        match_timeout_seconds: 0.2,
+        results_seconds: 0.2,
+    });
+    for index in 0..4 {
+        game.player(
+            &format!("p{index}"),
+            Vec3::new(index as f32 * 8.0, 40.0, 0.0),
+        );
+    }
+
+    game.advance(0.6, 12);
+    assert_eq!(game.world.cloned::<&Lobby>().phase, Phase::Playing);
+
+    let players = game.players();
+    // One player eliminated outright, and one killed but still waiting to come
+    // back when the match runs out. Both are ordinary ways for a match to end.
+    let eliminated = game.world.entity_from_id(players[0]);
+    for _ in 0..MAX_LIVES {
+        kill(eliminated, DeathCause::Void);
+        eliminated.remove(RespawnAt::id());
+        eliminated.get::<&mut Health>(|health| health.current = health.max);
+    }
+    let waiting = game.world.entity_from_id(players[1]);
+    kill(waiting, DeathCause::Void);
+    assert!(
+        waiting.has(RespawnAt::id()),
+        "the setup did not queue a respawn"
+    );
+
+    let mut reached_hub = false;
+    for _ in 0..200 {
+        game.advance(0.05, 1);
+        if game.world.cloned::<&Lobby>().phase == Phase::Waiting {
+            reached_hub = true;
+            break;
+        }
+    }
+    assert!(reached_hub, "never returned to the hub");
+
+    for player in game.players() {
+        let player = game.world.entity_from_id(player);
+        let name = player.name();
+        assert!(
+            player.try_get::<&Placement>(|p| p.0).is_none(),
+            "{name} carried a finishing position of {:?} into the next match",
+            player.try_get::<&Placement>(|p| p.0)
+        );
+        assert!(
+            player.try_get::<&RespawnAt>(|r| r.0).is_none(),
+            "{name} is still queued to respawn at {:?}, against a clock that has been reset to \
+             zero",
+            player.try_get::<&RespawnAt>(|r| r.0)
+        );
+        assert!(
+            player.try_get::<&InvulnerableUntil>(|u| u.0).is_none(),
+            "{name} kept a respawn immunity until {:?} from the previous match",
+            player.try_get::<&InvulnerableUntil>(|u| u.0)
+        );
+    }
+}
+
+/// Every phase change is announced.
+#[test]
+fn each_phase_change_is_broadcast() {
+    let mut game = Game::new();
+    game.world.set(LobbyConfig {
+        min_players: 2,
+        full_players: 4,
+        countdown_at_min: 0.2,
+        countdown_at_three_quarters: 0.2,
+        countdown_at_full: 0.2,
+        prepare_seconds: 0.2,
+        match_timeout_seconds: 0.2,
+        results_seconds: 0.2,
+    });
+    for index in 0..4 {
+        game.player(
+            &format!("p{index}"),
+            Vec3::new(index as f32 * 8.0, 40.0, 0.0),
+        );
+    }
+    game.advance(3.0, 60);
+
+    let said = game.server.broadcasts();
+    for expected in ["starts shortly", "Get ready", "Go!", "Game over"] {
+        assert!(
+            said.iter().any(|line| line.contains(expected)),
+            "never said {expected:?}: {said:?}"
+        );
+    }
+}
+
+/// The results screen ends when its timer runs out, and not before.
+///
+/// Generated cases reach this boundary only by luck: a phase drawn one time in
+/// five and a timer that has to land inside one step of zero. It is the only
+/// input at which the comparison's direction shows, so it is written out.
+#[test]
+fn the_results_screen_ends_exactly_when_its_timer_does() {
+    let config = LobbyConfig::default();
+    let ended = |timer| Lobby {
+        phase: Phase::Ended,
+        timer,
+    };
+
+    let next = step(&config, ended(1.0), 0.5, 8, 1);
+    assert_eq!(next.phase, Phase::Ended);
+    assert!((next.timer - 0.5).abs() < EPS, "{}", next.timer);
+
+    // Exactly out, which is the boundary.
+    let next = step(&config, ended(0.5), 0.5, 8, 1);
+    assert_eq!(
+        next.phase,
+        Phase::Waiting,
+        "a results screen whose timer hit exactly zero did not end"
+    );
+    assert!(next.timer.abs() < EPS);
+
+    let next = step(&config, ended(0.1), 0.5, 8, 1);
+    assert_eq!(next.phase, Phase::Waiting);
+    assert!(next.timer.abs() < EPS, "{}", next.timer);
+}
+
+/// Preparation becomes play at exactly zero as well.
+#[test]
+fn preparation_becomes_play_exactly_when_its_timer_does() {
+    let config = LobbyConfig::default();
+    let preparing = |timer| Lobby {
+        phase: Phase::Preparing,
+        timer,
+    };
+
+    let next = step(&config, preparing(1.0), 0.5, 8, 8);
+    assert_eq!(next.phase, Phase::Preparing);
+    assert!((next.timer - 0.5).abs() < EPS);
+
+    let next = step(&config, preparing(0.5), 0.5, 8, 8);
+    assert_eq!(next.phase, Phase::Playing);
+    assert!(next.timer.abs() < EPS);
+}
+
+/// The match clock counts the seconds a match has been running.
+///
+/// It is what every deadline in the game is measured against -- respawns, kill
+/// credit, respawn immunity -- so a clock that advances by the wrong amount
+/// moves all of them at once, and one that never advances freezes them all.
+#[test]
+fn the_match_clock_counts_up_while_a_match_runs() {
+    let mut game = Game::new();
+    game.world.set(LobbyConfig {
+        min_players: 2,
+        full_players: 4,
+        countdown_at_min: 0.2,
+        countdown_at_three_quarters: 0.2,
+        countdown_at_full: 0.2,
+        prepare_seconds: 0.2,
+        match_timeout_seconds: 600.0,
+        results_seconds: 0.2,
+    });
+    for index in 0..4 {
+        game.player(
+            &format!("p{index}"),
+            Vec3::new(index as f32 * 8.0, 40.0, 0.0),
+        );
+    }
+
+    let mut started = false;
+    for _ in 0..100 {
+        game.advance(0.05, 1);
+        if game.world.cloned::<&Lobby>().phase == Phase::Playing {
+            started = true;
+            break;
+        }
+    }
+    assert!(started, "the match never started");
+
+    let before = game.world.cloned::<&MatchClock>().0;
+    game.advance(1.0, 20);
+    let after = game.world.cloned::<&MatchClock>().0;
+
+    assert!(
+        (after - before - 1.0).abs() < 1e-3,
+        "a second of play moved the clock from {before} to {after}"
+    );
+}
+
+/// The match clock only runs while a match does.
+#[test]
+fn the_match_clock_advances_only_during_play() {
+    let mut game = Game::new();
+    game.player("solo", Vec3::new(0.0, 40.0, 0.0));
+
+    // One player is never enough to start, so the lobby stays in the hub.
+    game.advance(2.0, 40);
+    assert_eq!(game.world.cloned::<&Lobby>().phase, Phase::Waiting);
+    assert!(
+        game.world.cloned::<&MatchClock>().0.abs() < EPS,
+        "the clock ran in the hub: {}",
+        game.world.cloned::<&MatchClock>().0
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Projectiles
+// ---------------------------------------------------------------------------
+
+mod projectiles {
+    use flecs_ecs::prelude::*;
+    use glam::Vec3;
+    use smash::{
+        module::{
+            player::{Health, Player, Position},
+            projectile::{Flight, Payload, Projectile, fire},
+        },
+        server::{PlayerId, mock::Call},
+    };
+
+    use super::{EPS, Game};
+
+    fn count_projectiles(game: &Game) -> i32 {
+        game.world
+            .query::<()>()
+            .with(Projectile::id())
+            .build()
+            .count()
+    }
+
+    /// A projectile flies, falls, and expires on its own timer.
+    ///
+    /// The whole integration step was unchecked: gravity, the position update
+    /// and the countdown are one line each and any of them could have been the
+    /// wrong operator without a test noticing.
+    #[test]
+    fn a_projectile_flies_falls_and_expires() {
+        let mut game = Game::new();
+        let shooter = game.player("shooter", Vec3::ZERO);
+        let shooter = game.world.entity_from_id(shooter);
+
+        fire(
+            shooter.world(),
+            shooter,
+            Flight {
+                position: Vec3::new(0.0, 50.0, 0.0),
+                velocity: Vec3::new(10.0, 0.0, 0.0),
+                gravity: 20.0,
+                seconds_left: 1.0,
+                radius: 0.5,
+            },
+            Payload::new(5.0, 1.0),
+        );
+        assert_eq!(count_projectiles(&game), 1);
+
+        // One tenth of a second, in two ticks of 0.05.
+        game.advance(0.1, 2);
+
+        let mut seen: Option<Flight> = None;
+        game.world
+            .query::<&Flight>()
+            .build()
+            .each(|flight| seen = Some(*flight));
+        let flight = seen.expect("the projectile is still in the air");
+
+        // Horizontal motion is unaffected by gravity: 10 blocks a second for a
+        // tenth of a second is one block.
+        assert!(
+            (flight.position.x - 1.0).abs() < 1e-3,
+            "travelled {} horizontally in 0.1s at 10 blocks a second",
+            flight.position.x
+        );
+        // And it has started falling rather than rising.
+        assert!(
+            flight.position.y < 50.0,
+            "gravity pushed it up to {}",
+            flight.position.y
+        );
+        assert!(flight.velocity.y < 0.0, "velocity is {}", flight.velocity.y);
+        assert!(
+            (flight.seconds_left - 0.9).abs() < 1e-3,
+            "{} seconds left after 0.1s of a 1.0s life",
+            flight.seconds_left
+        );
+
+        // Past its lifetime it is gone rather than lingering.
+        game.advance(1.0, 20);
+        assert_eq!(
+            count_projectiles(&game),
+            0,
+            "an expired projectile survived"
+        );
+    }
+
+    /// A projectile hits the nearest player in range and then stops existing.
+    #[test]
+    fn a_projectile_hits_the_nearest_target_and_is_consumed() {
+        let mut game = Game::new();
+        let shooter = game.player("shooter", Vec3::new(-20.0, 0.0, 0.0));
+        let near = game.player("near", Vec3::new(0.0, 0.0, 0.0));
+        let far = game.player("far", Vec3::new(1.5, 0.0, 0.0));
+        let shooter = game.world.entity_from_id(shooter);
+
+        fire(
+            shooter.world(),
+            shooter,
+            Flight {
+                position: Vec3::new(0.0, 0.0, 0.0),
+                velocity: Vec3::ZERO,
+                gravity: 0.0,
+                seconds_left: 5.0,
+                radius: 4.0,
+            },
+            Payload::new(6.0, 1.0),
+        );
+        game.advance(0.05, 1);
+
+        let health_of = |entity| game.world.entity_from_id(entity).cloned::<&Health>();
+        assert!(
+            health_of(near).current < health_of(near).max,
+            "the nearest player was not hit"
+        );
+        assert!(
+            (health_of(far).current - health_of(far).max).abs() < EPS,
+            "a projectile hit two players at once"
+        );
+        assert_eq!(
+            count_projectiles(&game),
+            0,
+            "the projectile was not consumed"
+        );
+        assert!(
+            game.server
+                .calls()
+                .iter()
+                .any(|call| matches!(call, Call::AddVelocity(id, _) if *id == PlayerId(2))),
+            "the victim was not knocked back"
+        );
+    }
+
+    /// A target standing exactly on the projectile's radius is hit.
+    ///
+    /// The contact check is one `distance > radius`, and the boundary is the
+    /// only input that tells it from `>=`. Everything either side of it agrees.
+    #[test]
+    fn a_target_exactly_on_the_radius_is_hit() {
+        let mut game = Game::new();
+        let shooter = game.player("shooter", Vec3::new(-40.0, 0.0, 0.0));
+        let edge = game.player("edge", Vec3::new(3.0, 0.0, 0.0));
+        let shooter = game.world.entity_from_id(shooter);
+
+        fire(
+            shooter.world(),
+            shooter,
+            Flight {
+                position: Vec3::ZERO,
+                velocity: Vec3::ZERO,
+                gravity: 0.0,
+                seconds_left: 0.5,
+                // Exactly the distance to `edge`, which is representable
+                // exactly, so the comparison is not decided by rounding.
+                radius: 3.0,
+            },
+            Payload::new(4.0, 1.0),
+        );
+        game.advance(0.05, 1);
+
+        let health = game.world.entity_from_id(edge).cloned::<&Health>();
+        assert!(
+            health.current < health.max,
+            "a target exactly on the radius was missed"
+        );
+    }
+
+    /// The nearest is chosen however the world happens to store them.
+    ///
+    /// The comparison that picks a winner runs over entities in whatever order
+    /// the query yields, so a test where the nearest is also the first proves
+    /// only that the first one wins. Here the distant target is created first
+    /// and has to be displaced.
+    #[test]
+    fn the_nearest_target_wins_even_when_it_is_seen_last() {
+        let mut game = Game::new();
+        let shooter = game.player("shooter", Vec3::new(-60.0, 0.0, 0.0));
+        // Created before the nearer one on purpose.
+        let distant = game.player("distant", Vec3::new(3.5, 0.0, 0.0));
+        let close = game.player("close", Vec3::new(0.5, 0.0, 0.0));
+        let shooter = game.world.entity_from_id(shooter);
+
+        fire(
+            shooter.world(),
+            shooter,
+            Flight {
+                position: Vec3::ZERO,
+                velocity: Vec3::ZERO,
+                gravity: 0.0,
+                seconds_left: 0.5,
+                radius: 6.0,
+            },
+            Payload::new(4.0, 1.0),
+        );
+        game.advance(0.05, 1);
+
+        let health_of = |entity| game.world.entity_from_id(entity).cloned::<&Health>();
+        assert!(
+            health_of(close).current < health_of(close).max,
+            "the nearer target was not the one hit"
+        );
+        assert!(
+            (health_of(distant).current - health_of(distant).max).abs() < EPS,
+            "the further target was hit as well"
+        );
+    }
+
+    /// A projectile never hits the player who fired it.
+    #[test]
+    fn a_projectile_passes_through_its_own_shooter() {
+        let mut game = Game::new();
+        let shooter = game.player("shooter", Vec3::ZERO);
+        let shooter = game.world.entity_from_id(shooter);
+        let before = shooter.cloned::<&Health>();
+
+        fire(
+            shooter.world(),
+            shooter,
+            Flight {
+                position: Vec3::ZERO,
+                velocity: Vec3::ZERO,
+                gravity: 0.0,
+                seconds_left: 0.5,
+                radius: 10.0,
+            },
+            Payload::new(9.0, 1.0),
+        );
+        game.advance(0.2, 4);
+
+        assert!(
+            (shooter.cloned::<&Health>().current - before.current).abs() < EPS,
+            "a projectile hit the player who fired it"
+        );
+    }
+
+    /// A projectile passes through a corpse to reach somebody still alive.
+    #[test]
+    fn a_projectile_ignores_the_dead() {
+        let mut game = Game::new();
+        let shooter = game.player("shooter", Vec3::new(-30.0, 0.0, 0.0));
+        let corpse = game.player("corpse", Vec3::ZERO);
+        let alive = game.player("alive", Vec3::new(2.0, 0.0, 0.0));
+        let shooter = game.world.entity_from_id(shooter);
+        game.world
+            .entity_from_id(corpse)
+            .get::<&mut Health>(|health| health.current = 0.0);
+
+        fire(
+            shooter.world(),
+            shooter,
+            Flight {
+                position: Vec3::ZERO,
+                velocity: Vec3::ZERO,
+                gravity: 0.0,
+                seconds_left: 0.5,
+                radius: 5.0,
+            },
+            Payload::new(4.0, 1.0),
+        );
+        game.advance(0.05, 1);
+
+        let health = game.world.entity_from_id(alive).cloned::<&Health>();
+        assert!(
+            health.current < health.max,
+            "the projectile stopped on a body instead of reaching the living"
+        );
+    }
+
+    /// Nothing in range means nothing happens, and the projectile flies on.
+    #[test]
+    fn a_projectile_with_nothing_in_range_keeps_going() {
+        let mut game = Game::new();
+        let shooter = game.player("shooter", Vec3::ZERO);
+        game.player("distant", Vec3::new(500.0, 0.0, 0.0));
+        let shooter = game.world.entity_from_id(shooter);
+
+        fire(
+            shooter.world(),
+            shooter,
+            Flight {
+                position: Vec3::new(100.0, 0.0, 0.0),
+                velocity: Vec3::new(1.0, 0.0, 0.0),
+                gravity: 0.0,
+                seconds_left: 5.0,
+                radius: 2.0,
+            },
+            Payload::new(4.0, 1.0),
+        );
+        game.advance(0.2, 4);
+        assert_eq!(
+            count_projectiles(&game),
+            1,
+            "a projectile hit nothing and died"
+        );
+    }
+
+    /// The extra effect runs, with the victim it hit.
+    #[test]
+    fn the_on_hit_payload_runs_against_the_victim() {
+        use smash::module::projectile::Impact;
+
+        #[derive(Component, Debug, Default)]
+        struct Marked;
+
+        fn mark(impact: &Impact<'_>) {
+            impact.victim.add(Marked::id());
+        }
+
+        let mut game = Game::new();
+        game.world.component::<Marked>();
+        let shooter = game.player("shooter", Vec3::new(-40.0, 0.0, 0.0));
+        let victim = game.player("victim", Vec3::ZERO);
+        let shooter = game.world.entity_from_id(shooter);
+
+        fire(
+            shooter.world(),
+            shooter,
+            Flight {
+                position: Vec3::ZERO,
+                velocity: Vec3::ZERO,
+                gravity: 0.0,
+                seconds_left: 1.0,
+                radius: 3.0,
+            },
+            Payload::new(3.0, 1.0).then(mark),
+        );
+        game.advance(0.05, 1);
+
+        assert!(
+            game.world.entity_from_id(victim).has(Marked::id()),
+            "the on-hit effect never ran"
+        );
+    }
+
+    /// A player entity with no `Player` tag is not a target.
+    #[test]
+    fn a_projectile_only_targets_players() {
+        let mut game = Game::new();
+        let shooter = game.player("shooter", Vec3::new(-40.0, 0.0, 0.0));
+        let shooter = game.world.entity_from_id(shooter);
+        // A prop: it has the components but not the tag.
+        game.world
+            .entity_named("scenery")
+            .set(Position(Vec3::ZERO))
+            .set(Health::full(20.0));
+
+        fire(
+            shooter.world(),
+            shooter,
+            Flight {
+                position: Vec3::ZERO,
+                velocity: Vec3::ZERO,
+                gravity: 0.0,
+                seconds_left: 0.3,
+                radius: 3.0,
+            },
+            Payload::new(3.0, 1.0),
+        );
+        game.advance(0.05, 1);
+        assert_eq!(
+            count_projectiles(&game),
+            1,
+            "the projectile hit something that is not a player"
+        );
+        let _ = Player::id();
+    }
+}

--- a/events/smash/tests/verification.rs
+++ b/events/smash/tests/verification.rs
@@ -1792,6 +1792,98 @@ mod projectiles {
         );
     }
 
+    /// A projectile that passes through somebody hits them, however fast it
+    /// was going.
+    ///
+    /// One tick of a fast projectile is a long line: Barrage's arrows cover
+    /// three blocks a step against a hit radius well under one, so a contact
+    /// test that only looks at where the projectile ended up leaves most of the
+    /// flight path as a hole a player can stand in. This puts the target
+    /// squarely in the middle of a step, where both endpoints miss it by a
+    /// wide margin and only the swept segment connects.
+    #[test]
+    fn a_fast_projectile_hits_what_it_passes_through() {
+        let mut game = Game::new();
+        let shooter = game.player("shooter", Vec3::new(0.0, 0.0, 40.0));
+        let target = game.player("target", Vec3::ZERO);
+        let shooter = game.world.entity_from_id(shooter);
+
+        // 120 blocks a second is six blocks in one 0.05s tick: from -3 to +3,
+        // straight through a target at the origin. Both endpoints are three
+        // blocks away from a radius of half a block.
+        fire(
+            shooter.world(),
+            shooter,
+            Flight {
+                position: Vec3::new(-3.0, 0.0, 0.0),
+                velocity: Vec3::new(120.0, 0.0, 0.0),
+                gravity: 0.0,
+                seconds_left: 5.0,
+                radius: 0.5,
+            },
+            Payload::new(4.0, 1.0),
+        );
+        game.advance(0.05, 1);
+
+        let health = game.world.entity_from_id(target).cloned::<&Health>();
+        assert!(
+            health.current < health.max,
+            "a projectile passed straight through a player without touching them"
+        );
+
+        // And it connected where it actually crossed, not at either end of the
+        // step. That point is what the knockback is measured away from, so a
+        // wrong one launches the victim in a wrong direction.
+        let contact = game
+            .server
+            .calls()
+            .into_iter()
+            .find_map(|call| match call {
+                Call::Cue(at, _) => Some(at),
+                _ => None,
+            })
+            .expect("a hit is cued where it landed");
+        assert!(
+            contact.distance(Vec3::ZERO) < 0.5,
+            "the hit was reported at {contact}, which is not where the path crossed the target"
+        );
+    }
+
+    /// A path that goes past somebody still misses them.
+    ///
+    /// The other half of the segment test: widening the contact check until
+    /// everything within a step is hit would pass the test above and break the
+    /// game.
+    #[test]
+    fn a_fast_projectile_that_passes_wide_still_misses() {
+        let mut game = Game::new();
+        let shooter = game.player("shooter", Vec3::new(0.0, 0.0, 40.0));
+        let bystander = game.player("bystander", Vec3::new(0.0, 0.0, 4.0));
+        let shooter = game.world.entity_from_id(shooter);
+
+        // The same six block step along x, with the bystander four blocks off
+        // it in z.
+        fire(
+            shooter.world(),
+            shooter,
+            Flight {
+                position: Vec3::new(-3.0, 0.0, 0.0),
+                velocity: Vec3::new(120.0, 0.0, 0.0),
+                gravity: 0.0,
+                seconds_left: 5.0,
+                radius: 0.5,
+            },
+            Payload::new(4.0, 1.0),
+        );
+        game.advance(0.05, 1);
+
+        let health = game.world.entity_from_id(bystander).cloned::<&Health>();
+        assert!(
+            (health.current - health.max).abs() < EPS,
+            "a projectile four blocks off its path hit somebody"
+        );
+    }
+
     /// A projectile never hits the player who fired it.
     #[test]
     fn a_projectile_passes_through_its_own_shooter() {

--- a/flake.nix
+++ b/flake.nix
@@ -147,6 +147,113 @@
               text = ''cargo nextest run "$@"'';
             };
 
+            # How much of the game the tests actually check, as a number.
+            #
+            # A mutant is a deliberate change to the source: a `<` flipped to
+            # `<=`, a function body replaced with a constant. A mutant the suite
+            # still passes with is a line the tests execute without checking, so
+            # the surviving count measures verification rather than coverage --
+            # `nix run .#test` staying green while a mutant lives is exactly
+            # what this catches and what a coverage percentage cannot.
+            #
+            # Scope and exclusions live in `.cargo/mutants.toml`, next to the
+            # reasons for them. The budget is here because it is a policy
+            # question rather than a configuration one.
+            #
+            # Raising MUTANT_BUDGET is a change to how much of the game is
+            # checked, so it needs the same argument in a pull request that
+            # deleting a test would. A mutant genuinely not worth killing gets
+            # an exclusion in `mutants.toml` with a reason beside it instead.
+            #
+            # Roughly fifteen minutes on four cores; not part of `nix flake
+            # check`, which only builds this script.
+            mutants = {
+              deps = [
+                pkgs.cargo-mutants
+                pkgs.cargo-nextest
+                pkgs.coreutils
+                pkgs.git
+              ];
+              text = ''
+                budget="''${MUTANT_BUDGET:-0}"
+                root="$(git rev-parse --show-toplevel)"
+                cd "$root"
+
+                out="''${MUTANT_OUTPUT:-$root/target/mutants}"
+                rc=0
+                cargo mutants --test-tool nextest -j "$(nproc)" --output "$out" "$@" || rc=$?
+                # 0 is a clean sweep and 2 is "some survived", which is the
+                # normal case and is judged against the budget below. Anything
+                # else is cargo-mutants itself failing, and that is not a
+                # verdict on the tests.
+                case "$rc" in
+                  0 | 2) ;;
+                  *)
+                    echo "cargo-mutants exited $rc, which is a tool failure rather than a result" >&2
+                    exit "$rc"
+                    ;;
+                esac
+
+                missed="$(wc -l < "$out/mutants.out/missed.txt" | tr -d ' ')"
+                caught="$(wc -l < "$out/mutants.out/caught.txt" | tr -d ' ')"
+                echo "mutants: $caught killed, $missed survived (budget $budget)"
+
+                if [ "$missed" -gt "$budget" ]; then
+                  echo "" >&2
+                  echo "FAIL: $missed mutants survived, which is more than the budget of $budget." >&2
+                  echo "Each line below is a change to the source that every test still passes with." >&2
+                  echo "" >&2
+                  cat "$out/mutants.out/missed.txt" >&2
+                  exit 1
+                fi
+
+                if [ "$missed" -lt "$budget" ]; then
+                  echo "The budget is now loose by $((budget - missed)). Lower MUTANT_BUDGET in flake.nix to hold the ground."
+                fi
+              '';
+            };
+
+            # The unbounded version of the decoder fuzz that `nix run .#test`
+            # runs a fixed slice of.
+            #
+            # The gate runs four thousand cases from seed zero, the same four
+            # thousand every time, because a check that fuzzes differently on
+            # every run fails for somebody else on a case they cannot get back.
+            # This walks the seed base forward instead and does not stop, which
+            # is the same generator searching rather than checking. Leave it
+            # running; a failure prints the seed, and the seed is enough to
+            # reproduce the case in the one-second version.
+            fuzz = {
+              deps = [
+                pkgs.cargo-nextest
+                pkgs.git
+              ];
+              text = ''
+                root="$(git rev-parse --show-toplevel)"
+                cd "$root"
+
+                export HYPERION_FUZZ_SEEDS="''${HYPERION_FUZZ_SEEDS:-4096}"
+                export HYPERION_FUZZ_CASES="''${HYPERION_FUZZ_CASES:-256}"
+                base="''${HYPERION_FUZZ_SEED_BASE:-0}"
+                batch=$(( HYPERION_FUZZ_SEEDS ))
+
+                echo "fuzzing the packet decoder from seed $base, $batch seeds a round; ctrl-c to stop"
+                while :; do
+                  export HYPERION_FUZZ_SEED_BASE="$base"
+                  # One line: a backslash continuation is literal inside a Nix
+                  # indented string and reaches the shell as a stray argument.
+                  if ! cargo nextest run -p hyperion-minecraft-proto --no-capture -E 'binary(decode_fuzz)' "$@"; then
+                    echo "" >&2
+                    echo "a case in seeds $base..$(( base + batch )) broke the decoder." >&2
+                    echo "reproduce it with the gate-sized run:" >&2
+                    echo "  HYPERION_FUZZ_SEED_BASE=$base HYPERION_FUZZ_SEEDS=$batch HYPERION_FUZZ_CASES=$HYPERION_FUZZ_CASES nix run .#test -- -p hyperion-minecraft-proto" >&2
+                    exit 1
+                  fi
+                  base=$(( base + batch ))
+                done
+              '';
+            };
+
             # Only tests whose name contains "miri" run under it; the rest are
             # far too slow to interpret.
             miri = {


### PR DESCRIPTION
## The number

Mutation testing over `events/smash/src/module/*.rs`:

| | before | after |
|---|---|---|
| killed | 148 | 292 |
| survived | **119** | **0** |
| viable | 267 | 292 |
| **killed** | **55.4%** | **100%** |

A surviving mutant is a deliberate change to the source that every test still
passes with, so it is a line the suite runs without checking. 119 of them is
what "460 tests, all green" was actually worth on the game modules.

The two columns are measured against different trees, which is worth being
plain about. The "before" is `f3ceff4`, the commit this started from, at 287
mutants. #996, #997 and #1000 landed while it was being written and added
about three hundred lines to the modules in scope, so the "after" is a fresh
sweep of the rebased tree at 313 mutants. That sweep found three survivors in
the ability code #997 brought in and two in the swept-path collision from
#996, and those are covered here too, which is why there are commits in this
branch about code it did not write.

Two mutants are excluded rather than budgeted, each with the argument next to
it in `.cargo/mutants.toml`: `tick_cooldowns`' `remaining > 0.0` guard, where
`>=` cannot differ for any reachable value, and `nearest_target`'s
`distance < closest`, where `<=` differs only on an exact distance tie between
two players who are both equally the nearest, and where killing it would mean
freezing flecs' table iteration order into an assertion.

`nix run .#mutants` is the gate and the budget is **0**, so any change that
adds an unchecked line fails it. It is about forty minutes on four cores and
is not part of `nix flake check`, which only builds the script. The guard was
watched in both directions before being trusted: passing at budget 0, and
failing with the intended message at budget -1.

## What the survivors said

The 119 were not evenly spread, and the pattern is the useful part. Three
whole modules had no test that checked any value they produced:

* **`projectile.rs`** (20 survivors) had no test at all. Gravity, the position
  integration, the lifetime countdown, the target search and the shooter
  exclusion were all executed by other tests and checked by none.
* **`knockback::vanilla`** (8) is the function the design document compares
  against. Every existing test called it with the attacker at the origin,
  where `victim - origin` and `victim + origin` are the same vector, so the
  direction term could not be distinguished from its own negation.
* **`lobby.rs`'s side effects** (11). `scatter`, `reset` and `announce` could
  each be replaced with an empty function and the suite stayed green. That is
  what led to the bug below.

The rest were boundaries. `killer_of` stamped its hits at clock zero in every
test, where `now - at` and `now + at` agree. `Lives::colour` had three arms no
test named, so one could fall through to the next unnoticed. `Armor::reduction`
was only ever checked for being in range, never for being 4% a point.

## One bug, and where it came from

`lobby::reset` restored lives and health when a match ended and left
`Placement`, `RespawnAt` and `InvulnerableUntil` on the players. Fixed here.

* A stale `Placement` is a finishing position from the previous match sitting
  on somebody who has not finished this one, which is what a results screen
  reads.
* A stale `RespawnAt` is a deadline measured against a clock `reset` has just
  set back to zero, so a player who died in the closing seconds of one match
  spends the opening of the next one dead and spectating for as long as the old
  clock said.
* A stale `InvulnerableUntil` is the same arithmetic the other way: untouchable,
  and immune to the kill plane, for that long instead.

Nothing could have caught this before, because nothing ran two matches in one
world. `verification.rs::a_new_match_starts_with_no_leftovers_from_the_last_one`
does now.

## Is the simulation deterministic?

Yes, and bit exactly. `determinism.rs` seeds a world, runs a nine hundred action
script, and compares a fingerprint of the whole observable state after every
tick: lives, health, position, velocity, ground state, jumps, energy, respawn
and immunity deadlines, per ability cooldowns keyed by hotbar slot, the lobby
phase and timer, the match clock, and the full log of calls that reached the
server. Floats go in by their bits, not through a tolerance.

Five seeds, four repeats each, with unrelated worlds built and run in between so
that anything leaking across worlds gets a chance to shift. No divergence at any
tick. The call log is also compared call by call rather than only by hash, so a
future failure names the first call that differs.

This was the finding most worth having gone looking for, and the answer is the
boring one.

## Properties, including the ones that were wrong

`properties.rs` has 21. The interesting output is the four that failed, because
in three of them the property was wrong and the code was right, and saying which
is the whole exercise:

1. **"A hit inside the invulnerability window changes velocity but not health."**
   False here, and the code is right. `apply_damage` checks the immunity before
   anything else, so `Smashed` is never emitted and no knockback is computed
   either. A player who could still be launched off the map while immune would
   be immune to the damage and dead anyway. The property is now that the hit is
   a complete no-op.

2. **"An ability never knocks its own caster back."** False, obviously so once
   the generator found it: a leap, a blink and a charge are abilities whose
   entire purpose is to move the player who used them. Dropped.

3. **"An ability never hurts the player who used it."** Also false. Slime Slam
   hands a quarter of its damage back on purpose. The property that survives
   contact is about the shared primitive: `splash` excludes the caster, so a kit
   that wants recoil has to ask for it and a kit that does not cannot get it by
   accident. That version also pins the radius boundary, which matters because
   the condition is one three way `&&`.

4. **"A full lobby settles in the hub."** False: a server that keeps its players
   starts another match. Replaced with the cycle, phase by phase in order.

The fourth failure was a bug in the test rather than in either: `Game::advance`
takes seconds and a step count, and reading it as a tick count meant a test
waiting one second for a thirteen second cooldown and reporting that cooldowns
never expire.

Invariants are checked after **every tick** of every generated script, not at the
end: lives never exceed four and never wrap below zero, health stays inside its
own bar, energy stays inside its own, cooldowns never go negative, elimination
and placement agree with the life count, and an alive player is never below the
kill plane.

## A skew the invariants found

The kill plane invariant failed on the first generated run, and it was not a
bug. `MatchClock` is advanced by `smash::lobby_tick`, which `LobbyModule`
registers after every module that reads the clock, so every reader sees it one
tick stale. Fifty milliseconds is invisible in play, but it is worth writing
down, because it applies to respawn deadlines and kill credit as well as to the
kill plane, and the invariant would otherwise have been quietly weakened to hide
it. The comment in `harness/mod.rs` says which way the skew runs.

## The module contract

`contract.rs` gives every module a declared contract and then imports it into a
world holding only what it declares. It found one undeclared dependency and made
two known cycles explicit:

* **`Damage` reaches into `lives::InvulnerableUntil`** while running, and `Lives`
  cannot be imported without `Damage`'s `MatchClock`. Nothing else in the suite
  imports one without the other, so nothing else could have noticed.
* **`Arena` needs `Lives` and `Lobby` to run** its kill plane while `Lives` names
  `&Arena` in a system signature and so needs `Arena` to import.

Both are mutual, and only the fact that half of each cycle is deferred to tick
time makes a linear import list possible at all. The contract separates the two
kinds of edge for exactly that reason: import time requirements are asserted to
be acyclic and ordered, runtime ones are allowed to point forward and have to
say why.

A missing component aborts inside flecs with a message naming the component and
nothing else, so the panic is caught and reported per module. A failure now
reads as a list of module names and what each one reached for.

## The fuzzer

`decode_fuzz.rs` puts arbitrary bytes into `FrameDecoder`, which is the one
surface an unauthenticated peer owns. 4096 cases in the gate, from a seeded
generator so the corpus is the same on every machine; `nix run .#fuzz` walks the
seed base forward and does not stop. A failure prints the seed and the generator
is a pure function of it, so an hour long run reproduces in a second. The corpus
is weighted towards nearly valid frames, because uniform noise dies on the first
length prefix and never reaches the compression layer.

No panics found.

The interesting result is the allocation half. `decode_allocation.rs` installs a
counting global allocator and measures what a peer can buy:

```
declared       1024:  7 bytes on the wire ->     44,336 bytes allocated
declared  1,048,576:  8 bytes on the wire ->  1,091,888 bytes allocated
declared  8,388,608:  9 bytes on the wire ->  8,431,921 bytes allocated
declared  8,388,609:  9 bytes on the wire ->     43,313 bytes allocated
```

Nine bytes buy an 8.4 MB allocation, a ratio of about 900,000 to one, because
`Decompressor::inflate` reserves and zeroes the declared length before looking
at the payload. That is not a bug in this crate: it is what
`CompressionDecoder.inflate` does and 8 MiB is Mojang's own
`MAXIMUM_UNCOMPRESSED_LENGTH`, so the number is pinned rather than lowered. The
last row is what makes it survivable, and it is what the test defends: one byte
over the ceiling and the frame is refused on its declared length alone. The
ceiling is per packet rather than per connection, so rate limiting at the proxy
is still the thing standing between a peer and repeating it.

## What I did not do

**Coverage guided fuzzing.** `nix run .#fuzz` is a structured generator with a
moving seed, not libFuzzer, so it explores by construction rather than by
coverage feedback. Adding `cargo-fuzz` means a nested crate inside the tree that
`cargoUnit` builds from `./.`, and three other agents are rebasing on this flake
today; the risk of breaking their build was not worth it in the same change that
establishes the baseline. It is the obvious follow up and the decode path is
where it would pay.

**Mutation testing of the kits.** `module/kits/**` is 700 mutants of declarative
data, mostly "this ability's radius is a different number", which is a balance
question rather than a correctness one, and it would quadruple the gate's
runtime. `modularity.rs` already proves the kit machinery from outside the
crate. The reason is recorded in `mutants.toml` next to the exclusion.

**One equivalent mutant is excluded rather than budgeted.** `tick_cooldowns`
guards its decrement with `remaining > 0.0`; relaxing that to `>=` changes
nothing for any reachable value, since at exactly zero the body computes
`(0.0 - dt).max(0.0)`. No test can kill it, so carrying it in the budget would
be one mutant of permanent slack.

## Gates

All on aarch64-darwin, at 313503c rebased onto origin/main.

```
nix run .#fmt -- --check    rc=0
nix run .#lint              rc=0
nix run .#test              rc=0   548 tests run: 548 passed, 1 skipped
nix run .#e2e               rc=0   reached play state, 4096 chunk packets
nix run .#smash-e2e         rc=0   a whole match ran at protocol 776, all seven steps proved
nix flake check             rc=0   all checks passed (built the new mutants and fuzz derivations)
nix run .#mutants           rc=0   265 killed, 0 survived (budget 0), 39m
```

The suite went from 460 to 548 tests. `nix run .#smash-e2e` was run on
`HYPERION_PLAYER_PORT=41565 HYPERION_SERVER_PORT=51565` so as not to touch the
ports other work is holding.
