### PR TITLE
feat(commands): tab completion from live game state, declared on the clap derive

### DIFF
--- a/crates/hyperion-clap/src/completion.rs
+++ b/crates/hyperion-clap/src/completion.rs
@@ -1,0 +1,309 @@
+//! Where the cursor is in a half-typed command.
+//!
+//! Split out from the registration in [`crate`] and generic over the node
+//! handle, because everything here is arithmetic over a string and a command's
+//! shape and that is the part with the off-by-ones in it. The tests below run
+//! without a world, a server or a socket.
+
+/// One step of a command's shape, as the walk reads it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Step<T> {
+    /// The word a token has to equal, for a subcommand. `None` for a value the
+    /// player types.
+    pub literal: Option<String>,
+    /// The clap id, which is the name a declaration uses to reach this step.
+    pub id: String,
+    /// The command tree node carrying this step's completion source.
+    pub node: T,
+    /// A greedy value takes the rest of the line rather than one word.
+    ///
+    /// clap spells this as an argument accepting more than one value, which is
+    /// how `/kit Iron Golem` is one kit name and not two.
+    pub greedy: bool,
+    /// The steps that may follow this one.
+    pub next: Vec<Self>,
+}
+
+/// The one thing a suggestion response needs to know.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Cursor<T> {
+    /// The tree node whose completions to offer.
+    pub node: T,
+    /// Byte offset into the whole command text where the replaced span starts.
+    ///
+    /// The client replaces from here to the end of what was typed, so a
+    /// suggestion may contain a space: completing `/kit Iron Gol` replaces
+    /// `Iron Gol` rather than just `Gol`.
+    pub start: usize,
+    /// What has already been typed for this value.
+    pub prefix: String,
+}
+
+/// Byte offset and text of each whitespace-delimited token.
+fn tokens(text: &str) -> Vec<(usize, &str)> {
+    let mut out = Vec::new();
+    let mut start = None;
+    for (index, character) in text.char_indices() {
+        if character.is_whitespace() {
+            if let Some(from) = start.take() {
+                out.push((from, &text[from..index]));
+            }
+        } else if start.is_none() {
+            start = Some(index);
+        }
+    }
+    if let Some(from) = start {
+        out.push((from, &text[from..]));
+    }
+    out
+}
+
+/// The step a already-typed token takes.
+///
+/// A subcommand wins over a value, so `/perms set` follows the `set` literal
+/// rather than reading `set` as somebody's name.
+fn advance<'a, T>(here: &'a [Step<T>], token: &str) -> Option<&'a Step<T>> {
+    here.iter()
+        .find(|step| {
+            step.literal
+                .as_deref()
+                .is_some_and(|literal| literal.eq_ignore_ascii_case(token))
+        })
+        .or_else(|| here.iter().find(|step| step.literal.is_none()))
+}
+
+/// Which node `text` is asking for completions of, and the span a suggestion
+/// replaces.
+///
+/// `None` when nothing should be offered: the cursor is still inside the
+/// command's own name, which the client completes from the graph without asking
+/// anybody, or it has reached a point where only subcommand literals follow,
+/// which the client also has.
+#[must_use]
+pub fn locate<T: Copy>(steps: &[Step<T>], text: &str) -> Option<Cursor<T>> {
+    if !text.starts_with('/') {
+        return None;
+    }
+
+    let words = tokens(text);
+    if words.is_empty() {
+        return None;
+    }
+
+    // An open token is one the cursor is still inside, which is any run of
+    // non-whitespace the text ends on. A trailing space closes it and starts
+    // the next value empty.
+    let open = !text.ends_with(char::is_whitespace);
+
+    if open && words.len() == 1 {
+        // Still typing the command's name. Not ours to answer.
+        return None;
+    }
+
+    // Tokens after the command name that are finished, so the walk consumes
+    // them rather than completing them.
+    let complete = if open {
+        words.len() - 2
+    } else {
+        words.len() - 1
+    };
+
+    let (start, prefix) = if open {
+        let (from, _) = words[words.len() - 1];
+        (from, text[from..].to_owned())
+    } else {
+        (text.len(), String::new())
+    };
+
+    let mut here = steps;
+    for position in 0..complete {
+        let (from, token) = words[position + 1];
+        let step = advance(here, token)?;
+
+        if step.greedy {
+            // The greedy value runs from its first word to the cursor, and the
+            // suggestion replaces all of it. Without this `/kit Iron Gol`
+            // completes to `/kit Iron Iron Golem`.
+            return Some(Cursor {
+                node: step.node,
+                start: from,
+                prefix: text[from..].to_owned(),
+            });
+        }
+
+        here = &step.next;
+    }
+
+    let step = here.iter().find(|step| step.literal.is_none())?;
+    Some(Cursor {
+        node: step.node,
+        start,
+        prefix,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cursor, Step, locate};
+
+    fn value(id: &str, node: u32, greedy: bool, next: Vec<Step<u32>>) -> Step<u32> {
+        Step {
+            literal: None,
+            id: id.to_owned(),
+            node,
+            greedy,
+            next,
+        }
+    }
+
+    fn literal(name: &str, node: u32, next: Vec<Step<u32>>) -> Step<u32> {
+        Step {
+            literal: Some(name.to_owned()),
+            id: name.to_owned(),
+            node,
+            greedy: false,
+            next,
+        }
+    }
+
+    /// `/kit`, whose one argument takes every remaining word because half the
+    /// kit names have a space in them.
+    fn kit() -> Vec<Step<u32>> {
+        vec![value("name", 1, true, vec![])]
+    }
+
+    /// `/perms set <player> <group>` and `/perms get <player>`.
+    fn perms() -> Vec<Step<u32>> {
+        vec![
+            literal("set", 10, vec![value("player", 11, false, vec![value(
+                "group",
+                12,
+                false,
+                vec![],
+            )])]),
+            literal("get", 20, vec![value("player", 21, false, vec![])]),
+        ]
+    }
+
+    #[test]
+    fn typing_the_command_name_is_the_clients_own_business() {
+        assert_eq!(locate(&kit(), "/ki"), None);
+        assert_eq!(locate(&kit(), "/kit"), None);
+    }
+
+    #[test]
+    fn a_trailing_space_opens_the_first_argument() {
+        assert_eq!(
+            locate(&kit(), "/kit "),
+            Some(Cursor {
+                node: 1,
+                start: 5,
+                prefix: String::new(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_partial_word_is_the_prefix_and_names_its_own_span() {
+        assert_eq!(
+            locate(&kit(), "/kit Iron"),
+            Some(Cursor {
+                node: 1,
+                start: 5,
+                prefix: "Iron".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_greedy_argument_spans_every_word_it_has_taken() {
+        // The span starts at `Iron`, not at `Gol`, so the client replaces the
+        // whole name rather than appending to it.
+        assert_eq!(
+            locate(&kit(), "/kit Iron Gol"),
+            Some(Cursor {
+                node: 1,
+                start: 5,
+                prefix: "Iron Gol".to_owned(),
+            })
+        );
+        assert_eq!(
+            locate(&kit(), "/kit Iron "),
+            Some(Cursor {
+                node: 1,
+                start: 5,
+                prefix: "Iron ".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn extra_whitespace_does_not_shift_the_span() {
+        assert_eq!(
+            locate(&kit(), "/kit   Iron"),
+            Some(Cursor {
+                node: 1,
+                start: 7,
+                prefix: "Iron".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_position_offering_only_subcommands_is_answered_by_the_graph() {
+        assert_eq!(locate(&perms(), "/perms "), None);
+        assert_eq!(locate(&perms(), "/perms s"), None);
+    }
+
+    #[test]
+    fn a_subcommand_literal_is_consumed_rather_than_read_as_a_value() {
+        assert_eq!(
+            locate(&perms(), "/perms set "),
+            Some(Cursor {
+                node: 11,
+                start: 11,
+                prefix: String::new(),
+            })
+        );
+        assert_eq!(
+            locate(&perms(), "/perms get Bo"),
+            Some(Cursor {
+                node: 21,
+                start: 11,
+                prefix: "Bo".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn the_walk_reaches_the_second_argument_of_a_subcommand() {
+        assert_eq!(
+            locate(&perms(), "/perms set Bob "),
+            Some(Cursor {
+                node: 12,
+                start: 15,
+                prefix: String::new(),
+            })
+        );
+        assert_eq!(
+            locate(&perms(), "/perms set Bob Adm"),
+            Some(Cursor {
+                node: 12,
+                start: 15,
+                prefix: "Adm".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn running_off_the_end_of_a_command_offers_nothing() {
+        assert_eq!(locate(&perms(), "/perms set Bob Admin extra"), None);
+        assert_eq!(locate(&perms(), "/perms get Bob "), None);
+    }
+
+    #[test]
+    fn text_that_is_not_a_command_is_refused() {
+        assert_eq!(locate(&kit(), "kit Iron"), None);
+        assert_eq!(locate(&kit(), ""), None);
+    }
+}

--- a/crates/hyperion-clap/src/lib.rs
+++ b/crates/hyperion-clap/src/lib.rs
@@ -1,8 +1,56 @@
-use std::iter::zip;
+//! Minecraft commands derived from clap.
+//!
+//! A command reaches a player through two protocol mechanisms, and this crate
+//! feeds both of them off the same clap definition:
+//!
+//! * the **command graph**, sent once when a player joins, which is what makes
+//!   a slash list the server's commands and tells the client how to parse each
+//!   argument. [`MinecraftCommand::register`] builds it out of the derive:
+//!   subcommands become literal nodes, positionals become argument nodes, and
+//!   an argument taking more than one value becomes a greedy string so a kit
+//!   name with a space in it is one value rather than two.
+//! * **command suggestions**, the request and response pair the client sends
+//!   when a player presses tab. [`completion::locate`] decides which node the
+//!   cursor is on, and [`hyperion::simulation::command::suggestions`] asks that
+//!   node what it may be completed to.
+//!
+//! # Declaring where an argument's completions come from
+//!
+//! An argument whose clap type already enumerates itself needs no declaration:
+//! a `ValueEnum` positional carries its possible values into the graph at
+//! registration. An argument completed from live game state names the flecs tag
+//! its candidates carry:
+//!
+//! ```ignore
+//! KitCommand::register(registry, world).completes("name", Kit::id());
+//! ```
+//!
+//! and the module that owns that tag says once how to render one of them:
+//!
+//! ```ignore
+//! world
+//!     .component::<Kit>()
+//!     .set(SuggestionLabel(|kit| kit.try_get::<&KitName>(|name| name.0.to_owned())));
+//! ```
+//!
+//! Nothing between those two lines is a list of kits. The completions are a
+//! query over whatever carries the tag when the player presses tab.
+//!
+//! `hyperion::simulation::Player` arrives with its label already set, so an
+//! argument naming a player is one line and no new vocabulary:
+//!
+//! ```ignore
+//! PermissionCommand::register(registry, world).completes("player", Player::id());
+//! ```
+
+pub mod completion;
 
 use clap::{Arg as ClapArg, Parser, ValueEnum, ValueHint, error::ErrorKind};
 use flecs_ecs::{
-    core::{Entity, EntityView, EntityViewGet, World, WorldGet, WorldProvider, id},
+    core::{
+        ComponentId, Entity, EntityView, EntityViewGet, IdOperations, IntoEntity, World, WorldGet,
+        WorldProvider, id,
+    },
     prelude::{Component, Module},
 };
 use hyperion::{
@@ -11,21 +59,183 @@ use hyperion::{
         packets::play::clientbound::{CommandSuggestions, command_suggestions},
     },
     net::{Compose, ConnectionId, DataBundle, agnostic, protocol::Clientbound},
-    simulation::{IgnMap, command::get_root_command_entity, handlers::PacketSwitchQuery},
+    simulation::{
+        IgnMap, Player,
+        command::{FixedSuggestions, Suggests, get_root_command_entity, suggestions},
+        handlers::PacketSwitchQuery,
+    },
     storage::CommandCompletionRequest,
 };
 pub use hyperion_clap_macros::CommandPermission;
 pub use hyperion_command;
 use hyperion_command::{CommandHandler, CommandRegistry};
 use hyperion_permission::Group;
-use valence_protocol::packets::play::command_tree_s2c::StringArg;
+use valence_protocol::packets::play::command_tree_s2c::{Parser as ValenceParser, StringArg};
+
+use crate::completion::Step;
+
+/// Whether a clap argument takes more than one value, which makes it one
+/// greedy Brigadier string rather than a run of single words.
+fn is_greedy(arg: &ClapArg) -> bool {
+    arg.get_num_args()
+        .is_some_and(|range| range.max_values() > 1)
+}
+
+/// Build the graph nodes under `parent` for one clap command, and return the
+/// shape the completion walk reads.
+///
+/// Positionals chain one after another because that is the order they are
+/// typed in; subcommands hang off the end of that chain as literals, which for
+/// every command here means directly off the command's own node.
+fn build(
+    world: &World,
+    parent: Entity,
+    cmd: &clap::Command,
+    has_permission: fn(&World, Entity) -> bool,
+) -> Vec<Step<Entity>> {
+    let mut on = parent;
+    let mut created = Vec::new();
+
+    for arg in cmd.get_positionals() {
+        let display = arg
+            .get_value_names()
+            .and_then(|names| names.first())
+            .map_or_else(
+                || arg.get_id().to_string(),
+                |name| name.to_ascii_lowercase(),
+            );
+
+        let kind = if is_greedy(arg) {
+            StringArg::GreedyPhrase
+        } else {
+            StringArg::SingleWord
+        };
+        let node = world
+            .entity()
+            .set(hyperion::simulation::command::Command::argument(
+                display,
+                ValenceParser::String(kind),
+            ))
+            .child_of(on);
+
+        // A clap `ValueEnum` has already written down every value it accepts,
+        // so an argument built from one completes with nothing else declared.
+        let possible: Vec<String> = arg
+            .get_possible_values()
+            .iter()
+            .map(|value| value.get_name().to_owned())
+            .collect();
+        if !possible.is_empty() {
+            node.set(FixedSuggestions(possible));
+        }
+
+        created.push((arg, node.id()));
+        on = node.id();
+    }
+
+    let mut steps: Vec<Step<Entity>> = cmd
+        .get_subcommands()
+        .map(|sub| {
+            let literal = world
+                .entity()
+                .set(hyperion::simulation::command::Command::literal(
+                    sub.get_name().to_owned(),
+                    has_permission,
+                ))
+                .child_of(on);
+            Step {
+                literal: Some(sub.get_name().to_owned()),
+                id: sub.get_name().to_owned(),
+                node: literal.id(),
+                greedy: false,
+                next: build(world, literal.id(), sub, has_permission),
+            }
+        })
+        .collect();
+
+    // Folded from the back so each positional owns what follows it.
+    for (arg, node) in created.into_iter().rev() {
+        steps = vec![Step {
+            literal: None,
+            id: arg.get_id().to_string(),
+            node,
+            greedy: is_greedy(arg),
+            next: steps,
+        }];
+    }
+
+    steps
+}
+
+/// Collect every value step in a shape, so a declaration can name one.
+fn value_steps(steps: &[Step<Entity>], out: &mut Vec<(String, Entity)>) {
+    for step in steps {
+        if step.literal.is_none() {
+            out.push((step.id.clone(), step.node));
+        }
+        value_steps(&step.next, out);
+    }
+}
+
+/// A registered command, for declaring where its arguments complete from.
+///
+/// Returned by [`MinecraftCommand::register`]. Ignoring it is fine: a command
+/// whose arguments all know their own values, or which has none, needs nothing
+/// further.
+pub struct Registered<'w> {
+    world: &'w World,
+    /// Every value step, by the clap id of the field that produced it.
+    values: Vec<(String, Entity)>,
+}
+
+impl Registered<'_> {
+    /// Complete the argument named `arg` from every entity carrying `tag`.
+    ///
+    /// `arg` is the clap id, which for a derived command is the struct field's
+    /// name. `tag` is a flecs component id, and the candidates are whatever
+    /// carries it when the player presses tab: this is an edge in the world,
+    /// not a snapshot of one.
+    ///
+    /// The tag needs a [`SuggestionLabel`] saying how to render one of its
+    /// entities, which the module owning the tag sets once.
+    ///
+    /// Every argument by that name, not the first: one clap id can reach more
+    /// than one node, because `/perms set <player>` and `/perms get <player>`
+    /// are two nodes of the same command and a player means the same thing in
+    /// both. Wiring only the first is the kind of half-working completion that
+    /// looks like a protocol bug from the client.
+    ///
+    /// # Panics
+    /// When the command has no argument by that name. A completion that
+    /// silently never fires is the failure this whole mechanism exists to
+    /// avoid, so a typo here stops the server at startup rather than at the
+    /// moment somebody presses tab.
+    ///
+    /// [`SuggestionLabel`]: hyperion::simulation::command::SuggestionLabel
+    pub fn completes(&self, arg: &str, tag: impl IntoEntity) -> &Self {
+        let tag = tag.into_entity(self.world);
+
+        let mut wired = 0;
+        for &(_, node) in self.values.iter().filter(|(id, _)| id == arg) {
+            self.world.entity_from_id(node).add((Suggests, tag));
+            wired += 1;
+        }
+
+        if wired == 0 {
+            let known: Vec<&str> = self.values.iter().map(|(id, _)| id.as_str()).collect();
+            panic!("no command argument named {arg}; this command has {known:?}");
+        }
+
+        self
+    }
+}
 
 pub trait MinecraftCommand: Parser + CommandPermission {
     fn execute(self, system: EntityView<'_>, caller: Entity);
 
     fn pre_register(_world: &World) {}
 
-    fn register(registry: &mut CommandRegistry, world: &World) {
+    fn register<'w>(registry: &mut CommandRegistry, world: &'w World) -> Registered<'w> {
         Self::pre_register(world);
 
         let cmd = Self::command();
@@ -40,22 +250,15 @@ pub trait MinecraftCommand: Parser + CommandPermission {
         let node_to_register =
             hyperion::simulation::command::Command::literal(name.clone(), has_permissions);
 
-        let mut on = world
+        let root = world
             .entity()
             .set(node_to_register)
             .child_of(get_root_command_entity());
 
-        for arg in cmd.get_arguments() {
-            use valence_protocol::packets::play::command_tree_s2c::Parser as ValenceParser;
-            let name = arg.get_value_names().unwrap().first().unwrap();
-            let name = name.to_ascii_lowercase();
-            let node_to_register = hyperion::simulation::command::Command::argument(
-                name,
-                ValenceParser::String(StringArg::SingleWord),
-            );
+        let shape = build(world, root.id(), &cmd, has_permissions);
 
-            on = world.entity().set(node_to_register).child_of(on);
-        }
+        let mut values = Vec::new();
+        value_steps(&shape, &mut values);
 
         let on_execute = |input: &str, system: EntityView<'_>, caller: Entity| {
             let input = input.split_whitespace();
@@ -110,118 +313,55 @@ pub trait MinecraftCommand: Parser + CommandPermission {
         };
 
         let on_tab_complete = Box::new(
-            |packet_switch_query: &mut PacketSwitchQuery<'_>,
-             completion: &CommandCompletionRequest| {
-                let full_query = completion.query.as_str();
-                let id = completion.id;
+            move |packet_switch_query: &mut PacketSwitchQuery<'_>,
+                  completion: &CommandCompletionRequest| {
+                let text = completion.query.as_str();
 
-                let Some(query) = full_query.strip_prefix('/') else {
-                    // todo: send error message to player
-                    tracing::warn!("could not parse command {full_query}");
-                    return;
+                // Every request is answered, including with nothing. A client
+                // that pressed tab is blocked on this reply: `ask_server` hands
+                // the client's own suggestion machinery a future that only this
+                // packet completes, so dropping the request stops the player
+                // seeing even the suggestions the client worked out for itself.
+                let (span, matched) = match completion::locate(&shape, text) {
+                    Some(cursor) => {
+                        let prefix = cursor.prefix.to_lowercase();
+                        let matched: Vec<String> =
+                            suggestions(packet_switch_query.world, cursor.node)
+                                .into_iter()
+                                .filter(|value| value.to_lowercase().starts_with(&prefix))
+                                .collect();
+                        ((cursor.start, cursor.prefix.len()), matched)
+                    }
+                    // The cursor is on the command's own name or past the last
+                    // argument. Nothing to offer, and an empty span at the end
+                    // of the line is the range vanilla replaces with nothing.
+                    None => ((text.len(), 0), Vec::new()),
                 };
 
-                let mut query = query.split_whitespace();
-                let _command_name = query.next().unwrap();
-
-                let command = Self::command();
-                let mut positionals = command.get_positionals();
-
-                'positionals: for (input_arg, cmd_arg) in zip(query, positionals.by_ref()) {
-                    // see if anything matches
-                    let possible_values = cmd_arg.get_possible_values();
-                    for possible in &possible_values {
-                        if possible.matches(input_arg, true) {
-                            continue 'positionals;
-                        }
-                    }
-
-                    // nothing matches! let's see if a substring matches
-                    let mut substring_matches = possible_values
-                        .iter()
-                        .filter(|possible| {
-                            // todo: this is inefficient
-                            possible
-                                .get_name()
-                                .to_lowercase()
-                                .starts_with(&input_arg.to_lowercase())
-                        })
-                        .peekable();
-
-                    if substring_matches.peek().is_none() {
-                        // no matches
-                        return;
-                    }
-
-                    let suggestions = substring_matches
-                        .map(clap::builder::PossibleValue::get_name)
-                        .map(|name| command_suggestions::Entry {
-                            text: name,
-                            tooltip: None,
-                        })
-                        .collect();
-
-                    let start = input_arg.as_ptr() as usize - full_query.as_ptr() as usize;
-                    let len = input_arg.len();
-
-                    let start = i32::try_from(start).unwrap();
-                    let len = i32::try_from(len).unwrap();
-
-                    let packet = CommandSuggestions {
-                        id,
-                        start,
-                        length: len,
-                        suggestions,
-                    };
-
-                    packet_switch_query
-                        .compose
-                        .unicast(
-                            Clientbound::new(PacketId::CommandSuggestions.to_raw(), &packet),
-                            packet_switch_query.io_ref,
-                        )
-                        .unwrap();
-
-                    // todo: send possible matches to player
-                    return;
-                }
-
-                let Some(remaining_positional) = positionals.next() else {
-                    // we are all done completing
+                let (Ok(start), Ok(length)) = (i32::try_from(span.0), i32::try_from(span.1)) else {
+                    tracing::warn!("a command longer than 2GB is not worth completing");
                     return;
                 };
-
-                let possible_values = remaining_positional.get_possible_values();
-
-                let names = possible_values
-                    .iter()
-                    .map(clap::builder::PossibleValue::get_name);
-
-                let suggestions = names
-                    .into_iter()
-                    .map(|name| command_suggestions::Entry {
-                        text: name,
-                        tooltip: None,
-                    })
-                    .collect();
-
-                let start = full_query.len();
-                let start = i32::try_from(start).unwrap();
 
                 let packet = CommandSuggestions {
-                    id,
+                    id: completion.id,
                     start,
-                    length: 0,
-                    suggestions,
+                    length,
+                    suggestions: matched
+                        .iter()
+                        .map(|text| command_suggestions::Entry {
+                            text,
+                            tooltip: None,
+                        })
+                        .collect(),
                 };
 
-                packet_switch_query
-                    .compose
-                    .unicast(
-                        Clientbound::new(PacketId::CommandSuggestions.to_raw(), &packet),
-                        packet_switch_query.io_ref,
-                    )
-                    .unwrap();
+                if let Err(error) = packet_switch_query.compose.unicast(
+                    Clientbound::new(PacketId::CommandSuggestions.to_raw(), &packet),
+                    packet_switch_query.io_ref,
+                ) {
+                    tracing::warn!("dropping a command suggestion response: {error}");
+                }
             },
         );
 
@@ -234,6 +374,8 @@ pub trait MinecraftCommand: Parser + CommandPermission {
         tracing::info!("registering command {name}");
 
         registry.register(name, handler);
+
+        Registered { world, values }
     }
 }
 
@@ -358,7 +500,11 @@ impl Module for ClapCommandModule {
         world.import::<hyperion_command::CommandModule>();
 
         world.get::<&mut CommandRegistry>(|registry| {
-            PermissionCommand::register(registry, world);
+            // Both spellings of the player argument, `set` and `get`, complete
+            // from whoever is connected. The group argument declares nothing:
+            // it is a clap `ValueEnum`, so registration already carried its
+            // four values into the graph.
+            PermissionCommand::register(registry, world).completes("player", Player::id());
         });
     }
 }

--- a/crates/hyperion/src/simulation/command.rs
+++ b/crates/hyperion/src/simulation/command.rs
@@ -23,7 +23,10 @@ use std::io::Write;
 
 use anyhow::Context as _;
 use flecs_ecs::{
-    core::{Entity, EntityViewGet, IdOperations, World},
+    core::{
+        Builder, Entity, EntityView, EntityViewGet, IdOperations, QueryAPI, QueryBuilderImpl,
+        QueryFlags, World,
+    },
     macros::Component,
 };
 use hyperion_minecraft_proto::{
@@ -70,6 +73,82 @@ pub(crate) static ROOT_COMMAND: once_cell::sync::OnceCell<Entity> =
 
 pub fn get_root_command_entity() -> Entity {
     *ROOT_COMMAND.get().unwrap()
+}
+
+/// Relation on a command argument node: `(Suggests, tag)` says the values a
+/// client may complete this argument to are the entities carrying `tag`.
+///
+/// A relation rather than a registry of strings because the candidates already
+/// exist as entities, and a second copy of them is a second thing to keep in
+/// step. `/kit` suggests whatever carries smash's `Kit` tag at the moment the
+/// player presses tab, so a kit added, renamed or removed changes what the
+/// client offers with nothing else edited.
+#[derive(Component)]
+pub struct Suggests;
+
+/// On a tag entity that is the target of [`Suggests`]: how to render one of the
+/// entities carrying it as the text a client completes to. Returning `None`
+/// leaves that entity out.
+///
+/// It sits on the tag rather than on the argument node because it describes the
+/// thing being suggested, not the argument doing the suggesting. Every argument
+/// that suggests kits renders a kit the same way, and only the kit module knows
+/// that a kit's name is in its `KitName`.
+#[derive(Component)]
+pub struct SuggestionLabel(pub fn(EntityView<'_>) -> Option<String>);
+
+/// Completions an argument's own type already knows.
+///
+/// `hyperion-clap` fills this in from a clap `ValueEnum`'s possible values, so
+/// an argument whose type enumerates itself completes without anything being
+/// declared anywhere. A node carrying this ignores [`Suggests`].
+#[derive(Component)]
+pub struct FixedSuggestions(pub Vec<String>);
+
+/// Every value `node` may be completed to right now.
+///
+/// Answers from [`FixedSuggestions`] when the argument's type knows its own
+/// values, and otherwise follows every `(Suggests, tag)` edge and asks each
+/// entity carrying `tag` for its [`SuggestionLabel`]. A node with neither has
+/// no completions, which is the right answer for a free-form argument such as
+/// a chat message.
+///
+/// The query matches prefabs and disabled entities, because a completion source
+/// is game state in whatever form the module that owns it chose: smash's kits
+/// are prefabs, and flecs leaves prefabs out of a query unless asked.
+#[must_use]
+pub fn suggestions(world: &World, node: Entity) -> Vec<String> {
+    let view = world.entity_from_id(node);
+
+    if let Some(fixed) = view.try_get::<&FixedSuggestions>(|fixed| fixed.0.clone()) {
+        return fixed;
+    }
+
+    let mut tags = Vec::new();
+    view.each_target(Suggests, |tag| tags.push(tag.id()));
+
+    let mut out = Vec::new();
+    for tag in tags {
+        let Some(label) = world
+            .entity_from_id(tag)
+            .try_get::<&SuggestionLabel>(|label| label.0)
+        else {
+            warn!("a command argument suggests {tag}, which carries no SuggestionLabel");
+            continue;
+        };
+
+        world
+            .query::<()>()
+            .with(tag)
+            .query_flags(QueryFlags::MatchPrefab | QueryFlags::MatchDisabled)
+            .build()
+            .each_entity(|entity, ()| {
+                if let Some(text) = label(entity) {
+                    out.push(text);
+                }
+            });
+    }
+    out
 }
 
 impl Command {
@@ -349,9 +428,127 @@ pub fn get_command_packet(world: &World, root: Entity, player_opt: Option<Entity
 
 #[cfg(test)]
 mod tests {
+    use flecs_ecs::core::ComponentId;
     use hyperion_minecraft_proto::{Decode, Reader};
 
     use super::*;
+
+    /// Stands in for smash's `Kit`: a tag whose bearers are what an argument
+    /// completes to.
+    #[derive(Component)]
+    struct Choice;
+
+    /// Stands in for `KitName`.
+    #[derive(Component)]
+    struct Label(&'static str);
+
+    /// A world with the completion vocabulary registered, a `Choice` tag that
+    /// knows how to render itself, and one argument node pointed at it.
+    fn completion_world() -> (World, Entity) {
+        let world = World::new();
+        world.component::<Command>();
+        world.component::<Suggests>();
+        world.component::<SuggestionLabel>();
+        world.component::<FixedSuggestions>();
+        world.component::<Label>();
+        world.component::<Choice>().set(SuggestionLabel(|entity| {
+            entity.try_get::<&Label>(|label| label.0.to_owned())
+        }));
+
+        let node = world.entity().set(Command::argument(
+            "choice",
+            Parser::String(StringArg::GreedyPhrase),
+        ));
+        node.add((Suggests, Choice::id()));
+
+        let id = node.id();
+        (world, id)
+    }
+
+    #[test]
+    fn an_argument_with_no_source_offers_nothing() {
+        let world = World::new();
+        world.component::<Command>();
+        world.component::<Suggests>();
+        world.component::<SuggestionLabel>();
+        world.component::<FixedSuggestions>();
+
+        let node = world.entity().set(Command::argument(
+            "message",
+            Parser::String(StringArg::GreedyPhrase),
+        ));
+
+        assert!(suggestions(&world, node.id()).is_empty());
+    }
+
+    #[test]
+    fn suggestions_are_whatever_carries_the_tag_right_now() {
+        let (world, node) = completion_world();
+
+        // Prefabs, which is the shape smash's kits take, and which flecs leaves
+        // out of a query unless it is asked for them.
+        world
+            .prefab_named("golem")
+            .add(Choice::id())
+            .set(Label("Iron Golem"));
+        let skeleton = world
+            .prefab_named("skeleton")
+            .add(Choice::id())
+            .set(Label("Skeleton"));
+
+        let mut offered = suggestions(&world, node);
+        offered.sort();
+        assert_eq!(offered, vec![
+            "Iron Golem".to_owned(),
+            "Skeleton".to_owned()
+        ]);
+
+        // The point of the relation: the completions follow the world rather
+        // than a list somebody has to remember to edit.
+        skeleton.destruct();
+        assert_eq!(suggestions(&world, node), vec!["Iron Golem".to_owned()]);
+
+        world
+            .prefab_named("wolf")
+            .add(Choice::id())
+            .set(Label("Wolf"));
+        let mut offered = suggestions(&world, node);
+        offered.sort();
+        assert_eq!(offered, vec!["Iron Golem".to_owned(), "Wolf".to_owned()]);
+    }
+
+    #[test]
+    fn a_bearer_with_no_label_is_left_out_rather_than_offered_blank() {
+        let (world, node) = completion_world();
+
+        world.entity().add(Choice::id()).set(Label("Named"));
+        world.entity().add(Choice::id());
+
+        assert_eq!(suggestions(&world, node), vec!["Named".to_owned()]);
+    }
+
+    #[test]
+    fn a_type_that_knows_its_own_values_answers_without_the_world() {
+        let (world, node) = completion_world();
+
+        world
+            .prefab_named("golem")
+            .add(Choice::id())
+            .set(Label("Iron Golem"));
+
+        // What `hyperion-clap` writes for a clap `ValueEnum`. It wins over the
+        // relation, because an argument whose type enumerates itself cannot
+        // accept anything else.
+        world.entity_from_id(node).set(FixedSuggestions(vec![
+            "survival".to_owned(),
+            "creative".to_owned(),
+        ]));
+
+        assert_eq!(suggestions(&world, node), vec![
+            "survival".to_owned(),
+            "creative".to_owned()
+        ]);
+    }
 
     /// The bytes a tree encodes to, id byte and all.
     fn encode(tree: &CommandTree) -> Vec<u8> {

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -741,6 +741,13 @@ impl Module for SimModule {
 
         world.component::<PlayerSkin>();
         world.component::<Command>();
+        // The completion vocabulary. `Suggests` is a relation, so it has to be
+        // a registered entity before an argument node can point at anything
+        // with it, and `flecs_manual_registration` means that will not happen
+        // on its own.
+        world.component::<command::Suggests>();
+        world.component::<command::SuggestionLabel>();
+        world.component::<command::FixedSuggestions>();
 
         component!(world, IgnMap);
 
@@ -748,6 +755,17 @@ impl Module for SimModule {
 
         world.component::<Name>();
         component!(world, Name).opaque_func(meta_ser_stringify_type_display::<Name>);
+
+        // A command argument declared with `.completes("player", Player::id())`
+        // offers whoever is connected at the moment the player presses tab.
+        // Here rather than in a game module because both halves are hyperion's:
+        // it owns `Player` and it owns the `Name` that login puts on one, so
+        // every event wants the same answer and none of them should restate it.
+        world
+            .component::<Player>()
+            .set(command::SuggestionLabel(|player| {
+                player.try_get::<&Name>(std::string::ToString::to_string)
+            }));
 
         world.component::<AiTargetable>();
         world.component::<ImmuneStatus>().meta();

--- a/events/smash/src/command.rs
+++ b/events/smash/src/command.rs
@@ -6,18 +6,25 @@
 use std::fmt::Write;
 
 use clap::Parser;
-use flecs_ecs::core::{Entity, EntityView, EntityViewGet, World, WorldGet, WorldProvider};
+use flecs_ecs::core::{
+    ComponentId, Entity, EntityView, EntityViewGet, World, WorldGet, WorldProvider,
+};
 use hyperion::net::{Compose, ConnectionId, agnostic};
 use hyperion_clap::{CommandPermission, MinecraftCommand, hyperion_command::CommandRegistry};
 
 use crate::module::{
     ability,
-    kit::{self, KitBlurb, KitName},
+    kit::{self, Kit, KitBlurb, KitName},
     lobby,
 };
 
 pub fn register(registry: &mut CommandRegistry, world: &World) {
-    KitCommand::register(registry, world);
+    // The kit names a client offers on tab are a query over the kit prefabs,
+    // taken when the player presses tab. Adding a kit changes what `/kit `
+    // completes to and there is no list here to update, which is the same claim
+    // the rest of this crate makes about kits and the same way it is kept
+    // honest: `tests/modularity.rs` adds one from outside the crate.
+    KitCommand::register(registry, world).completes("name", Kit::id());
     KitsCommand::register(registry, world);
     AbilitiesCommand::register(registry, world);
     CrystalCommand::register(registry, world);

--- a/events/smash/src/module/kit.rs
+++ b/events/smash/src/module/kit.rs
@@ -10,6 +10,7 @@
 //! test in `tests/modularity.rs` adds a kit from outside the crate to prove it.
 
 use flecs_ecs::prelude::*;
+use hyperion::simulation::command::SuggestionLabel;
 
 use crate::{
     flecs_ext::EntityViewExt,
@@ -429,7 +430,19 @@ impl Module for KitModule {
     fn module(world: &World) {
         world.module::<Self>("smash::Kit");
 
-        world.component::<Kit>();
+        // A `/kit` completion is a query over whatever carries this tag, and
+        // this is the one place that says what a kit's name is. Nothing else
+        // in the completion path knows a kit from a map or an ability.
+        //
+        // `SuggestionLabel` is registered here as well as by `HyperionCore`,
+        // the same way this crate registers hyperion's `Position` and `Health`:
+        // `tests/contract.rs` runs each module in a world holding only what
+        // that module declares, so a component reached for and never registered
+        // aborts there rather than on a server.
+        world.component::<SuggestionLabel>();
+        world.component::<Kit>().set(SuggestionLabel(|kit| {
+            kit.try_get::<&KitName>(|name| name.0.to_owned())
+        }));
         world.component::<KitStats>();
         world.component::<KitName>();
         world.component::<KitCost>();

--- a/flake.nix
+++ b/flake.nix
@@ -569,6 +569,25 @@
               '';
             };
 
+            # The same gate again, driving a client that types rather than
+            # walks.
+            #
+            # `smash-e2e` and `smash-map-e2e` both prove things about a world.
+            # This one never leaves the hub: it reads the command graph the
+            # server sends on join and then presses tab, which is the whole of
+            # the completion path and touches nothing else. Its ports default
+            # off `smash-map-e2e`'s so all four gates can run at once.
+            completions-e2e = {
+              deps = [ pkgs.git ];
+              text = ''
+                export HYPERION_EVENT=smash
+                export HYPERION_E2E_CLIENT=tools/completions-check.py
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + 4000)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + 4000)}}"
+                exec "${lib.getExe runners.e2e}" "$@"
+              '';
+            };
+
             # `nix run .#dev` runs bedwars; this runs the same stack on smash.
             smash-dev = {
               deps = [ pkgs.process-compose pkgs.git ];
@@ -721,10 +740,23 @@
               timeout = 480;
             };
 
+            # Whether a player who types a slash sees anything. Two protocol
+            # mechanisms answer that, the command graph and the suggestion
+            # request, and neither is visible to a Rust test: the graph is a
+            # packet nobody sends unless a client joins, and a suggestion is a
+            # reply to a packet only a client sends.
+            completions-e2e = e2e.mkCheck {
+              name = "hyperion-completions-e2e";
+              gameServer = gameBinaries.smash;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "completions-check.py";
+            };
+
             # `checks.e2e` above took the names the two app wrappers used to
             # hold, and those wrappers still have to pass shellcheck.
             e2e-app = scripts.e2e;
             smash-e2e-app = scripts.smash-e2e;
+            completions-e2e-app = scripts.completions-e2e;
 
             # The pinned world URL still has to be the one the server asks for.
             genmap-url-pinned = e2e.genMapUrlPinned;

--- a/tools/completions-check.py
+++ b/tools/completions-check.py
@@ -1,0 +1,653 @@
+#!/usr/bin/env python3
+"""Prove tab completion works, on the wire, against a running smash server.
+
+A player who types a slash and sees nothing cannot tell which of two mechanisms
+failed, and neither can a unit test. Both are checked here, in the order a
+client meets them.
+
+  * **the command graph** (`ClientboundCommandsPacket`) is what makes a slash
+    list the server's commands at all, and what tells the client that an
+    argument exists and how to parse it. It is also what marks an argument
+    `minecraft:ask_server`, which is the only reason a vanilla client ever
+    sends a suggestion request. One packet carries all of that and one thing
+    sends it, an `OnSet Group` observer in `hyperion-permission` that fires
+    when the player enters play. That is a load-bearing accident: a command
+    graph is not a permissions concern, the observer's own comment argues only
+    about when it is safe to send, and nothing but this gate notices if it
+    stops firing. Claim one below is that guard.
+  * **command suggestions** (`ServerboundCommandSuggestionPacket` and its
+    reply) is what fills the popup once it does ask. This is the half that was
+    broken: the old handler could only answer from a clap `ValueEnum`, so
+    `/kit `, whose argument is a `Vec<String>`, matched nothing and sent no
+    reply at all.
+
+The assertions worth having are the ones with two independent sources. What
+`/kit ` offers is compared against what `/kits` prints, so neither side is a
+constant in this file: both are the live kit roster, reached by two different
+paths through the server. What `/perms set <player> ` offers is compared
+against the values clap names in its own parse error, which is the same clap
+definition the graph was derived from, read back out through the chat channel
+rather than the completion one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import pathlib
+import re
+import struct
+import sys
+import time
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+ROOT = TOOLS.parent
+REGISTRY_SOURCE = ROOT / "crates/hyperion-minecraft-proto/src/generated/registry.rs"
+
+
+def _load_client():
+    """Import `client-26.2.py`, whose file name is not a Python identifier."""
+    path = TOOLS / "client-26.2.py"
+    spec = importlib.util.spec_from_file_location("client_26_2", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+base = _load_client()
+var_int = base.var_int
+take_var_int = base.take_var_int
+mc_string = base.mc_string
+take_string = base.take_string
+
+# Serverbound play ids, from
+# crates/hyperion-minecraft-proto/src/generated/packet_id.rs.
+C2S_ACCEPT_TELEPORTATION = 0x00
+C2S_CHAT_COMMAND = 0x07
+C2S_COMMAND_SUGGESTION = 0x0F
+C2S_KEEP_ALIVE = 0x1C
+
+# Clientbound play ids this file decodes.
+S2C_COMMAND_SUGGESTIONS = 0x0F
+S2C_COMMANDS = 0x10
+S2C_DISCONNECT = 0x20
+S2C_KEEP_ALIVE = 0x2C
+S2C_LOGIN = 0x31
+S2C_PLAYER_POSITION = 0x48
+S2C_SYSTEM_CHAT = 0x79
+
+# `ClientboundCommandsPacket.NodeStub`, from
+# crates/hyperion-minecraft-proto/src/packets/play/player.rs.
+MASK_TYPE = 3
+FLAG_REDIRECT = 8
+FLAG_CUSTOM_SUGGESTIONS = 16
+
+# The provider that makes a client ask the server rather than answer from the
+# graph. Every hyperion argument is server state, so every one uses it.
+ASK_SERVER = "minecraft:ask_server"
+
+# `brigadier:string`'s one property, `StringArgumentKind`.
+STRING_KINDS = {0: "single_word", 1: "quotable_phrase", 2: "greedy_phrase"}
+
+# Minecraft's section-sign colour codes, which a client strips before display.
+COLOUR = re.compile("§.")
+
+# `KitsCommand` writes each kit as its name in yellow and then its blurb in
+# grey, so the colour change is where the name ends. Matched on the raw line
+# rather than the stripped one because the separator between them is the only
+# thing that says which is which.
+KIT_LINE = re.compile("§e(.+?)§7")
+
+# clap's own account of what an argument accepts, from the error it raises when
+# handed something else.
+POSSIBLE_VALUES = re.compile(r"\[possible values: ([^\]]*)\]")
+
+
+# --- the command graph, decoded ---------------------------------------------
+
+
+def argument_type_names():
+    """`minecraft:command_argument_type`, in network id order.
+
+    Read out of the generated registry table rather than listed here, because
+    the ids are positions in that table and a protocol bump moves them. A
+    parser named wrongly would let a wrong-parser bug pass.
+    """
+    text = REGISTRY_SOURCE.read_text()
+    start = text.find("pub static COMMAND_ARGUMENT_TYPE: Registry = Registry {")
+    if start < 0:
+        raise SystemExit("no COMMAND_ARGUMENT_TYPE in %s" % REGISTRY_SOURCE)
+    # From `entries`, not from the declaration: the registry's own name sits
+    # above it and looks exactly like an entry, which shifts every id by one
+    # and turns `brigadier:string` into `brigadier:long`. That reads a
+    # properties byte that is not there and desynchronises the whole tree.
+    start = text.index("entries: &[", start)
+    end = text.index("};", start)
+    names = re.findall(r'"([a-z0-9_.]+:[a-z0-9_./]+)"', text[start:end])
+    if "brigadier:string" not in names:
+        raise SystemExit(
+            "COMMAND_ARGUMENT_TYPE in %s has %d entries and no brigadier:string, "
+            "so this read the table wrong" % (REGISTRY_SOURCE, len(names))
+        )
+    return names
+
+
+def take_argument_type(payload, offset, names):
+    """An argument type id and whatever properties it carries.
+
+    The thirteen types that carry properties are spelled out because skipping
+    them wrongly does not fail here: it reads the next node's fields as this
+    one's and produces a plausible tree that is not the one the server sent.
+    """
+    raw, offset = take_var_int(payload, offset)
+    if raw >= len(names):
+        raise SystemExit("argument type id %d is not in this protocol version" % raw)
+    name = names[raw]
+
+    if name == "brigadier:string":
+        kind, offset = take_var_int(payload, offset)
+        return "%s/%s" % (name, STRING_KINDS.get(kind, kind)), offset
+    if name in ("brigadier:float", "brigadier:double"):
+        flags = payload[offset]
+        offset += 1
+        width = 4 if name.endswith("float") else 8
+        return name, offset + width * (bool(flags & 1) + bool(flags & 2))
+    if name in ("brigadier:integer", "brigadier:long"):
+        flags = payload[offset]
+        offset += 1
+        width = 4 if name.endswith("integer") else 8
+        return name, offset + width * (bool(flags & 1) + bool(flags & 2))
+    if name in ("minecraft:entity", "minecraft:score_holder"):
+        return name, offset + 1
+    if name == "minecraft:time":
+        return name, offset + 4
+    if name in (
+        "minecraft:resource_or_tag",
+        "minecraft:resource_or_tag_key",
+        "minecraft:resource",
+        "minecraft:resource_key",
+        "minecraft:resource_selector",
+    ):
+        _registry, offset = take_string(payload, offset)
+        return name, offset
+    # The other forty-four are a `SingletonArgumentInfo` and write nothing.
+    return name, offset
+
+
+class Node:
+    def __init__(self, kind, name, parser, suggests, children):
+        self.kind = kind
+        self.name = name
+        self.parser = parser
+        self.suggests = suggests
+        self.children = children
+
+
+def decode_commands(payload, names):
+    """`ClientboundCommandsPacket` into nodes, root first."""
+    count, offset = take_var_int(payload)
+    nodes = []
+    for _ in range(count):
+        flags = payload[offset]
+        offset += 1
+        child_count, offset = take_var_int(payload, offset)
+        children = []
+        for _ in range(child_count):
+            child, offset = take_var_int(payload, offset)
+            children.append(child)
+        if flags & FLAG_REDIRECT:
+            _redirect, offset = take_var_int(payload, offset)
+        kind = flags & MASK_TYPE
+        name = None
+        parser = None
+        suggests = None
+        if kind == 1:
+            name, offset = take_string(payload, offset)
+        elif kind == 2:
+            name, offset = take_string(payload, offset)
+            parser, offset = take_argument_type(payload, offset, names)
+            if flags & FLAG_CUSTOM_SUGGESTIONS:
+                suggests, offset = take_string(payload, offset)
+        nodes.append(Node(kind, name, parser, suggests, children))
+
+    root, offset = take_var_int(payload, offset)
+    if offset != len(payload):
+        raise SystemExit(
+            "Commands has %d trailing byte(s), so this decoded it wrong and "
+            "every claim below would be about a tree nobody sent"
+            % (len(payload) - offset)
+        )
+    if root != 0 or not nodes or nodes[root].kind != 0:
+        raise SystemExit("Commands root index %d is not a root node" % root)
+    for index, node in enumerate(nodes):
+        for child in node.children:
+            if not 0 <= child < len(nodes):
+                raise SystemExit(
+                    "node %d points at %d, which is not a node" % (index, child)
+                )
+    return nodes
+
+
+def path_of(nodes, words):
+    """Follow literal names from the root and return the node they reach."""
+    at = 0
+    for word in words:
+        for child in nodes[at].children:
+            if nodes[child].kind == 1 and nodes[child].name == word:
+                at = child
+                break
+        else:
+            return None
+    return nodes[at]
+
+
+def arguments_under(nodes, node):
+    """The argument nodes directly under `node`."""
+    return [nodes[child] for child in node.children if nodes[child].kind == 2]
+
+
+# --- the client -------------------------------------------------------------
+
+
+def strip_colour(text):
+    return COLOUR.sub("", text)
+
+
+def take_nbt_string(payload, offset):
+    """A network-NBT tag that is a bare string, which is every line here.
+
+    `Component::text(..).to_tag()` collapses a component with no style and no
+    children to `Tag::String`, so a full NBT reader would be dead weight.
+    """
+    kind = payload[offset]
+    offset += 1
+    if kind != 0x08:
+        raise SystemExit("chat carried NBT tag type 0x%02X, not a string" % kind)
+    (length,) = struct.unpack(">H", payload[offset : offset + 2])
+    offset += 2
+    return payload[offset : offset + length].decode("utf-8", "replace"), offset + length
+
+
+class Suggestion:
+    """One `ClientboundCommandSuggestionsPacket`."""
+
+    def __init__(self, start, length, entries):
+        self.start = start
+        self.length = length
+        self.entries = entries
+
+    def replaced(self, text):
+        """The span of `text` a client overwrites when one is accepted."""
+        return text[self.start : self.start + self.length]
+
+
+class CompletionClient(base.Client):
+    """One scripted player that asks for completions and reads the answers."""
+
+    def __init__(self, host, port, name, started):
+        super().__init__(host, port, name, lambda line: None)
+        self.started = started
+        self.log = self._log
+        self.arg_types = argument_type_names()
+        self.graph = None
+        # Raw, colour codes and all: the codes are what say where a kit's name
+        # ends and its blurb begins.
+        self.chat = []
+        self.answers = {}
+        self.next_id = 1
+
+    def _log(self, line):
+        print(
+            "[%6.1fs] [%s] %s" % (time.time() - self.started, self.name, line),
+            flush=True,
+        )
+
+    # --- acting ---
+
+    def run_command(self, text):
+        self.log("-> /%s" % text)
+        self.send(C2S_CHAT_COMMAND, mc_string(text))
+
+    def ask(self, text):
+        """Send a suggestion request and return the id its reply will carry."""
+        identifier = self.next_id
+        self.next_id += 1
+        self.send(C2S_COMMAND_SUGGESTION, var_int(identifier) + mc_string(text))
+        self.log("-> CommandSuggestion id=%d %r" % (identifier, text))
+        return identifier
+
+    # --- reading ---
+
+    def pump(self, until, seconds, what):
+        """Read packets until `until()` holds, or fail saying what was awaited."""
+        deadline = time.time() + seconds
+        while not until():
+            if time.time() >= deadline:
+                raise SystemExit("timed out after %.0fs waiting for %s" % (seconds, what))
+            packet_id, payload = self.recv()
+            self.handle(packet_id, payload)
+
+    def handle(self, packet_id, payload):
+        if packet_id == S2C_COMMANDS:
+            try:
+                self.graph = decode_commands(payload, self.arg_types)
+            except Exception:
+                self.log("Commands payload: %s" % payload.hex())
+                raise
+            self.log(
+                "<- Commands %d nodes, %d commands at the root"
+                % (len(self.graph), len(self.graph[0].children))
+            )
+        elif packet_id == S2C_COMMAND_SUGGESTIONS:
+            self.answers.update([self.decode_suggestions(payload)])
+        elif packet_id == S2C_SYSTEM_CHAT:
+            text, _ = take_nbt_string(payload, 0)
+            self.chat.extend(text.split("\n"))
+            self.log("<- chat: %s" % strip_colour(text).replace("\n", " | ")[:200])
+        elif packet_id == S2C_PLAYER_POSITION:
+            teleport_id, _ = take_var_int(payload)
+            self.send(C2S_ACCEPT_TELEPORTATION, var_int(teleport_id))
+        elif packet_id == S2C_KEEP_ALIVE:
+            self.send(C2S_KEEP_ALIVE, payload[:8])
+        elif packet_id == S2C_LOGIN:
+            self.entity_id = struct.unpack(">i", payload[:4])[0]
+            self.joined = True
+            self.log("** in the world ** entity_id=%d" % self.entity_id)
+        elif packet_id == S2C_DISCONNECT:
+            raise SystemExit("disconnected: %s" % payload[:120].hex())
+
+    def decode_suggestions(self, payload):
+        identifier, offset = take_var_int(payload)
+        start, offset = take_var_int(payload, offset)
+        length, offset = take_var_int(payload, offset)
+        count, offset = take_var_int(payload, offset)
+        entries = []
+        for _ in range(count):
+            text, offset = take_string(payload, offset)
+            has_tooltip = payload[offset]
+            offset += 1
+            if has_tooltip:
+                _tooltip, offset = take_nbt_string(payload, offset)
+            entries.append(text)
+        if offset != len(payload):
+            raise SystemExit(
+                "CommandSuggestions has %d trailing byte(s)" % (len(payload) - offset)
+            )
+        self.log(
+            "<- CommandSuggestions id=%d start=%d length=%d %s"
+            % (identifier, start, length, entries)
+        )
+        return identifier, Suggestion(start, length, entries)
+
+    def suggestions_for(self, text, seconds=20.0):
+        """Ask, wait for the reply, and hand back the whole response."""
+        identifier = self.ask(text)
+        self.pump(
+            lambda: identifier in self.answers,
+            seconds,
+            "a suggestion response for %r" % text,
+        )
+        return self.answers[identifier]
+
+    def chat_after(self, command, until, seconds=20.0):
+        """Run a command and read chat until `until(new_lines)` is satisfied."""
+        mark = len(self.chat)
+        self.run_command(command)
+        self.pump(lambda: until(self.chat[mark:]), seconds, "the reply to /%s" % command)
+        return self.chat[mark:]
+
+
+# --- the claims -------------------------------------------------------------
+
+
+class Check:
+    """The claims this run makes, and the evidence for each."""
+
+    ORDER = [
+        "a joining player is sent the command graph",
+        "an argument tells the client to ask the server",
+        "tab on /kit offers the live kit roster",
+        "a typed prefix narrows the offer and names the span it replaces",
+        "a kit name with a space is completed as one value",
+        "an argument whose clap type enumerates itself needs no declaration",
+        "a player argument offers whoever is connected",
+    ]
+
+    def __init__(self, started):
+        self.started = started
+        self.proof = {claim: None for claim in self.ORDER}
+
+    def log(self, line):
+        print("[%6.1fs] %s" % (time.time() - self.started, line), flush=True)
+
+    def prove(self, claim, evidence):
+        self.proof[claim] = evidence
+        self.log("PROVED %s: %s" % (claim, evidence))
+
+    def report(self):
+        print("")
+        print("=" * 78)
+        unproved = [claim for claim, evidence in self.proof.items() if evidence is None]
+        for claim in self.ORDER:
+            evidence = self.proof[claim]
+            print("  %-4s %s" % ("ok" if evidence else "MISS", claim))
+            if evidence:
+                print("       %s" % evidence)
+        print("=" * 78)
+        if unproved:
+            print(
+                "RESULT: %d claim(s) unproved: %s" % (len(unproved), "; ".join(unproved))
+            )
+            return 1
+        print("RESULT: every completion claim held")
+        return 0
+
+
+def kits_from_listing(lines):
+    """The kit roster as `/kits` prints it.
+
+    `KitsCommand` walks the same prefabs `/kit ` completes from, but reaches
+    them through `kit::registry` rather than through the `(Suggests, Kit)`
+    relation, so the two agreeing is two paths agreeing rather than one path
+    asked twice.
+    """
+    return [match.group(1) for line in lines for match in [KIT_LINE.search(line)] if match]
+
+
+def run(args):
+    started = time.time()
+    check = Check(started)
+
+    client = CompletionClient(args.host, args.port, args.name, started)
+    client.handshake(args.host, args.port, 2)
+    client.login()
+    client.configuration()
+    client.log("configuration acknowledged")
+
+    # 1. The graph arrives without anybody asking for it.
+    client.pump(
+        lambda: client.graph is not None and client.joined,
+        args.timeout,
+        "the command graph and the Login packet",
+    )
+    graph = client.graph
+    literals = sorted(
+        graph[child].name for child in graph[0].children if graph[child].kind == 1
+    )
+    for wanted in ("kit", "kits", "perms"):
+        if wanted not in literals:
+            raise SystemExit(
+                "the command graph has no /%s, only %s. A client that never "
+                "receives a command cannot complete it." % (wanted, literals)
+            )
+    check.prove(
+        "a joining player is sent the command graph",
+        "%d nodes arrived unasked for, listing %d commands at the root: %s"
+        % (len(graph), len(literals), ", ".join(literals)),
+    )
+
+    # 2. And its arguments are marked ask_server, which is the only reason a
+    #    vanilla client ever sends a suggestion request at all.
+    kit_args = arguments_under(graph, path_of(graph, ["kit"]))
+    if len(kit_args) != 1:
+        raise SystemExit("/kit has %d argument nodes, expected one" % len(kit_args))
+    name_arg = kit_args[0]
+    if name_arg.parser != "brigadier:string/greedy_phrase":
+        raise SystemExit(
+            "/kit <%s> is %s. A kit name with a space in it needs a greedy "
+            "string, or the client sends two arguments" % (name_arg.name, name_arg.parser)
+        )
+    if name_arg.suggests != ASK_SERVER:
+        raise SystemExit(
+            "/kit <%s> names suggestion provider %r, so a vanilla client would "
+            "answer out of the graph and never ask" % (name_arg.name, name_arg.suggests)
+        )
+
+    set_node = path_of(graph, ["perms", "set"])
+    if set_node is None:
+        raise SystemExit("the graph has no /perms set, only %s" % literals)
+    set_args = arguments_under(graph, set_node)
+    if len(set_args) != 1 or set_args[0].suggests != ASK_SERVER:
+        raise SystemExit("/perms set does not lead to one ask_server argument")
+    check.prove(
+        "an argument tells the client to ask the server",
+        "/kit <%s> is %s with provider %s, and /perms set <%s> is %s with the "
+        "same provider"
+        % (
+            name_arg.name,
+            name_arg.parser,
+            name_arg.suggests,
+            set_args[0].name,
+            set_args[0].parser,
+        ),
+    )
+
+    # 3. What tab offers, against what the game says its kits are.
+    listing = client.chat_after("kits", lambda lines: len(kits_from_listing(lines)) > 1)
+    roster = kits_from_listing(listing)
+
+    offered = client.suggestions_for("/kit ")
+    if sorted(offered.entries) != sorted(roster):
+        raise SystemExit(
+            "tab on '/kit ' offered %r but /kits lists %r. The completions and "
+            "the game disagree about what a kit is."
+            % (sorted(offered.entries), sorted(roster))
+        )
+    if offered.start != len("/kit ") or offered.length != 0:
+        raise SystemExit(
+            "'/kit ' would replace %r, which is not the empty span after the space"
+            % offered.replaced("/kit ")
+        )
+    check.prove(
+        "tab on /kit offers the live kit roster",
+        "the %d names tab offers are exactly the %d /kits prints (%s), reached "
+        "through the (Suggests, Kit) relation rather than a second list"
+        % (len(offered.entries), len(roster), ", ".join(sorted(roster))),
+    )
+
+    # 4. A prefix narrows it, and the span the client replaces is the prefix.
+    subject = sorted(roster)[0]
+    typed = "/kit " + subject[:2]
+    narrowed = client.suggestions_for(typed)
+    expected = sorted(k for k in roster if k.lower().startswith(subject[:2].lower()))
+    if sorted(narrowed.entries) != expected:
+        raise SystemExit(
+            "tab on %r offered %r, expected %r"
+            % (typed, sorted(narrowed.entries), expected)
+        )
+    if narrowed.replaced(typed) != subject[:2]:
+        raise SystemExit(
+            "tab on %r would replace %r rather than the %r that was typed"
+            % (typed, narrowed.replaced(typed), subject[:2])
+        )
+    check.prove(
+        "a typed prefix narrows the offer and names the span it replaces",
+        "%r offered %s and marked %r for replacement, so accepting one leaves "
+        "the line well formed" % (typed, expected, narrowed.replaced(typed)),
+    )
+
+    # 5. The greedy argument. Half the roster has a space in its name, and a
+    #    client that replaces only the last word turns a half-typed "Iron Gol"
+    #    into "Iron Iron Golem".
+    spaced = next((kit for kit in sorted(roster) if " " in kit), None)
+    if spaced is None:
+        raise SystemExit("no kit has a space in its name, so nothing tests greediness")
+    head, tail = spaced.split(" ", 1)
+    typed = "/kit %s %s" % (head, tail[:2])
+    greedy = client.suggestions_for(typed)
+    if spaced not in greedy.entries:
+        raise SystemExit(
+            "tab on %r offered %r, which does not include %r"
+            % (typed, greedy.entries, spaced)
+        )
+    if greedy.replaced(typed) != "%s %s" % (head, tail[:2]):
+        raise SystemExit(
+            "tab on %r would replace %r rather than the whole half-typed name, "
+            "so accepting it would duplicate the first word"
+            % (typed, greedy.replaced(typed))
+        )
+    check.prove(
+        "a kit name with a space is completed as one value",
+        "%r offered %r and marked %r for replacement, both words of it"
+        % (typed, spaced, greedy.replaced(typed)),
+    )
+
+    # 6. The `ValueEnum` path, checked against clap's own account of what the
+    #    argument accepts. Nothing in the server declares this one's values.
+    refusal = client.chat_after(
+        "perms set %s definitely-not-a-group" % args.name,
+        lambda lines: any(POSSIBLE_VALUES.search(strip_colour(line)) for line in lines),
+    )
+    listed = [
+        POSSIBLE_VALUES.search(strip_colour(line)).group(1)
+        for line in refusal
+        if POSSIBLE_VALUES.search(strip_colour(line))
+    ][0]
+    accepted = sorted(re.findall(r"[a-z][a-z0-9-]*", listed))
+
+    groups = client.suggestions_for("/perms set %s " % args.name)
+    if sorted(groups.entries) != accepted:
+        raise SystemExit(
+            "tab on '/perms set <player> ' offered %r but clap says the "
+            "argument accepts %r" % (sorted(groups.entries), accepted)
+        )
+    check.prove(
+        "an argument whose clap type enumerates itself needs no declaration",
+        "tab offered %s, exactly what clap says it accepts, and no line in the "
+        "server declares it: registration read the ValueEnum" % ", ".join(accepted),
+    )
+
+    # 7. The second live source: a different tag, owned by a different crate,
+    #    reached through the same relation.
+    #    Both spellings, because `set` and `get` are two nodes carrying the one
+    #    clap id `player`: a declaration that wired only the first would pass
+    #    on `set` and offer nothing on `get`.
+    for command in ("/perms set ", "/perms get "):
+        players = client.suggestions_for(command)
+        if players.entries != [args.name]:
+            raise SystemExit(
+                "tab on %r offered %r, but %s is the only player connected"
+                % (command, players.entries, args.name)
+            )
+    check.prove(
+        "a player argument offers whoever is connected",
+        "the one connected player, %s, is the one name offered under both "
+        "/perms set and /perms get, queried through (Suggests, Player) at the "
+        "moment tab was pressed" % args.name,
+    )
+
+    return check.report()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=25565)
+    parser.add_argument("--name", default="Completer")
+    parser.add_argument("--timeout", type=float, default=60.0)
+    args = parser.parse_args()
+    sys.exit(run(args))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A player on a real 26.2 client got no completion for `/kit`. Two protocol
mechanisms carry that experience and only one of them was broken, which is
worth stating plainly because the branch this continues assumed the other one.

## What was already wired, and what was not

**The command graph arrives, and always did.** `ClientboundCommandsPacket` is
what makes a slash list the server's commands and what marks an argument
`minecraft:ask_server`, the flag that is the only reason a vanilla client ever
asks for suggestions. It is sent by an `OnSet Group` observer in
`hyperion-permission` that fires when a joining player enters play.

The inherited work added a second copy from `join::enter_world`, on the
argument that the observer's `PacketState::Play` filter was never satisfied on
the way in. That was checked rather than believed: with the observer left alone
and the new send removed, the gate below still sees the graph arrive exactly
once. So the hunk was a duplicate packet justified by a false comment, and it
is not in this branch.

This is worth flagging even though nothing needs fixing: a command graph is not
a permissions concern, and the observer sends it as a side effect of a group
being set. Claim one of the new gate is the guard that notices if that ever
stops happening.

**The suggestion reply was the broken half.** The old `on_tab_complete` could
only answer out of a clap `PossibleValue`, so `/kit `, whose argument is a
`Vec<String>`, matched nothing and returned without sending a packet at all. It
also computed the replaced span with pointer arithmetic over
`split_whitespace`, which cannot express a value containing a space, and half
the kit roster has one.

## What a module writes now

An argument whose clap type enumerates itself needs no declaration:
registration carries a `ValueEnum`'s possible values into `FixedSuggestions`.
That is why `/perms set <player> ` offers banned, normal, moderator and admin
with nothing in the server naming them.

An argument completed from live game state names the flecs tag its candidates
carry:

```rust
KitCommand::register(registry, world).completes("name", Kit::id());
```

and the module owning that tag says once how to render one:

```rust
world.component::<Kit>()
    .set(SuggestionLabel(|kit| kit.try_get::<&KitName>(|name| name.0.to_owned())));
```

Nothing between those two lines is a list of kits. `(Suggests, tag)` is a
relation on the argument node, and answering a tab press is a query over
whatever carries that tag at that moment, so a kit added, renamed or removed
changes what the client offers with nothing else edited.

`completes` wires every node carrying that clap id rather than the first, which
is what makes `/perms set <player>` and `/perms get <player>` both work.
Naming an argument that does not exist panics at startup, because a completion
that silently never fires is the failure this whole thing exists to avoid.

`hyperion::simulation::Player` ships with its label already set, so an argument
naming a player is one line and no new vocabulary.

Every request is now answered, including with nothing. `ask_server` hands the
client's own suggestion machinery a future that only the reply completes, so
dropping a request stops the player seeing even the suggestions the client had
worked out for itself.

## Verified

`nix run .#completions-e2e` and `checks.completions-e2e` boot smash and drive
`tools/completions-check.py` through the real protocol. Two of its claims have
two independent sources: the names `/kit ` offers are compared against the ones
`/kits` prints, and the values `/perms set <player> ` offers are compared
against the ones clap names in its own parse error. Neither expectation is a
constant in the test file.

```
[   0.3s] [Completer] <- Commands 12 nodes, 5 commands at the root
[   0.4s] [Completer] <- CommandSuggestions id=1 start=5 length=0 ['Skeleton', 'Iron Golem', 'Spider', 'Slime', 'Enderman', 'Sky Squid', 'Creeper', 'Wolf', 'Snowman', 'Wither Skeleton', 'Zombie', 'Cow', 'Blaze', 'Chicken', 'Guardian']
[   0.4s] [Completer] <- CommandSuggestions id=2 start=5 length=2 ['Blaze']
[   0.5s] [Completer] <- CommandSuggestions id=3 start=5 length=7 ['Iron Golem']
[   0.6s] [Completer] <- CommandSuggestions id=4 start=21 length=0 ['banned', 'normal', 'moderator', 'admin']
[   0.7s] [Completer] <- CommandSuggestions id=5 start=11 length=0 ['Completer']

  ok   a joining player is sent the command graph
  ok   an argument tells the client to ask the server
  ok   tab on /kit offers the live kit roster
  ok   a typed prefix narrows the offer and names the span it replaces
  ok   a kit name with a space is completed as one value
  ok   an argument whose clap type enumerates itself needs no declaration
  ok   a player argument offers whoever is connected
RESULT: every completion claim held
```

`nix run .#lint` clean. `nix run .#test` 597 passed, 1 skipped.

`crates/hyperion-clap/src/completion.rs` holds the cursor arithmetic on its own,
with unit tests that need no world, a server or a socket, and
`crates/hyperion/src/simulation/command.rs` tests that suggestions follow the
world rather than a snapshot of it: a destroyed prefab stops being offered.

## What a reviewer should not assume

**The sandboxed `checks.completions-e2e` has not been built here**, only
evaluated. It is the same `mkCheck` shape as `smash-e2e`, which needs no
seeded world, and the app form of the same driver passes; CI builds the
derivation.

**No vanilla client has been driven through this.** Every assertion is the
scripted client reading real bytes, and the reasoning about what a vanilla
client does with an unanswered request is read off Mojang's own sources rather
than observed.

**One unrelated thing showed up in the logs and was left alone**: the proxy
logs `server sent BroadcastChannel for a channel that does not exist` on every
join, before `adding channel`. It predates this branch and is out of scope
here.

Written by Claude (Opus 4.5) driving the repository's own gates.
