### PR TITLE
feat(smash): give every hit and every ability a sound

### DIFF
--- a/crates/hyperion/src/net/agnostic.rs
+++ b/crates/hyperion/src/net/agnostic.rs
@@ -4,4 +4,4 @@ mod chat;
 pub use chat::{Chat, chat};
 
 mod sound;
-pub use sound::{Sound, SoundBuilder, sound};
+pub use sound::{RANGE_PER_VOLUME, Sound, SoundBuilder, SoundCategory, sound};

--- a/crates/hyperion/src/net/agnostic/sound.rs
+++ b/crates/hyperion/src/net/agnostic/sound.rs
@@ -1,6 +1,13 @@
+//! Positioned sound, as a packet any caller can send without naming one.
+//!
+//! The whole point of this module is that a game says *what* it wants heard,
+//! *where*, *how loud* and *under whose volume slider*, and never touches a
+//! packet id, a registry holder or a fixed point encoding. Everything below the
+//! [`SoundBuilder`] is that translation.
+
 use std::io::Write;
 
-use glam::Vec3;
+use glam::{I16Vec2, Vec3};
 use hyperion_minecraft_proto::{
     Holder,
     generated::packet_id::play::clientbound::PacketId,
@@ -8,7 +15,69 @@ use hyperion_minecraft_proto::{
     types::{SoundEventDirect, SoundSource},
 };
 
-use crate::{PacketBundle, net::protocol::Clientbound};
+use crate::{
+    PacketBundle,
+    net::{Compose, ConnectionId, protocol::Clientbound},
+};
+
+/// Which of the player's volume sliders governs a sound.
+///
+/// The client mixes every sound through the category the server names, so a
+/// player who has turned Hostile Creatures down hears a Wither Skull quieter
+/// and their own UI clicks unchanged. Sending everything as
+/// [`Self::Master`] takes that choice away from them, which is why this is a
+/// parameter rather than a constant.
+///
+/// Mirrors `net.minecraft.sounds.SoundSource`. It is restated here rather than
+/// re-exported so that a caller names a category and not a protocol type, which
+/// is the promise the rest of [`crate::net::agnostic`] makes.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+pub enum SoundCategory {
+    #[default]
+    Master,
+    Music,
+    Records,
+    Weather,
+    Blocks,
+    /// Monsters. A mob ability belongs here.
+    Hostile,
+    /// Passive and neutral mobs.
+    Neutral,
+    /// Other players, and the swing of a weapon connecting.
+    Players,
+    Ambient,
+    Voice,
+    /// Menus, buttons and anything that is feedback rather than a thing in the
+    /// world. A countdown tick is this.
+    Ui,
+}
+
+impl SoundCategory {
+    const fn to_source(self) -> SoundSource {
+        match self {
+            Self::Master => SoundSource::Master,
+            Self::Music => SoundSource::Music,
+            Self::Records => SoundSource::Records,
+            Self::Weather => SoundSource::Weather,
+            Self::Blocks => SoundSource::Blocks,
+            Self::Hostile => SoundSource::Hostile,
+            Self::Neutral => SoundSource::Neutral,
+            Self::Players => SoundSource::Players,
+            Self::Ambient => SoundSource::Ambient,
+            Self::Voice => SoundSource::Voice,
+            Self::Ui => SoundSource::Ui,
+        }
+    }
+}
+
+/// How far a sound at volume 1.0 carries, in blocks.
+///
+/// The client attenuates a sound linearly to nothing at `16 * volume` blocks
+/// from where the server put it, so volume is a range control as much as a
+/// loudness one and raising it above 1.0 is how a caller says "this should be
+/// heard across the arena". Who is *sent* the packet at all is a separate and
+/// coarser decision: see [`Sound::broadcast_near`].
+pub const RANGE_PER_VOLUME: f32 = 16.0;
 
 /// A positioned sound, ready to send to any number of players.
 #[must_use]
@@ -17,6 +86,7 @@ pub struct Sound {
     /// Position in eighths of a block, which is the fixed point
     /// `ClientboundSoundPacket` uses.
     position: glam::IVec3,
+    category: SoundCategory,
     volume: f32,
     pitch: f32,
     seed: i64,
@@ -27,18 +97,28 @@ pub struct SoundBuilder {
     position: Vec3,
     pitch: f32,
     volume: f32,
+    category: SoundCategory,
     seed: Option<i64>,
     sound: valence_ident::Ident,
 }
 
 impl SoundBuilder {
+    /// Playback speed, and with it the perceived size of whatever made the
+    /// noise. The client clamps this to `0.5..=2.0`.
     pub const fn pitch(mut self, pitch: f32) -> Self {
         self.pitch = pitch;
         self
     }
 
+    /// Loudness at the source, and the range: see [`RANGE_PER_VOLUME`].
     pub const fn volume(mut self, volume: f32) -> Self {
         self.volume = volume;
+        self
+    }
+
+    /// Which of the listener's volume sliders applies.
+    pub const fn category(mut self, category: SoundCategory) -> Self {
+        self.category = category;
         self
     }
 
@@ -53,6 +133,7 @@ impl SoundBuilder {
             // `ClientboundSoundPacket` writes `(int) (x * 8.0)`, so the client
             // resolves a sound to an eighth of a block and no finer.
             position: (self.position * 8.0).as_ivec3(),
+            category: self.category,
             volume: self.volume,
             pitch: self.pitch,
             // A seed the server does not choose is one the client cannot
@@ -60,6 +141,57 @@ impl SoundBuilder {
             // variant of a multi-sample sound.
             seed: self.seed.unwrap_or_else(|| fastrand::i64(..)),
         }
+    }
+}
+
+impl Sound {
+    /// Where it plays, back in blocks.
+    ///
+    /// Round-trips through the wire's fixed point, so this is what a client
+    /// will resolve the sound to rather than what the caller asked for.
+    #[must_use]
+    pub fn position(&self) -> Vec3 {
+        self.position.as_vec3() / 8.0
+    }
+
+    /// The chunk the proxy centres a local broadcast on.
+    fn chunk(&self) -> I16Vec2 {
+        // Eighths of a block to chunks: sixteen blocks of eight eighths each.
+        let chunk = self.position.div_euclid(glam::IVec3::splat(8 * 16));
+        I16Vec2::new(
+            i16::try_from(chunk.x).unwrap_or(0),
+            i16::try_from(chunk.z).unwrap_or(0),
+        )
+    }
+
+    /// Play it for everyone close enough to hear, attenuated by their distance
+    /// from its position.
+    ///
+    /// The attenuation is the client's: it is handed a point and works out how
+    /// loud that is from where the listener stands. All the server decides is
+    /// who is sent the packet at all, and it decides that by chunk, not by
+    /// [`RANGE_PER_VOLUME`], so a loud sound can still be culled by a listener
+    /// being several chunks out. That is the same rule vanilla's own chunk
+    /// tracking applies, and it is why volume is the wrong tool for reaching a
+    /// player on the far side of the map: see [`Self::play_to`].
+    ///
+    /// # Errors
+    /// If the packet cannot be encoded or queued.
+    pub fn broadcast_near(&self, compose: &Compose) -> anyhow::Result<()> {
+        compose.broadcast_local(self, self.chunk()).send()
+    }
+
+    /// Play it for one player and nobody else.
+    ///
+    /// Sent unattenuated if the caller builds it at the listener's own
+    /// position, which is what a sound about the match rather than about a
+    /// place wants: a countdown tick should not be quieter for whoever is
+    /// standing furthest from the origin.
+    ///
+    /// # Errors
+    /// If the packet cannot be encoded or queued.
+    pub fn play_to(&self, compose: &Compose, to: ConnectionId) -> anyhow::Result<()> {
+        compose.unicast(self, to)
     }
 }
 
@@ -75,7 +207,7 @@ impl PacketBundle for &Sound {
                 // distance rather than a server override.
                 fixed_range: None,
             }),
-            source: SoundSource::Master,
+            source: self.category.to_source(),
             x: self.position.x,
             y: self.position.y,
             z: self.position.z,
@@ -92,6 +224,7 @@ pub const fn sound(sound: valence_ident::Ident, position: Vec3) -> SoundBuilder 
         position,
         pitch: 1.0,
         volume: 1.0,
+        category: SoundCategory::Master,
         seed: None,
         sound,
     }

--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -8,8 +8,11 @@
 //! tick of latency and buys immunity from that whole class of bug.
 //!
 //! [`Cue`] and [`HotbarItem`] are the game's own closed vocabulary. Choosing
-//! which Minecraft sound, particle and item each one becomes is a hosting
-//! decision, so the mapping lives here and nowhere under `src/module/`.
+//! which Minecraft particle and item each one becomes is a hosting decision, so
+//! the mapping lives here and nowhere under `src/module/`. [`Sound`] is the
+//! exception and arrives already naming a vanilla sound event, because which
+//! noise an ability makes is part of what the ability *is* and belongs with the
+//! kit that declares it; all that is left here is the encoding.
 
 use std::sync::{Arc, Mutex};
 
@@ -38,7 +41,9 @@ use hyperion_inventory::PlayerInventory;
 use hyperion_utils::EntityExt;
 use valence_nbt::{Compound, List, Value};
 
-use crate::server::{Channel, Cue, HotbarItem, PlayerId, Server, SidebarLine, Text};
+use crate::server::{
+    Channel, Cue, HotbarItem, PlayerId, Server, SidebarLine, Sound, SoundCategory, Text,
+};
 
 /// One deferred write.
 ///
@@ -83,6 +88,14 @@ enum Op {
     Play {
         at: Vec3,
         cue: Cue,
+    },
+    PlaySound {
+        at: Vec3,
+        sound: Sound,
+    },
+    PlaySoundTo {
+        player: Entity,
+        sound: Sound,
     },
 }
 
@@ -174,6 +187,17 @@ impl Server for HyperionServer {
 
     fn cue(&self, at: Vec3, cue: Cue) {
         self.push(Op::Play { at, cue });
+    }
+
+    fn play_sound(&self, at: Vec3, sound: Sound) {
+        self.push(Op::PlaySound { at, sound });
+    }
+
+    fn play_sound_to(&self, player: PlayerId, sound: Sound) {
+        self.push(Op::PlaySoundTo {
+            player: entity_of(player),
+            sound,
+        });
     }
 }
 
@@ -320,6 +344,65 @@ fn apply(world: WorldRef<'_>, compose: &Compose, op: Op) {
             );
         }
         Op::Play { at, cue } => play_cue(compose, at, cue),
+        Op::PlaySound { at, sound } => {
+            let Some(packet) = encode(at, sound) else {
+                return;
+            };
+            if let Err(error) = packet.broadcast_near(compose) {
+                tracing::warn!("dropping a smash sound: {error}");
+            }
+        }
+        Op::PlaySoundTo { player, sound } => {
+            let entity = world.entity_from_id(player);
+            if !entity.is_alive() {
+                return;
+            }
+            let Some(connection) = entity.try_get::<&ConnectionId>(|id| *id) else {
+                return;
+            };
+            // At the listener's own ears rather than anywhere in the world, so
+            // it is the same loudness wherever they are standing.
+            let at = entity
+                .try_get::<&hyperion::simulation::Position>(|p| **p)
+                .unwrap_or(Vec3::ZERO);
+            let Some(packet) = encode(at, sound) else {
+                return;
+            };
+            if let Err(error) = packet.play_to(compose, connection) {
+                tracing::warn!("dropping a smash sound: {error}");
+            }
+        }
+    }
+}
+
+/// Turn the game's sound into hyperion's.
+///
+/// `None` only for an id that is not a valid identifier at all, which is a bug
+/// in a kit declaration rather than a runtime condition; `tests/sound.rs` holds
+/// every id in the game to the vanilla registry so one cannot reach here.
+fn encode(at: Vec3, sound: Sound) -> Option<agnostic::Sound> {
+    let ident = hyperion::valence_ident::Ident::new(sound.id)
+        .inspect_err(|error| tracing::warn!("{} is not a sound id: {error}", sound.id))
+        .ok()?;
+    Some(
+        agnostic::sound(ident, at)
+            .volume(sound.volume)
+            .pitch(sound.pitch)
+            .category(category(sound.category))
+            .build(),
+    )
+}
+
+const fn category(category: SoundCategory) -> agnostic::SoundCategory {
+    match category {
+        SoundCategory::Master => agnostic::SoundCategory::Master,
+        SoundCategory::Weather => agnostic::SoundCategory::Weather,
+        SoundCategory::Blocks => agnostic::SoundCategory::Blocks,
+        SoundCategory::Hostile => agnostic::SoundCategory::Hostile,
+        SoundCategory::Neutral => agnostic::SoundCategory::Neutral,
+        SoundCategory::Players => agnostic::SoundCategory::Players,
+        SoundCategory::Ambient => agnostic::SoundCategory::Ambient,
+        SoundCategory::Ui => agnostic::SoundCategory::Ui,
     }
 }
 
@@ -459,7 +542,14 @@ fn sidebar(compose: &Compose, to: ConnectionId, title: &Text, lines: &[SidebarLi
     }
 }
 
-/// The game's six cues, as Minecraft sounds and particles.
+/// The game's three cues, as Minecraft particles.
+///
+/// Sound used to be decided here as well, from a six-variant enum, which is why
+/// every ability in the game shared four noises between them. Audio now arrives
+/// already named: the game picks the vanilla sound event, because which sound
+/// an ability makes is a design decision belonging to the kit that declares it,
+/// and only the encoding is a hosting one. What is still a hosting decision,
+/// and so still here, is which particle each cue draws.
 ///
 /// `[INFERRED]` throughout: Mineplex's own choices are not in the leaked source,
 /// which loaded them from the same spreadsheet as everything else.
@@ -467,30 +557,10 @@ fn sidebar(compose: &Compose, to: ConnectionId, title: &Text, lines: &[SidebarLi
 const CUE_SPREAD: f32 = 0.4;
 
 fn play_cue(compose: &Compose, at: Vec3, cue: Cue) {
-    let sound = match cue {
-        Cue::Explosion => "minecraft:entity.generic.explode",
-        Cue::Teleport => "minecraft:entity.enderman.teleport",
-        Cue::Hurt => "minecraft:entity.player.hurt",
-        Cue::Death => "minecraft:entity.player.big_fall",
-        Cue::AbilityReady => "minecraft:block.note_block.pling",
-        Cue::Charge => "minecraft:block.note_block.hat",
-    };
-
-    if let Ok(ident) = hyperion::valence_ident::Ident::new(sound) {
-        let packet = agnostic::sound(ident, at).volume(1.0).pitch(1.0).build();
-        if let Err(error) = compose.broadcast(&packet).send() {
-            tracing::warn!("dropping a smash sound: {error}");
-        }
-    }
-
     let particle = match cue {
-        Cue::Explosion => Some(Particle::Explosion),
-        Cue::Teleport => Some(Particle::Portal),
-        Cue::Death => Some(Particle::Cloud),
-        Cue::Hurt | Cue::AbilityReady | Cue::Charge => None,
-    };
-    let Some(particle) = particle else {
-        return;
+        Cue::Explosion => Particle::Explosion,
+        Cue::Teleport => Particle::Portal,
+        Cue::Death => Particle::Cloud,
     };
     let packet = LevelParticles {
         // A cue marks something that just happened to a player, so it is worth

--- a/events/smash/src/command.rs
+++ b/events/smash/src/command.rs
@@ -179,8 +179,11 @@ fn json(entry: &ability::Declared) -> String {
     }
     let _unused = write!(
         out,
-        r#""requires_ground":{},"refunds_on_hit":{},"ultimate":{},"proves":["#,
-        entry.requires_ground, entry.refunds_on_hit, entry.ultimate,
+        r#""requires_ground":{},"refunds_on_hit":{},"ultimate":{},"sound":"{}","proves":["#,
+        entry.requires_ground,
+        entry.refunds_on_hit,
+        entry.ultimate,
+        escape(entry.sound),
     );
     for (index, observable) in entry.proves.iter().enumerate() {
         if index > 0 {

--- a/events/smash/src/lib.rs
+++ b/events/smash/src/lib.rs
@@ -28,6 +28,7 @@ use crate::module::{
     ability::AbilityModule, arena::ArenaModule, damage::DamageModule, kit::KitModule,
     kits::StockKits, knockback::KnockbackModule, lives::LivesModule, lobby::LobbyModule,
     player::PlayerModule, projectile::ProjectileModule, scoreboard::ScoreboardModule,
+    sound::SoundModule,
 };
 
 /// The whole game.
@@ -49,6 +50,10 @@ impl Module for SmashModule {
         world.import::<PlayerModule>();
         world.import::<KnockbackModule>();
         world.import::<DamageModule>();
+        // Before the abilities and the kits: both declare sound relationships,
+        // and a relationship used before it is registered is not the one the
+        // module later configures.
+        world.import::<SoundModule>();
         world.import::<AbilityModule>();
         world.import::<KitModule>();
         world.import::<ArenaModule>();

--- a/events/smash/src/module.rs
+++ b/events/smash/src/module.rs
@@ -9,3 +9,4 @@ pub mod lobby;
 pub mod player;
 pub mod projectile;
 pub mod scoreboard;
+pub mod sound;

--- a/events/smash/src/module/ability.rs
+++ b/events/smash/src/module/ability.rs
@@ -16,7 +16,10 @@ use glam::Vec3;
 
 use crate::{
     flecs_ext::{EntityViewExt, WorldRefExt},
-    module::player::{Energy, Facing, Health, OnGround, Player, Position},
+    module::{
+        player::{Energy, Facing, Health, OnGround, Player, Position},
+        sound::{self, PlaysOnCast},
+    },
     server::{Cue, PlayerId, Server, ServerHandle},
 };
 
@@ -288,6 +291,11 @@ pub fn activate(player: EntityView<'_>, slot: u8, charge: f32) -> Result<(), Ref
         } else if let Some(f) = ability.try_get::<&OnActivate>(|f| *f) {
             f.0(&cast);
         }
+        // One place, for every ability in the game. The dispatcher still names
+        // no kit: what to play is read off the ability entity that just fired.
+        if let Some(sound) = sound::declared(ability, PlaysOnCast) {
+            server.play_sound(cast.position.0, sound);
+        }
     });
 
     commit(ability, player);
@@ -329,6 +337,10 @@ pub struct Declared {
     /// Granted by the Smash Crystal rather than at spawn.
     pub ultimate: bool,
     pub proves: &'static [Observable],
+    /// The vanilla sound event firing it plays, read back off the ability's
+    /// `(PlaysOnCast, sound)` edge. Empty for an ability that declared none,
+    /// which is what `tests/sound.rs` fails on.
+    pub sound: &'static str,
 }
 
 /// Every ability every registered kit declares, kit registration order first
@@ -368,6 +380,8 @@ pub fn manifest(world: &World) -> Vec<Declared> {
                 refunds_on_hit: ability.has(RefundsOnHit::id()),
                 ultimate: ability.has(Ultimate::id()),
                 proves: ability.try_get::<&Proves>(|p| p.0).unwrap_or(&[]),
+                sound: crate::module::sound::declared(ability, PlaysOnCast)
+                    .map_or("", |sound| sound.id),
             });
         });
         abilities.sort_by_key(|ability| ability.slot);

--- a/events/smash/src/module/damage.rs
+++ b/events/smash/src/module/damage.rs
@@ -13,8 +13,9 @@ use crate::{
     module::{
         knockback::{Knockback, Smashed},
         player::{self, Health, Player, Position},
+        sound::{self, PlaysOnHurt},
     },
-    server::{Cue, PlayerId, ServerHandle},
+    server::{PlayerId, ServerHandle},
 };
 
 /// Where a hit came from. Several kits' passives key off this — Creeper's
@@ -203,8 +204,11 @@ impl Module for DamageModule {
 
                 world.get::<&ServerHandle>(|server| {
                     server.set_health(*player, current, max);
-                    server.cue(position.0, Cue::Hurt);
                 });
+                // The victim's own kit cries out, wherever the hit came from
+                // and whether or not it moved them. How *hard* it landed is the
+                // knockback observer's to say: see `sound::impact`.
+                sound::play_kit_voice(world, victim, PlaysOnHurt, position.0);
 
                 player::notify(victim, &Smashed {
                     attacker: event.attacker,

--- a/events/smash/src/module/kit.rs
+++ b/events/smash/src/module/kit.rs
@@ -23,8 +23,9 @@ use crate::{
         damage::Armor,
         knockback::KnockbackTaken,
         player::{Energy, Health, JumpsLeft},
+        sound::{self, Levels, PlaysOnCast, PlaysOnDeath, PlaysOnHurt},
     },
-    server::HotbarItem,
+    server::{HotbarItem, SoundCategory},
 };
 
 /// Tag on kit prefabs.
@@ -115,12 +116,13 @@ const fn noop(_: &Cast<'_>) {}
 ///     slot: 1,
 ///     cooldown: 7.0,
 ///     proves: &[Observable::TeleportsCaster],
+///     sound: "minecraft:entity.enderman.teleport",
 ///     activate: blink,
 ///     ..AbilitySpec::DEFAULT
 /// }
 /// ```
 ///
-/// `proves` is the one field with no sensible default. Everything else
+/// `proves` and `sound` are the two fields with no sensible default. Everything else
 /// describes the ability; that field is the ability's own claim about what a
 /// player will see, and it is what the two gates enumerate. Leaving it empty is
 /// caught by `tests/abilities.rs`, so a kit cannot be added without saying what
@@ -148,6 +150,13 @@ pub struct AbilitySpec {
     pub refunds_on_hit: bool,
     /// What a client sees when this fires. Must not be empty.
     pub proves: &'static [Observable],
+    /// The vanilla sound event firing this plays, e.g.
+    /// `minecraft:entity.blaze.shoot`. Must not be empty, and must be a sound
+    /// the client already owns: `tests/sound.rs` enumerates the whole roster
+    /// and holds every id against the generated `minecraft:sound_event`
+    /// registry, so an ability that forgets one fails there rather than going
+    /// quietly silent in play.
+    pub sound: &'static str,
     pub activate: fn(&Cast<'_>),
 }
 
@@ -163,6 +172,7 @@ impl AbilitySpec {
         requires_ground: false,
         refunds_on_hit: false,
         proves: &[],
+        sound: "",
         activate: noop,
     };
 }
@@ -171,6 +181,22 @@ impl Default for AbilitySpec {
     fn default() -> Self {
         Self::DEFAULT
     }
+}
+
+/// How loud an ultimate's cast is, against 1.0 for an ordinary ability.
+pub const ULTIMATE_VOLUME: f32 = 1.6;
+
+/// The voice of the mob a kit is.
+///
+/// Two sounds and not three: what *landing* a hit sounds like is deliberately
+/// the same for every kit, so that its pitch and volume can mean how hard
+/// rather than who. See [`crate::module::sound::IMPACT`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct KitSounds {
+    /// Played on the victim when they are hurt, whoever hurt them.
+    pub hurt: &'static str,
+    /// Played where they died.
+    pub death: &'static str,
 }
 
 /// Builds one kit prefab. Returned by [`define`].
@@ -200,6 +226,27 @@ impl<'w> KitBuilder<'w> {
     #[must_use]
     pub fn blurb(self, text: &'static str) -> Self {
         self.kit.set(KitBlurb(text));
+        self
+    }
+
+    /// What this kit's mob sounds like when it is hurt and when it dies.
+    ///
+    /// Hung off the kit prefab as `(PlaysOnHurt, sound)` and
+    /// `(PlaysOnDeath, sound)`, so the damage and death paths reach it through
+    /// the player's own `(Playing, kit)` edge and no subsystem learns a kit
+    /// name to do it.
+    #[must_use]
+    pub fn sounds(self, sounds: KitSounds) -> Self {
+        let voice = Levels {
+            // A kit is a mob, and a mob's voice belongs under the slider a
+            // player uses to turn mobs down.
+            category: SoundCategory::Hostile,
+            ..Levels::default()
+        };
+        self.kit
+            .add((PlaysOnHurt, sound::intern(self.world, sounds.hurt, voice)));
+        self.kit
+            .add((PlaysOnDeath, sound::intern(self.world, sounds.death, voice)));
         self
     }
 
@@ -257,6 +304,26 @@ impl<'w> KitBuilder<'w> {
         }
         if ultimate {
             ability.add(Ultimate::id());
+        }
+        // On the ability entity, not in a table somewhere keyed by its name.
+        // What a player fires is an instance of this prefab, and how the
+        // declaration reaches that instance is `module/sound.rs`'s business.
+        if !spec.sound.is_empty() {
+            let sound = sound::intern(self.world, spec.sound, Levels {
+                // Every kit is a combatant whatever mob it is skinned as, so
+                // they all belong under one slider and a player who turns
+                // monsters down turns the whole roster down evenly. The two
+                // categories that are deliberately not this are the impact of
+                // a hit, which is `Players`, and the countdown, which is `Ui`.
+                category: SoundCategory::Hostile,
+                // An ultimate carries further, and volume is range: see
+                // `hyperion::net::agnostic::RANGE_PER_VOLUME`. A Smash Crystal
+                // going off is the loudest thing in a match and should be heard
+                // by people who are not in it yet.
+                volume: if ultimate { ULTIMATE_VOLUME } else { 1.0 },
+                ..Levels::default()
+            });
+            ability.add((PlaysOnCast, sound));
         }
         // Every ability the kit has, ultimate included, hangs off the same
         // relationship, so one traversal enumerates the whole kit. What

--- a/events/smash/src/module/kits/blaze.rs
+++ b/events/smash/src/module/kits/blaze.rs
@@ -11,15 +11,12 @@
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 
-use crate::{
-    module::{
-        ability::{Cast, Observable, splash_at},
-        damage::{DamageKind, Damaged, hurt},
-        kit::{self, AbilitySpec, KitStats},
-        knockback::Knockback,
-        player::{Health, Player, Position},
-    },
-    server::Cue,
+use crate::module::{
+    ability::{Cast, Observable, splash_at},
+    damage::{DamageKind, Damaged, hurt},
+    kit::{self, AbilitySpec, KitSounds, KitStats},
+    knockback::Knockback,
+    player::{Health, Player, Position},
 };
 
 /// `[VERIFIED]`: "it can be cancelled by taking 4 or more damage" while
@@ -44,10 +41,15 @@ impl Module for Blaze {
             energy: Some((100.0, 20.0)),
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.blaze.hurt",
+            death: "minecraft:entity.blaze.death",
+        })
         .cost(8000)
         .blurb("Set people on fire. Armour will not save them.")
         .ability(AbilitySpec {
             name: "Inferno",
+            sound: "minecraft:entity.blaze.shoot",
             item: "minecraft:iron_sword",
             slot: 1,
             description: "Spew flame. No knockback, and armour does not reduce it.",
@@ -59,6 +61,7 @@ impl Module for Blaze {
         })
         .ability(AbilitySpec {
             name: "Firefly",
+            sound: "minecraft:entity.blaze.ambient",
             item: "minecraft:iron_axe",
             slot: 2,
             description: "Charge a second and a half, then ram. Four damage while charging \
@@ -75,6 +78,7 @@ impl Module for Blaze {
         })
         .ultimate(AbilitySpec {
             name: "Phoenix",
+            sound: "minecraft:item.firecharge.use",
             item: "minecraft:nether_star",
             slot: 8,
             description: "Twenty seconds of Firefly with no charge and free flight.",
@@ -122,7 +126,6 @@ fn inferno(cast: &Cast<'_>) {
             kind: DamageKind::Environment,
         });
     }
-    cast.server.cue(ahead, Cue::Charge);
 }
 
 /// `[APPROXIMATED]` damage; the 1.5-second charge is `[VERIFIED]`.

--- a/events/smash/src/module/kits/chicken.rs
+++ b/events/smash/src/module/kits/chicken.rs
@@ -14,7 +14,7 @@ use crate::{
     flecs_ext::EntityViewExt,
     module::{
         ability::{Cast, Cooldown, Grants, Named, Observable},
-        kit::{self, AbilitySpec, KitStats},
+        kit::{self, AbilitySpec, KitSounds, KitStats},
         projectile::{Flight, Impact, Payload, fire},
     },
     server::Cue,
@@ -42,10 +42,15 @@ impl Module for Chicken {
             energy: Some((100.0, 25.0)),
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.chicken.hurt",
+            death: "minecraft:entity.chicken.death",
+        })
         .cost(8000)
         .blurb("Cannot take a hit, and does not have to.")
         .ability(AbilitySpec {
             name: "Egg Blaster",
+            sound: "minecraft:entity.egg.throw",
             item: "minecraft:iron_sword",
             slot: 1,
             description: "A stream of eggs. No knockback, but it stops people moving.",
@@ -59,6 +64,7 @@ impl Module for Chicken {
         })
         .ability(AbilitySpec {
             name: "Chicken Missile",
+            sound: "minecraft:entity.chicken.egg",
             item: "minecraft:iron_axe",
             slot: 2,
             description: "A chick that explodes. Recharges the instant it hits something.",
@@ -70,6 +76,7 @@ impl Module for Chicken {
         })
         .ultimate(AbilitySpec {
             name: "Aerial Gunner",
+            sound: "minecraft:entity.chicken.ambient",
             item: "minecraft:nether_star",
             slot: 8,
             description: "Unlimited flight and eggs, for twenty seconds.",

--- a/events/smash/src/module/kits/cow.rs
+++ b/events/smash/src/module/kits/cow.rs
@@ -11,13 +11,10 @@
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 
-use crate::{
-    module::{
-        ability::{Cast, Observable, splash_at},
-        kit::{self, AbilitySpec, KitStats},
-        projectile::{Flight, Payload, fire},
-    },
-    server::Cue,
+use crate::module::{
+    ability::{Cast, Observable, splash_at},
+    kit::{self, AbilitySpec, KitSounds, KitStats},
+    projectile::{Flight, Payload, fire},
 };
 
 /// `[VERIFIED]`: "you will slowly gain speed levels (up to 4)".
@@ -37,10 +34,15 @@ impl Module for Cow {
             regen: 0.25,
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.cow.hurt",
+            death: "minecraft:entity.cow.death",
+        })
         .cost(6000)
         .blurb("Hard to move and hard to stop once it is moving.")
         .ability(AbilitySpec {
             name: "Angry Herd",
+            sound: "minecraft:entity.cow.ambient",
             item: "minecraft:iron_axe",
             slot: 1,
             description: "Five cows in a line. Each one can hit you.",
@@ -52,6 +54,7 @@ impl Module for Cow {
         })
         .ability(AbilitySpec {
             name: "Milk Spiral",
+            sound: "minecraft:entity.cow.milk",
             item: "minecraft:iron_shovel",
             slot: 2,
             description: "A helix of milk that carries you with it. Hits at most two people.",
@@ -67,6 +70,7 @@ impl Module for Cow {
         })
         .ultimate(AbilitySpec {
             name: "Mooshroom Madness",
+            sound: "minecraft:entity.mooshroom.convert",
             item: "minecraft:nether_star",
             slot: 8,
             description: "Become a mooshroom: more damage, five more hearts, faster abilities.",
@@ -114,7 +118,6 @@ fn milk_spiral(cast: &Cast<'_>) {
             0.9,
         );
     }
-    cast.server.cue(cast.position.0, Cue::Charge);
 }
 
 /// `[VERIFIED]` "5 more hearts".

--- a/events/smash/src/module/kits/creeper.rs
+++ b/events/smash/src/module/kits/creeper.rs
@@ -13,7 +13,7 @@ use crate::{
     module::{
         ability::{Cast, Observable, splash},
         damage::DamageKind,
-        kit::{self, AbilitySpec, KitStats},
+        kit::{self, AbilitySpec, KitSounds, KitStats},
         player::Player,
         projectile::{Flight, Impact, Payload, fire},
     },
@@ -43,10 +43,15 @@ impl Module for Creeper {
             regen: 0.40,
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.creeper.hurt",
+            death: "minecraft:entity.creeper.death",
+        })
         .cost(4000)
         .blurb("Hits harder than anything and dies to a stiff breeze.")
         .ability(AbilitySpec {
             name: "Sulphur Bomb",
+            sound: "minecraft:entity.creeper.primed",
             item: "minecraft:iron_axe",
             slot: 1,
             description: "Throw coal. It goes off on whatever it touches.",
@@ -57,6 +62,7 @@ impl Module for Creeper {
         })
         .ability(AbilitySpec {
             name: "Explosion",
+            sound: "minecraft:entity.generic.explode",
             item: "minecraft:iron_shovel",
             slot: 2,
             // The wiki: "charge up for 1.5 seconds, then explode ... achieving
@@ -70,6 +76,7 @@ impl Module for Creeper {
         })
         .ultimate(AbilitySpec {
             name: "Atomic Blast",
+            sound: "minecraft:entity.wither.spawn",
             item: "minecraft:nether_star",
             slot: 8,
             description: "The same idea, without the restraint.",

--- a/events/smash/src/module/kits/enderman.rs
+++ b/events/smash/src/module/kits/enderman.rs
@@ -14,7 +14,7 @@ use glam::Vec3;
 use crate::{
     module::{
         ability::{Cast, Observable},
-        kit::{self, AbilitySpec, KitStats},
+        kit::{self, AbilitySpec, KitSounds, KitStats},
         player::Position,
         projectile::{Flight, Payload, fire},
     },
@@ -44,10 +44,15 @@ impl Module for Enderman {
             jump_power: 0.9,
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.enderman.hurt",
+            death: "minecraft:entity.enderman.death",
+        })
         .cost(4000)
         .blurb("Throw the arena at people, then blink away before they reach you.")
         .ability(AbilitySpec {
             name: "Block Toss",
+            sound: "minecraft:block.stone.place",
             item: "minecraft:iron_sword",
             slot: 0,
             description: "Pick up a block and hurl it. Charge it for the extra point.",
@@ -59,6 +64,7 @@ impl Module for Enderman {
         })
         .ability(AbilitySpec {
             name: "Blink",
+            sound: "minecraft:entity.enderman.teleport",
             item: "minecraft:iron_axe",
             slot: 1,
             description: "Instantly cross sixteen blocks in the direction you are looking.",
@@ -69,6 +75,7 @@ impl Module for Enderman {
         })
         .ability(AbilitySpec {
             name: "Teleport",
+            sound: "minecraft:entity.ender_pearl.throw",
             item: "minecraft:compass",
             slot: 2,
             description: "Charge, then go wherever you are looking. Getting hit cancels it.",
@@ -80,6 +87,7 @@ impl Module for Enderman {
         })
         .ultimate(AbilitySpec {
             name: "Dragon Rider",
+            sound: "minecraft:entity.ender_dragon.flap",
             item: "minecraft:nether_star",
             slot: 8,
             description: "Ride a dragon through everyone.",

--- a/events/smash/src/module/kits/guardian.rs
+++ b/events/smash/src/module/kits/guardian.rs
@@ -16,7 +16,7 @@ use crate::{
     module::{
         ability::{Cast, Observable, splash_at},
         damage::MatchClock,
-        kit::{self, AbilitySpec, KitStats},
+        kit::{self, AbilitySpec, KitSounds, KitStats},
         player::{Player, Position},
         projectile::{Flight, Impact, Payload, fire},
     },
@@ -53,10 +53,15 @@ impl Module for Guardian {
             regen: 0.25,
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.guardian.hurt",
+            death: "minecraft:entity.guardian.death",
+        })
         .cost(8000)
         .blurb("Pick somebody. They are now your problem and you are theirs.")
         .ability(AbilitySpec {
             name: "Whirlpool Axe",
+            sound: "minecraft:entity.player.splash.high_speed",
             item: "minecraft:iron_axe",
             slot: 1,
             description: "A shard that pulls, like a weaker hook on a shorter cooldown.",
@@ -68,6 +73,7 @@ impl Module for Guardian {
         })
         .ability(AbilitySpec {
             name: "Water Splash",
+            sound: "minecraft:entity.generic.splash",
             item: "minecraft:iron_sword",
             slot: 2,
             description: "Bounce up, dragging everyone within five blocks with you.",
@@ -83,6 +89,7 @@ impl Module for Guardian {
         })
         .ability(AbilitySpec {
             name: "Target Laser",
+            sound: "minecraft:entity.guardian.attack",
             item: "minecraft:iron_pickaxe",
             slot: 3,
             description: "Mark someone within ten blocks. Everything hurts them more for eight \
@@ -95,6 +102,7 @@ impl Module for Guardian {
         })
         .ultimate(AbilitySpec {
             name: "Tidal Wave",
+            sound: "minecraft:entity.elder_guardian.curse",
             item: "minecraft:nether_star",
             slot: 8,
             description: "Everything in the water goes where the water goes.",
@@ -201,7 +209,6 @@ fn target_laser(cast: &Cast<'_>) {
         against: Some(victim),
         until: now + LASER_SECONDS,
     });
-    cast.server.cue(cast.position.0, Cue::AbilityReady);
 }
 
 fn tidal_wave(cast: &Cast<'_>) {

--- a/events/smash/src/module/kits/iron_golem.rs
+++ b/events/smash/src/module/kits/iron_golem.rs
@@ -13,7 +13,7 @@ use glam::Vec3;
 use crate::{
     module::{
         ability::{Cast, Observable, splash, splash_at},
-        kit::{self, AbilitySpec, KitStats},
+        kit::{self, AbilitySpec, KitSounds, KitStats},
         player::Position,
         projectile::{Flight, Impact, Payload, fire},
     },
@@ -40,9 +40,14 @@ impl Module for IronGolem {
             jump_power: 0.9,
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.iron_golem.hurt",
+            death: "minecraft:entity.iron_golem.death",
+        })
         .blurb("Command space in the arena. Pull enemies in, then hit like a truck.")
         .ability(AbilitySpec {
             name: "Fissure",
+            sound: "minecraft:block.deepslate.break",
             item: "minecraft:iron_axe",
             slot: 1,
             description: "Split the ground in a line, launching whoever it reaches.",
@@ -54,6 +59,7 @@ impl Module for IronGolem {
         })
         .ability(AbilitySpec {
             name: "Iron Hook",
+            sound: "minecraft:block.chain.place",
             item: "minecraft:iron_pickaxe",
             slot: 2,
             description: "Throw a hook. On a hit it drags them to you.",
@@ -64,6 +70,7 @@ impl Module for IronGolem {
         })
         .ability(AbilitySpec {
             name: "Seismic Slam",
+            sound: "minecraft:entity.iron_golem.attack",
             item: "minecraft:iron_shovel",
             slot: 3,
             description: "Leap, then land hard. Everything nearby goes flying.",
@@ -75,6 +82,7 @@ impl Module for IronGolem {
         })
         .ultimate(AbilitySpec {
             name: "Earthquake",
+            sound: "minecraft:entity.ravager.roar",
             item: "minecraft:nether_star",
             slot: 8,
             description: "Shake the whole map. Anyone touching the ground pays.",

--- a/events/smash/src/module/kits/skeleton.rs
+++ b/events/smash/src/module/kits/skeleton.rs
@@ -11,14 +11,11 @@
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 
-use crate::{
-    module::{
-        ability::{Cast, Observable, charge_steps, splash},
-        kit::{self, AbilitySpec, KitStats},
-        player::Position,
-        projectile::{Flight, Impact, Payload, fire},
-    },
-    server::Cue,
+use crate::module::{
+    ability::{Cast, Observable, charge_steps, splash},
+    kit::{self, AbilitySpec, KitSounds, KitStats},
+    player::Position,
+    projectile::{Flight, Impact, Payload, fire},
 };
 
 /// Flat, regardless of draw. `KitSkeleton.arrowDamage` overwrites the vanilla
@@ -47,9 +44,14 @@ impl Module for Skeleton {
             jump_power: 0.9,
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.skeleton.hurt",
+            death: "minecraft:entity.skeleton.death",
+        })
         .blurb("Keep everyone at arm's length, then overcharge the bow and let go.")
         .ability(AbilitySpec {
             name: "Barrage",
+            sound: "minecraft:entity.arrow.shoot",
             item: "minecraft:bow",
             slot: 0,
             description: "Hold to load arrows, up to five. Release to fire them all.",
@@ -63,6 +65,7 @@ impl Module for Skeleton {
         })
         .ability(AbilitySpec {
             name: "Bone Explosion",
+            sound: "minecraft:block.bone_block.break",
             item: "minecraft:iron_axe",
             slot: 1,
             description: "Scatter your bones. Little damage, enormous knockback.",
@@ -73,6 +76,7 @@ impl Module for Skeleton {
         })
         .ability(AbilitySpec {
             name: "Roped Arrow",
+            sound: "minecraft:entity.fishing_bobber.throw",
             item: "minecraft:arrow",
             slot: 2,
             description: "Fire an arrow and be dragged after it. Your way back onto the map.",
@@ -87,6 +91,7 @@ impl Module for Skeleton {
         })
         .ultimate(AbilitySpec {
             name: "Arrow Storm",
+            sound: "minecraft:item.crossbow.shoot",
             item: "minecraft:nether_star",
             slot: 8,
             description: "Fire without ever reloading.",
@@ -122,7 +127,6 @@ fn barrage(cast: &Cast<'_>) {
     for index in 0..arrows.min(MAX_BARRAGE_ARROWS) {
         arrow(cast, index as f32 * 0.02);
     }
-    cast.server.cue(cast.position.0, Cue::Charge);
 }
 
 /// Damage 6 over radius 7 at a 2.5x knockback multiplier — the highest of any

--- a/events/smash/src/module/kits/sky_squid.rs
+++ b/events/smash/src/module/kits/sky_squid.rs
@@ -13,7 +13,7 @@ use glam::Vec3;
 use crate::{
     module::{
         ability::{Cast, Observable, splash_at},
-        kit::{self, AbilitySpec, KitStats},
+        kit::{self, AbilitySpec, KitSounds, KitStats},
         projectile::{Flight, Payload, fire},
     },
     server::Cue,
@@ -38,10 +38,15 @@ impl Module for SkySquid {
             regen: 0.25,
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.squid.hurt",
+            death: "minecraft:entity.squid.death",
+        })
         .cost(3000)
         .blurb("Seven pellets up close, and one second of being untouchable.")
         .ability(AbilitySpec {
             name: "Super Squid",
+            sound: "minecraft:entity.squid.ambient",
             item: "minecraft:iron_sword",
             slot: 1,
             description: "One second of flight, and nothing can touch you during it.",
@@ -52,6 +57,7 @@ impl Module for SkySquid {
         })
         .ability(AbilitySpec {
             name: "Ink Shotgun",
+            sound: "minecraft:entity.squid.squirt",
             item: "minecraft:iron_axe",
             slot: 2,
             description: "Seven ink sacs at once. All seven is 12 damage and almost never happens.",
@@ -62,6 +68,7 @@ impl Module for SkySquid {
         })
         .ability(AbilitySpec {
             name: "Fish Flurry",
+            sound: "minecraft:entity.cod.flop",
             item: "minecraft:iron_shovel",
             slot: 3,
             description: "Fish erupt from the ground for four seconds. Hard to walk out of.",
@@ -73,6 +80,7 @@ impl Module for SkySquid {
         })
         .ultimate(AbilitySpec {
             name: "Storm Squid",
+            sound: "minecraft:entity.lightning_bolt.thunder",
             item: "minecraft:nether_star",
             slot: 8,
             description: "Fly, and call lightning down once a second.",
@@ -93,7 +101,6 @@ fn super_squid(cast: &Cast<'_>) {
         cast.player,
         cast.facing.0.normalize_or_zero() * 1.1 + Vec3::Y * 0.9,
     );
-    cast.server.cue(cast.position.0, Cue::Charge);
 }
 
 fn ink_shotgun(cast: &Cast<'_>) {

--- a/events/smash/src/module/kits/slime.rs
+++ b/events/smash/src/module/kits/slime.rs
@@ -16,7 +16,7 @@ use crate::{
     module::{
         ability::{Cast, Observable, splash_at},
         damage::{DamageKind, Damaged, hurt},
-        kit::{self, AbilitySpec, KitStats},
+        kit::{self, AbilitySpec, KitSounds, KitStats},
         knockback::Knockback,
         player::Energy,
     },
@@ -49,9 +49,14 @@ impl Module for Slime {
             energy: Some((1.0, ENERGY_REGEN_PER_SECOND)),
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.slime.hurt",
+            death: "minecraft:entity.slime.death",
+        })
         .blurb("Spend yourself to send enemies flying, and shrink while you do it.")
         .ability(AbilitySpec {
             name: "Slime Rocket",
+            sound: "minecraft:entity.slime.squish",
             item: "minecraft:iron_sword",
             slot: 0,
             description: "Hold to grow a rocket out of yourself. Release to launch it.",
@@ -65,6 +70,7 @@ impl Module for Slime {
         })
         .ability(AbilitySpec {
             name: "Slime Slam",
+            sound: "minecraft:entity.slime.attack",
             item: "minecraft:iron_axe",
             slot: 1,
             description: "Throw yourself at someone. You take a quarter of it back.",
@@ -82,6 +88,7 @@ impl Module for Slime {
         })
         .ultimate(AbilitySpec {
             name: "Giga Slime",
+            sound: "minecraft:entity.slime.jump",
             item: "minecraft:nether_star",
             slot: 8,
             description: "Become enormous and untouchable. Everything near you dies.",

--- a/events/smash/src/module/kits/snowman.rs
+++ b/events/smash/src/module/kits/snowman.rs
@@ -9,13 +9,10 @@
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 
-use crate::{
-    module::{
-        ability::{Cast, Observable, splash_at},
-        kit::{self, AbilitySpec, KitStats},
-        projectile::{Flight, Payload, fire},
-    },
-    server::Cue,
+use crate::module::{
+    ability::{Cast, Observable, splash_at},
+    kit::{self, AbilitySpec, KitSounds, KitStats},
+    projectile::{Flight, Payload, fire},
 };
 
 /// `[VERIFIED]`: "You also deal 1 more damage to mobs who are on your snow."
@@ -37,10 +34,15 @@ impl Module for Snowman {
             energy: Some((100.0, 18.0)),
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.snow_golem.hurt",
+            death: "minecraft:entity.snow_golem.death",
+        })
         .cost(5000)
         .blurb("Own the ground you are standing on.")
         .ability(AbilitySpec {
             name: "Blizzard",
+            sound: "minecraft:entity.snow_golem.shoot",
             item: "minecraft:iron_sword",
             slot: 1,
             description: "Snowballs, endlessly. Low damage, good knockback, best at an edge.",
@@ -52,6 +54,7 @@ impl Module for Snowman {
         })
         .ability(AbilitySpec {
             name: "Ice Path",
+            sound: "minecraft:block.snow.place",
             item: "minecraft:iron_axe",
             slot: 2,
             description: "A path of ice wherever you point, and a hop so you do not fall through.",
@@ -62,6 +65,7 @@ impl Module for Snowman {
         })
         .ability(AbilitySpec {
             name: "Arctic Aura",
+            sound: "minecraft:entity.snow_golem.ambient",
             item: "minecraft:snow_block",
             slot: 3,
             description: "Snow around you. Slows them, and you hit a point harder on it.",
@@ -73,6 +77,7 @@ impl Module for Snowman {
         })
         .ultimate(AbilitySpec {
             name: "Snow Turret",
+            sound: "minecraft:entity.snowball.throw",
             item: "minecraft:nether_star",
             slot: 8,
             description: "A snowman that shoots for you. Twenty seconds, three of them.",
@@ -108,7 +113,6 @@ fn ice_path(cast: &Cast<'_>) {
         cast.player,
         Vec3::Y * 0.42 + cast.facing.0.normalize_or_zero() * 0.6,
     );
-    cast.server.cue(cast.position.0, Cue::Charge);
 }
 
 /// `[APPROXIMATED]`: the aura is modelled as a pulse rather than as placed snow,

--- a/events/smash/src/module/kits/spider.rs
+++ b/events/smash/src/module/kits/spider.rs
@@ -12,13 +12,10 @@
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 
-use crate::{
-    module::{
-        ability::{Cast, Observable, splash},
-        kit::{self, AbilitySpec, KitStats},
-        projectile::{Flight, Payload, fire},
-    },
-    server::Cue,
+use crate::module::{
+    ability::{Cast, Observable, splash},
+    kit::{self, AbilitySpec, KitSounds, KitStats},
+    projectile::{Flight, Payload, fire},
 };
 
 #[derive(Component)]
@@ -39,10 +36,15 @@ impl Module for Spider {
             jump_control: true,
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.spider.hurt",
+            death: "minecraft:entity.spider.death",
+        })
         .cost(0)
         .blurb("Fast, fragile and everywhere at once. Leap where you look.")
         .ability(AbilitySpec {
             name: "Needler",
+            sound: "minecraft:entity.bee.sting",
             item: "minecraft:iron_sword",
             slot: 1,
             description: "Spray six needles. They poison, which armour does not stop.",
@@ -54,6 +56,7 @@ impl Module for Spider {
         })
         .ability(AbilitySpec {
             name: "Spin Web",
+            sound: "minecraft:block.cobweb.place",
             item: "minecraft:iron_axe",
             slot: 2,
             description: "Launch forward, trailing web. Mostly a way back onto the map.",
@@ -64,6 +67,7 @@ impl Module for Spider {
         })
         .ultimate(AbilitySpec {
             name: "Spiders Nest",
+            sound: "minecraft:entity.spider.ambient",
             item: "minecraft:nether_star",
             slot: 8,
             description: "A dome of web. Everything you hit heals you.",
@@ -110,7 +114,6 @@ fn needler(cast: &Cast<'_>) {
 fn spin_web(cast: &Cast<'_>) {
     let launch = cast.facing.0.normalize_or_zero() * 1.4 + Vec3::Y * 0.45;
     cast.server.add_velocity(cast.player, launch);
-    cast.server.cue(cast.position.0, Cue::Charge);
 }
 
 /// `[APPROXIMATED]`: the dome traps, which needs block writes the game half

--- a/events/smash/src/module/kits/wither_skeleton.rs
+++ b/events/smash/src/module/kits/wither_skeleton.rs
@@ -16,7 +16,7 @@ use crate::{
     module::{
         ability::{Cast, Observable, splash_at},
         damage::MatchClock,
-        kit::{self, AbilitySpec, KitStats},
+        kit::{self, AbilitySpec, KitSounds, KitStats},
         projectile::{Flight, Impact, Payload, fire},
     },
     server::Cue,
@@ -47,10 +47,15 @@ impl Module for WitherSkeleton {
             regen: 0.30,
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.wither_skeleton.hurt",
+            death: "minecraft:entity.wither_skeleton.death",
+        })
         .cost(6000)
         .blurb("Leave a copy of yourself somewhere useful, then be there instead.")
         .ability(AbilitySpec {
             name: "Guided Wither Skull",
+            sound: "minecraft:entity.wither.shoot",
             item: "minecraft:iron_sword",
             slot: 1,
             description: "A skull with a wide blast. Hold to steer it.",
@@ -62,6 +67,7 @@ impl Module for WitherSkeleton {
         })
         .ability(AbilitySpec {
             name: "Wither Image",
+            sound: "minecraft:entity.illusioner.mirror_move",
             item: "minecraft:iron_axe",
             slot: 2,
             description: "Drop a copy of yourself. Use it again to swap places with it.",
@@ -72,6 +78,7 @@ impl Module for WitherSkeleton {
         })
         .ultimate(AbilitySpec {
             name: "Wither Swap",
+            sound: "minecraft:entity.shulker.teleport",
             item: "minecraft:nether_star",
             slot: 8,
             description: "Every image at once.",
@@ -127,7 +134,6 @@ fn wither_image(cast: &Cast<'_>) {
         at: cast.position.0,
         until: now + IMAGE_SECONDS,
     });
-    cast.server.cue(cast.position.0, Cue::Charge);
 }
 
 fn wither_swap(cast: &Cast<'_>) {

--- a/events/smash/src/module/kits/wolf.rs
+++ b/events/smash/src/module/kits/wolf.rs
@@ -16,11 +16,10 @@ use crate::{
     module::{
         ability::{Cast, Observable},
         damage::{DamageKind, Damaged, MeleeBonus},
-        kit::{self, AbilitySpec, KitName, KitStats, Playing},
+        kit::{self, AbilitySpec, KitName, KitSounds, KitStats, Playing},
         player::Player,
         projectile::{Flight, Impact, Payload, fire},
     },
-    server::Cue,
 };
 
 /// Damage added per landed melee hit, and the ceiling it climbs to.
@@ -54,10 +53,15 @@ impl Module for Wolf {
             jump_control: true,
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.wolf.hurt",
+            death: "minecraft:entity.wolf.death",
+        })
         .cost(4000)
         .blurb("Stick to somebody and every hit lands harder than the last.")
         .ability(AbilitySpec {
             name: "Cub Tackle",
+            sound: "minecraft:entity.baby_wolf.ambient",
             item: "minecraft:iron_axe",
             slot: 1,
             description: "Throw a cub. Whoever it lands on can barely move for five seconds.",
@@ -68,6 +72,7 @@ impl Module for Wolf {
         })
         .ability(AbilitySpec {
             name: "Wolf Strike",
+            sound: "minecraft:entity.wolf.growl",
             item: "minecraft:iron_shovel",
             slot: 2,
             description: "Launch at what you are looking at. Triple knockback on a tackled target.",
@@ -82,6 +87,7 @@ impl Module for Wolf {
         })
         .ultimate(AbilitySpec {
             name: "Frenzy",
+            sound: "minecraft:entity.wolf_angry.growl",
             item: "minecraft:nether_star",
             slot: 8,
             description: "Twenty seconds of everything at once.",
@@ -172,7 +178,6 @@ fn wolf_strike(cast: &Cast<'_>) {
 
     cast.server
         .add_velocity(cast.player, cast.facing.0.normalize_or_zero() * 1.6);
-    cast.server.cue(cast.position.0, Cue::Charge);
 
     let caster = cast.caster.id();
     let mut combo = false;

--- a/events/smash/src/module/kits/zombie.rs
+++ b/events/smash/src/module/kits/zombie.rs
@@ -10,7 +10,7 @@ use glam::Vec3;
 use crate::{
     module::{
         ability::{Cast, Observable, splash_at},
-        kit::{self, AbilitySpec, KitStats},
+        kit::{self, AbilitySpec, KitSounds, KitStats},
         player::Position,
         projectile::{Flight, Impact, Payload, fire},
     },
@@ -31,10 +31,15 @@ impl Module for Zombie {
             regen: 0.25,
             ..KitStats::default()
         })
+        .sounds(KitSounds {
+            hurt: "minecraft:entity.zombie.hurt",
+            death: "minecraft:entity.zombie.death",
+        })
         .cost(6000)
         .blurb("Something for every range, and nothing outstanding at any of them.")
         .ability(AbilitySpec {
             name: "Bile Blaster",
+            sound: "minecraft:entity.witch.throw",
             item: "minecraft:iron_axe",
             slot: 1,
             description: "Spray bile. It lands where you point and hurts what it lands on.",
@@ -45,6 +50,7 @@ impl Module for Zombie {
         })
         .ability(AbilitySpec {
             name: "Deaths Grasp",
+            sound: "minecraft:entity.fishing_bobber.retrieve",
             item: "minecraft:bow",
             slot: 2,
             description: "An arrow that drags whoever it hits back to you.",
@@ -56,6 +62,7 @@ impl Module for Zombie {
         })
         .ultimate(AbilitySpec {
             name: "Night of the Living Dead",
+            sound: "minecraft:entity.zombie.ambient",
             item: "minecraft:nether_star",
             slot: 8,
             description: "The dead get up around you.",

--- a/events/smash/src/module/knockback.rs
+++ b/events/smash/src/module/knockback.rs
@@ -17,8 +17,11 @@ use flecs_ecs::prelude::*;
 use glam::Vec3;
 
 use crate::{
-    module::player::{Health, OnGround, Player, Position},
-    server::{Cue, PlayerId, ServerHandle},
+    module::{
+        player::{Health, OnGround, Player, Position},
+        sound,
+    },
+    server::{PlayerId, ServerHandle},
 };
 
 /// The constants of Mineplex's knockback pipeline, as data.
@@ -241,7 +244,15 @@ impl Module for KnockbackModule {
                         let impulse =
                             resolve(*model, k, event.knockback.origin, position.0, ground.0);
                         server.add_velocity(*player, impulse);
-                        server.cue(position.0, Cue::Hurt);
+                        // The one number in the game that says how hard a hit
+                        // was is the one it launches you with, and it is
+                        // already computed here. A jab and a full smash are the
+                        // same sound at different pitch and volume, so what a
+                        // player hears tracks what the physics did rather than
+                        // which button produced it.
+                        if let Some(sound) = sound::impact(impulse) {
+                            server.play_sound(position.0, sound);
+                        }
                     });
             });
     }

--- a/events/smash/src/module/lives.rs
+++ b/events/smash/src/module/lives.rs
@@ -14,8 +14,9 @@ use crate::{
         damage::{KILL_CREDIT_WINDOW, LastHitAt, LastHitBy, MatchClock},
         kit,
         player::{self, Health, JumpsLeft, Player, Position},
+        sound::{self, PlaysOnDeath},
     },
-    server::{Channel, Cue, NamedColor, PlayerId, ServerHandle, Text},
+    server::{Channel, Cue, NamedColor, PlayerId, ServerHandle, Sound, SoundCategory, Text},
 };
 
 /// Mineplex's `MAX_LIVES`.
@@ -28,6 +29,12 @@ pub const DEATH_SPECTATE_SECS: f32 = 4.0;
 /// Seconds of immunity after respawning. Mineplex's `RESPAWN_INVUL`, and it is
 /// cancelled early the moment you use an item so you cannot camp under it.
 pub const RESPAWN_INVULNERABLE_SECS: f32 = 1.5;
+
+/// How loud an elimination is, against 1.0 for a sound at natural volume.
+///
+/// Volume is range, so this is really "how far away should somebody be and
+/// still be told the match just got smaller". Everyone in the arena.
+pub const ELIMINATION_VOLUME: f32 = 2.0;
 
 #[derive(Component, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Lives(pub u8);
@@ -340,9 +347,14 @@ impl Module for LivesModule {
 
                 let name = victim.name();
                 let killer = killer_of(victim, clock);
+                let at = sound::position_of(victim);
+                // The kit's last word, where it fell. Reached through the
+                // player's own `(Playing, kit)` edge, so this module still does
+                // not know that kits have names.
+                sound::play_kit_voice(world, victim, PlaysOnDeath, at);
 
                 world.get::<&ServerHandle>(|server| {
-                    server.cue(Vec3::ZERO, Cue::Death);
+                    server.cue(at, Cue::Death);
                     match killer {
                         Some(killer) => {
                             let killer_name = world.entity_from_id(killer).name();
@@ -379,6 +391,15 @@ impl Module for LivesModule {
                     let placement = u32::try_from(remaining_alive(world)).unwrap_or(0);
                     victim.add(Eliminated::id());
                     victim.set(Placement(placement));
+                    // Louder than the death that preceded it, because losing a
+                    // life and losing the match are the same animation and only
+                    // the sound tells the arena which one it just watched.
+                    sound::play_at(
+                        world,
+                        at,
+                        Sound::new(sound::ELIMINATION, SoundCategory::Ui)
+                            .volume(ELIMINATION_VOLUME),
+                    );
                     player::notify(victim, &EliminatedEvent { placement });
                 } else {
                     victim.set(RespawnAt(clock + DEATH_SPECTATE_SECS));
@@ -413,8 +434,6 @@ impl Module for LivesModule {
             });
     }
 }
-
-use glam::Vec3;
 
 /// How many players are still in the match.
 #[must_use]

--- a/events/smash/src/module/lobby.rs
+++ b/events/smash/src/module/lobby.rs
@@ -20,8 +20,9 @@ use crate::{
         kit,
         lives::{Eliminated, InvulnerableUntil, Lives, Placement, RespawnAt},
         player::{Health, Player, Position},
+        sound,
     },
-    server::{Channel, PlayerId, ServerHandle, Text},
+    server::{Channel, PlayerId, ServerHandle, Sound, SoundCategory, Text},
 };
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
@@ -259,12 +260,43 @@ impl Module for LobbyModule {
                     world.get::<&mut MatchClock>(|clock| clock.0 += dt);
                 }
 
+                tick_countdown(&world, before, after);
+
                 if before.phase != after.phase {
                     on_phase_change(&world, before.phase, after.phase);
                 }
             }
         });
     }
+}
+
+/// Whether a phase is one whose timer is a countdown to something.
+///
+/// Both of the phases before a match are: the lobby countdown runs out into
+/// `Preparing`, and `Preparing` runs out into the match itself. `Playing`
+/// counts *up* and `Ended` is a results screen nobody is waiting on, so neither
+/// is ticked.
+const fn counts_down(phase: Phase) -> bool {
+    matches!(phase, Phase::Countdown | Phase::Preparing)
+}
+
+/// A tick a second through the last seconds before the match, to everyone.
+///
+/// Driven off the whole-second boundary the timer just crossed rather than off
+/// a counter of its own, so it stays right when a join shortens the countdown
+/// and cannot drift from the number the rest of the game is working to. A
+/// transition between the two counting-down phases is not a boundary crossing:
+/// `Preparing` starts at nine seconds having just been handed a fresh timer,
+/// and treating that as a tick would double up on the handover.
+fn tick_countdown(world: &WorldRef<'_>, before: Lobby, after: Lobby) {
+    if !counts_down(after.phase) || before.phase != after.phase {
+        return;
+    }
+    let (was, now) = (before.timer.ceil(), after.timer.ceil());
+    if now >= was || now <= 0.0 || now > f32::from(sound::COUNTDOWN_AUDIBLE_SECONDS) {
+        return;
+    }
+    sound::play_to_everyone(*world, sound::countdown_tick(now));
 }
 
 fn on_phase_change(world: &WorldRef<'_>, from: Phase, to: Phase) {
@@ -277,8 +309,15 @@ fn on_phase_change(world: &WorldRef<'_>, from: Phase, to: Phase) {
         Phase::Playing => {
             world.get::<&mut MatchClock>(|clock| clock.0 = 0.0);
             announce(world, "Go!");
+            sound::play_to_everyone(
+                *world,
+                Sound::new(sound::MATCH_START, SoundCategory::Master),
+            );
         }
-        Phase::Ended => announce(world, "Game over."),
+        Phase::Ended => {
+            announce(world, "Game over.");
+            sound::play_to_everyone(*world, Sound::new(sound::MATCH_END, SoundCategory::Ui));
+        }
         Phase::Waiting => reset(world),
     }
 

--- a/events/smash/src/module/projectile.rs
+++ b/events/smash/src/module/projectile.rs
@@ -19,8 +19,9 @@ use crate::{
         damage::{DamageKind, Damaged, hurt},
         knockback::Knockback,
         player::{Health, Player, Position},
+        sound,
     },
-    server::{Cue, ServerHandle},
+    server::{PlayerId, ServerHandle, Sound, SoundCategory},
 };
 
 /// Tag on projectile entities.
@@ -149,7 +150,24 @@ impl Module for ProjectileModule {
                     at,
                 });
 
-                world.get::<&ServerHandle>(|server| server.cue(at, Cue::Hurt));
+                world.get::<&ServerHandle>(|server| {
+                    // At the crossing point, not at either endpoint of the
+                    // step and not at the victim: a projectile that connects
+                    // mid-step connected somewhere neither of those is.
+                    server.play_sound(
+                        at,
+                        Sound::new(sound::PROJECTILE_HIT, SoundCategory::Players),
+                    );
+                    // And the shooter gets told, however far away they are.
+                    if let Some(id) =
+                        shooter.and_then(|s| world.entity_at(s).try_get::<&PlayerId>(|p| *p))
+                    {
+                        server.play_sound_to(
+                            id,
+                            Sound::new(sound::RANGED_HITMARKER, SoundCategory::Players),
+                        );
+                    }
+                });
                 projectile.destruct();
             });
     }

--- a/events/smash/src/module/sound.rs
+++ b/events/smash/src/module/sound.rs
@@ -1,0 +1,349 @@
+//! Sounds are entities, and whatever makes a noise points at one.
+//!
+//! The alternative is a `match` from an ability's name to a string. That is a
+//! second registry: it lives in a different file from the abilities, nothing
+//! makes the two agree, and the day a kit is renamed the game goes quiet in a
+//! way no test notices. Here the sound is a component on the ability entity
+//! itself, reached the same way everything else about an ability is reached, so
+//! there is one registry and it is the world.
+//!
+//! Three relationships, named for the occasion rather than for the sound:
+//!
+//! * `(PlaysOnCast, sound)` on an ability -- what firing it sounds like.
+//! * `(PlaysOnHurt, sound)` on a kit -- what the mob you are playing says when
+//!   it is hit.
+//! * `(PlaysOnDeath, sound)` on a kit -- and when it dies.
+//!
+//! All three are `Exclusive`, because an occasion has one sound and a second
+//! declaration is a correction rather than an addition. Without it a kit that
+//! redeclares gets both edges and [`declared`] answers with whichever was added
+//! first, which is a silently stale sound and no error anywhere.
+//!
+//! They are also `(OnInstantiate, Inherit)`, which is a storage choice and not
+//! a behavioural one. [`crate::module::kit::apply`] gives a player their own
+//! ability entities with `is_a(prefab)`; flecs' default is `Override`, which
+//! copies the pair onto every instance, and `Inherit` leaves the one copy on
+//! the prefab and resolves through the `IsA` edge. Both read back the same, and
+//! this was checked by removing the trait and watching
+//! `tests/sound.rs::firing_an_ability_plays_the_sound_it_declared` stay green.
+//! `Inherit` is kept because a sound is static data shared by every instance,
+//! which is what the trait is for, and that test is what would catch either
+//! choice being wrong.
+//!
+//! What is *not* relational, deliberately: the impact sound a hit makes, the
+//! countdown, and the two match-boundary sounds. See [`IMPACT`].
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+
+use crate::{
+    module::{
+        kit::Playing,
+        player::{Player, Position},
+    },
+    server::{PlayerId, ServerHandle, Sound, SoundCategory},
+};
+
+/// The vanilla sound event this entity stands for.
+#[derive(Component, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct SoundId(pub &'static str);
+
+/// How it plays when nothing scales it.
+#[derive(Component, Debug, Copy, Clone, PartialEq)]
+pub struct Levels {
+    pub category: SoundCategory,
+    pub volume: f32,
+    pub pitch: f32,
+}
+
+impl Default for Levels {
+    fn default() -> Self {
+        Self {
+            category: SoundCategory::Hostile,
+            volume: 1.0,
+            pitch: 1.0,
+        }
+    }
+}
+
+/// Relationship: `(PlaysOnCast, sound)` on an ability.
+#[derive(Component, Debug)]
+pub struct PlaysOnCast;
+
+/// Relationship: `(PlaysOnHurt, sound)` on a kit.
+#[derive(Component, Debug)]
+pub struct PlaysOnHurt;
+
+/// Relationship: `(PlaysOnDeath, sound)` on a kit.
+#[derive(Component, Debug)]
+pub struct PlaysOnDeath;
+
+/// What a hit sounds like, before the knockback scales it.
+///
+/// One sound for every hit in the game, on purpose, and the only place in this
+/// file that is a constant rather than a relationship. Super Smash Mobs asks a
+/// player one question hundreds of times a match -- did that connect, and how
+/// hard -- and [`impact`] answers it by moving the pitch and the volume of this
+/// sound. A comparison is only readable against a fixed reference: give fifteen
+/// kits fifteen different impact timbres and the pitch shift stops meaning
+/// "harder" and starts meaning "a different kit hit me". The kit's own voice is
+/// still heard, on the *victim*, through `(PlaysOnHurt, sound)`.
+pub const IMPACT: &str = "minecraft:entity.player.attack.strong";
+
+/// A projectile connecting, at the point on its path where it did.
+///
+/// Separate from [`IMPACT`], which plays on the victim: this one says *where*
+/// a shot crossed somebody, which for a fast projectile is not where either
+/// end of that tick's step was. It is the only sound in the game positioned
+/// somewhere other than at a player.
+pub const PROJECTILE_HIT: &str = "minecraft:entity.arrow.hit";
+
+/// The hitmarker, played to the shooter alone.
+///
+/// Vanilla's own answer to "did that land", and the reason it is a unicast at
+/// the shooter's ears rather than a positioned sound is that a Barrage arrow
+/// can connect forty blocks away, where a positioned sound is inaudible and the
+/// shooter learns nothing.
+pub const RANGED_HITMARKER: &str = "minecraft:entity.arrow.hit_player";
+
+/// One second closer to the start of the match.
+pub const COUNTDOWN_TICK: &str = "minecraft:block.note_block.hat";
+
+/// How many of the last seconds of a countdown are ticked out loud.
+///
+/// Not the whole countdown, which is sixty seconds at the minimum player count:
+/// a tick a second for a minute is a metronome nobody asked for. The last few
+/// are the ones a player is actually counting.
+pub const COUNTDOWN_AUDIBLE_SECONDS: u8 = 5;
+
+/// How much the pitch climbs with each second closer to the start.
+pub const COUNTDOWN_PITCH_STEP: f32 = 0.2;
+
+/// One countdown tick, rising as the wait runs out.
+///
+/// `seconds_left` counts down to one, and the pitch climbs with each tick so
+/// the sequence itself says how close the start is without a player having to
+/// read the number. Inside the client's `0.5..=2.0` by construction: five
+/// seconds out is 1.0 and one second out is 1.8.
+#[must_use]
+pub fn countdown_tick(seconds_left: f32) -> Sound {
+    let window = f32::from(COUNTDOWN_AUDIBLE_SECONDS);
+    let steps = (window - seconds_left).clamp(0.0, window);
+    Sound::new(COUNTDOWN_TICK, SoundCategory::Ui).pitch(COUNTDOWN_PITCH_STEP.mul_add(steps, 1.0))
+}
+
+/// Go.
+pub const MATCH_START: &str = "minecraft:entity.ender_dragon.growl";
+
+/// Results are up.
+pub const MATCH_END: &str = "minecraft:ui.toast.challenge_complete";
+
+/// Somebody is out of lives and out of the match.
+///
+/// Positioned where they were standing rather than played to everyone: the
+/// arena wants to know *where* it just lost a player, and the beacon's falling
+/// tone is the one vanilla sound that reads as something switching off.
+pub const ELIMINATION: &str = "minecraft:block.beacon.deactivate";
+
+/// Knockback magnitude, in blocks per tick, that counts as a full smash.
+///
+/// Read off the model rather than guessed: [`crate::module::knockback::resolve`]
+/// gives `0.2 + 0.48 * strength` horizontally, and a strength of about 2.5 is
+/// where the vertical cap stops rising and a hit becomes the sideways launch
+/// that ends a life. That is roughly 1.4 blocks a tick of total impulse, so a
+/// hit at or above this is one a spectator should hear across the arena.
+pub const SMASH_IMPULSE: f32 = 1.4;
+
+/// The lightest hit that still makes a noise, in blocks per tick.
+///
+/// Below this the hit did essentially nothing -- a zero-knockback ability tick,
+/// a victim standing exactly on a splash centre -- and a sound for it is noise
+/// that makes the real hits harder to hear.
+pub const QUIET_IMPULSE: f32 = 0.05;
+
+/// Pitch of the lightest audible hit, and of the hardest.
+///
+/// Down, not up, as the hit gets harder. A bigger, heavier collision resonates
+/// lower, so a falling pitch is the direction a player already reads as "that
+/// was more". Both ends sit inside the client's `0.5..=2.0` clamp with room to
+/// spare, because a value the client silently flattens is a value that stops
+/// carrying information at exactly the moment the hit matters most.
+pub const JAB_PITCH: f32 = 1.5;
+pub const SMASH_PITCH: f32 = 0.7;
+
+/// Volume of the lightest audible hit, and of the hardest.
+///
+/// Up as the hit gets harder, which does two things at once. It is louder, and
+/// because a client culls a sound past `16 * volume` blocks it also carries
+/// further: a jab is a local event and a full smash is heard by the whole
+/// arena, which is the information a spectator wants and the reason volume is
+/// scaled as well as pitch rather than instead of it.
+pub const JAB_VOLUME: f32 = 0.55;
+pub const SMASH_VOLUME: f32 = 1.6;
+
+/// The sound one hit makes, given the impulse it launched the victim with.
+///
+/// `None` for a hit that moved nobody. The interpolation is linear in impulse
+/// magnitude and saturates at [`SMASH_IMPULSE`], so every hit above a full
+/// smash sounds the same rather than continuing to deepen into the clamp.
+#[must_use]
+pub fn impact(impulse: Vec3) -> Option<Sound> {
+    let magnitude = impulse.length();
+    if !magnitude.is_finite() || magnitude < QUIET_IMPULSE {
+        return None;
+    }
+    let t = (magnitude / SMASH_IMPULSE).clamp(0.0, 1.0);
+    Some(Sound {
+        id: IMPACT,
+        category: SoundCategory::Players,
+        volume: (SMASH_VOLUME - JAB_VOLUME).mul_add(t, JAB_VOLUME),
+        pitch: (SMASH_PITCH - JAB_PITCH).mul_add(t, JAB_PITCH),
+    })
+}
+
+/// The entity standing for `id` played at `levels`, created the first time it
+/// is asked for.
+///
+/// Interning rather than a fresh entity per declaration, so the graph has one
+/// node per sound and "which abilities play this" is a query. Kits declare
+/// themselves once at startup, so the linear scan costs nothing that matters
+/// and buys not having to keep a side table in step with the world.
+///
+/// Keyed on the levels as well as the id, which is the part that is easy to get
+/// wrong. Keying on the id alone means the second caller to ask for the same
+/// sound at a different volume silently gets the first caller's volume back,
+/// and the symptom is a kit that is quieter than it declared with nothing
+/// anywhere saying so.
+#[must_use]
+pub fn intern<'w>(world: &'w World, id: &'static str, levels: Levels) -> EntityView<'w> {
+    if let Some(found) = lookup(world, id, levels) {
+        return found;
+    }
+    world.entity().set(SoundId(id)).set(levels)
+}
+
+/// The entity for `id` at `levels`, if one has been interned.
+#[must_use]
+pub fn lookup<'w>(world: &'w World, id: &str, levels: Levels) -> Option<EntityView<'w>> {
+    let mut found: Option<Entity> = None;
+    world
+        .query::<(&SoundId, &Levels)>()
+        .build()
+        .each_entity(|entity, (sound, existing)| {
+            if found.is_none() && sound.0 == id && *existing == levels {
+                found = Some(entity.id());
+            }
+        });
+    found.map(|id| world.entity_from_id(id))
+}
+
+/// The sound `subject` declares for `occasion`, if it declares one.
+///
+/// `target` and not `each_target`, because `ecs_get_target` is the one that
+/// follows an `IsA` edge to the prefab a player's ability instance was made
+/// from. See this module's own documentation for why that matters.
+#[must_use]
+pub fn declared(subject: EntityView<'_>, occasion: impl IntoEntity) -> Option<Sound> {
+    let sound = subject.target(occasion, 0)?;
+    let id = sound.try_get::<&SoundId>(|s| s.0)?;
+    let levels = sound.try_get::<&Levels>(|l| *l).unwrap_or_default();
+    Some(Sound {
+        id,
+        category: levels.category,
+        volume: levels.volume,
+        pitch: levels.pitch,
+    })
+}
+
+/// The kit prefab a player is playing, which is where their voice lives.
+#[must_use]
+pub fn kit_of(player: EntityView<'_>) -> Option<EntityView<'_>> {
+    player.target(Playing, 0)
+}
+
+/// Play whatever `subject` declares for `occasion`, at `at`. A subject that
+/// declares nothing makes no noise, which is the honest outcome and is what
+/// `tests/sound.rs` enumerates against.
+pub fn play_declared(
+    world: WorldRef<'_>,
+    subject: EntityView<'_>,
+    occasion: impl IntoEntity,
+    at: Vec3,
+) {
+    let Some(sound) = declared(subject, occasion) else {
+        return;
+    };
+    world.get::<&ServerHandle>(|server| server.play_sound(at, sound));
+}
+
+/// Play `sound` for everyone in the match, at their own ears.
+///
+/// A per-player unicast rather than one positioned broadcast: a countdown or a
+/// result is about the match and not about a place, so it should be the same
+/// loudness for the player standing on the far platform.
+pub fn play_to_everyone(world: WorldRef<'_>, sound: Sound) {
+    let mut listeners = Vec::new();
+    world
+        .query::<&PlayerId>()
+        .with(Player::id())
+        .build()
+        .each(|id| listeners.push(*id));
+    world.get::<&ServerHandle>(|server| {
+        for listener in listeners {
+            server.play_sound_to(listener, sound);
+        }
+    });
+}
+
+/// Where a player is, for a sound that belongs to something happening to them.
+#[must_use]
+pub fn position_of(player: EntityView<'_>) -> Vec3 {
+    player.try_get::<&Position>(|p| p.0).unwrap_or(Vec3::ZERO)
+}
+
+/// Play whatever the kit `player` is on declares for `occasion`, at `at`.
+///
+/// The subject is the kit prefab and it is reached through the player's own
+/// `(Playing, kit)` edge, so the damage and death paths never learn that kits
+/// have names, let alone what they are.
+pub fn play_kit_voice(
+    world: WorldRef<'_>,
+    player: EntityView<'_>,
+    occasion: impl IntoEntity,
+    at: Vec3,
+) {
+    let Some(kit) = kit_of(player) else {
+        return;
+    };
+    play_declared(world, kit, occasion, at);
+}
+
+/// Play `sound` at `at`, for everyone close enough to hear it.
+pub fn play_at(world: WorldRef<'_>, at: Vec3, sound: Sound) {
+    world.get::<&ServerHandle>(|server| server.play_sound(at, sound));
+}
+
+#[derive(Component)]
+pub struct SoundModule;
+
+impl Module for SoundModule {
+    fn module(world: &World) {
+        world.module::<Self>("smash::Sound");
+
+        world.component::<SoundId>();
+        world.component::<Levels>();
+
+        // See this module's own documentation for what each of these two buys
+        // and, for one of them, what it does not.
+        for relationship in [
+            world.component::<PlaysOnCast>().id(),
+            world.component::<PlaysOnHurt>().id(),
+            world.component::<PlaysOnDeath>().id(),
+        ] {
+            world
+                .entity_from_id(relationship)
+                .add(flecs::Exclusive)
+                .add((flecs::OnInstantiate, flecs::Inherit));
+        }
+    }
+}

--- a/events/smash/src/server.rs
+++ b/events/smash/src/server.rs
@@ -100,16 +100,87 @@ pub struct HotbarItem {
     pub lore: Vec<String>,
 }
 
-/// A one-shot audiovisual cue. Purely cosmetic, so the game never branches on
-/// whether it succeeded.
+/// A one-shot burst of particles. Purely cosmetic, so the game never branches
+/// on whether it succeeded.
+///
+/// Sound used to travel on this enum too, which is why every ability that
+/// wanted to be heard reached for [`Self::Explosion`] and the game had four
+/// noises for fifty-one abilities. Audio is now [`Sound`], which carries the
+/// vanilla sound event itself rather than a name something else has to map, so
+/// what is left here is only the particle: three shapes, each of which really
+/// is one of three things a client can be shown.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Cue {
     Explosion,
     Teleport,
-    Hurt,
     Death,
-    AbilityReady,
-    Charge,
+}
+
+/// Which of the listener's volume sliders governs a sound.
+///
+/// A player who has turned monsters down should hear a Wither Skull quieter and
+/// their own countdown unchanged, and the only thing that can arrange that is
+/// the server naming the right category. Mirrors the vanilla `SoundSource`
+/// ordinals; the adapter is what turns one into the other.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+pub enum SoundCategory {
+    #[default]
+    Master,
+    Weather,
+    Blocks,
+    /// Monsters. Most kit abilities are this.
+    Hostile,
+    /// Passive and neutral mobs.
+    Neutral,
+    /// Other players, and a weapon connecting.
+    Players,
+    Ambient,
+    /// Feedback rather than a thing in the world: a countdown, a result.
+    Ui,
+}
+
+/// One sound, exactly as it goes on the wire.
+///
+/// A vanilla sound event id and nothing else, because every sound this game
+/// plays has to be one a client already owns. Shipping an id the client does
+/// not know is silence with no error anywhere, so `tests/sound.rs` holds every
+/// id in the game against the generated `minecraft:sound_event` registry.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Sound {
+    /// A vanilla sound event id, e.g. `minecraft:entity.blaze.shoot`.
+    pub id: &'static str,
+    pub category: SoundCategory,
+    /// Loudness at the source. Also the range: a client culls a sound past
+    /// `16 * volume` blocks and attenuates linearly to nothing there, so this
+    /// is how far away a hit can be felt as much as how loud it is.
+    pub volume: f32,
+    /// Playback speed. The client clamps it to `0.5..=2.0`.
+    pub pitch: f32,
+}
+
+impl Sound {
+    /// A sound at its natural volume and pitch.
+    #[must_use]
+    pub const fn new(id: &'static str, category: SoundCategory) -> Self {
+        Self {
+            id,
+            category,
+            volume: 1.0,
+            pitch: 1.0,
+        }
+    }
+
+    #[must_use]
+    pub const fn volume(mut self, volume: f32) -> Self {
+        self.volume = volume;
+        self
+    }
+
+    #[must_use]
+    pub const fn pitch(mut self, pitch: f32) -> Self {
+        self.pitch = pitch;
+        self
+    }
 }
 
 /// Where a message goes on screen.
@@ -122,7 +193,7 @@ pub enum Channel {
 
 /// Everything the game asks the host server to do.
 ///
-/// Kept to eight methods on purpose. Anything that can be computed from
+/// Kept small on purpose. Anything that can be computed from
 /// mirrored components is computed in the game instead of being asked for here,
 /// because every method on this trait is a wiring task later and a virtual call
 /// now.
@@ -150,6 +221,18 @@ pub trait Server: Send + Sync + 'static {
     fn set_spectating(&self, player: PlayerId, spectating: bool);
 
     fn cue(&self, at: Vec3, cue: Cue);
+
+    /// Play a sound at a point in the world. Everyone close enough hears it,
+    /// attenuated by how far they are standing from `at`.
+    fn play_sound(&self, at: Vec3, sound: Sound);
+
+    /// Play a sound only `player` hears, at their own ears, so it is the same
+    /// loudness wherever they are standing.
+    ///
+    /// For feedback that is about the match rather than about a place: a
+    /// countdown tick has no position, and playing one in the world would make
+    /// it quieter for whoever happened to be furthest from the origin.
+    fn play_sound_to(&self, player: PlayerId, sound: Sound);
 }
 
 /// Singleton holding the live [`Server`].

--- a/events/smash/src/server/mock.rs
+++ b/events/smash/src/server/mock.rs
@@ -9,7 +9,7 @@ use std::sync::Mutex;
 
 use glam::Vec3;
 
-use super::{Channel, Cue, HotbarItem, PlayerId, Server, SidebarLine, Text};
+use super::{Channel, Cue, HotbarItem, PlayerId, Server, SidebarLine, Sound, Text};
 
 /// One thing the game asked the server to do.
 #[derive(Debug, Clone, PartialEq)]
@@ -23,6 +23,10 @@ pub enum Call {
     Sidebar(PlayerId, Text, Vec<SidebarLine>),
     Spectating(PlayerId, bool),
     Cue(Vec3, Cue),
+    /// A positioned sound, heard by everyone in range.
+    Sound(Vec3, Sound),
+    /// A sound only one player hears.
+    SoundTo(PlayerId, Sound),
 }
 
 #[derive(Default)]
@@ -80,6 +84,30 @@ impl MockServer {
             .collect()
     }
 
+    /// Every positioned sound so far, with where it played.
+    #[must_use]
+    pub fn sounds(&self) -> Vec<(Vec3, Sound)> {
+        self.calls()
+            .iter()
+            .filter_map(|call| match call {
+                Call::Sound(at, sound) => Some((*at, *sound)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Every sound sent to `player` alone.
+    #[must_use]
+    pub fn sounds_to(&self, player: PlayerId) -> Vec<Sound> {
+        self.calls()
+            .iter()
+            .filter_map(|call| match call {
+                Call::SoundTo(id, sound) if *id == player => Some(*sound),
+                _ => None,
+            })
+            .collect()
+    }
+
     #[must_use]
     pub fn broadcasts(&self) -> Vec<String> {
         self.calls()
@@ -127,5 +155,13 @@ impl Server for MockServer {
 
     fn cue(&self, at: Vec3, cue: Cue) {
         self.push(Call::Cue(at, cue));
+    }
+
+    fn play_sound(&self, at: Vec3, sound: Sound) {
+        self.push(Call::Sound(at, sound));
+    }
+
+    fn play_sound_to(&self, player: PlayerId, sound: Sound) {
+        self.push(Call::SoundTo(player, sound));
     }
 }

--- a/events/smash/tests/contract.rs
+++ b/events/smash/tests/contract.rs
@@ -38,6 +38,7 @@ use smash::{
         player::{self, Health, OnGround, Player, PlayerModule, Position},
         projectile::ProjectileModule,
         scoreboard::ScoreboardModule,
+        sound::{self, Levels, PlaysOnCast, PlaysOnHurt, SoundModule},
     },
     server::{PlayerId, ServerHandle, mock::MockServer},
 };
@@ -138,7 +139,10 @@ fn contracts() -> Vec<Contract> {
             // `MatchClock`. A second mutual pair, found by this test rather
             // than by reading: nothing else in the suite imports one without
             // the other, so nothing else could have noticed.
-            runtime_requires: &["Lives"],
+            //
+            // The victim's kit cries out when it is hurt, which walks Sound's
+            // `(PlaysOnHurt, sound)` edge from the kit Kit's `Playing` names.
+            runtime_requires: &["Lives", "Sound", "Kit"],
             exercise: |_world, player| {
                 player.set(Armor(10.0));
                 hurt(player, Damaged {
@@ -152,13 +156,44 @@ fn contracts() -> Vec<Contract> {
             },
         },
         Contract {
+            name: "Sound",
+            import: |world| {
+                world.import::<SoundModule>();
+            },
+            // Registration touches only this module's own components. What
+            // needs Player is the module's own API: `play_to_everyone` queries
+            // `Player` and `PlayerId`, and `position_of` reads `Position`.
+            requires: &["Player"],
+            // `kit_of` walks the `Playing` relationship, which Kit owns, and
+            // Kit cannot import without Ability, which is imported after this.
+            // A forward edge, and the reason this field exists.
+            runtime_requires: &["Kit"],
+            exercise: |world, player| {
+                let voice = sound::intern(world, "minecraft:block.note_block.hat", Levels {
+                    volume: 0.5,
+                    ..Levels::default()
+                });
+                let subject = world.entity().add((PlaysOnCast, voice));
+                let declared = sound::declared(subject, PlaysOnCast)
+                    .expect("a sound hung off an entity reads back off it");
+                assert!((declared.volume - 0.5).abs() < 1e-6);
+
+                // The two paths that reach out of this module: one through the
+                // player's kit, one over every player.
+                sound::play_kit_voice(world.into(), player, PlaysOnHurt, Vec3::ZERO);
+                sound::play_to_everyone(world.into(), declared);
+            },
+        },
+        Contract {
             name: "Ability",
             import: |world| {
                 world.import::<AbilityModule>();
             },
             requires: &["Player", "Knockback", "Damage"],
-            // `activate` clears the respawn immunity, which is Lives'.
-            runtime_requires: &["Lives"],
+            // `activate` clears the respawn immunity, which is Lives'; and it
+            // reads the firing ability's `(PlaysOnCast, sound)` edge, which is
+            // Sound's.
+            runtime_requires: &["Lives", "Sound"],
             exercise: |world, player| {
                 // No kit, so no ability is granted and this is the empty path
                 // through the dispatcher. That it runs at all is the claim.
@@ -172,7 +207,8 @@ fn contracts() -> Vec<Contract> {
                 world.import::<KitModule>();
             },
             requires: &["Player", "Knockback", "Damage", "Ability"],
-            runtime_requires: &[],
+            // Declaring a kit interns its ability and voice sounds.
+            runtime_requires: &["Sound"],
             exercise: |world, player| {
                 let kit =
                     smash::module::kit::define(world, "Contract", smash::module::kit::KitStats {
@@ -216,7 +252,9 @@ fn contracts() -> Vec<Contract> {
             // `smash::respawn` names `&Arena` in its signature, so Arena must
             // be imported first. This is the hard half of the cycle.
             requires: &["Player", "Knockback", "Damage", "Ability", "Kit", "Arena"],
-            runtime_requires: &["Lobby"],
+            // A death plays the kit's last word and, on the last life, the
+            // elimination.
+            runtime_requires: &["Lobby", "Sound"],
             exercise: |_world, player| {
                 kill(player, DeathCause::Void);
                 assert_eq!(
@@ -250,7 +288,8 @@ fn contracts() -> Vec<Contract> {
                 "Arena",
                 "Lives",
             ],
-            runtime_requires: &[],
+            // The countdown and the two match boundaries.
+            runtime_requires: &["Sound"],
             exercise: |world, _player| {
                 world.progress_time(0.05);
                 assert!(world.cloned::<&Lobby>().timer >= 0.0);
@@ -281,7 +320,11 @@ fn contracts() -> Vec<Contract> {
             import: |world| {
                 world.import::<StockKits>();
             },
-            requires: &["Player", "Knockback", "Damage", "Ability", "Kit"],
+            // An import-time requirement rather than a runtime one, and the
+            // difference is the whole shape of this module: every kit is built
+            // inside `module()`, so all fifteen intern their sounds before this
+            // import returns.
+            requires: &["Player", "Knockback", "Damage", "Sound", "Ability", "Kit"],
             runtime_requires: &[],
             exercise: |world, _player| {
                 assert!(

--- a/events/smash/tests/sound.rs
+++ b/events/smash/tests/sound.rs
@@ -1,0 +1,635 @@
+//! Every sound the game can make, enumerated from the world rather than listed.
+//!
+//! A silent ability is the worst kind of bug this game has, because nothing
+//! fails: the physics are right, the packets that carry damage and knockback go
+//! out, and the only symptom is that the player cannot feel the hit they just
+//! landed. There is no assertion a scripted client can make about hearing
+//! something, so every check here is on the packet the adapter would encode --
+//! the `MockServer` call log, which is the same seam `tests/abilities.rs` reads.
+//!
+//! The sweeps walk [`ability::manifest`] and [`kit::registry`], which are
+//! queries over the world, so a kit added tomorrow is covered the moment its
+//! module runs and an ability that quietly declares no sound fails here rather
+//! than in play.
+
+mod harness;
+
+use std::collections::BTreeMap;
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use harness::Game;
+use hyperion::hyperion_minecraft_proto::generated::registry::SOUND_EVENT;
+use smash::{
+    module::{
+        ability::{self, Declared},
+        damage::{DamageKind, Damaged, MatchClock, hurt},
+        kit::{self, KitName},
+        knockback::Knockback,
+        lives::{self, DeathCause, Eliminated, Lives},
+        lobby::{Lobby, LobbyConfig, Phase},
+        player::{Energy, Health, OnGround, Position},
+        sound::{self, Levels, PlaysOnCast, PlaysOnDeath, PlaysOnHurt},
+    },
+    server::{PlayerId, Sound},
+};
+
+/// Whether `id` is a sound event a vanilla client already owns.
+///
+/// This is the check that makes "use a vanilla sound" enforceable rather than a
+/// convention. A sound event the client has never heard of is not an error
+/// anywhere: the packet encodes, the client receives it, looks the name up,
+/// finds nothing and plays silence. The generated registry is the same table
+/// the client resolves against, so a typo fails here instead.
+fn is_vanilla(id: &str) -> bool {
+    SOUND_EVENT.id_of(id).is_some()
+}
+
+/// The whole roster, as a fresh world.
+fn manifest() -> Vec<Declared> {
+    ability::manifest(&Game::new().world)
+}
+
+/// The guard that makes every other sweep in this file mandatory.
+///
+/// An ability with no sound would pass a test that only checked the sounds that
+/// exist, because there would be nothing to check. This is the one that refuses
+/// it, and the count is a lower bound rather than an equality so that adding a
+/// kit does not require editing a number here -- adding one that forgets a
+/// sound still fails.
+#[test]
+fn every_ability_declares_a_sound() {
+    let manifest = manifest();
+    assert!(
+        manifest.len() >= 50,
+        "the registry only found {} abilities; something is not being discovered",
+        manifest.len()
+    );
+
+    let silent: Vec<_> = manifest
+        .iter()
+        .filter(|entry| entry.sound.is_empty())
+        .map(|entry| format!("{} / {}", entry.kit, entry.name))
+        .collect();
+    assert!(
+        silent.is_empty(),
+        "these abilities make no noise when they fire: {silent:?}"
+    );
+}
+
+/// Two abilities that sound the same are one ability as far as a player's ears
+/// are concerned, which defeats the point of giving them sounds at all.
+#[test]
+fn no_two_abilities_sound_alike() {
+    let mut by_sound: BTreeMap<&str, Vec<String>> = BTreeMap::new();
+    for entry in manifest() {
+        by_sound
+            .entry(entry.sound)
+            .or_default()
+            .push(format!("{} / {}", entry.kit, entry.name));
+    }
+    let shared: Vec<_> = by_sound
+        .iter()
+        .filter(|(_, users)| users.len() > 1)
+        .map(|(sound, users)| format!("{sound} is played by {users:?}"))
+        .collect();
+    assert!(shared.is_empty(), "{}", shared.join("\n"));
+}
+
+/// Every id in the game, from every source, against the client's own table.
+///
+/// The constants are swept alongside the declarations because they fail exactly
+/// the same way and are written in exactly the same place: a string literal
+/// nobody has spelled out loud.
+#[test]
+fn every_sound_id_is_one_a_vanilla_client_owns() {
+    let mut wrong = Vec::new();
+
+    for entry in manifest() {
+        if !is_vanilla(entry.sound) {
+            wrong.push(format!(
+                "{} / {} plays {}, which is not a vanilla sound event",
+                entry.kit, entry.name, entry.sound
+            ));
+        }
+    }
+
+    let game = Game::new();
+    for kit in kit::registry(&game.world) {
+        let kit = game.world.entity_from_id(kit);
+        let name = kit.try_get::<&KitName>(|n| n.0).unwrap_or("<unnamed>");
+        for (occasion, declared) in [
+            ("hurt", sound::declared(kit, PlaysOnHurt)),
+            ("death", sound::declared(kit, PlaysOnDeath)),
+        ] {
+            if let Some(declared) = declared
+                && !is_vanilla(declared.id)
+            {
+                wrong.push(format!(
+                    "{name}'s {occasion} sound {} is not a vanilla sound event",
+                    declared.id
+                ));
+            }
+        }
+    }
+
+    for (what, id) in [
+        ("impact", sound::IMPACT),
+        ("projectile hit", sound::PROJECTILE_HIT),
+        ("ranged hitmarker", sound::RANGED_HITMARKER),
+        ("countdown tick", sound::COUNTDOWN_TICK),
+        ("match start", sound::MATCH_START),
+        ("match end", sound::MATCH_END),
+        ("elimination", sound::ELIMINATION),
+    ] {
+        if !is_vanilla(id) {
+            wrong.push(format!(
+                "the {what} sound {id} is not a vanilla sound event"
+            ));
+        }
+    }
+
+    assert!(wrong.is_empty(), "{}", wrong.join("\n"));
+}
+
+/// A kit with no voice is a kit that is silent when it is hit and silent when
+/// it dies, which is most of what a player hears in a match.
+#[test]
+fn every_kit_declares_a_voice() {
+    let game = Game::new();
+    let kits = kit::registry(&game.world);
+    assert!(
+        kits.len() >= 15,
+        "the registry only found {} kits",
+        kits.len()
+    );
+
+    let mut mute = Vec::new();
+    for kit in kits {
+        let kit = game.world.entity_from_id(kit);
+        let name = kit.try_get::<&KitName>(|n| n.0).unwrap_or("<unnamed>");
+        for (occasion, declared) in [
+            ("hurt", sound::declared(kit, PlaysOnHurt)),
+            ("death", sound::declared(kit, PlaysOnDeath)),
+        ] {
+            if declared.is_none() {
+                mute.push(format!("{name} declares no {occasion} sound"));
+            }
+        }
+    }
+    assert!(mute.is_empty(), "{}", mute.join("\n"));
+}
+
+/// The sweep that a declaration alone cannot pass: fire every ability in the
+/// game and check the sound it declared actually went out.
+///
+/// This is the one that catches the relationship being wrong rather than the
+/// data. `kit::apply` gives a player their own ability *instances*, made with
+/// `is_a` of the kit's prefab, so what a player fires is never the entity a kit
+/// declared the sound on. Every check above reads the prefab and would go on
+/// passing while every player in the game was silent. Nothing but firing it
+/// finds that, and it is what pins the `(OnInstantiate, ...)` choice in
+/// `module/sound.rs` whichever way that choice goes.
+#[test]
+fn firing_an_ability_plays_the_sound_it_declared() {
+    let mut failures = Vec::new();
+
+    for entry in manifest() {
+        let bench = Bench::new();
+        bench.equip(entry.kit);
+        if !bench.arm(&entry) {
+            failures.push(format!(
+                "{} / {}: the Smash Crystal granted nothing, so it could not be fired",
+                entry.kit, entry.name
+            ));
+            continue;
+        }
+        bench.game.server.take();
+        bench.press(&entry);
+
+        let heard: Vec<&str> = bench
+            .game
+            .server
+            .sounds()
+            .iter()
+            .map(|(_, played)| played.id)
+            .collect();
+        if !heard.contains(&entry.sound) {
+            failures.push(format!(
+                "{} / {} declares {} and firing it played {heard:?}",
+                entry.kit, entry.name, entry.sound
+            ));
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// An ultimate is the loudest thing in a match, and volume is range: see
+/// `hyperion::net::agnostic::RANGE_PER_VOLUME`. A crystal going off should reach
+/// people who are nowhere near it.
+#[test]
+fn an_ultimate_is_louder_than_an_ordinary_ability() {
+    let mut failures = Vec::new();
+
+    for entry in manifest().into_iter().filter(|entry| entry.ultimate) {
+        let bench = Bench::new();
+        bench.equip(entry.kit);
+        assert!(bench.arm(&entry));
+        bench.game.server.take();
+        bench.press(&entry);
+
+        let volume = bench
+            .game
+            .server
+            .sounds()
+            .into_iter()
+            .find(|(_, played)| played.id == entry.sound)
+            .map(|(_, played)| played.volume);
+        match volume {
+            Some(volume) if volume >= kit::ULTIMATE_VOLUME => {}
+            other => failures.push(format!(
+                "{} / {} is an ultimate and played at {other:?}, not {}",
+                entry.kit,
+                entry.name,
+                kit::ULTIMATE_VOLUME
+            )),
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// A melee swing that connects is heard where it landed.
+///
+/// Both halves: the impact, which is the same sound for every kit so that its
+/// pitch can mean how hard, and the victim's own kit crying out, which is what
+/// says who was hit.
+#[test]
+fn a_melee_connect_is_heard_at_the_victim() {
+    let bench = Bench::new();
+    bench.equip("Zombie");
+    let victim_at = Vec3::new(2.0, 0.0, 0.0);
+    bench
+        .game
+        .world
+        .entity_from_id(bench.victim)
+        .set(Position(victim_at));
+    bench.game.server.take();
+
+    bench.swing(6.0, 1.0);
+
+    let heard = bench.game.server.sounds();
+    let impact = heard
+        .iter()
+        .find(|(_, played)| played.id == sound::IMPACT)
+        .unwrap_or_else(|| panic!("a melee hit made no impact sound; the log is {heard:?}"));
+    assert!(
+        impact.0.distance(victim_at) < 1e-3,
+        "the impact played at {} and the victim was at {victim_at}",
+        impact.0
+    );
+
+    let voice = sound::declared(
+        kit::by_name(&bench.game.world, "Zombie").expect("the registry lost Zombie"),
+        PlaysOnHurt,
+    )
+    .expect("Zombie declares a hurt sound");
+    assert!(
+        heard
+            .iter()
+            .any(|(at, played)| played.id == voice.id && at.distance(victim_at) < 1e-3),
+        "the victim's kit did not cry out; the log is {heard:?}"
+    );
+}
+
+/// The whole point: a jab and a full smash are the same sound and do not sound
+/// the same.
+///
+/// Driven through the real damage and knockback pipeline rather than by calling
+/// `sound::impact` directly, because the claim being made is about what a player
+/// hears in a match and the mapping is only half of that. The other half is
+/// that the impulse reaching the sound is the one the physics computed.
+#[test]
+fn a_harder_hit_sounds_different_from_a_light_one() {
+    let jab = impact_of(1.0);
+    let smash = impact_of(4.0);
+
+    assert!(
+        smash.pitch < jab.pitch,
+        "a harder hit should be lower: jab {} vs smash {}",
+        jab.pitch,
+        smash.pitch
+    );
+    assert!(
+        smash.volume > jab.volume,
+        "a harder hit should be louder and carry further: jab {} vs smash {}",
+        jab.volume,
+        smash.volume
+    );
+    assert_eq!(
+        jab.id, smash.id,
+        "the two must be the same sound, or the pitch means which kit rather than how hard"
+    );
+}
+
+/// The impact sound one melee hit with an ability multiplier of `multiplier`
+/// produces, taken off the wire rather than computed.
+fn impact_of(multiplier: f32) -> Sound {
+    let bench = Bench::new();
+    bench.equip("Zombie");
+    bench.game.server.take();
+    bench.swing(6.0, multiplier);
+    let heard = bench.game.server.sounds();
+    let Some((_, played)) = heard.iter().find(|(_, played)| played.id == sound::IMPACT) else {
+        panic!("a hit at x{multiplier} made no impact sound; the log is {heard:?}")
+    };
+    *played
+}
+
+/// The mapping saturates, so the loudest hit in the game is a value a client
+/// will honour rather than one it silently clamps.
+///
+/// A pitch outside `0.5..=2.0` is flattened by the client, which is exactly the
+/// moment the sound stops carrying information: every hit past the clamp sounds
+/// identical to every other, and the hardest hits are the ones a player most
+/// needs to be able to tell apart.
+#[test]
+fn the_impact_mapping_stays_inside_what_a_client_will_play() {
+    for magnitude in [0.05f32, 0.2, 0.7, 1.4, 5.0, 50.0] {
+        let played = sound::impact(Vec3::X * magnitude)
+            .unwrap_or_else(|| panic!("a hit of {magnitude} blocks a tick was silent"));
+        assert!(
+            (0.5..=2.0).contains(&played.pitch),
+            "a hit of {magnitude} asked for pitch {}, which the client would clamp",
+            played.pitch
+        );
+        assert!(
+            played.volume > 0.0,
+            "a hit of {magnitude} was played at no volume"
+        );
+    }
+
+    // Saturating rather than continuing to deepen: two hits well past a full
+    // smash are the same sound, which is honest, because they are the same
+    // outcome.
+    let big = sound::impact(Vec3::X * 5.0).expect("a large hit is audible");
+    let bigger = sound::impact(Vec3::X * 50.0).expect("a larger hit is audible");
+    assert!((big.pitch - bigger.pitch).abs() < 1e-6);
+    assert!((big.volume - bigger.volume).abs() < 1e-6);
+
+    // And a hit that moved nobody says nothing, rather than adding a sound to
+    // every zero-knockback ability tick.
+    assert!(sound::impact(Vec3::ZERO).is_none());
+    assert!(sound::impact(Vec3::X * (sound::QUIET_IMPULSE * 0.5)).is_none());
+    assert!(sound::impact(Vec3::X * f32::NAN).is_none());
+}
+
+/// Dying plays the kit's last word where it fell; running out of lives adds the
+/// elimination on top, because the two look identical on screen.
+#[test]
+fn dying_and_being_eliminated_sound_different() {
+    let bench = Bench::new();
+    bench.equip("Creeper");
+    let caster = bench.game.world.entity_from_id(bench.caster);
+    let at = Vec3::new(5.0, 1.0, -3.0);
+    caster.set(Position(at));
+
+    let voice = sound::declared(
+        kit::by_name(&bench.game.world, "Creeper").expect("the registry lost Creeper"),
+        PlaysOnDeath,
+    )
+    .expect("Creeper declares a death sound");
+
+    bench.game.server.take();
+    lives::kill(caster, DeathCause::Damage);
+    let heard = bench.game.server.sounds();
+    assert!(
+        heard
+            .iter()
+            .any(|(where_, played)| played.id == voice.id && where_.distance(at) < 1e-3),
+        "a death played {heard:?} rather than the kit's death sound at {at}"
+    );
+    assert!(
+        !heard
+            .iter()
+            .any(|(_, played)| played.id == sound::ELIMINATION),
+        "losing one life of four sounded like an elimination"
+    );
+
+    // Down to the last one, then take it.
+    caster.set(Lives(1));
+    caster.set(Position(at));
+    bench.game.server.take();
+    lives::kill(caster, DeathCause::Damage);
+    let heard = bench.game.server.sounds();
+    assert!(
+        heard
+            .iter()
+            .any(|(_, played)| played.id == sound::ELIMINATION),
+        "running out of lives played {heard:?} and no elimination"
+    );
+}
+
+/// The last seconds before a match are counted out loud, once each, rising, to
+/// everyone.
+///
+/// Per player rather than positioned: a countdown is about the match and not
+/// about a place, so it must not be quieter for whoever is standing furthest
+/// from the origin.
+#[test]
+fn the_countdown_ticks_once_a_second_and_then_the_match_starts() {
+    let mut game = Game::new();
+    // Two players is enough to start, and a countdown just longer than the
+    // audible window so the whole run of ticks is inside one phase.
+    game.world.set(LobbyConfig {
+        min_players: 2,
+        full_players: 4,
+        countdown_at_min: 6.0,
+        countdown_at_three_quarters: 6.0,
+        countdown_at_full: 6.0,
+        prepare_seconds: 0.5,
+        match_timeout_seconds: 600.0,
+        results_seconds: 5.0,
+    });
+    let listener = game.player("listener", Vec3::ZERO);
+    game.player("other", Vec3::new(80.0, 0.0, 0.0));
+    let listener = game.world.entity_from_id(listener).cloned::<&PlayerId>();
+
+    game.advance(6.0, 120);
+    assert_eq!(game.world.cloned::<&Lobby>().phase, Phase::Countdown);
+
+    // Every whole second inside the audible window, once each, rising. Built
+    // from the same function the game calls rather than from a literal, so this
+    // is a claim about the sequence and not a copy of the pitch table.
+    let mut wanted: Vec<f32> = (1..=sound::COUNTDOWN_AUDIBLE_SECONDS)
+        .map(|second| sound::countdown_tick(f32::from(second)).pitch)
+        .collect();
+    wanted.reverse();
+
+    let ticks: Vec<f32> = game
+        .server
+        .sounds_to(listener)
+        .into_iter()
+        .filter(|played| played.id == sound::COUNTDOWN_TICK)
+        .map(|played| played.pitch)
+        .collect();
+    assert_eq!(
+        ticks,
+        wanted,
+        "the countdown should tick once a second through its last {} and rise as it goes",
+        sound::COUNTDOWN_AUDIBLE_SECONDS
+    );
+
+    // Through the prepare phase and into the match.
+    game.server.take();
+    game.advance(1.0, 20);
+    assert_eq!(game.world.cloned::<&Lobby>().phase, Phase::Playing);
+    assert!(
+        game.server
+            .sounds_to(listener)
+            .iter()
+            .any(|played| played.id == sound::MATCH_START),
+        "nothing marked the start of the match"
+    );
+
+    // And the end, which one player leaving brings on.
+    game.server.take();
+    game.world
+        .entity_from_id(game.players()[1])
+        .set(Lives(0))
+        .add(Eliminated::id());
+    game.advance(1.0, 20);
+    assert_eq!(game.world.cloned::<&Lobby>().phase, Phase::Ended);
+    assert!(
+        game.server
+            .sounds_to(listener)
+            .iter()
+            .any(|played| played.id == sound::MATCH_END),
+        "nothing marked the end of the match"
+    );
+}
+
+/// A caster, a victim, and the two things a test here wants to do to them.
+struct Bench {
+    game: Game,
+    caster: Entity,
+    victim: Entity,
+}
+
+/// Far enough that a victim standing on a splash centre is still launched away
+/// from it, and close enough that a melee-range ability reaches. The same
+/// reasoning as `tests/abilities.rs`.
+const REACH: f32 = 3.5;
+
+impl Bench {
+    fn new() -> Self {
+        let mut game = Game::new();
+        let caster = game.player("caster", Vec3::ZERO);
+        let victim = game.player("victim", Vec3::new(REACH, 0.0, 0.0));
+        game.world.set(MatchClock(1.0));
+        Self {
+            game,
+            caster,
+            victim,
+        }
+    }
+
+    fn caster(&self) -> EntityView<'_> {
+        self.game.world.entity_from_id(self.caster)
+    }
+
+    /// Put both of them on `name`, standing up and full of everything.
+    fn equip(&self, name: &str) {
+        let world = &self.game.world;
+        let chosen =
+            kit::by_name(world, name).unwrap_or_else(|| panic!("the registry lost {name}"));
+        for entity in [self.caster, self.victim] {
+            let player = world.entity_from_id(entity);
+            kit::apply(world, player, chosen);
+            player.set(OnGround(true));
+            player.get::<&mut Health>(|health| health.current = health.max);
+            if let Some(mut energy) = player.try_get::<&Energy>(|e| *e) {
+                energy.current = energy.max;
+                player.set(energy);
+            }
+        }
+    }
+
+    /// Hand the caster a Smash Crystal if this entry needs one. `false` only if
+    /// one was needed and did not arrive.
+    fn arm(&self, entry: &Declared) -> bool {
+        if !entry.ultimate || ability::granted_in_slot(self.caster(), entry.slot).is_some() {
+            return true;
+        }
+        kit::grant_ultimate(&self.game.world, self.caster(), 600.0)
+    }
+
+    /// Fire `entry` the way a player would, and let anything it launched land.
+    fn press(&self, entry: &Declared) {
+        match entry.charge_time {
+            Some(seconds) => {
+                ability::use_slot(self.caster(), entry.slot);
+                self.game.advance(seconds, 8);
+                ability::release_slot(self.caster(), entry.slot);
+            }
+            None => ability::use_slot(self.caster(), entry.slot),
+        }
+        self.game.advance(1.5, 30);
+    }
+
+    /// One melee swing from the caster into the victim.
+    fn swing(&self, damage: f32, multiplier: f32) {
+        let from = self.caster().cloned::<&Position>().0;
+        hurt(self.game.world.entity_from_id(self.victim), Damaged {
+            attacker: Some(self.caster),
+            amount: damage,
+            knockback: Knockback::from(from).times(multiplier),
+            kind: DamageKind::Melee,
+        });
+    }
+}
+
+/// Redeclaring an occasion's sound replaces it rather than adding a second one.
+///
+/// The relationships are `Exclusive` and this is what that buys. Without it the
+/// second declaration sits alongside the first, `declared` answers with
+/// whichever flecs stored first, and a kit that has been retuned goes on
+/// playing the sound it used to have with nothing anywhere reporting it.
+#[test]
+fn declaring_a_sound_twice_keeps_the_second() {
+    let game = Game::new();
+    let quiet = sound::intern(
+        &game.world,
+        "minecraft:block.note_block.hat",
+        Levels::default(),
+    );
+    let loud = sound::intern(
+        &game.world,
+        "minecraft:block.note_block.bell",
+        Levels::default(),
+    );
+
+    let subject = game.world.entity().add((PlaysOnCast, quiet));
+    subject.add((PlaysOnCast, loud));
+
+    let declared = sound::declared(subject, PlaysOnCast).expect("a redeclared sound still reads");
+    assert_eq!(
+        declared.id, "minecraft:block.note_block.bell",
+        "the first declaration outlived the one that replaced it"
+    );
+}
+
+/// Almost everything here is a sweep over the registry; the three checks that
+/// are not name a kit, and a renamed kit would turn those into a panic in a
+/// helper rather than a failure anybody can read.
+#[test]
+fn the_kits_this_file_names_are_still_in_the_registry() {
+    let game = Game::new();
+    for name in ["Zombie", "Creeper"] {
+        assert!(
+            kit::by_name(&game.world, name).is_some(),
+            "{name} is gone; the hand-written checks in tests/sound.rs need a new subject"
+        );
+    }
+}

--- a/events/smash/tests/verification.rs
+++ b/events/smash/tests/verification.rs
@@ -2095,10 +2095,12 @@ mod projectiles {
             .calls()
             .into_iter()
             .find_map(|call| match call {
-                Call::Cue(at, _) => Some(at),
+                Call::Sound(at, sound) if sound.id == smash::module::sound::PROJECTILE_HIT => {
+                    Some(at)
+                }
                 _ => None,
             })
-            .expect("a hit is cued where it landed");
+            .expect("a hit is heard where it landed");
         assert!(
             contact.distance(Vec3::ZERO) < 0.5,
             "the hit was reported at {contact}, which is not where the path crossed the target"

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -115,6 +115,7 @@ S2C_SET_ACTION_BAR_TEXT = 0x57
 S2C_SET_ENTITY_MOTION = 0x65
 S2C_SET_HEALTH = 0x68
 S2C_SET_TITLE_TEXT = 0x72
+S2C_SOUND = 0x75
 S2C_SYSTEM_CHAT = 0x79
 
 # `ServerboundMovePlayerPacket` packs the ground flag into a bitfield; bit 0 is
@@ -158,6 +159,36 @@ def take_lp_vec3(payload, offset):
     ), offset
 
 
+def take_sound(payload):
+    """`ClientboundSoundPacket`, as far as this file cares about it.
+
+    The sound event is a `Holder`: a var int that is either an index into the
+    client's `minecraft:sound_event` registry, biased by one, or zero followed
+    by the event inline. hyperion sends the registries by name and has no id
+    table to look one up in, so it always writes the inline form -- which is
+    also the only form this reads, because an id would tell a test nothing it
+    could compare against a kit declaration.
+
+    Returns `(id, source, position, volume, pitch)` with the position back in
+    blocks; the wire carries it in eighths.
+    """
+    holder, offset = take_var_int(payload)
+    if holder != 0:
+        return None
+    length, offset = take_var_int(payload, offset)
+    sound_id = payload[offset : offset + length].decode("utf-8", "replace")
+    offset += length
+    # `fixedRange` is optional and hyperion leaves it out, but a present one
+    # would shift everything after it.
+    has_range = payload[offset]
+    offset += 1
+    if has_range:
+        offset += 4
+    source, offset = take_var_int(payload, offset)
+    x, y, z, volume, pitch = struct.unpack(">iiiff", payload[offset : offset + 20])
+    return sound_id, source, (x / 8.0, y / 8.0, z / 8.0), volume, pitch
+
+
 def take_nbt_string(payload, offset):
     """Read a network-NBT tag that is a bare string.
 
@@ -183,6 +214,18 @@ REGION_STRIDE = 512
 
 # events/smash/src/module/lives.rs: Mineplex's `MAX_LIVES`.
 MAX_LIVES = 4
+
+# events/smash/src/module/sound.rs: `IMPACT`, the one sound every hit in the
+# game makes. Named here rather than read off the manifest because it is not an
+# ability's sound: it belongs to the hit, and its pitch and volume are what say
+# how hard that hit was.
+IMPACT_SOUND = "minecraft:entity.player.attack.strong"
+
+# How far the sound may be from where the client last claimed the victim was, in
+# blocks. Not zero: the server plays it at the position in its own mirror, which
+# is a tick or two behind whatever the client last sent, and the wire quantises
+# to an eighth of a block on top.
+IMPACT_TOLERANCE = 3.0
 
 # events/smash/src/module/knockback.rs: `KnockbackModel::default`, Mineplex's
 # own numbers. Restated here so the check below is a check and not a
@@ -343,6 +386,10 @@ class MatchClient(base.Client):
         self.seen = {}
         self.action_bar = []
         self.teleported_to = []
+        # Every `ClientboundSoundPacket` this client has been sent, decoded.
+        # Collected per client rather than once, because a positioned sound goes
+        # out on the chunk channel and a player is not always in their own.
+        self.sounds = []
         self.last_position_sent = 0.0
         self.alive = True
 
@@ -512,6 +559,7 @@ class Match:
         if args.abilities:
             self.proof["the server published its ability registry"] = None
             self.proof["every declared ability did what it declared"] = None
+            self.proof["every declared ability was heard"] = None
             self.proof["cooldowns refused a second use"] = None
         self.proof.update({
             "four in play": None,
@@ -519,6 +567,7 @@ class Match:
             "kits equipped": None,
             "arena is a committed map": None,
             "knockback from an ability": None,
+            "a hit was heard where it landed": None,
             "life lost and respawned": None,
             "match ended, back in the hub": None,
         })
@@ -531,6 +580,9 @@ class Match:
         self.sweep_failures = []
         self.cooldown_results = []
         self.cooldown_failures = []
+        # Abilities whose declared sound never arrived, and any sound that
+        # arrived in a form a client could not resolve.
+        self.sound_failures = []
         # Velocity packets seen this window, keyed by entity id. Collected from
         # every client rather than one, because a player is not always in their
         # own broadcast channel and the caster's own launch has to be visible.
@@ -633,6 +685,20 @@ class Match:
         elif packet_id == S2C_SET_TITLE_TEXT:
             text, _ = take_nbt_string(payload, 0)
             client.log("<- title: %s" % text)
+        elif packet_id == S2C_SOUND:
+            heard = take_sound(payload)
+            if heard is None:
+                self.sound_failures.append(
+                    "a sound arrived as a registry id; hyperion sends no id table, "
+                    "so a client would have nothing to resolve it against"
+                )
+                return
+            client.sounds.append(heard)
+            sound_id, _source, at, volume, pitch = heard
+            client.log(
+                "<- sound %s at (%.1f, %.1f, %.1f) vol %.2f pitch %.2f"
+                % ((sound_id,) + at + (volume, pitch))
+            )
         elif packet_id == S2C_SET_ACTION_BAR_TEXT:
             text, _ = take_nbt_string(payload, 0)
             client.action_bar.append(text)
@@ -854,6 +920,16 @@ class Match:
                 "%d abilities fired by a real client, each one checked against "
                 "the effects its own registry entry names" % len(self.manifest),
             )
+        if self.sound_failures:
+            for line in self.sound_failures:
+                self.log("SOUND FAILED %s" % line)
+        else:
+            self.prove(
+                "every declared ability was heard",
+                "%d abilities fired by a real client, each one answered by a "
+                "ClientboundSoundPacket carrying the vanilla sound event its own "
+                "registry entry names" % len(self.manifest),
+            )
         if self.cooldown_failures:
             for line in self.cooldown_failures:
                 self.log("COOLDOWN FAILED %s" % line)
@@ -985,6 +1061,7 @@ class Match:
         for client in self.clients:
             client.action_bar.clear()
             client.teleported_to.clear()
+            client.sounds.clear()
         return {
             "melee": melee,
             "health": {client.name: client.health for client in self.clients},
@@ -1051,6 +1128,10 @@ class Match:
                 )
         return found
 
+    def window_sounds(self):
+        """Every sound id any client has been sent since the last baseline."""
+        return {heard[0] for client in self.clients for heard in client.sounds}
+
     def probe_cooldown(self, entry):
         """Right-click again straight away and expect to be told no."""
         if entry["cooldown"] < 1.0 or entry["refunds_on_hit"]:
@@ -1082,9 +1163,10 @@ class Match:
         label = "%s / %s" % (entry["kit"], entry["name"])
         outstanding = list(entry["proves"])
         evidence = []
+        heard = False
 
         for attempt in range(SWEEP_ATTEMPTS):
-            if not outstanding:
+            if not outstanding and heard:
                 break
             self.stage(entry, attempt)
             if not self.arm(entry):
@@ -1100,12 +1182,23 @@ class Match:
                 if name in outstanding:
                     outstanding.remove(name)
                     evidence.append("%s: %s" % (name, note))
-            if outstanding:
+            # After `observe`, which is what waits out the window the sound
+            # arrives in.
+            if entry["sound"] in self.window_sounds():
+                if not heard:
+                    evidence.append("heard: %s" % entry["sound"])
+                heard = True
+            if outstanding or not heard:
                 self.wait(entry["cooldown"] + 0.5)
 
         if outstanding:
             self.sweep_failures.append(
                 "%s declares %s and did not do it" % (label, ", ".join(outstanding))
+            )
+        if not heard:
+            self.sound_failures.append(
+                "%s declares the sound %s and firing it sent no such packet"
+                % (label, entry["sound"])
             )
         self.sweep_results.append(
             "%-42s %s" % (label, "; ".join(evidence) or "nothing reached a client")
@@ -1325,6 +1418,61 @@ class Match:
         for victim in self.victims():
             attacker.attack(victim)
 
+    def check_impact_sound(self, victim):
+        """A hit is heard where it landed, at a pitch and volume that say how
+        hard.
+
+        The `knockback from an ability` proof above says the launch reached a
+        client. This says the *feedback* did, which is the whole reason this
+        change exists: the physics were already right and the player could not
+        feel them. The two are checked at the same moment because they come from
+        the same event.
+        """
+        vx, vy, vz = victim.position
+        impacts = [
+            heard
+            for client in self.clients
+            for heard in client.sounds
+            if heard[0] == IMPACT_SOUND
+        ]
+        near = [
+            heard
+            for heard in impacts
+            if distance(heard[2], (vx, vy, vz)) < IMPACT_TOLERANCE
+        ]
+        if not near:
+            self.log(
+                "no impact sound arrived near %s at (%.1f, %.1f, %.1f); %d were "
+                "heard elsewhere" % (victim.name, vx, vy, vz, len(impacts))
+            )
+            return
+
+        levels = sorted({(round(h[4], 3), round(h[3], 3)) for h in impacts})
+        _sound_id, _source, at, volume, pitch = near[0]
+        spread = ""
+        if len(levels) > 1:
+            softest, loudest = levels[-1], levels[0]
+            spread = (
+                ". Across the match the hits ranged from pitch %.2f at volume "
+                "%.2f to pitch %.2f at volume %.2f, so a jab and a smash do not "
+                "sound the same" % (softest[0], softest[1], loudest[0], loudest[1])
+            )
+        self.prove(
+            "a hit was heard where it landed",
+            "%s took an impact at (%.1f, %.1f, %.1f), %.2f blocks from where "
+            "they stand, at pitch %.2f and volume %.2f%s"
+            % (
+                victim.name,
+                at[0],
+                at[1],
+                at[2],
+                distance(at, (vx, vy, vz)),
+                pitch,
+                volume,
+                spread,
+            ),
+        )
+
     def check_knockback(self):
         """Hold the launch the ability produced against the model.
 
@@ -1397,6 +1545,7 @@ class Match:
                     attacker.name,
                 ),
             )
+            self.check_impact_sound(victim)
             return
 
         self.log(


### PR DESCRIPTION
## Super Smash Mobs was silent

`rg -c "Sound" events/smash/src/` returned 0. For comparison the same
measurement gave Particle 6, Title 7, ActionBar 6. Fifty-one abilities shared
four noises between them, all four picked by a six-variant `Cue` enum in the
hosting layer, and nothing at all marked a hit landing, a death, an
elimination, the countdown or the start of a match.

That matters here more than it would elsewhere. The physics are done and
verified tick-accurate against a real Java server, and knockback is the only
thing in this game that kills you, so the whole read on "did I connect, and how
hard" is audio-visual. The simulation was right and the player could not feel
it.

## A sound is an entity, and whatever makes a noise points at one

Three relationships, named for the occasion rather than for the sound:

* `(PlaysOnCast, sound)` on an ability
* `(PlaysOnHurt, sound)` on a kit
* `(PlaysOnDeath, sound)` on a kit

All three `Exclusive`, so a kit that redeclares gets a correction and not a
second edge. The dispatcher in `module/ability.rs` reads what to play off the
ability entity that just fired, so it still names no kit. The damage and death
paths reach a kit's voice through the player's own `(Playing, kit)` edge, so
they never learn that kits have names either.

The alternative would have been a match from an ability name to a string. That
is a second registry: it lives in a different file from the abilities, nothing
makes the two agree, and the day a kit is renamed the game goes quiet in a way
no test notices.

Each of the fifty-one abilities gets its own vanilla sound event, declared
alongside its name, item, slot and cooldown in the kit that owns it, and each
of the fifteen kits gets a hurt and a death voice. Every id is distinct, and
`tests/sound.rs` fails on a duplicate.

## How hard the hit was

The knockback model already computes the impulse it launches a victim with, and
that impulse is 1:1 with Mineplex's. `sound::impact` maps its magnitude onto one
sound:

| impulse (blocks/tick) | pitch | volume |
| --- | --- | --- |
| below 0.05 | silent | silent |
| 0.05 | 1.50 | 0.55 |
| 1.40 and above | 0.70 | 1.60 |

Linear in between, saturating at 1.4, which is where the model's vertical cap
stops rising and a hit becomes the sideways launch that ends a life. Pitch falls
as the hit gets harder, because a bigger collision resonates lower. Volume rises,
and volume is also range: a client attenuates to nothing at `16 * volume`
blocks, so a jab is a local event and a full smash is heard across the arena.

One sound and not fifteen, deliberately. A pitch shift only reads as "harder"
against a fixed reference; give each kit its own impact timbre and it starts
reading as "a different kit hit me". The kit's own voice is still heard, on the
victim, through `(PlaysOnHurt, sound)`.

## Everything else that now makes a noise

Melee and ability connects, projectile contact at the point on the path where it
crossed (not at either end of the tick's step), a hitmarker to the shooter alone
however far away they are, taking knockback, dying, being eliminated, the last
five seconds of the countdown rising a step a second, the start of the match and
the end of it.

## Below the game

`hyperion::net::agnostic::sound` grows a `SoundCategory`, so a player who has
turned Hostile Creatures down hears the roster quieter and their own countdown
unchanged, and two ways to send: `broadcast_near` for something that happened
somewhere, `play_to` for something about the match, which is sent at the
listener's own ears so it is not quieter for whoever is furthest from the
origin. `Cue` keeps only the three variants that really are a particle.

No audio assets and no resource pack. An id a client does not know is silence
with no error anywhere, so `tests/sound.rs` holds all eighty-six ids in the game
against the generated `minecraft:sound_event` registry.

## Gates

`events/smash/tests/sound.rs`, run by `nix run .#test`, is a sweep over
`ability::manifest` and `kit::registry` rather than a list, so a kit added
tomorrow is covered the moment its module runs. It fires every ability in the
game through the mock seam and checks the sound it declared actually went out,
which is the check a declaration alone cannot pass.

`nix run .#smash-e2e` now decodes `ClientboundSoundPacket` and requires that
every ability the server publishes answers with a packet carrying its own
declared sound event, and that a hit is heard within three blocks of the victim.
That is the half the Rust test cannot see: a mock call log says nothing about
whether the adapter encodes or the proxy delivers.

Six of the new guards were watched to fail, each with the message intended: the
`Exclusive` trait removed, an ability's sound blanked, two abilities sharing a
sound, an invented sound id, the magnitude mapping flattened to a constant, and
the impact unhooked from the knockback observer.

## What I changed about the draft this started from

The uncommitted draft did not compile: it narrowed `Cue` without removing the
twelve call sites that used the variants it dropped. Those are gone now, and the
nine of them that were pure cast feedback are covered by the `(PlaysOnCast,
sound)` dispatcher instead.

Its module documentation claimed `(OnInstantiate, Inherit)` was load bearing and
that without it every player's copy of every ability would be silent. That is
false: flecs' default `Override` copies the pair onto each instance and reads
back identically. I confirmed it by removing the trait and watching the whole
sweep stay green. The trait is kept, because static data shared by every
instance is what it is for, and the comment now says that instead of the
opposite.

`intern` keyed on the sound id alone, so the second caller to ask for the same
sound at a different volume would silently get the first caller's volume back.
It is keyed on the levels too now. `Sound::audible_radius` was dead and its
documentation described behaviour `broadcast_near` does not have, so it is gone.

## Not done

Nothing marks a projectile being fired as distinct from the ability that fired
it, and no sound distinguishes an ability being refused for cooldown from one
that fired. Both are one relationship away and neither is in this change.

The categories are one decision I would flag for review: every kit ability is
`Hostile`, including Cow's and Chicken's, on the grounds that in this game a kit
is a combatant whatever mob it is skinned as and they should all move together
on one slider. The argument for splitting passive kits onto `Neutral` is
reasonable and I did not take it.

## The Flake job is red and it is not this change

`nix flake check` fails on the runner with `experimental Nix feature
'ca-derivations' is disabled` and a list of `store path ... does not exist` for
derivations nobody here touched, including `libraqm`, `libaio` and `wcwidth`.
The identical failure is on #1002, which merged with it in place. Filed as
ENG-10819.

The two checks it takes down that this change does touch were run locally on
aarch64-darwin instead:

```
$ nix build .#checks.aarch64-darwin.smash-e2e -L
...
hyperion-smash-e2e>  282.37s         proved      every declared ability was heard
hyperion-smash-e2e>  282.37s                     51 abilities fired by a real client, each one
                                                 answered by a ClientboundSoundPacket carrying the
                                                 vanilla sound event its own registry entry names
hyperion-smash-e2e>  282.37s         proved      a hit was heard where it landed
hyperion-smash-e2e>  282.37s                     P3 took an impact at (498.9, 65.0, 13.0), 0.09
                                                 blocks from where they stand, at pitch 0.70 and
                                                 volume 1.60
hyperion-smash-e2e>  282.37s       RESULT: a whole match ran at protocol 776
rc=0

$ nix run .#test
     Summary [  61.999s] 610 tests run: 610 passed, 1 skipped
rc=0

$ nix run .#lint
rc=0
```

---

AI-authored: written by Claude (Opus 4.5) under human direction. The design
decisions above are mine unless a comment in the code cites Mineplex.
