### PR TITLE
feat(smash): pick a kit by right-clicking its mob in the middle of the lobby

### DIFF
--- a/crates/hyperion-minecraft-proto/src/packets/play/entity.rs
+++ b/crates/hyperion-minecraft-proto/src/packets/play/entity.rs
@@ -25,7 +25,7 @@ pub use super::clientbound::{
 use crate::{
     Decode, Encode, Error, Reader, RegistryId, Result, Uuid, Writer,
     item::{Slot, nbt::NbtScan},
-    types::Vec3,
+    types::{InteractionHand, Vec3},
 };
 
 // --- rotation -------------------------------------------------------------
@@ -255,6 +255,31 @@ pub struct AddEntity {
     /// Type-specific spawn data; zero for everything that does not define one.
     #[proto(varint)]
     pub data: i32,
+}
+
+/// `minecraft:interact`, sent serverbound as play id 26.
+///
+/// Layout from `net.minecraft.network.protocol.game.ServerboundInteractPacket#STREAM_CODEC`,
+/// which `protocol.json` models field by field but marks `complete: false` with
+/// the reason `unmodelled statement: double z`. That reason is about the
+/// `Vec3#LP_STREAM_CODEC` inside it, which this crate does have and uses below,
+/// so the generator's refusal costs the whole packet rather than the one field
+/// it could not follow. Hand-written here for that reason and nothing else; the
+/// field list is the extractor's, not a reading of a wiki.
+///
+/// 26.2 split attacking out into `minecraft:attack`, so this now only ever
+/// means a right-click on an entity, and there is no leading action
+/// discriminant the way there was through 1.21.
+#[derive(Debug, Clone, Copy, PartialEq, Encode, Decode)]
+pub struct Interact {
+    #[proto(varint)]
+    pub entity_id: i32,
+    pub hand: InteractionHand,
+    /// Where on the entity the ray landed, relative to the entity's position.
+    #[proto(with = lp_vec3)]
+    pub location: Vec3,
+    /// Whether the player was sneaking.
+    pub using_secondary_action: bool,
 }
 
 /// `minecraft:set_entity_motion`, sent clientbound as play id 101.

--- a/crates/hyperion/src/simulation/entity_kind.rs
+++ b/crates/hyperion/src/simulation/entity_kind.rs
@@ -1,141 +1,57 @@
 use flecs_ecs::{core::ComponentOrPairId, macros::Component};
-use hyperion_minecraft_proto::entity_type::EntityType;
+use hyperion_minecraft_proto::entity_type::{EntityType, entity_type};
 
-/// What kind of thing an entity is.
+/// Declare [`EntityKind`] and the list of every one of them together.
 ///
-/// The discriminants are flecs enum tags and carry no protocol meaning. They
-/// used to be sent as `minecraft:entity_type` ids, which worked only because
-/// 1.20.1 happened to number that registry the way this list is ordered;
-/// [`Self::entity_type`] is now the only thing allowed to produce an id.
-#[derive(Component, Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[repr(C)]
-#[flecs(meta)]
-pub enum EntityKind {
-    Allay,
-    AreaEffectCloud,
-    ArmorStand,
-    Arrow,
-    Axolotl,
-    Bat,
-    Bee,
-    Blaze,
-    BlockDisplay,
-    Boat,
-    Camel,
-    Cat,
-    CaveSpider,
-    ChestBoat,
-    ChestMinecart,
-    Chicken,
-    Cod,
-    CommandBlockMinecart,
-    Cow,
-    Creeper,
-    Dolphin,
-    Donkey,
-    DragonFireball,
-    Drowned,
-    Egg,
-    ElderGuardian,
-    EndCrystal,
-    EnderDragon,
-    EnderPearl,
-    Enderman,
-    Endermite,
-    Evoker,
-    EvokerFangs,
-    ExperienceBottle,
-    ExperienceOrb,
-    EyeOfEnder,
-    FallingBlock,
-    FireworkRocket,
-    Fox,
-    Frog,
-    FurnaceMinecart,
-    Ghast,
-    Giant,
-    GlowItemFrame,
-    GlowSquid,
-    Goat,
-    Guardian,
-    Hoglin,
-    HopperMinecart,
-    Horse,
-    Husk,
-    Illusioner,
-    Interaction,
-    IronGolem,
-    Item,
-    ItemDisplay,
-    ItemFrame,
-    Fireball,
-    LeashKnot,
-    Lightning,
-    Llama,
-    LlamaSpit,
-    MagmaCube,
-    Marker,
-    Minecart,
-    Mooshroom,
-    Mule,
-    Ocelot,
-    Painting,
-    Panda,
-    Parrot,
-    Phantom,
-    Pig,
-    Piglin,
-    PiglinBrute,
-    Pillager,
-    PolarBear,
-    Potion,
-    Pufferfish,
-    Rabbit,
-    Ravager,
-    Salmon,
-    Sheep,
-    Shulker,
-    ShulkerBullet,
-    Silverfish,
-    Skeleton,
-    SkeletonHorse,
-    Slime,
-    SmallFireball,
-    Sniffer,
-    SnowGolem,
-    Snowball,
-    SpawnerMinecart,
-    SpectralArrow,
-    Spider,
-    Squid,
-    Stray,
-    Strider,
-    Tadpole,
-    TextDisplay,
-    Tnt,
-    TntMinecart,
-    TraderLlama,
-    Trident,
-    TropicalFish,
-    Turtle,
-    Vex,
-    Villager,
-    Vindicator,
-    WanderingTrader,
-    Warden,
-    Witch,
-    Wither,
-    WitherSkeleton,
-    WitherSkull,
-    Wolf,
-    Zoglin,
-    Zombie,
-    ZombieHorse,
-    ZombieVillager,
-    ZombifiedPiglin,
-    Player,
-    FishingBobber,
-    Gui,
+/// A macro so that [`EntityKind::ALL`] cannot fall behind the enum. The list is
+/// what makes the name-to-kind direction possible at all, and a hand-written
+/// copy of 125 variants is a copy that is wrong the first time somebody adds a
+/// mob and does not think to scroll down.
+macro_rules! entity_kinds {
+    ($($name:ident),* $(,)?) => {
+        /// What kind of thing an entity is.
+        ///
+        /// The discriminants are flecs enum tags and carry no protocol meaning.
+        /// They used to be sent as `minecraft:entity_type` ids, which worked
+        /// only because 1.20.1 happened to number that registry the way this
+        /// list is ordered; [`EntityKind::entity_type`] is now the only thing
+        /// allowed to produce an id.
+        #[derive(Component, Copy, Clone, Debug, PartialEq, Eq, Hash)]
+        #[repr(C)]
+        #[flecs(meta)]
+        pub enum EntityKind {
+            $($name),*
+        }
+
+        impl EntityKind {
+            /// Every kind, in declaration order.
+            pub const ALL: &'static [Self] = &[$(Self::$name),*];
+        }
+    };
+}
+
+entity_kinds! {
+    Allay, AreaEffectCloud, ArmorStand, Arrow, Axolotl, Bat,
+    Bee, Blaze, BlockDisplay, Boat, Camel, Cat,
+    CaveSpider, ChestBoat, ChestMinecart, Chicken, Cod, CommandBlockMinecart,
+    Cow, Creeper, Dolphin, Donkey, DragonFireball, Drowned,
+    Egg, ElderGuardian, EndCrystal, EnderDragon, EnderPearl, Enderman,
+    Endermite, Evoker, EvokerFangs, ExperienceBottle, ExperienceOrb, EyeOfEnder,
+    FallingBlock, FireworkRocket, Fox, Frog, FurnaceMinecart, Ghast,
+    Giant, GlowItemFrame, GlowSquid, Goat, Guardian, Hoglin,
+    HopperMinecart, Horse, Husk, Illusioner, Interaction, IronGolem,
+    Item, ItemDisplay, ItemFrame, Fireball, LeashKnot, Lightning,
+    Llama, LlamaSpit, MagmaCube, Marker, Minecart, Mooshroom,
+    Mule, Ocelot, Painting, Panda, Parrot, Phantom,
+    Pig, Piglin, PiglinBrute, Pillager, PolarBear, Potion,
+    Pufferfish, Rabbit, Ravager, Salmon, Sheep, Shulker,
+    ShulkerBullet, Silverfish, Skeleton, SkeletonHorse, Slime, SmallFireball,
+    Sniffer, SnowGolem, Snowball, SpawnerMinecart, SpectralArrow, Spider,
+    Squid, Stray, Strider, Tadpole, TextDisplay, Tnt,
+    TntMinecart, TraderLlama, Trident, TropicalFish, Turtle, Vex,
+    Villager, Vindicator, WanderingTrader, Warden, Witch, Wither,
+    WitherSkeleton, WitherSkull, Wolf, Zoglin, Zombie, ZombieHorse,
+    ZombieVillager, ZombifiedPiglin, Player, FishingBobber, Gui,
 }
 
 impl EntityKind {
@@ -149,6 +65,21 @@ impl EntityKind {
     /// Every arm names a constant from the generated table, so a version bump
     /// that renames or drops a type stops this file compiling rather than
     /// leaving a stale id to be discovered on the wire.
+    /// The kind whose entity type is named `name`, such as `minecraft:creeper`.
+    ///
+    /// The reverse of [`Self::entity_type`], done by searching [`Self::ALL`]
+    /// rather than by a second table. A table would be a second place the
+    /// pairing is written, and the day the two disagree the wrong mob appears
+    /// in the world with nothing to say why.
+    #[must_use]
+    pub fn named(name: &str) -> Option<Self> {
+        let wanted = entity_type(name)?;
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|kind| kind.entity_type() == Some(wanted))
+    }
+
     #[must_use]
     pub const fn entity_type(self) -> Option<EntityType> {
         let entity_type = match self {

--- a/crates/hyperion/src/simulation/event.rs
+++ b/crates/hyperion/src/simulation/event.rs
@@ -121,7 +121,37 @@ pub struct Command {
     pub by: Entity,
 }
 
-pub struct BlockInteract {}
+/// A player right-clicked an entity.
+///
+/// `minecraft:interact`, which since 26.2 means nothing else: attacking left
+/// with the packet split out into `minecraft:attack`. A game whose furniture is
+/// alive -- a shopkeeper, a kit selector's mobs -- has no other way to hear a
+/// click on it, and until this existed the packet reached the dispatch table
+/// and fell straight through it.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct EntityInteract {
+    /// The entity that was clicked.
+    pub target: Entity,
+    pub from: Entity,
+    pub hand: Hand,
+}
+
+/// A player right-clicked a block.
+///
+/// Raised for every `use_item_on`, before the door and block-placement
+/// branches decide whether they also want it. Those two are the only other
+/// things that packet can mean, and both of them are about changing the world;
+/// a block that is a button, a shop or a kit selector is a block whose click
+/// has to be heard even though nothing about the world changes, and until this
+/// carried a position there was no way to hear one.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct BlockInteract {
+    /// The block that was clicked, not the space in front of it.
+    pub position: IVec3,
+    pub from: Entity,
+    pub hand: Hand,
+    pub sequence: i32,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ClientStatusCommand {

--- a/crates/hyperion/src/simulation/handlers.rs
+++ b/crates/hyperion/src/simulation/handlers.rs
@@ -24,6 +24,7 @@ use hyperion_minecraft_proto::{
     },
     packets::play::{
         clientbound::OpenBook,
+        entity::Interact,
         serverbound::{self as c2s, client_command, player_action, player_command},
     },
     types::{Direction, HumanoidArm, InteractionHand},
@@ -137,6 +138,7 @@ pub fn route(id: i32) -> Route {
         PacketId::ClientCommand => Route::Act(client_command),
         PacketId::ClientInformation => Route::Act(client_information),
         PacketId::CommandSuggestion => Route::Act(command_suggestion),
+        PacketId::Interact => Route::Act(interact),
         PacketId::ContainerClose => Route::Act(container_close),
         PacketId::MovePlayerPos => Route::Act(move_player_pos),
         PacketId::MovePlayerPosRot => Route::Act(move_player_pos_rot),
@@ -248,6 +250,27 @@ fn attack(body: &[u8], query: &mut PacketSwitchQuery<'_>) -> anyhow::Result<()> 
             origin: query.id,
             target: Entity::from_minecraft_id(packet.entity_id),
             damage: 1.0,
+        },
+        query.world,
+    );
+
+    Ok(())
+}
+
+/// A right-click on an entity.
+///
+/// The mirror of [`attack`], which 26.2 split out of this packet. Nothing here
+/// decides what the click means: the position on the entity and the sneak flag
+/// are dropped because no caller has wanted them, and the game is left to
+/// resolve the target however it likes.
+fn interact(body: &[u8], query: &mut PacketSwitchQuery<'_>) -> anyhow::Result<()> {
+    let packet: Interact = decode_body(body)?;
+
+    query.events.push(
+        event::EntityInteract {
+            target: Entity::from_minecraft_id(packet.entity_id),
+            from: query.id,
+            hand: hand(packet.hand),
         },
         query.world,
     );
@@ -579,6 +602,23 @@ fn use_item_on(body: &[u8], query: &mut PacketSwitchQuery<'_>) -> anyhow::Result
 
     let hit = packet.block_hit;
     let interacted = IVec3::new(hit.block_pos.x, hit.block_pos.y, hit.block_pos.z);
+
+    // Raised for the click itself, ahead of the two branches below that ask
+    // what the click should *change*. A game whose blocks are interactive --
+    // a kit selector, a shop, a button -- needs the position of the block that
+    // was clicked and nothing else, and neither `ToggleDoor` nor `PlaceBlock`
+    // will fire for it: the first wants an openable block and the second wants
+    // a placeable item in hand, so an empty-handed click on a quartz plinth
+    // used to reach the world as nothing at all.
+    query.events.push(
+        event::BlockInteract {
+            position: interacted,
+            from: query.id,
+            hand: hand(packet.hand),
+            sequence: packet.sequence,
+        },
+        query.world,
+    );
 
     let Some(interacted_block) = query.blocks.get_block(interacted) else {
         return Ok(());

--- a/crates/hyperion/src/storage/event/queue/mod.rs
+++ b/crates/hyperion/src/storage/event/queue/mod.rs
@@ -51,6 +51,8 @@ define_events! {
     event::ItemInteract,
     event::SetSkin,
     event::AttackEntity,
+    event::BlockInteract,
+    event::EntityInteract,
     event::ChatMessage,
     event::Command,
     event::DestroyBlock,

--- a/docs/smash-design.md
+++ b/docs/smash-design.md
@@ -559,13 +559,55 @@ process carries on, which is a hard failure to read. Making it a flag lets
 `nix run .#smash` be a whole server in one process and `nix run .#smash-dev`
 run the deployed shape with no race.
 
+### New: `events/smash/src/module/selector.rs`
+
+Mineplex's waiting lobby put one mob per kit on a pedestal of coloured wool and
+you right-clicked the mob you wanted to be. This is that: a ring of fifteen
+podiums in the middle of the hub, each a wool block with the kit's own mob
+standing on it, generated from the roster at boot so adding a kit adds a podium.
+
+Everything about it is a relation. A podium *is* its `(Offers, kit)` edge and a
+mob *is* its `(StandsOn, podium)` edge, so a click that arrives naming an entity
+becomes a kit in two hops with no table keyed on entity id or block position.
+Whether a mob is taken is a query for any player with `(Playing, thatKit)`,
+derived on every call rather than stored, which is what makes a disconnect free
+a mob with no cleanup code anywhere: the claim was the player's edge and the
+player is gone.
+
+**One player per mob.** Nothing found says whether Mineplex reserved a kit, and
+since kits were bought per account with gems it would be a strange rule to have
+shipped, so treat this as ours. The claim lasts the rest of the match without a
+second rule saying so, because `lobby::choose` already refuses any kit change
+once the match commits.
+
+**How a player is told.** The wool goes green to red the moment somebody takes
+the mob, which is the only channel that works in the last seconds of a countdown
+when nobody is reading chat, and it says *which* mob is gone. The action bar
+line explains a refusal that has already happened rather than delivering the
+news. There is no sound yet; that belongs with the audio work.
+
+Making the mob clickable took a change to the engine. hyperion routed no
+entity-interaction packet, so `minecraft:interact` reached the dispatch table
+and fell through it. It is routed now as `event::EntityInteract`, and since 26.2
+split attacking out into `minecraft:attack` that packet means a right-click and
+nothing else. Its body is hand-written in `packets/play/entity.rs`: the
+extractor models the field list but marks the packet `complete: false` over one
+statement inside the `Vec3` LP codec, which this crate already has.
+
 ### New: `events/smash/src/command.rs`
 
-Not in the original plan. `/kit <name>` and `/kits`, through `hyperion-clap`,
-because there is no kit menu and something has to select a kit. A Minecraft
-command argument is one whitespace-delimited token and half the kit names have
-a space in them, so `/kit` matches on the name with case and punctuation
-discarded: `/kit irongolem` finds `Iron Golem`.
+`/kit <name>` and `/kits`, through `hyperion-clap`. No longer the only way to
+pick a kit, but still the one a screen reader can use and the one every gate
+that is not testing the selector reaches for. A Minecraft command argument is
+one whitespace-delimited token and half the kit names have a space in them, so
+`/kit` matches on the name with case and punctuation discarded: `/kit irongolem`
+finds `Iron Golem`.
+
+`/podiums` answers with one JSON object per podium: which kit, where its mob
+stands, what colour its wool is and who holds it. It exists so that
+`tools/smash-selector.py` can right-click a podium without recomputing the ring
+in Python, which would be a second copy of the geometry and would keep passing
+after the real ring moved.
 
 ### Changed: `events/smash/Cargo.toml`
 

--- a/events/smash/src/command.rs
+++ b/events/smash/src/command.rs
@@ -1,7 +1,10 @@
-//! Chat commands, which are the only way to pick a kit until there is a menu.
+//! Chat commands.
 //!
-//! Mineplex used a compass and an inventory GUI in the hub. `/kit <name>` is the
-//! same choice made through the one input surface that already works.
+//! The way to pick a kit is to right-click its podium in the hub; see
+//! [`crate::module::selector`]. `/kit <name>` is the same choice made by typing
+//! rather than by walking, which is what a screen reader needs and what every
+//! gate that is not testing the selector itself uses. Mineplex had both too:
+//! the pedestals in the waiting lobby, and `/kit` opening a GUI.
 
 use std::fmt::Write;
 
@@ -15,7 +18,7 @@ use hyperion_clap::{CommandPermission, MinecraftCommand, hyperion_command::Comma
 use crate::module::{
     ability,
     kit::{self, Kit, KitBlurb, KitName},
-    lobby,
+    lobby, selector,
 };
 
 pub fn register(registry: &mut CommandRegistry, world: &World) {
@@ -26,6 +29,7 @@ pub fn register(registry: &mut CommandRegistry, world: &World) {
     // honest: `tests/modularity.rs` adds one from outside the crate.
     KitCommand::register(registry, world).completes("name", Kit::id());
     KitsCommand::register(registry, world);
+    PodiumsCommand::register(registry, world);
     AbilitiesCommand::register(registry, world);
     CrystalCommand::register(registry, world);
 }
@@ -197,6 +201,67 @@ fn json(entry: &ability::Declared) -> String {
 
 fn escape(text: &str) -> String {
     text.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// The line `/podiums` prefixes each podium with. See [`MANIFEST_PREFIX`].
+pub const PODIUM_PREFIX: &str = "smash-podium ";
+
+/// The line that closes the podium manifest, with the count before it.
+pub const PODIUM_END_PREFIX: &str = "smash-podiums-end ";
+
+/// Say where every kit podium stands and who has taken it.
+///
+/// The selector's ring is generated from the roster at boot, so its geometry
+/// exists only in the world. Without this, a gate that wants to right-click a
+/// podium has to recompute the ring, which is a copy of
+/// [`selector::ring`](crate::module::selector::ring) that goes stale the day
+/// the ring moves and keeps passing while it does. This is that copy deleted:
+/// the server says where the blocks are, and the client clicks what it is
+/// told.
+///
+/// It is a player-facing command too, and answers "which mobs are still free"
+/// without walking the ring, which is the thing a screen reader cannot do.
+#[derive(Parser, CommandPermission, Debug)]
+#[command(name = "podiums")]
+#[command_permission(group = "Normal")]
+pub struct PodiumsCommand;
+
+impl MinecraftCommand for PodiumsCommand {
+    fn execute(self, system: EntityView<'_>, caller: Entity) {
+        let world = system.world();
+        let offers = selector::manifest(&world);
+        for offer in &offers {
+            tell(world, caller, &format!("{PODIUM_PREFIX}{}", podium(offer)));
+        }
+        tell(
+            world,
+            caller,
+            &format!("{PODIUM_END_PREFIX}{}", offers.len()),
+        );
+    }
+}
+
+/// One podium as a JSON object, hand-rolled for the reasons [`json`] gives.
+fn podium(offer: &selector::Offer) -> String {
+    let mut out = String::new();
+    let _unused = write!(
+        out,
+        r#"{{"kit":"{}","x":{},"y":{},"z":{},"base_y":{},"wool":"{}","mob":"{}","held_by":"#,
+        escape(offer.name),
+        offer.click.x,
+        offer.click.y,
+        offer.click.z,
+        offer.base.y,
+        escape(offer.wool),
+        escape(offer.mob),
+    );
+    match &offer.held_by {
+        Some(who) => {
+            let _unused = write!(out, r#""{}"}}"#, escape(who));
+        }
+        None => out.push_str("null}"),
+    }
+    out
 }
 
 /// Pick up a Smash Crystal.

--- a/events/smash/src/input.rs
+++ b/events/smash/src/input.rs
@@ -20,6 +20,7 @@ use crate::{
         kit::{self, KitStats, Playing},
         knockback::Knockback,
         player::{Player, Position},
+        selector,
     },
     server::PlayerId,
 };
@@ -71,6 +72,36 @@ impl Module for InputModule {
                     let player = world.entity_from_id(event.entity);
                     if let Some(slot) = held_slot(player) {
                         ability::use_slot(player, slot);
+                    }
+                }
+            });
+
+        // Right-clicking a mob in the lobby, which is how a kit is picked.
+        // Every entity in the world reaches this and `selector::click_mob`
+        // answers for the fifteen that are standing on podiums.
+        world
+            .system_named::<&mut EventQueue<event::EntityInteract>>("smash::on_entity_interact")
+            .each_iter(|it, _, queue| {
+                let world = it.world();
+                for event in queue.drain() {
+                    let player = world.entity_from_id(event.from);
+                    if player.has(Player::id()) {
+                        let _unused = selector::click_mob(&world, player, event.target);
+                    }
+                }
+            });
+
+        // Right-clicking the wool a mob is standing on, which does the same
+        // thing. Every block in the world reaches this, and `selector::click`
+        // answers for the handful that are podiums.
+        world
+            .system_named::<&mut EventQueue<event::BlockInteract>>("smash::on_block_interact")
+            .each_iter(|it, _, queue| {
+                let world = it.world();
+                for event in queue.drain() {
+                    let player = world.entity_from_id(event.from);
+                    if player.has(Player::id()) {
+                        let _unused = selector::click(&world, player, event.position);
                     }
                 }
             });

--- a/events/smash/src/lib.rs
+++ b/events/smash/src/lib.rs
@@ -28,7 +28,7 @@ use crate::module::{
     ability::AbilityModule, arena::ArenaModule, damage::DamageModule, kit::KitModule,
     kits::StockKits, knockback::KnockbackModule, lives::LivesModule, lobby::LobbyModule,
     player::PlayerModule, projectile::ProjectileModule, scoreboard::ScoreboardModule,
-    sound::SoundModule,
+    selector::SelectorModule, sound::SoundModule,
 };
 
 /// The whole game.
@@ -61,6 +61,7 @@ impl Module for SmashModule {
         world.import::<ProjectileModule>();
         world.import::<LobbyModule>();
         world.import::<ScoreboardModule>();
+        world.import::<SelectorModule>();
         world.import::<StockKits>();
     }
 }

--- a/events/smash/src/module.rs
+++ b/events/smash/src/module.rs
@@ -9,4 +9,5 @@ pub mod lobby;
 pub mod player;
 pub mod projectile;
 pub mod scoreboard;
+pub mod selector;
 pub mod sound;

--- a/events/smash/src/module/kit.rs
+++ b/events/smash/src/module/kit.rs
@@ -96,6 +96,28 @@ pub struct KitCost(pub u32);
 #[derive(Component, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KitBlurb(pub &'static str);
 
+/// The mob that stands on this kit's podium in the lobby.
+///
+/// A vanilla entity id, the same vocabulary [`AbilitySpec::item`] uses for
+/// items. It is the kit's own to declare for the same reason its abilities
+/// are: nothing outside a kit file may name a kit, so a selector that mapped
+/// kit to mob centrally would be the one table this crate has spent its whole
+/// design avoiding.
+///
+/// Mostly the obvious thing, because the roster is named after the mobs. The
+/// two that are not are the ones whose kit name is Mineplex's rather than
+/// Mojang's: the Sky Squid is a `minecraft:squid` and the Snowman is a
+/// `minecraft:snow_golem`.
+#[derive(Component, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct KitMob(pub &'static str);
+
+/// What a kit that never called [`KitBuilder::mob`] stands on its podium.
+///
+/// A podium still appears, because a kit nobody can select is worse than an
+/// ugly one, and `tests/selector.rs` fails on any registered kit that leaves it
+/// at this.
+pub const DEFAULT_MOB: &str = "minecraft:armor_stand";
+
 /// Marks the ability the Smash Crystal unlocks, rather than one of the four the
 /// kit starts with.
 #[derive(Component, Debug)]
@@ -247,6 +269,13 @@ impl<'w> KitBuilder<'w> {
             .add((PlaysOnHurt, sound::intern(self.world, sounds.hurt, voice)));
         self.kit
             .add((PlaysOnDeath, sound::intern(self.world, sounds.death, voice)));
+        self
+    }
+
+    /// The mob that stands on this kit's podium. See [`KitMob`].
+    #[must_use]
+    pub fn mob(self, entity: &'static str) -> Self {
+        self.kit.set(KitMob(entity));
         self
     }
 
@@ -468,6 +497,54 @@ pub fn registry(world: &World) -> Vec<Entity> {
     kits
 }
 
+/// Who is playing what, right now.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Claim {
+    pub kit: Entity,
+    pub player: Entity,
+}
+
+/// Every kit somebody is currently playing.
+///
+/// Derived on every call by walking the `(Playing, kit)` edges themselves.
+/// There is deliberately no `taken` flag on a kit and no set of claims kept on
+/// the side, because a second copy of this answer is a thing that can disagree
+/// with the first, and the disagreement that matters is the one nobody
+/// notices: a player who disconnects is destroyed and takes their edge with
+/// them, so this function frees their mob on the very next call and a cached
+/// set would go on reserving it for somebody who left.
+#[must_use]
+pub fn claims(world: &World) -> Vec<Claim> {
+    let mut found = Vec::new();
+    world
+        .query::<()>()
+        .with((Playing, id::<flecs::Wildcard>()))
+        .build()
+        .each_entity(|player, ()| {
+            let Some(kit) = player.find_target(Playing, |_| true) else {
+                return;
+            };
+            found.push(Claim {
+                kit: kit.id(),
+                player: player.id(),
+            });
+        });
+    found
+}
+
+/// The one player playing `kit`, if anybody is.
+///
+/// One, and not a list, because [`Playing`] is registered `Exclusive` and the
+/// selection rule is one player per mob; a second holder is a bug rather than
+/// a case to handle, and `tests/selector.rs` is what says so.
+#[must_use]
+pub fn claimant(world: &World, kit: Entity) -> Option<Entity> {
+    claims(world)
+        .into_iter()
+        .find(|claim| claim.kit == kit)
+        .map(|claim| claim.player)
+}
+
 /// Look a kit up by its [`KitName`].
 ///
 /// Deliberately not `world.try_lookup(name)`: a kit prefab is created inside
@@ -514,6 +591,7 @@ impl Module for KitModule {
         world.component::<KitName>();
         world.component::<KitCost>();
         world.component::<KitBlurb>();
+        world.component::<KitMob>();
         world.component::<Ultimate>();
         world.component::<Playing>().add(flecs::Exclusive);
     }

--- a/events/smash/src/module/kits/blaze.rs
+++ b/events/smash/src/module/kits/blaze.rs
@@ -47,6 +47,7 @@ impl Module for Blaze {
         })
         .cost(8000)
         .blurb("Set people on fire. Armour will not save them.")
+        .mob("minecraft:blaze")
         .ability(AbilitySpec {
             name: "Inferno",
             sound: "minecraft:entity.blaze.shoot",

--- a/events/smash/src/module/kits/chicken.rs
+++ b/events/smash/src/module/kits/chicken.rs
@@ -48,6 +48,7 @@ impl Module for Chicken {
         })
         .cost(8000)
         .blurb("Cannot take a hit, and does not have to.")
+        .mob("minecraft:chicken")
         .ability(AbilitySpec {
             name: "Egg Blaster",
             sound: "minecraft:entity.egg.throw",

--- a/events/smash/src/module/kits/cow.rs
+++ b/events/smash/src/module/kits/cow.rs
@@ -40,6 +40,7 @@ impl Module for Cow {
         })
         .cost(6000)
         .blurb("Hard to move and hard to stop once it is moving.")
+        .mob("minecraft:cow")
         .ability(AbilitySpec {
             name: "Angry Herd",
             sound: "minecraft:entity.cow.ambient",

--- a/events/smash/src/module/kits/creeper.rs
+++ b/events/smash/src/module/kits/creeper.rs
@@ -49,6 +49,7 @@ impl Module for Creeper {
         })
         .cost(4000)
         .blurb("Hits harder than anything and dies to a stiff breeze.")
+        .mob("minecraft:creeper")
         .ability(AbilitySpec {
             name: "Sulphur Bomb",
             sound: "minecraft:entity.creeper.primed",

--- a/events/smash/src/module/kits/enderman.rs
+++ b/events/smash/src/module/kits/enderman.rs
@@ -50,6 +50,7 @@ impl Module for Enderman {
         })
         .cost(4000)
         .blurb("Throw the arena at people, then blink away before they reach you.")
+        .mob("minecraft:enderman")
         .ability(AbilitySpec {
             name: "Block Toss",
             sound: "minecraft:block.stone.place",

--- a/events/smash/src/module/kits/guardian.rs
+++ b/events/smash/src/module/kits/guardian.rs
@@ -59,6 +59,7 @@ impl Module for Guardian {
         })
         .cost(8000)
         .blurb("Pick somebody. They are now your problem and you are theirs.")
+        .mob("minecraft:guardian")
         .ability(AbilitySpec {
             name: "Whirlpool Axe",
             sound: "minecraft:entity.player.splash.high_speed",

--- a/events/smash/src/module/kits/iron_golem.rs
+++ b/events/smash/src/module/kits/iron_golem.rs
@@ -45,6 +45,7 @@ impl Module for IronGolem {
             death: "minecraft:entity.iron_golem.death",
         })
         .blurb("Command space in the arena. Pull enemies in, then hit like a truck.")
+        .mob("minecraft:iron_golem")
         .ability(AbilitySpec {
             name: "Fissure",
             sound: "minecraft:block.deepslate.break",

--- a/events/smash/src/module/kits/skeleton.rs
+++ b/events/smash/src/module/kits/skeleton.rs
@@ -49,6 +49,7 @@ impl Module for Skeleton {
             death: "minecraft:entity.skeleton.death",
         })
         .blurb("Keep everyone at arm's length, then overcharge the bow and let go.")
+        .mob("minecraft:skeleton")
         .ability(AbilitySpec {
             name: "Barrage",
             sound: "minecraft:entity.arrow.shoot",

--- a/events/smash/src/module/kits/sky_squid.rs
+++ b/events/smash/src/module/kits/sky_squid.rs
@@ -44,6 +44,7 @@ impl Module for SkySquid {
         })
         .cost(3000)
         .blurb("Seven pellets up close, and one second of being untouchable.")
+        .mob("minecraft:squid")
         .ability(AbilitySpec {
             name: "Super Squid",
             sound: "minecraft:entity.squid.ambient",

--- a/events/smash/src/module/kits/slime.rs
+++ b/events/smash/src/module/kits/slime.rs
@@ -54,6 +54,7 @@ impl Module for Slime {
             death: "minecraft:entity.slime.death",
         })
         .blurb("Spend yourself to send enemies flying, and shrink while you do it.")
+        .mob("minecraft:slime")
         .ability(AbilitySpec {
             name: "Slime Rocket",
             sound: "minecraft:entity.slime.squish",

--- a/events/smash/src/module/kits/snowman.rs
+++ b/events/smash/src/module/kits/snowman.rs
@@ -40,6 +40,7 @@ impl Module for Snowman {
         })
         .cost(5000)
         .blurb("Own the ground you are standing on.")
+        .mob("minecraft:snow_golem")
         .ability(AbilitySpec {
             name: "Blizzard",
             sound: "minecraft:entity.snow_golem.shoot",

--- a/events/smash/src/module/kits/spider.rs
+++ b/events/smash/src/module/kits/spider.rs
@@ -42,6 +42,7 @@ impl Module for Spider {
         })
         .cost(0)
         .blurb("Fast, fragile and everywhere at once. Leap where you look.")
+        .mob("minecraft:spider")
         .ability(AbilitySpec {
             name: "Needler",
             sound: "minecraft:entity.bee.sting",

--- a/events/smash/src/module/kits/wither_skeleton.rs
+++ b/events/smash/src/module/kits/wither_skeleton.rs
@@ -53,6 +53,7 @@ impl Module for WitherSkeleton {
         })
         .cost(6000)
         .blurb("Leave a copy of yourself somewhere useful, then be there instead.")
+        .mob("minecraft:wither_skeleton")
         .ability(AbilitySpec {
             name: "Guided Wither Skull",
             sound: "minecraft:entity.wither.shoot",

--- a/events/smash/src/module/kits/wolf.rs
+++ b/events/smash/src/module/kits/wolf.rs
@@ -59,6 +59,7 @@ impl Module for Wolf {
         })
         .cost(4000)
         .blurb("Stick to somebody and every hit lands harder than the last.")
+        .mob("minecraft:wolf")
         .ability(AbilitySpec {
             name: "Cub Tackle",
             sound: "minecraft:entity.baby_wolf.ambient",

--- a/events/smash/src/module/kits/zombie.rs
+++ b/events/smash/src/module/kits/zombie.rs
@@ -37,6 +37,7 @@ impl Module for Zombie {
         })
         .cost(6000)
         .blurb("Something for every range, and nothing outstanding at any of them.")
+        .mob("minecraft:zombie")
         .ability(AbilitySpec {
             name: "Bile Blaster",
             sound: "minecraft:entity.witch.throw",

--- a/events/smash/src/module/lobby.rs
+++ b/events/smash/src/module/lobby.rs
@@ -17,12 +17,12 @@ use crate::{
     module::{
         arena::Arena,
         damage::MatchClock,
-        kit,
+        kit::{self, KitName},
         lives::{Eliminated, InvulnerableUntil, Lives, Placement, RespawnAt},
         player::{Health, Player, Position},
-        sound,
+        selector, sound,
     },
-    server::{Channel, PlayerId, ServerHandle, Sound, SoundCategory, Text},
+    server::{Channel, NamedColor, PlayerId, ServerHandle, Sound, SoundCategory, Text},
 };
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
@@ -185,19 +185,47 @@ pub struct PhaseChanged {
     pub to: Phase,
 }
 
-/// Pick a kit in the hub. Refused once the match has committed, which is the
-/// one rule the lobby imposes on kits.
+/// Pick a kit in the hub, by name.
 ///
 /// # Errors
-/// If the phase is past [`Phase::Countdown`], or the name is not a kit.
-pub fn select_kit(world: &World, player: EntityView<'_>, name: &str) -> Result<(), &'static str> {
+/// As [`choose`], plus a name that is not a kit.
+pub fn select_kit(world: &World, player: EntityView<'_>, name: &str) -> Result<(), String> {
+    let Some(chosen) = kit::by_name(world, name) else {
+        return Err("No such kit.".to_owned());
+    };
+    choose(world, player, chosen)
+}
+
+/// Pick a kit in the hub.
+///
+/// Two rules, and both of them live here rather than on either of the two
+/// surfaces a player reaches them through, so a podium click and `/kit` cannot
+/// come to different answers:
+///
+/// * Not once the match has committed. This is the only rule the lobby imposes
+///   on kits, and it is also what makes a claim last the rest of the match
+///   without anything having to say so: past [`Phase::Countdown`] nothing can
+///   change a kit at all.
+/// * Not a mob somebody else is already playing. Derived from their
+///   `(Playing, kit)` edge on every call, so a player who disconnects frees
+///   their mob with no cleanup anywhere. See [`crate::module::selector`] for
+///   why this rule exists and why it is this server's own and not a
+///   reconstruction of anything.
+///
+/// # Errors
+/// If the phase is past [`Phase::Countdown`], or somebody else holds the kit.
+pub fn choose(world: &World, player: EntityView<'_>, chosen: EntityView<'_>) -> Result<(), String> {
     let phase = world.cloned::<&Lobby>().phase;
     if !matches!(phase, Phase::Waiting | Phase::Countdown) {
-        return Err("You cannot change kit once the game has started.");
+        return Err("You cannot change kit once the game has started.".to_owned());
     }
-    let Some(chosen) = kit::by_name(world, name) else {
-        return Err("No such kit.");
-    };
+    if let Some(holder) = kit::claimant(world, chosen.id())
+        && holder != player.id()
+    {
+        return Err(selector::taken_message(world, chosen, holder));
+    }
+
+    let name = chosen.try_get::<&KitName>(|name| name.0).unwrap_or("");
     kit::apply(world, player, chosen);
 
     if let Some(id) = player.try_get::<&PlayerId>(|p| *p) {
@@ -205,6 +233,13 @@ pub fn select_kit(world: &World, player: EntityView<'_>, name: &str) -> Result<(
         world.get::<&ServerHandle>(|server| {
             server.set_hotbar(id, &hotbar);
             server.send_message(id, Channel::Chat, Text::text(format!("Kit set to {name}.")));
+            // The same channel the refusal uses, so a player watching one spot
+            // on the screen sees both answers there.
+            server.send_message(
+                id,
+                Channel::ActionBar,
+                Text::text(format!("You are the {name}.")).color(NamedColor::Green),
+            );
         });
     }
     Ok(())

--- a/events/smash/src/module/selector.rs
+++ b/events/smash/src/module/selector.rs
@@ -1,0 +1,476 @@
+//! The kit selector: a ring of podiums in the middle of the lobby, one per
+//! mob, and you right-click the one you want.
+//!
+//! ## What Mineplex did
+//!
+//! The SSM waiting lobby put one mob per kit on a pedestal and you clicked the
+//! mob you wanted to be. The Mineplex Wiki describes the waiting lobby's
+//! centrepiece as "mobs ... standing atop pedestals of coloured wool and stone
+//! brick slabs, allowing you to click/right-click on them to select kits", and
+//! its kit page notes that in SSM's case the pedestals carried "each individual
+//! mob" rather than the stand-in zombies other games used. It also records what
+//! the wool was for: the colour said what you had to do to unlock the kit, with
+//! free kits yellow, gem kits green and achievement kits purple.
+//!
+//! This rebuilds both halves of that:
+//!
+//! * A podium is a wool block with the kit's own mob standing on it, and the
+//!   mob is what you right-click. Not a head block, not an armour stand: the
+//!   real entity, which is what makes the ring readable from across the lobby.
+//! * The wool's colour is the status readout. Mineplex used it for "can you
+//!   afford this"; this uses it for "has somebody taken this", which is the
+//!   question a player in a filling lobby is actually asking.
+//!
+//! ## One player per mob
+//!
+//! Nothing found says whether Mineplex reserved a kit. Neither the wiki's kit
+//! and waiting-lobby pages nor the SSM forum threads mention a reservation in
+//! either direction, and since kits were bought per account with gems, a rule
+//! that let one player lock another out of something they had paid for would
+//! be a strange one to have shipped. So treat exclusivity as this server's
+//! choice and not as a reconstruction: it exists because the operator asked
+//! for a selector that answers when you click a mob somebody else has, and
+//! "answers" is only meaningful if the answer is no.
+//!
+//! The claim lasts exactly as long as the player does, and it is enforced only
+//! where a kit can still be changed. [`crate::module::lobby::choose`] already
+//! refuses any change once the match commits, so past that point the claim is
+//! frozen for the rest of the match without a second rule saying so, and a
+//! player who disconnects frees their mob immediately because the edge that
+//! was the claim goes with the entity. No disconnect handler exists here, and
+//! that is the point: there is nothing to clean up.
+//!
+//! ## Everything here is relations
+//!
+//! A podium *is* its `(Offers, kit)` edge; there is no table from block
+//! position to kit name and no id anybody has to keep in step. A mob being
+//! taken *is* somebody's `(Playing, kit)` edge; see
+//! [`crate::module::kit::claims`] for why that is derived on demand and never
+//! written down.
+//!
+//! `/kit` and `/kits` still work and are still what the tests and a screen
+//! reader use, but nobody should have to type a command to play.
+
+use flecs_ecs::prelude::*;
+use glam::IVec3;
+
+use crate::{
+    flecs_ext::EntityViewExt,
+    module::{
+        kit::{self, KitMob, KitName},
+        lobby,
+    },
+    server::{Channel, NamedColor, PlayerId, ServerHandle, Text},
+};
+
+/// Tag on a selector podium.
+#[derive(Component, Debug)]
+pub struct Podium;
+
+/// Relationship: `(Offers, kit)` on a podium.
+///
+/// The podium's entire identity. A click resolves to a kit by following this
+/// edge, so moving a podium, renaming a kit or reordering the roster cannot
+/// desynchronise anything: there is no second place the pairing is written.
+#[derive(Component, Debug)]
+pub struct Offers;
+
+/// Where a podium stands, in world block coordinates.
+///
+/// One block: `base`, the coloured wool. The kit's own [`KitMob`] stands on top
+/// of it, at [`Plinth::stand`], and is a real entity rather than a block.
+///
+/// Both are clickable, and that is deliberate. Clicking the mob is the point
+/// and is what a player does. Clicking the wool is the same selection through
+/// a surface that cannot fail to render, and it is what the unit tests use,
+/// because a mob needs a host to exist and the game half is testable without
+/// one.
+///
+/// Making the mob clickable at all took a change to the engine: hyperion routed
+/// no entity-interaction packet, so a right-click on an entity arrived and fell
+/// through the dispatch table. `PacketId::Interact` is routed now, and since
+/// 26.2 split attacking out into `Attack` that packet means a right-click and
+/// nothing else.
+#[derive(Component, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Plinth {
+    pub base: IVec3,
+}
+
+impl Plinth {
+    /// The block the kit's mob stands in.
+    #[must_use]
+    pub const fn stand(self) -> IVec3 {
+        IVec3::new(self.base.x, self.base.y + 1, self.base.z)
+    }
+
+    /// Whether a click on `position` is a click on this podium.
+    ///
+    /// The wool and the block the mob stands in, so a click that misses the mob
+    /// by a pixel and lands on the block behind it still means what the player
+    /// meant.
+    #[must_use]
+    pub fn covers(self, position: IVec3) -> bool {
+        position == self.base || position == self.stand()
+    }
+}
+
+/// The wool a free podium stands on.
+///
+/// Green and red rather than anything cleverer, because this is the whole
+/// answer to "how is a player told a mob is taken". It has to survive being
+/// read at a glance from across the lobby in the last four seconds of a
+/// countdown, by somebody who is not reading chat and has no reason to expect
+/// a message. Colour is the only channel that works under those conditions,
+/// and it says *which* mob is gone rather than only that something was
+/// refused. The action bar line below explains a refusal that has already
+/// happened; the wool is what stops the refusal being a surprise.
+///
+/// Wool specifically because that is what Mineplex's pedestals were made of
+/// and used for exactly this job, and because the hub is already furnished in
+/// quartz and sea lanterns: a sea-lantern base would read as more lobby
+/// scenery rather than as a thing to click.
+pub const FREE_BLOCK: &str = "minecraft:lime_wool";
+
+/// The wool a taken podium stands on. See [`FREE_BLOCK`].
+pub const TAKEN_BLOCK: &str = "minecraft:red_wool";
+
+/// The y of a podium's wool, in the hub's local coordinates.
+///
+/// The hub floor's top face is y 64, so a player stands at 65 and this is
+/// level with their feet. The icon at 66 is then at chest height, which is
+/// where a crosshair naturally falls.
+pub const PLINTH_Y: i32 = 65;
+
+/// Blocks between one podium and the next, along the ring.
+///
+/// The radius is derived from this and the roster size rather than fixed, so
+/// the ring grows when a kit is added instead of eventually putting two
+/// podiums in the same block. A constant gap is also what a player reads as
+/// a row of things rather than a crowd.
+pub const GAP: f32 = 3.5;
+
+/// Outside the raised centre and outside the ring of hub spawn points, so a
+/// small roster still makes a ring somebody can walk around and nobody spawns
+/// inside a podium.
+pub const MIN_RADIUS: f32 = 8.0;
+
+/// Inside the hub's glass wall, which stands at radius 19.
+pub const MAX_RADIUS: f32 = 17.0;
+
+/// Where the podiums stand, relative to the hub's own origin.
+///
+/// Pure, and in registration order, which makes the ring stable across boots:
+/// a player who learns where their mob is finds it in the same place tomorrow.
+#[must_use]
+pub fn ring(count: usize) -> Vec<IVec3> {
+    if count == 0 {
+        return Vec::new();
+    }
+
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "a roster of 2^24 kits is not a thing"
+    )]
+    let n = count as f32;
+    let radius = (GAP * n / core::f32::consts::TAU).clamp(MIN_RADIUS, MAX_RADIUS);
+
+    (0..count)
+        .map(|index| {
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "index is smaller than the count above"
+            )]
+            let angle = core::f32::consts::TAU * index as f32 / n;
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "radius is clamped to 17 blocks"
+            )]
+            let at = IVec3::new(
+                (radius * angle.cos()).round() as i32,
+                PLINTH_Y,
+                (radius * angle.sin()).round() as i32,
+            );
+            at
+        })
+        .collect()
+}
+
+/// Stand up one podium per registered kit, centred on `origin`.
+///
+/// Any podiums already standing are torn down first, so calling this twice
+/// rebuilds the ring rather than producing two of it.
+///
+/// # Panics
+/// If two podiums would occupy the same block. That is a roster too big for
+/// [`MAX_RADIUS`] at [`GAP`] spacing, and it is a failure worth having at boot
+/// rather than a kit nobody can click.
+pub fn build(world: &World, origin: IVec3) {
+    let mut standing = Vec::new();
+    world
+        .query::<()>()
+        .with(Podium::id())
+        .build()
+        .each_entity(|podium, ()| standing.push(podium.id()));
+    for podium in standing {
+        world.entity_from_id(podium).destruct();
+    }
+
+    let kits = kit::registry(world);
+    let mut placed: Vec<IVec3> = Vec::with_capacity(kits.len());
+
+    for (kit, at) in kits.iter().zip(ring(kits.len())) {
+        let base = at + origin;
+        assert!(
+            !placed.contains(&base),
+            "two kit podiums want the block at {base}; the roster has outgrown the ring"
+        );
+        placed.push(base);
+
+        world
+            .entity()
+            .add(Podium::id())
+            .set(Plinth { base })
+            .add((Offers, *kit));
+    }
+}
+
+/// Every podium, with the kit it offers and where it stands.
+#[must_use]
+pub fn podiums(world: &World) -> Vec<(Entity, Plinth, Entity)> {
+    let mut found = Vec::new();
+    world
+        .query::<&Plinth>()
+        .with(Podium::id())
+        .build()
+        .each_entity(|podium, plinth| {
+            let Some(kit) = podium.find_target(Offers, |_| true) else {
+                return;
+            };
+            found.push((podium.id(), *plinth, kit.id()));
+        });
+    found
+}
+
+/// The podium whose plinth or icon block is at `position`.
+#[must_use]
+pub fn podium_at(world: &World, position: IVec3) -> Option<(Entity, Entity)> {
+    podiums(world)
+        .into_iter()
+        .find(|(_, plinth, _)| plinth.covers(position))
+        .map(|(podium, _, kit)| (podium, kit))
+}
+
+/// What the plinth block under each podium should be, right now.
+///
+/// Recomputed from the live claims rather than remembered, and returned rather
+/// than written, so the rule is testable without a Minecraft world anywhere
+/// near it. The host compares this against the blocks actually in the world and
+/// writes the ones that differ.
+#[must_use]
+pub fn plinths(world: &World) -> Vec<(IVec3, &'static str)> {
+    let claims = kit::claims(world);
+    podiums(world)
+        .into_iter()
+        .map(|(_, plinth, kit)| {
+            let taken = claims.iter().any(|claim| claim.kit == kit);
+            (plinth.base, if taken { TAKEN_BLOCK } else { FREE_BLOCK })
+        })
+        .collect()
+}
+
+/// Which mob stands on each podium, and where.
+///
+/// Names rather than anything typed, because the game half must not know what
+/// a hyperion entity is: the host turns each name into a real mob. See
+/// [`crate::terrain`].
+#[must_use]
+pub fn mobs(world: &World) -> Vec<(Entity, IVec3, &'static str)> {
+    podiums(world)
+        .into_iter()
+        .map(|(podium, plinth, kit)| {
+            let mob = world
+                .entity_from_id(kit)
+                .try_get::<&KitMob>(|mob| mob.0)
+                .unwrap_or(kit::DEFAULT_MOB);
+            (podium, plinth.stand(), mob)
+        })
+        .collect()
+}
+
+/// One podium, as something outside the world can read.
+///
+/// Built by walking the same edges everything else here walks, so a reader gets
+/// the live answer and not a snapshot somebody remembered to refresh.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Offer {
+    /// The kit's [`KitName`].
+    pub name: &'static str,
+    /// Where the mob stands. Clicking the mob is the point; clicking this
+    /// block does the same thing, which is what a scripted client uses.
+    pub click: IVec3,
+    /// The wool under it, whose colour is the free-or-taken signal.
+    pub base: IVec3,
+    /// The block the wool is currently made of, so a reader can check the
+    /// colour it was told against the colour the world is showing.
+    pub wool: &'static str,
+    /// The mob standing on it, by vanilla entity id.
+    pub mob: &'static str,
+    /// Whoever is playing this mob, by name. Derived from `(Playing, kit)`.
+    pub held_by: Option<String>,
+}
+
+/// Every podium, for a reader outside the game.
+///
+/// This is what `/podiums` answers with and what the end to end gate drives
+/// itself from. It exists so that nothing outside this file has to know the
+/// ring's geometry: a gate that recomputed the podium positions in Python
+/// would be a second source of truth for the one thing this module owns, and
+/// it would keep passing after the ring moved.
+#[must_use]
+pub fn manifest(world: &World) -> Vec<Offer> {
+    let claims = kit::claims(world);
+    podiums(world)
+        .into_iter()
+        .filter_map(|(_, plinth, kit)| {
+            let entry = world.entity_from_id(kit);
+            let name = entry.try_get::<&KitName>(|name| name.0)?;
+            let taken = claims.iter().any(|claim| claim.kit == kit);
+            Some(Offer {
+                name,
+                click: plinth.stand(),
+                base: plinth.base,
+                wool: if taken { TAKEN_BLOCK } else { FREE_BLOCK },
+                mob: entry
+                    .try_get::<&KitMob>(|mob| mob.0)
+                    .unwrap_or(kit::DEFAULT_MOB),
+                held_by: claims
+                    .iter()
+                    .find(|claim| claim.kit == kit)
+                    .map(|claim| world.entity_from_id(claim.player).name()),
+            })
+        })
+        .collect()
+}
+
+/// Relationship: `(StandsOn, podium)` on a podium's mob.
+///
+/// The other half of the pair [`Offers`] starts. A click arrives naming an
+/// entity and nothing else, and this is what turns that entity back into a
+/// kit: mob to podium to kit, two edges, no table keyed on entity id and
+/// nothing to invalidate when a mob is respawned somewhere else.
+#[derive(Component, Debug)]
+pub struct StandsOn;
+
+/// A right-click on the mob `target`, from `player`.
+///
+/// Returns `false` when that entity is not a podium's mob, which is every
+/// other entity in the world including every other player.
+#[expect(
+    clippy::must_use_candidate,
+    reason = "called for the selection it makes; the bool only says whether the click was aimed \
+              at a podium, and both callers in `input.rs` are answering every entity and every \
+              block in the world"
+)]
+pub fn click_mob(world: &World, player: EntityView<'_>, target: Entity) -> bool {
+    let Some(podium) = world
+        .try_get_alive(target)
+        .and_then(|mob| mob.find_target(StandsOn, |_| true))
+    else {
+        return false;
+    };
+    let Some(kit) = podium.find_target(Offers, |_| true) else {
+        return false;
+    };
+    take(world, player, kit.id());
+    true
+}
+
+/// A right-click on the block at `position`, from `player`.
+///
+/// Returns `false` when that block is not part of a podium, which is every
+/// other block in the world.
+#[expect(clippy::must_use_candidate, reason = "see `click_mob`")]
+pub fn click(world: &World, player: EntityView<'_>, position: IVec3) -> bool {
+    let Some((_, kit)) = podium_at(world, position) else {
+        return false;
+    };
+    take(world, player, kit);
+    true
+}
+
+/// What both surfaces do once they know which kit was asked for.
+///
+/// One function, so a click on the mob and a click on the wool under it cannot
+/// come to different answers.
+fn take(world: &World, player: EntityView<'_>, kit: Entity) {
+    if let Err(reason) = lobby::choose(world, player, world.entity_from_id(kit)) {
+        refuse(world, player, &reason);
+    }
+    // On success `choose` has already sent the confirmation and the hotbar.
+}
+
+/// Tell `player` why the click did nothing.
+///
+/// The action bar, not chat. A refusal is about the click that just happened
+/// and stops mattering a second later, and chat during a countdown is where a
+/// line goes to be missed. It is the second-line answer in any case: the wool
+/// under the mob was already red before the click, so this explains a refusal
+/// rather than delivering the news.
+///
+/// No sound. A refusal cue would be a real improvement and it belongs with the
+/// rest of the audio work rather than bolted on here.
+fn refuse(world: &World, player: EntityView<'_>, reason: &str) {
+    let Some(id) = player.try_get::<&PlayerId>(|id| *id) else {
+        return;
+    };
+    world.get::<&ServerHandle>(|server| {
+        server.send_message(
+            id,
+            Channel::ActionBar,
+            Text::text(reason.to_owned()).color(NamedColor::Red),
+        );
+    });
+}
+
+/// The refusal a player sees when somebody else got there first.
+///
+/// A function rather than a `format!` at the call site because two surfaces
+/// produce it -- a podium click and `/kit` -- and a player who is told two
+/// different things by two paths through the same rule will believe the rule
+/// is two rules.
+#[must_use]
+pub fn taken_message(world: &World, kit: EntityView<'_>, holder: Entity) -> String {
+    let name = kit.try_get::<&KitName>(|name| name.0).unwrap_or("That kit");
+    format!(
+        "{name} is already taken by {}.",
+        world.entity_from_id(holder).name()
+    )
+}
+
+#[derive(Component)]
+pub struct SelectorModule;
+
+impl Module for SelectorModule {
+    fn module(world: &World) {
+        world.module::<Self>("smash::Selector");
+
+        world.component::<Podium>();
+        world.component::<Plinth>();
+        // Exclusive: a podium offers exactly one mob, so re-pointing one is a
+        // single `add` rather than a remove-then-add pair that can be
+        // interrupted halfway and leave a podium offering two kits.
+        world.component::<Offers>().add(flecs::Exclusive);
+        // Exclusive for the same reason: a mob stands on one podium, and a mob
+        // that claimed to stand on two would offer two kits from one click.
+        //
+        // Deleting the podium deletes the mob standing on it, which is what
+        // makes `build` a rebuild rather than a leak: tearing the ring down
+        // leaves no mobs behind for flecs to hand back to a later query, and
+        // there is no teardown loop here that somebody has to remember to
+        // extend when a podium grows a second thing attached to it.
+        world
+            .component::<StandsOn>()
+            .add(flecs::Exclusive)
+            .add_trait::<(flecs::OnDeleteTarget, flecs::Delete)>();
+    }
+}

--- a/events/smash/src/terrain.rs
+++ b/events/smash/src/terrain.rs
@@ -18,8 +18,12 @@ use flecs_ecs::prelude::*;
 use glam::{I16Vec2, IVec3, Vec3};
 use hyperion::{
     BlockKind, BlockState,
+    net::Channel as EntityChannel,
     runtime::AsyncRuntime,
-    simulation::{Uuid, blocks::Blocks},
+    simulation::{
+        Pitch, Position as MobPosition, Spawn, Uuid, Velocity, Yaw, blocks::Blocks,
+        entity_kind::EntityKind,
+    },
 };
 
 use crate::{
@@ -28,6 +32,7 @@ use crate::{
         arena::Arena,
         lobby::{Lobby, Phase, PhaseChanged},
         player::Player,
+        selector,
     },
     server::{PlayerId, ServerHandle},
 };
@@ -154,6 +159,15 @@ impl Module for MapModule {
                 stamp(&mut blocks, runtime, map);
             }
         });
+
+        // After the hub's own brushes, or the floor would be stamped over the
+        // podiums. The ring is generated rather than written into `hub.map`
+        // because it has to have exactly as many podiums as there are
+        // registered kits, and the map file has no way to ask.
+        selector::build(world, hub_origin);
+        stamp_podiums(&mut blocks, world);
+        stand_mobs(world);
+
         world.set(blocks);
 
         world.set(Hub {
@@ -219,6 +233,35 @@ impl Module for MapModule {
                 }
             });
 
+        // The plinth colours, recomputed from who is playing what and written
+        // only where they disagree with the world.
+        //
+        // A poll rather than an observer on the relation, because the thing
+        // that frees a mob most often is a player disconnecting, and that is an
+        // entity being destroyed rather than an edge being removed by anybody
+        // this file could watch. Reading the world back and writing only the
+        // difference is what keeps this from being a second source of truth:
+        // the blocks are the display, and `selector::plinths` is the only place
+        // that says what they should say.
+        world
+            .system_named::<&mut Blocks>("smash::render_podiums")
+            .each_iter(|it, _, blocks| {
+                let world = it.world();
+                for (at, block) in selector::plinths(&world) {
+                    let Some(kind) = BlockKind::from_str(block.trim_start_matches("minecraft:"))
+                    else {
+                        continue;
+                    };
+                    let wanted = BlockState::from_kind(kind);
+                    if blocks.get_block(at) == Some(wanted) {
+                        continue;
+                    }
+                    if let Err(error) = blocks.set_block(at, wanted) {
+                        tracing::warn!("could not repaint the podium at {at}: {error:?}");
+                    }
+                }
+            });
+
         // Back to the hub when the results screen is over. The game half ends a
         // match by resetting lives and health; where players physically go is a
         // hosting question, so it is answered here.
@@ -245,6 +288,73 @@ impl Module for MapModule {
                     }
                 });
             });
+    }
+}
+
+/// Write the kit selector's wool into the world for the first time.
+///
+/// Stamped at whatever the current state says, which at boot is every podium
+/// free, and then kept in step by `smash::render_podiums` below.
+fn stamp_podiums(blocks: &mut Blocks, world: &World) {
+    for (at, block) in selector::plinths(world) {
+        set_named(blocks, at, block);
+    }
+}
+
+/// Stand a real mob on each podium.
+///
+/// The half of the selector the game cannot build for itself: `selector` says
+/// which mob belongs where and this turns each name into a hyperion entity.
+/// `Channel` is what makes it visible, and visible to players who join later:
+/// the proxy tracks the channel's position and asks the server for the spawn
+/// packets when somebody comes into range, so a mob spawned at boot with
+/// nobody connected is still there when the first player walks up to it.
+///
+/// `(StandsOn, podium)` is the whole point. A click arrives naming an entity,
+/// and this edge is what turns that entity back into the kit it offers.
+///
+/// # Panics
+/// If a kit names a mob that is not a mob. Same reason [`set_named`] panics on
+/// a block that is not a block: a podium with nothing on it is a kit nobody
+/// can pick, and the hole would be the only report.
+fn stand_mobs(world: &World) {
+    for (podium, at, name) in selector::mobs(world) {
+        let kind = EntityKind::named(name).unwrap_or_else(|| panic!("{name:?} is not a mob"));
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "hub-local coordinates, tens of blocks"
+        )]
+        let position = Vec3::new(at.x as f32 + 0.5, at.y as f32, at.z as f32 + 0.5);
+        world
+            .entity()
+            .add_enum(kind)
+            .set(MobPosition::new(position.x, position.y, position.z))
+            // Facing the middle of the ring, so the row of them looks at a
+            // player walking through it rather than all one way.
+            .set(Yaw::new(facing(position)))
+            .set(Pitch::new(0.0))
+            .set(Velocity::new(0.0, 0.0, 0.0))
+            .add(id::<EntityChannel>())
+            .add((selector::StandsOn, podium))
+            .add(id::<Spawn>());
+    }
+}
+
+/// The yaw that points from `at` back at the hub's centre.
+fn facing(at: Vec3) -> f32 {
+    (-at.x).atan2(at.z).to_degrees()
+}
+
+/// Set the block at `at`, naming the block by its vanilla id.
+///
+/// # Panics
+/// If the id names no block. A mistyped wool colour would otherwise be a podium
+/// with a hole in it, and the hole would be the only report.
+fn set_named(blocks: &mut Blocks, at: IVec3, block: &str) {
+    let kind = BlockKind::from_str(block.trim_start_matches("minecraft:"))
+        .unwrap_or_else(|| panic!("{block:?} is not a block"));
+    if let Err(error) = blocks.set_block(at, BlockState::from_kind(kind)) {
+        tracing::warn!("could not put {block} at {at}: {error:?}");
     }
 }
 

--- a/events/smash/tests/contract.rs
+++ b/events/smash/tests/contract.rs
@@ -24,13 +24,13 @@ mod harness;
 use std::sync::Arc;
 
 use flecs_ecs::prelude::*;
-use glam::Vec3;
+use glam::{IVec3, Vec3};
 use smash::{
     module::{
         ability::AbilityModule,
         arena::{Arena, ArenaModule},
         damage::{Armor, DamageKind, DamageModule, Damaged, hurt},
-        kit::KitModule,
+        kit::{self, KitModule, KitStats},
         kits::StockKits,
         knockback::{Knockback, KnockbackModel, KnockbackModule, KnockbackTaken, Smashed},
         lives::{DeathCause, Lives, LivesModule, kill},
@@ -38,6 +38,7 @@ use smash::{
         player::{self, Health, OnGround, Player, PlayerModule, Position},
         projectile::ProjectileModule,
         scoreboard::ScoreboardModule,
+        selector::{self, SelectorModule, TAKEN_BLOCK},
         sound::{self, Levels, PlaysOnCast, PlaysOnHurt, SoundModule},
     },
     server::{PlayerId, ServerHandle, mock::MockServer},
@@ -313,6 +314,53 @@ fn contracts() -> Vec<Contract> {
             runtime_requires: &[],
             exercise: |world, _player| {
                 world.progress_time(0.05);
+            },
+        },
+        Contract {
+            name: "Selector",
+            import: |world| {
+                world.import::<SelectorModule>();
+            },
+            // Only `Player`, and only because every world this file builds puts
+            // a player in it. The module itself registers three components of
+            // its own, declares no system and names nothing else at
+            // registration, so it would import into a bare world.
+            requires: &["Player"],
+            // Everything a selection touches, which is only reached when
+            // somebody clicks: the kit registry it builds the ring from, and
+            // the lobby whose phase and rules decide whether the click lands.
+            runtime_requires: &[
+                "Player",
+                "Knockback",
+                "Damage",
+                "Ability",
+                "Kit",
+                "Arena",
+                "Lives",
+                "Lobby",
+            ],
+            exercise: |world, player| {
+                // A kit defined here rather than imported, because `StockKits`
+                // comes after this module and the point is that the ring is
+                // built from whatever the registry holds.
+                kit::define(world, "Contract", KitStats::default())
+                    .mob("minecraft:creeper")
+                    .register();
+                selector::build(world, IVec3::ZERO);
+
+                let (_, plinth, _) = selector::podiums(world)
+                    .into_iter()
+                    .next()
+                    .expect("one kit, one podium");
+                assert!(
+                    selector::click(world, player, plinth.stand()),
+                    "the podium did not answer a click"
+                );
+                assert_eq!(
+                    selector::plinths(world).first().map(|(_, block)| *block),
+                    Some(TAKEN_BLOCK),
+                    "the podium did not turn"
+                );
             },
         },
         Contract {

--- a/events/smash/tests/selector.rs
+++ b/events/smash/tests/selector.rs
@@ -1,0 +1,643 @@
+//! The in-world kit selector: the ring, the click, and who owns which mob.
+//!
+//! Two halves, and the split is the same one `scoreboard::render` draws. The
+//! geometry is a pure function of a count and is tested against the hub map
+//! file rather than against itself, so a podium that would stand inside a spawn
+//! point fails here. Everything else is driven through the same entry point the
+//! packet handler calls, against the mock seam, so what is asserted is what a
+//! client would be sent.
+
+mod harness;
+
+use flecs_ecs::prelude::*;
+use glam::{IVec3, Vec3};
+use harness::Game;
+use hyperion::{BlockKind, simulation::entity_kind::EntityKind};
+use smash::{
+    map,
+    module::{
+        kit::{self, KitMob, KitName, Playing},
+        lobby::{self, Lobby, LobbyConfig, Phase},
+        selector::{
+            self, FREE_BLOCK, MAX_RADIUS, MIN_RADIUS, PLINTH_Y, Plinth, StandsOn, TAKEN_BLOCK,
+        },
+    },
+    server::{Channel, PlayerId, mock::Call},
+};
+
+/// The hub's glass wall, from `maps/hub.map`.
+const WALL_RADIUS: f32 = 19.0;
+
+/// The raised centre the countdown is read from, from `maps/hub.map`.
+const DAIS_RADIUS: f32 = 4.0;
+
+fn radius(at: IVec3) -> f32 {
+    #[expect(clippy::cast_precision_loss, reason = "a hub is tens of blocks across")]
+    let (x, z) = (at.x as f32, at.z as f32);
+    x.hypot(z)
+}
+
+// ---------------------------------------------------------------------------
+// The ring, as pure geometry
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_empty_roster_makes_no_ring() {
+    assert!(selector::ring(0).is_empty());
+}
+
+#[test]
+fn every_kit_gets_its_own_block() {
+    for count in 1..=24 {
+        let ring = selector::ring(count);
+        assert_eq!(ring.len(), count);
+
+        let mut seen = ring.clone();
+        seen.sort_unstable_by_key(|at| (at.x, at.z));
+        seen.dedup();
+        assert_eq!(
+            seen.len(),
+            count,
+            "a roster of {count} puts two podiums in one block: {ring:?}"
+        );
+    }
+}
+
+#[test]
+fn the_ring_stands_between_the_dais_and_the_wall() {
+    for count in 1..=24 {
+        for at in selector::ring(count) {
+            assert_eq!(at.y, PLINTH_Y);
+            let radius = radius(at);
+            assert!(
+                radius > DAIS_RADIUS,
+                "a podium at {at} stands on the raised centre"
+            );
+            // Rounding to a block can move a podium half a block either way.
+            assert!(
+                (MIN_RADIUS - 1.0..=MAX_RADIUS + 1.0).contains(&radius),
+                "a podium at {at} is {radius} from the middle, outside the ring's own bounds"
+            );
+            assert!(
+                radius < WALL_RADIUS,
+                "a podium at {at} is inside the hub's glass wall"
+            );
+        }
+    }
+}
+
+/// A podium on a spawn point is a player spawning inside a block, which reads
+/// as the server being broken rather than as a placement mistake.
+#[test]
+fn no_podium_stands_on_a_hub_spawn_point() {
+    let hub = map::parse(map::HUB).expect("the hub map parses");
+    for count in 1..=24 {
+        for at in selector::ring(count) {
+            for spawn in &hub.spawns {
+                let gap = Vec3::new(
+                    #[expect(clippy::cast_precision_loss, reason = "hub-sized coordinates")]
+                    (at.x as f32 - spawn.x),
+                    0.0,
+                    #[expect(clippy::cast_precision_loss, reason = "hub-sized coordinates")]
+                    (at.z as f32 - spawn.z),
+                )
+                .length();
+                assert!(
+                    gap >= 1.5,
+                    "a roster of {count} puts a podium at {at}, {gap} blocks from the spawn at \
+                     {spawn}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn the_wool_and_the_block_the_mob_stands_in_are_one_podium() {
+    let plinth = Plinth {
+        base: IVec3::new(8, PLINTH_Y, 0),
+    };
+    assert_eq!(plinth.stand(), IVec3::new(8, PLINTH_Y + 1, 0));
+    assert!(plinth.covers(plinth.base));
+    assert!(plinth.covers(plinth.stand()));
+    assert!(!plinth.covers(IVec3::new(8, PLINTH_Y + 2, 0)));
+    assert!(!plinth.covers(IVec3::new(9, PLINTH_Y, 0)));
+}
+
+// ---------------------------------------------------------------------------
+// The roster's own data
+// ---------------------------------------------------------------------------
+
+/// A kit that does not say which mob it is gets an armour stand, which is
+/// indistinguishable from every other kit that forgot.
+#[test]
+fn every_kit_declares_a_distinct_mob() {
+    let game = Game::new();
+    let mut declared: Vec<(&str, &str)> = Vec::new();
+
+    for id in kit::registry(&game.world) {
+        let entry = game.world.entity_from_id(id);
+        let name = entry
+            .try_get::<&KitName>(|name| name.0)
+            .expect("a kit has a name");
+        let mob = entry
+            .try_get::<&KitMob>(|mob| mob.0)
+            .unwrap_or_else(|| panic!("{name} declares no mob, so its podium would be empty"));
+        assert_ne!(
+            mob,
+            kit::DEFAULT_MOB,
+            "{name} names the fallback explicitly, which is the same problem"
+        );
+        declared.push((name, mob));
+    }
+
+    assert!(!declared.is_empty(), "the registry is empty");
+    for (index, (name, mob)) in declared.iter().enumerate() {
+        for (other, other_mob) in &declared[index + 1..] {
+            assert_ne!(
+                mob, other_mob,
+                "{name} and {other} are the same mob, so the ring cannot be read"
+            );
+        }
+    }
+}
+
+/// The host panics at boot on a mob or a block it cannot resolve, which is the
+/// right thing for it to do and the wrong place to find out. A typo in one
+/// `.mob(...)` line would take the whole server down, so the same two lookups
+/// run here, where the failure is a test with a name on it.
+#[test]
+fn every_mob_and_block_the_ring_is_made_of_is_real() {
+    let game = Game::new();
+    selector::build(&game.world, IVec3::ZERO);
+
+    for block in [FREE_BLOCK, TAKEN_BLOCK] {
+        assert!(
+            BlockKind::from_str(block.trim_start_matches("minecraft:")).is_some(),
+            "{block} is not a block, so the server would panic while building the hub"
+        );
+    }
+
+    let mobs = selector::mobs(&game.world);
+    assert_eq!(mobs.len(), kit::registry(&game.world).len());
+    for (_, _, mob) in mobs {
+        assert!(
+            EntityKind::named(mob).is_some(),
+            "{mob} is not a mob, so the server would panic while building the hub"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The world the podiums live in
+// ---------------------------------------------------------------------------
+
+/// A world with the ring standing at the origin and the lobby short enough to
+/// run a whole match through in a test.
+fn lobby_with_podiums() -> Game {
+    let game = Game::new();
+    game.world.set(LobbyConfig {
+        min_players: 2,
+        full_players: 4,
+        countdown_at_min: 0.4,
+        countdown_at_three_quarters: 0.3,
+        countdown_at_full: 0.2,
+        prepare_seconds: 0.2,
+        match_timeout_seconds: 30.0,
+        results_seconds: 0.2,
+    });
+    selector::build(&game.world, IVec3::ZERO);
+    game
+}
+
+/// The podium offering `name`, and the block a player clicks to take it.
+fn podium_for(game: &Game, name: &str) -> Plinth {
+    let kit = kit::by_name(&game.world, name).expect("the registry has that kit");
+    selector::podiums(&game.world)
+        .into_iter()
+        .find(|(_, _, offered)| *offered == kit.id())
+        .map(|(_, plinth, _)| plinth)
+        .expect("every kit has a podium")
+}
+
+fn playing(game: &Game, player: Entity) -> Option<&'static str> {
+    game.world
+        .entity_from_id(player)
+        .find_target(Playing, |_| true)
+        .and_then(|kit| kit.try_get::<&KitName>(|name| name.0))
+}
+
+fn plinth_block(game: &Game, at: IVec3) -> &'static str {
+    selector::plinths(&game.world)
+        .into_iter()
+        .find(|(position, _)| *position == at)
+        .map(|(_, block)| block)
+        .expect("that block is a plinth")
+}
+
+use smash::flecs_ext::EntityViewExt;
+
+#[test]
+fn there_is_one_podium_per_kit_and_each_offers_a_different_one() {
+    let game = lobby_with_podiums();
+    let kits = kit::registry(&game.world);
+    let podiums = selector::podiums(&game.world);
+
+    assert_eq!(podiums.len(), kits.len());
+
+    let mut offered: Vec<Entity> = podiums.iter().map(|(_, _, kit)| *kit).collect();
+    offered.sort_unstable();
+    offered.dedup();
+    assert_eq!(offered.len(), kits.len(), "two podiums offer the same kit");
+}
+
+#[test]
+fn building_twice_rebuilds_the_ring_rather_than_doubling_it() {
+    let game = lobby_with_podiums();
+    let before = selector::podiums(&game.world).len();
+    selector::build(&game.world, IVec3::ZERO);
+    assert_eq!(selector::podiums(&game.world).len(), before);
+}
+
+#[test]
+fn a_right_click_on_a_podium_picks_that_mob() {
+    let mut game = lobby_with_podiums();
+    let player = game.player("alice", Vec3::new(0.0, 65.0, 0.0));
+    let podium = podium_for(&game, "Skeleton");
+
+    assert!(selector::click(
+        &game.world,
+        game.world.entity_from_id(player),
+        podium.stand()
+    ));
+    assert_eq!(playing(&game, player), Some("Skeleton"));
+}
+
+/// The wool is clickable as well as the mob, and it has to be: a click that
+/// misses the mob by a pixel lands on the block behind it, and a player who
+/// meant to pick the Slime should not be told nothing happened.
+#[test]
+fn the_wool_under_the_mob_picks_the_same_mob() {
+    let mut game = lobby_with_podiums();
+    let player = game.player("alice", Vec3::new(0.0, 65.0, 0.0));
+    let podium = podium_for(&game, "Slime");
+
+    assert!(selector::click(
+        &game.world,
+        game.world.entity_from_id(player),
+        podium.base
+    ));
+    assert_eq!(playing(&game, player), Some("Slime"));
+}
+
+/// The real path. A player right-clicks the mob, not the block under it, and
+/// the click arrives naming an entity and nothing else. `(StandsOn, podium)`
+/// is what turns that entity back into a kit.
+///
+/// The mob is stood up here rather than by the host, because the host is
+/// hyperion and the point of this half of the crate is that it runs without
+/// one. What the host does is the same two lines: make an entity, relate it.
+#[test]
+fn a_right_click_on_the_mob_picks_that_mob() {
+    let mut game = lobby_with_podiums();
+    let player = game.player("alice", Vec3::new(0.0, 65.0, 0.0));
+    let (podium, ..) = selector::podiums(&game.world)
+        .into_iter()
+        .find(|(_, plinth, _)| *plinth == podium_for(&game, "Creeper"))
+        .expect("the Creeper has a podium");
+
+    let mob = game.world.entity().add((StandsOn, podium)).id();
+
+    assert!(selector::click_mob(
+        &game.world,
+        game.world.entity_from_id(player),
+        mob
+    ));
+    assert_eq!(playing(&game, player), Some("Creeper"));
+}
+
+/// Every other entity in the world, which is mostly the other players.
+#[test]
+fn clicking_something_that_is_not_a_podium_mob_does_nothing() {
+    let mut game = lobby_with_podiums();
+    let alice = game.player("alice", Vec3::new(0.0, 65.0, 0.0));
+    let bob = game.player("bob", Vec3::new(2.0, 65.0, 0.0));
+
+    assert!(!selector::click_mob(
+        &game.world,
+        game.world.entity_from_id(alice),
+        bob
+    ));
+    assert_eq!(playing(&game, alice), None);
+}
+
+/// Tearing the ring down takes its mobs with it. Nothing here says so; the
+/// `(StandsOn, podium)` relation is declared to cascade, and this is the check
+/// that the declaration is the one that does it.
+#[test]
+fn rebuilding_the_ring_does_not_leave_its_mobs_behind() {
+    let game = lobby_with_podiums();
+    let (podium, ..) = selector::podiums(&game.world)
+        .into_iter()
+        .next()
+        .expect("a podium");
+    let mob = game.world.entity().add((StandsOn, podium)).id();
+    assert!(game.world.entity_from_id(mob).is_alive());
+
+    selector::build(&game.world, IVec3::ZERO);
+
+    assert!(
+        !game.world.entity_from_id(mob).is_alive(),
+        "the old ring's mobs are still standing in the new one"
+    );
+}
+
+#[test]
+fn clicking_a_block_that_is_not_a_podium_does_nothing() {
+    let mut game = lobby_with_podiums();
+    let player = game.player("alice", Vec3::new(0.0, 65.0, 0.0));
+
+    assert!(!selector::click(
+        &game.world,
+        game.world.entity_from_id(player),
+        IVec3::new(0, 64, 0)
+    ));
+    assert_eq!(playing(&game, player), None);
+}
+
+#[test]
+fn a_mob_somebody_else_is_playing_is_refused_and_says_who_has_it() {
+    let mut game = lobby_with_podiums();
+    let alice = game.player("alice", Vec3::new(0.0, 65.0, 0.0));
+    let bob = game.player("bob", Vec3::new(2.0, 65.0, 0.0));
+    let podium = podium_for(&game, "Spider");
+
+    assert!(selector::click(
+        &game.world,
+        game.world.entity_from_id(alice),
+        podium.stand()
+    ));
+    game.server.take();
+
+    assert!(selector::click(
+        &game.world,
+        game.world.entity_from_id(bob),
+        podium.stand()
+    ));
+
+    assert_eq!(playing(&game, bob), None, "bob took a mob that was taken");
+    assert_eq!(playing(&game, alice), Some("Spider"), "alice lost her mob");
+
+    let calls = game.server.calls();
+    let told = calls.iter().any(|call| {
+        matches!(call, Call::Message(id, Channel::ActionBar, text)
+            if *id == PlayerId(2)
+                && text.plain().contains("Spider")
+                && text.plain().contains("alice"))
+    });
+    assert!(told, "bob was not told who has the Spider: {calls:?}");
+}
+
+/// The same rule through the other door. A player who types the command and a
+/// player who clicks the podium must be told the same thing, or they will
+/// believe there are two rules.
+#[test]
+fn the_command_refuses_a_taken_mob_with_the_same_words() {
+    let mut game = lobby_with_podiums();
+    let alice = game.player("alice", Vec3::new(0.0, 65.0, 0.0));
+    let bob = game.player("bob", Vec3::new(2.0, 65.0, 0.0));
+
+    lobby::select_kit(&game.world, game.world.entity_from_id(alice), "Cow")
+        .expect("the Cow is free");
+
+    let refusal = lobby::select_kit(&game.world, game.world.entity_from_id(bob), "Cow")
+        .expect_err("the Cow is taken");
+    assert!(
+        refusal.contains("Cow") && refusal.contains("alice"),
+        "the command said {refusal:?}"
+    );
+    assert_eq!(playing(&game, bob), None);
+}
+
+#[test]
+fn taking_the_mob_you_already_have_is_not_a_refusal() {
+    let mut game = lobby_with_podiums();
+    let alice = game.player("alice", Vec3::new(0.0, 65.0, 0.0));
+    let podium = podium_for(&game, "Wolf");
+
+    for _ in 0..2 {
+        assert!(selector::click(
+            &game.world,
+            game.world.entity_from_id(alice),
+            podium.stand()
+        ));
+    }
+    assert_eq!(playing(&game, alice), Some("Wolf"));
+
+    let refused = game.server.calls().iter().any(
+        |call| matches!(call, Call::Message(_, Channel::ActionBar, text) if text.plain().contains("taken")),
+    );
+    assert!(!refused, "clicking your own podium was refused");
+}
+
+/// The manifest is the only thing outside this crate that is told where a
+/// podium is, so it has to agree with the world rather than describe one.
+#[test]
+fn the_manifest_names_every_podium_and_who_holds_it() {
+    let mut game = lobby_with_podiums();
+    let alice = game.player("alice", Vec3::new(0.0, 65.0, 0.0));
+    let taken = podium_for(&game, "Blaze");
+
+    let before = selector::manifest(&game.world);
+    assert_eq!(before.len(), selector::podiums(&game.world).len());
+    assert!(
+        before.iter().all(|offer| offer.held_by.is_none()),
+        "somebody holds a mob in an empty lobby: {before:?}"
+    );
+
+    selector::click(&game.world, game.world.entity_from_id(alice), taken.stand());
+
+    let after = selector::manifest(&game.world);
+    let blaze = after
+        .iter()
+        .find(|offer| offer.name == "Blaze")
+        .expect("the Blaze has a podium");
+    assert_eq!(blaze.held_by.as_deref(), Some("alice"));
+    assert_eq!(blaze.wool, TAKEN_BLOCK);
+    assert_eq!(blaze.click, taken.stand());
+    assert_eq!(blaze.base, taken.base);
+    assert_eq!(
+        after.iter().filter(|o| o.held_by.is_some()).count(),
+        1,
+        "one click held more than one mob"
+    );
+
+    // Clicking what the manifest says to click is the whole contract with the
+    // gate: every entry has to be a block the click handler answers.
+    for offer in &after {
+        assert!(
+            selector::podium_at(&game.world, offer.click).is_some(),
+            "{} says click {:?}, which is not a podium",
+            offer.name,
+            offer.click
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The colour, which is the part a player reads
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_podium_turns_red_when_its_mob_is_taken_and_nothing_else_does() {
+    let mut game = lobby_with_podiums();
+    let alice = game.player("alice", Vec3::new(0.0, 65.0, 0.0));
+    let taken = podium_for(&game, "Blaze");
+    let free = podium_for(&game, "Chicken");
+
+    assert_eq!(plinth_block(&game, taken.base), FREE_BLOCK);
+
+    selector::click(&game.world, game.world.entity_from_id(alice), taken.stand());
+
+    assert_eq!(plinth_block(&game, taken.base), TAKEN_BLOCK);
+    assert_eq!(plinth_block(&game, free.base), FREE_BLOCK);
+
+    let red = selector::plinths(&game.world)
+        .into_iter()
+        .filter(|(_, block)| *block == TAKEN_BLOCK)
+        .count();
+    assert_eq!(
+        red, 1,
+        "one player took one mob and lit more than one podium"
+    );
+}
+
+/// Nothing anywhere frees a mob on disconnect, and that is the point: the claim
+/// *is* the player's `(Playing, kit)` edge, so destroying the player destroys
+/// the claim. A cached set of taken kits would need a handler here, and the day
+/// somebody forgot to write one the mob would be reserved forever.
+#[test]
+fn a_holder_who_disconnects_frees_their_mob() {
+    let mut game = lobby_with_podiums();
+    let alice = game.player("alice", Vec3::new(0.0, 65.0, 0.0));
+    let bob = game.player("bob", Vec3::new(2.0, 65.0, 0.0));
+    let podium = podium_for(&game, "Creeper");
+
+    selector::click(
+        &game.world,
+        game.world.entity_from_id(alice),
+        podium.stand(),
+    );
+    assert_eq!(plinth_block(&game, podium.base), TAKEN_BLOCK);
+
+    // What hyperion does to a player whose connection drops.
+    game.world.entity_from_id(alice).destruct();
+
+    assert_eq!(plinth_block(&game, podium.base), FREE_BLOCK);
+    assert!(selector::click(
+        &game.world,
+        game.world.entity_from_id(bob),
+        podium.stand()
+    ));
+    assert_eq!(playing(&game, bob), Some("Creeper"));
+}
+
+// ---------------------------------------------------------------------------
+// The lobby running underneath it
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_selection_made_in_the_hub_survives_the_countdown_and_the_scatter() {
+    let mut game = lobby_with_podiums();
+    let alice = game.player("alice", Vec3::new(0.0, 65.0, 0.0));
+    let bob = game.player("bob", Vec3::new(2.0, 65.0, 0.0));
+
+    let hers = podium_for(&game, "Enderman");
+    let his = podium_for(&game, "Snowman");
+    selector::click(&game.world, game.world.entity_from_id(alice), hers.stand());
+    selector::click(&game.world, game.world.entity_from_id(bob), his.stand());
+
+    // Two players is `min_players`, so the countdown runs on its own.
+    game.advance(2.0, 40);
+    assert_eq!(
+        game.world.cloned::<&Lobby>().phase,
+        Phase::Playing,
+        "the match never started"
+    );
+
+    assert_eq!(playing(&game, alice), Some("Enderman"));
+    assert_eq!(playing(&game, bob), Some("Snowman"));
+    assert_eq!(plinth_block(&game, hers.base), TAKEN_BLOCK);
+    assert_eq!(plinth_block(&game, his.base), TAKEN_BLOCK);
+}
+
+#[test]
+fn a_podium_click_once_the_match_has_committed_is_refused() {
+    let mut game = lobby_with_podiums();
+    let alice = game.player("alice", Vec3::new(0.0, 65.0, 0.0));
+    let bob = game.player("bob", Vec3::new(2.0, 65.0, 0.0));
+
+    let hers = podium_for(&game, "Guardian");
+    selector::click(&game.world, game.world.entity_from_id(alice), hers.stand());
+    selector::click(
+        &game.world,
+        game.world.entity_from_id(bob),
+        podium_for(&game, "Zombie").stand(),
+    );
+
+    game.advance(2.0, 40);
+    assert_eq!(game.world.cloned::<&Lobby>().phase, Phase::Playing);
+    game.server.take();
+
+    let other = podium_for(&game, "Cow");
+    selector::click(&game.world, game.world.entity_from_id(alice), other.stand());
+
+    assert_eq!(
+        playing(&game, alice),
+        Some("Guardian"),
+        "a mid-match click changed a kit"
+    );
+    let told = game.server.calls().iter().any(|call| {
+        matches!(call, Call::Message(_, Channel::ActionBar, text)
+            if text.plain().contains("cannot change kit"))
+    });
+    assert!(told, "the mid-match refusal said nothing");
+}
+
+/// One holder per mob, whatever order the clicks arrive in.
+#[test]
+fn no_two_players_ever_hold_the_same_mob() {
+    let mut game = lobby_with_podiums();
+    let players: Vec<Entity> = (0..4)
+        .map(|index| {
+            #[expect(clippy::cast_precision_loss, reason = "four players")]
+            let x = index as f32;
+            game.player(&format!("p{index}"), Vec3::new(x, 65.0, 0.0))
+        })
+        .collect();
+
+    // Everybody goes for the same three podiums.
+    let contested: Vec<_> = ["Iron Golem", "Slime", "Skeleton"]
+        .into_iter()
+        .map(|name| podium_for(&game, name))
+        .collect();
+
+    for player in &players {
+        for podium in &contested {
+            selector::click(
+                &game.world,
+                game.world.entity_from_id(*player),
+                podium.stand(),
+            );
+        }
+    }
+
+    let mut held: Vec<Entity> = kit::claims(&game.world)
+        .into_iter()
+        .map(|claim| claim.kit)
+        .collect();
+    let total = held.len();
+    held.sort_unstable();
+    held.dedup();
+    assert_eq!(held.len(), total, "two players ended up on one mob");
+}

--- a/flake.nix
+++ b/flake.nix
@@ -555,6 +555,26 @@
               '';
             };
 
+            # The same gate again, driving a client that clicks the hub's kit
+            # podiums instead of playing the match.
+            #
+            # Separate from `smash-e2e` because it answers the question that
+            # comes before it. `smash-e2e` needs kits to already be picked and
+            # picks them by typing `/kit`; this one asks whether a player who
+            # never types anything can pick a mob by right-clicking it, and
+            # whether the game says so when the mob is somebody else's. Its
+            # ports default off the others again so every gate can run at once.
+            smash-selector-e2e = {
+              deps = [ pkgs.git ];
+              text = ''
+                export HYPERION_EVENT=smash
+                export HYPERION_E2E_CLIENT=tools/smash-selector.py
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + 4000)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + 4000)}}"
+                exec "${lib.getExe runners.e2e}" "$@"
+              '';
+            };
+
             # The same gate again, driving a client that reads blocks rather
             # than positions.
             #
@@ -763,11 +783,24 @@
               client = "completions-check.py";
             };
 
+            # The kit selector, driven by right-clicks on the podium mobs
+            # rather than by `/kit`. Shorter than the match gate because it
+            # never plays one: the longest thing in it is the countdown a full
+            # lobby runs.
+            smash-selector-e2e = e2e.mkCheck {
+              name = "hyperion-smash-selector-e2e";
+              gameServer = gameBinaries.smash;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "smash-selector.py";
+              timeout = 420;
+            };
+
             # `checks.e2e` above took the names the two app wrappers used to
             # hold, and those wrappers still have to pass shellcheck.
             e2e-app = scripts.e2e;
             smash-e2e-app = scripts.smash-e2e;
             completions-e2e-app = scripts.completions-e2e;
+            smash-selector-e2e-app = scripts.smash-selector-e2e;
 
             # The pinned world URL still has to be the one the server asks for.
             genmap-url-pinned = e2e.genMapUrlPinned;

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -189,22 +189,95 @@ def take_sound(payload):
     return sound_id, source, (x / 8.0, y / 8.0, z / 8.0), volume, pitch
 
 
-def take_nbt_string(payload, offset):
-    """Read a network-NBT tag that is a bare string.
+# NBT payload sizes for the fixed-width tag types.
+NBT_FIXED = {1: 1, 2: 2, 3: 4, 4: 8, 5: 4, 6: 8}
 
-    `Component::text(..).to_tag()` collapses a component with no style and no
-    children to `Tag::String`, which is every message this server sends, so a
-    full NBT reader would be dead weight. A tag of any other type is reported
-    rather than guessed at.
+
+def _nbt_read(buf, offset, kind):
+    """One NBT payload, as the little of it a chat component needs.
+
+    Strings, lists and compounds come back as themselves; everything else comes
+    back as `None` after being stepped over, because no readable part of a
+    component is stored in a number.
+    """
+    if kind in NBT_FIXED:
+        return None, offset + NBT_FIXED[kind]
+    if kind == 8:
+        (length,) = struct.unpack_from(">H", buf, offset)
+        offset += 2
+        return buf[offset : offset + length].decode("utf-8", "replace"), offset + length
+    if kind == 9:
+        element = buf[offset]
+        (count,) = struct.unpack_from(">i", buf, offset + 1)
+        offset += 5
+        values = []
+        for _ in range(count):
+            value, offset = _nbt_read(buf, offset, element)
+            values.append(value)
+        return values, offset
+    if kind == 10:
+        fields = {}
+        while True:
+            entry = buf[offset]
+            offset += 1
+            if entry == 0:
+                return fields, offset
+            (length,) = struct.unpack_from(">H", buf, offset)
+            offset += 2
+            name = buf[offset : offset + length].decode("utf-8", "replace")
+            offset += length
+            fields[name], offset = _nbt_read(buf, offset, entry)
+    if kind == 7:
+        (count,) = struct.unpack_from(">i", buf, offset)
+        return None, offset + 4 + count
+    if kind == 11:
+        (count,) = struct.unpack_from(">i", buf, offset)
+        return None, offset + 4 + 4 * count
+    if kind == 12:
+        (count,) = struct.unpack_from(">i", buf, offset)
+        return None, offset + 4 + 8 * count
+    raise ValueError("unknown NBT tag type %d at offset %d" % (kind, offset))
+
+
+def _nbt_plain(value):
+    """The words in a decoded component, with the styling discarded.
+
+    `Component::text` renders as `{text: "..."}` and picks up `extra` for
+    children and `color` for a style, and this walks the first two and ignores
+    the third. Matching the server's own `Component::plain`, which is what the
+    Rust tests assert against.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "".join(_nbt_plain(item) for item in value)
+    if isinstance(value, dict):
+        out = _nbt_plain(value.get("text", ""))
+        return out + _nbt_plain(value.get("extra", []))
+    return ""
+
+
+def take_nbt_string(payload, offset):
+    """Read one network-NBT chat component as plain text.
+
+    A component with no style and no children collapses to `Tag::String`, which
+    is what every message here was until the component API landed. Anything
+    coloured is a compound instead, so both shapes have to be read: a reader
+    that handled only the bare string reported an action bar full of
+    `<nbt tag type 0x0A>` and a gate that could no longer see what the server
+    said.
     """
     kind = payload[offset]
     offset += 1
-    if kind != 0x08:
-        return "<nbt tag type 0x%02X, not a string>" % kind, offset
-    (length,) = struct.unpack(">H", payload[offset : offset + 2])
-    offset += 2
-    text = payload[offset : offset + length].decode("utf-8", "replace")
-    return text, offset + length
+    if kind == 0x08:
+        (length,) = struct.unpack(">H", payload[offset : offset + 2])
+        offset += 2
+        return payload[offset : offset + length].decode("utf-8", "replace"), offset + length
+    if kind == 0x0A:
+        # Network NBT: the root compound carries no name of its own.
+        fields, offset = _nbt_read(payload, offset, 0x0A)
+        return _nbt_plain(fields), offset
+    return "<nbt tag type 0x%02X, neither a string nor a compound>" % kind, offset
 
 
 # events/smash/src/terrain.rs: the hub is region 0 and each arena sits a whole
@@ -941,14 +1014,113 @@ class Match:
                 % (len(self.cooldown_results), COOLDOWN_REFUSAL),
             )
 
+    def spares(self, testing):
+        """A mob for each victim that is not the one being tested.
+
+        One player per mob is the selector's rule and `/kit` obeys it too, so
+        the sweep cannot stand three clients on the kit under test the way it
+        used to: the attacker takes it and the other two are refused. The
+        attacker is the one whose abilities are being fired, so the attacker is
+        the one who gets it, and the victims stand on whatever is left.
+
+        Not any two. The kits named by `--kits` are reserved, because the match
+        that runs after the sweep hands those out and a victim still holding
+        one would refuse the client it is meant for. Everything else is taken
+        in registry order, which makes the pairing the same on every run.
+        """
+        reserved = {kit.strip() for kit in self.args.kits.split(",")}
+        reserved.add(testing)
+        seen = []
+        for entry in self.manifest:
+            if entry["kit"] not in reserved and entry["kit"] not in seen:
+                seen.append(entry["kit"])
+        return seen[: len(self.clients) - 1]
+
+    def plan_for(self, kit):
+        """Who plays what while `kit`'s abilities are being fired."""
+        plan = dict(zip((c.name for c in self.clients[1:]), self.spares(kit)))
+        plan[self.clients[0].name] = kit
+        if len(plan) < len(self.clients):
+            self.sweep_failures.append(
+                "the roster has too few mobs to give %d clients one each while "
+                "testing %s" % (len(self.clients), kit)
+            )
+            return None
+        return plan
+
+    def unwanted(self, plan):
+        """A mob nobody wants and nobody is standing on, to step aside onto."""
+        held = {client.kit for client in self.clients}
+        wanted = set(plan.values())
+        for entry in self.manifest:
+            if entry["kit"] not in wanted and entry["kit"] not in held:
+                return entry["kit"]
+        return None
+
+    def equip(self, plan):
+        """Put every client on the mob `plan` names, in a workable order.
+
+        Ordering matters now that one player holds one mob: a client that has
+        not yet moved off X refuses the client that wants X, and asking all of
+        them at once means whoever asked second loses. So each pass asks only
+        the clients whose mob is free or already theirs, waits, and goes round
+        again.
+
+        That is not enough on its own, and the first run of it proved so: when
+        the sweep moves from the Sky Squid to the Creeper, the attacker is
+        standing on the Sky Squid a victim now wants and the victim is standing
+        on the Creeper the attacker now wants. Nobody can go first. One of them
+        steps off onto a mob nobody in the plan wants, and the pass after that
+        is ordinary.
+
+        Everybody is asked even when they already hold the right mob, because
+        re-picking is the game's own way of saying "start of a life" and is how
+        the sweep gets its victims back to full health.
+        """
+        pending = list(self.clients)
+        for _ in range(4 * len(self.clients)):
+            if not pending:
+                break
+            owner = {
+                client.kit: client.name
+                for client in self.clients
+                if client.kit is not None
+            }
+            ready = [
+                client
+                for client in pending
+                if owner.get(plan[client.name], client.name) == client.name
+            ]
+            if ready:
+                for client in ready:
+                    client.kit = None
+                    client.command("kit %s" % plan[client.name])
+                self.wait_until(
+                    lambda: all(client.kit == plan[client.name] for client in ready),
+                    15.0,
+                )
+                pending = [
+                    client for client in pending if client.kit != plan[client.name]
+                ]
+                continue
+
+            stuck = pending[0]
+            aside = self.unwanted(plan)
+            if aside is None:
+                break
+            stuck.kit = None
+            stuck.command("kit %s" % aside)
+            self.wait_until(lambda: stuck.kit == aside, 15.0)
+        return all(client.kit == plan[client.name] for client in self.clients)
+
     def select_kit(self, kit):
-        """Put every client on `kit`, which also restores them to full health."""
-        for client in self.clients:
-            client.kit = None
-            client.command("kit %s" % kit)
-        if not self.wait_until(
-            lambda: all(client.kit == kit for client in self.clients), 15.0
-        ):
+        """Put the attacker on `kit` and the victims on something else.
+
+        Also restores everybody to full health, which is what makes it worth
+        calling again between attempts.
+        """
+        plan = self.plan_for(kit)
+        if plan is None or not self.equip(plan):
             return False
         # The hotbar is rebuilt a tick later, in PostUpdate, and an ability
         # cannot be used before the item backing it exists.
@@ -969,12 +1141,24 @@ class Match:
         every splash skips, and an ability would then read as doing nothing when
         it was the arrangement that was spent. Picking the kit again is the
         game's own way of saying "start of a life", so it is what is used.
+
+        Each victim re-picks the mob it is already standing on rather than the
+        attacker's, which is the only thing one player per mob leaves open. It
+        also makes the victims a constant across the whole sweep instead of
+        changing with every kit, so an ability that reads as weak is weak and
+        not measured against a tougher target than the last one.
         """
+        plan = self.plan_for(entry["kit"])
+        if plan is None:
+            return
         for victim in self.clients[1:]:
             victim.kit = None
-            victim.command("kit %s" % entry["kit"])
+            victim.command("kit %s" % plan[victim.name])
         self.wait_until(
-            lambda: all(victim.kit == entry["kit"] for victim in self.clients[1:]), 5.0
+            lambda: all(
+                victim.kit == plan[victim.name] for victim in self.clients[1:]
+            ),
+            5.0,
         )
 
         base = SWEEP_Z + attempt * ATTEMPT_STRIDE
@@ -1266,8 +1450,10 @@ class Match:
         # A command sent before the server has moved this connection into play
         # would be read against the configuration state's id table.
         at(in_play, lambda: None)
-        for client, kit in zip(self.clients, kits):
-            at(0.2, lambda c=client, k=kit: c.command("kit %s" % k))
+        # One call rather than one command per client, because one player per
+        # mob makes the order matter: a client still holding the mob the next
+        # one was assigned refuses it. `equip` sorts that out.
+        at(0.2, lambda: self.equip(dict(zip((c.name for c in self.clients), kits))))
 
         # Everything below waits for `Go!`, so the countdown's length is the
         # server's business and not a number written down here.
@@ -1662,8 +1848,13 @@ def main():
     )
     args = parser.parse_args()
 
-    if args.clients > len(args.kits.split(",")):
+    chosen = [kit.strip() for kit in args.kits.split(",")]
+    if args.clients > len(chosen):
         raise SystemExit("--kits needs one kit per client")
+    # One player per mob, so two clients cannot be given the same one: the
+    # second would be refused and the match would run a client short of a kit.
+    if len(set(chosen[: args.clients])) < args.clients:
+        raise SystemExit("--kits must name a different mob for each client")
 
     return Match(args).run()
 

--- a/tools/smash-selector.py
+++ b/tools/smash-selector.py
@@ -1,0 +1,948 @@
+#!/usr/bin/env python3
+"""Drive real clients through the kit selector: click a mob, be refused, leave.
+
+`smash-match.py` asks whether a match happens. This asks the question that comes
+before it: can a player walk up to the ring of podiums in the middle of the hub,
+right-click a mob and be playing it, and does the game answer honestly when the
+mob is already somebody else's.
+
+Four claims, and each one is checked against what a client was actually sent
+rather than against a return value:
+
+  1. a right-click on a podium picks that mob;
+  2. a second player clicking the same podium is refused, told who has it, and
+     is left with no kit;
+  3. the wool under the mob goes green to red on the wire when it is taken, and
+     back to green when the holder disconnects, which frees the mob;
+  4. a selection made in the hub survives the countdown, and a click after the
+     match commits is refused.
+
+Nothing here knows where a podium is. The ring is generated from the roster at
+boot, so the server is asked: `/podiums` answers with one JSON object per
+podium, and this file clicks the coordinates it is given. A gate that
+recomputed the ring would be a second copy of `selector::ring` and would go on
+passing after the real one moved.
+
+The framing, login and configuration handshake are `client-26.2.py`'s. The
+chunk and block-update decoders are `smash-map-check.py`'s. Both are imported
+rather than copied, so there is one place each of those is written down.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import pathlib
+import re
+import struct
+import sys
+import time
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+
+
+def _load(filename, name):
+    """Import a tool whose file name is not a Python identifier."""
+    spec = importlib.util.spec_from_file_location(name, TOOLS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+world = _load("smash-map-check.py", "smash_map_check")
+match = _load("smash-match.py", "smash_match")
+base = world.base
+
+var_int = base.var_int
+take_var_int = base.take_var_int
+mc_string = base.mc_string
+take_nbt_string = match.take_nbt_string
+BlockNames = world.BlockNames
+ROOT = TOOLS.parent
+ENTITY_TYPES = ROOT / "crates/hyperion-minecraft-proto/src/entity_type.rs"
+decode_chunk = world.decode_chunk
+decode_section_blocks_update = world.decode_section_blocks_update
+
+# Serverbound ids, from crates/hyperion-minecraft-proto/src/generated/packet_id.rs.
+C2S_ACCEPT_TELEPORTATION = 0x00
+C2S_CHAT_COMMAND = 0x07
+C2S_KEEP_ALIVE = 0x1C
+C2S_INTERACT = 0x1A
+C2S_MOVE_PLAYER_POS_ROT = 0x1F
+C2S_USE_ITEM_ON = 0x42
+
+S2C_DISCONNECT = world.S2C_DISCONNECT
+S2C_LEVEL_CHUNK_WITH_LIGHT = world.S2C_LEVEL_CHUNK_WITH_LIGHT
+S2C_SECTION_BLOCKS_UPDATE = world.S2C_SECTION_BLOCKS_UPDATE
+S2C_KEEP_ALIVE = world.S2C_KEEP_ALIVE
+S2C_LOGIN = world.S2C_LOGIN
+S2C_PLAYER_POSITION = world.S2C_PLAYER_POSITION
+S2C_ADD_ENTITY = 0x01
+S2C_SET_ACTION_BAR_TEXT = 0x57
+S2C_SYSTEM_CHAT = 0x79
+
+# events/smash/src/command.rs.
+PODIUM_PREFIX = "smash-podium "
+PODIUM_END_PREFIX = "smash-podiums-end "
+
+# events/smash/src/module/selector.rs. Restated rather than imported so that
+# this file checks the colours against the design and not against itself.
+FREE_BLOCK = "minecraft:lime_wool"
+TAKEN_BLOCK = "minecraft:red_wool"
+
+# events/smash/src/module/lobby.rs: `LobbyConfig::default`. Eight is
+# `full_players`, which is the shortest countdown the lobby will run and so the
+# cheapest way to reach a committed match.
+FULL_PLAYERS = 8
+
+ON_GROUND = 1
+# `smash-match.py`'s numbers: how far a step may carry a client and how often
+# one is sent. Anything faster is a step hyperion cannot account for, and it
+# answers those with a teleport back to where the player was last tick.
+POSITION_INTERVAL = 0.1
+STEP_BLOCKS = 4.0
+# Over the top of the hub's furniture rather than through it, which is also
+# well clear of the podiums the client is walking between.
+HUB_CLEAR_Y = 72.0
+
+# `Direction::Up`, the face a player clicking the top of a block hits.
+FACE_UP = 1
+
+
+def entity_names():
+    """Registry id to entity name, from the generated table.
+
+    The same trick `smash-map-check.py` uses for blocks, and for the same
+    reason: the numbering is Mojang's and restating it here would be a copy
+    that is wrong the next time the jar moves. Reading the table the server
+    encodes from is what makes "that is a creeper" a check rather than a hope.
+    """
+    pattern = re.compile(r'Self::new\("([^"]+)", (\d+)\)')
+    found = {int(number): name for name, number in pattern.findall(ENTITY_TYPES.read_text())}
+    if not found:
+        raise SystemExit("no entity types found in %s" % ENTITY_TYPES)
+    return found
+
+
+def stamp(started):
+    return "%7.2fs" % (time.time() - started)
+
+
+def block_pos(at):
+    """`BlockPos.asLong`: x in the top 26 bits, z in the next 26, y in the low 12."""
+    x, y, z = at
+    return ((x & 0x3FFFFFF) << 38) | ((z & 0x3FFFFFF) << 12) | (y & 0xFFF)
+
+
+class Client(base.Client):
+    """One scripted player, non-blocking, with the blocks it has been sent."""
+
+    def __init__(self, host, port, name, started):
+        super().__init__(host, port, name, lambda line: None)
+        self.started = started
+        self.log = self._log
+        self.buffer = b""
+        self.position = (0.0, 65.0, 0.0)
+        self.path = []
+        self.yaw = 0.0
+        self.pitch = 0.0
+        self.joined = False
+        self.entity_id = None
+        self.kit = None
+        self.action_bar = []
+        self.chat = []
+        self.podiums = []
+        self.podiums_expected = None
+        self.blocks = {}
+        # Entity id -> (x, y, z), from every `add_entity` this client was sent.
+        # How the gate finds a podium's mob: the server says where a podium is
+        # and the mob standing there is the entity at that block.
+        self.entities = {}
+        self.last_position_sent = 0.0
+        self.gone = False
+
+    def _log(self, line):
+        print("%s [%-3s] %s" % (stamp(self.started), self.name, line), flush=True)
+
+    def enter_play(self):
+        self.sock.settimeout(0.02)
+
+    def drain(self):
+        try:
+            chunk = self.sock.recv(1 << 20)
+            if not chunk:
+                raise ConnectionError("server closed the connection")
+            self.buffer += chunk
+        except (TimeoutError, BlockingIOError):
+            pass
+
+        out = []
+        while True:
+            length = 0
+            shift = 0
+            used = 0
+            complete = False
+            while used < len(self.buffer) and used < 5:
+                byte = self.buffer[used]
+                used += 1
+                length |= (byte & 0x7F) << shift
+                shift += 7
+                if not byte & 0x80:
+                    complete = True
+                    break
+            if not complete or len(self.buffer) < used + length:
+                return out
+            body = self.buffer[used : used + length]
+            self.buffer = self.buffer[used + length :]
+            out.append(self.decode_body(body))
+
+    def decode_body(self, body):
+        if self.threshold >= 0:
+            import zlib
+
+            size, offset = take_var_int(body)
+            body = zlib.decompress(body[offset:]) if size else body[offset:]
+        packet_id, offset = take_var_int(body)
+        return packet_id, body[offset:]
+
+    # --- acting ---------------------------------------------------------
+
+    def command(self, text):
+        self.log("-> /%s" % text)
+        self.send(C2S_CHAT_COMMAND, mc_string(text))
+
+    def right_click_mob(self, entity_id, note=""):
+        """`minecraft:interact`, which since 26.2 means a right-click.
+
+        Layout from `ServerboundInteractPacket#STREAM_CODEC`: the entity, the
+        hand, where on it the ray landed as an `LpVec3`, and whether the player
+        was sneaking. A zero byte is the whole of an `LpVec3` whose components
+        are all below `ABS_MIN_VALUE`, which is what a hit on the entity's own
+        origin encodes to.
+        """
+        self.log("-> right-click entity %d %s" % (entity_id, note))
+        self.send(
+            C2S_INTERACT,
+            var_int(entity_id) + var_int(0) + bytes([0]) + bytes([0]),
+        )
+
+    def right_click(self, at, note=""):
+        """`use_item_on` with an empty hand, which is what picking a kit is.
+
+        The offsets put the hit in the middle of the block's top face. Nothing
+        on the server reads them; they are filled in because a packet a real
+        client would never send is a packet this gate has no business sending.
+        """
+        self.log("-> right-click %s %s" % (at, note))
+        self.send(
+            C2S_USE_ITEM_ON,
+            var_int(0)
+            + struct.pack(">q", block_pos(at))
+            + var_int(FACE_UP)
+            + struct.pack(">fff", 0.5, 1.0, 0.5)
+            + bytes([0, 0])
+            + var_int(0),
+        )
+
+    def walk(self, destination):
+        x, _y, z = self.position
+        self.path = [
+            (x, HUB_CLEAR_Y, z),
+            (destination[0], HUB_CLEAR_Y, destination[2]),
+            destination,
+        ]
+
+    def arrived(self):
+        return not self.path
+
+    def look_at(self, at):
+        dx = at[0] - self.position[0]
+        dz = at[2] - self.position[2]
+        self.yaw = math.degrees(math.atan2(-dx, dz))
+        self.pitch = 0.0
+
+    def repeat_position(self):
+        now = time.time()
+        if now - self.last_position_sent < POSITION_INTERVAL:
+            return
+        self.last_position_sent = now
+
+        if self.path:
+            x, y, z = self.position
+            tx, ty, tz = self.path[0]
+            dx, dy, dz = tx - x, ty - y, tz - z
+            gap = math.sqrt(dx * dx + dy * dy + dz * dz)
+            if gap <= STEP_BLOCKS:
+                self.position = self.path.pop(0)
+            else:
+                scale = STEP_BLOCKS / gap
+                self.position = (x + dx * scale, y + dy * scale, z + dz * scale)
+
+        x, y, z = self.position
+        self.send(
+            C2S_MOVE_PLAYER_POS_ROT,
+            struct.pack(">dddffb", x, y, z, self.yaw, self.pitch, ON_GROUND),
+        )
+
+    def leave(self):
+        """Drop the connection the way a player who alt-F4s does."""
+        self.log("-- disconnecting")
+        self.gone = True
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+class Run:
+    """The session: a handful of clients, one transcript, and a verdict."""
+
+    def __init__(self, args):
+        self.args = args
+        self.started = time.time()
+        self.clients = []
+        self.names = BlockNames()
+        self.kinds = entity_names()
+        self.failures = []
+        self.proved = []
+        self.phase = "waiting"
+
+    # --- plumbing -------------------------------------------------------
+
+    def log(self, line):
+        print("%s      %s" % (stamp(self.started), line), flush=True)
+
+    def prove(self, claim, evidence):
+        self.proved.append((claim, evidence))
+        self.log("PROVED %-52s %s" % (claim, evidence))
+
+    def fail(self, why):
+        self.failures.append(why)
+        self.log("FAILED %s" % why)
+
+    def connect(self, count):
+        for _ in range(count):
+            name = "S%d" % (len(self.clients) + 1)
+            client = Client(self.args.host, self.args.port, name, self.started)
+            client.handshake(self.args.host, self.args.port, 2)
+            client.login()
+            client.configuration()
+            client.enter_play()
+            self.clients.append(client)
+        return self.clients[-count:]
+
+    def live(self):
+        return [client for client in self.clients if not client.gone]
+
+    def pump(self):
+        for client in self.live():
+            try:
+                for packet_id, payload in client.drain():
+                    self.handle(client, packet_id, payload)
+                if client.joined:
+                    client.repeat_position()
+            except (ConnectionError, OSError) as error:
+                client.log("connection ended: %s" % error)
+                client.gone = True
+
+    def wait_until(self, predicate, seconds, why=""):
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            self.pump()
+            if predicate():
+                return True
+            time.sleep(0.01)
+        self.pump()
+        if predicate():
+            return True
+        if why:
+            self.fail("timed out after %.0fs waiting for %s" % (seconds, why))
+        return False
+
+    def settle(self, seconds):
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            self.pump()
+            time.sleep(0.01)
+
+    def handle(self, client, packet_id, payload):
+        if packet_id == S2C_LOGIN:
+            client.entity_id = struct.unpack(">i", payload[:4])[0]
+            client.joined = True
+            client.log("** in the world ** entity_id=%d" % client.entity_id)
+        elif packet_id == S2C_PLAYER_POSITION:
+            teleport_id, offset = take_var_int(payload)
+            x, y, z = struct.unpack(">ddd", payload[offset : offset + 24])
+            client.position = (x, y, z)
+            client.path = []
+            client.send(C2S_ACCEPT_TELEPORTATION, var_int(teleport_id))
+        elif packet_id == S2C_KEEP_ALIVE:
+            client.send(C2S_KEEP_ALIVE, payload[:8])
+        elif packet_id == S2C_SYSTEM_CHAT:
+            text, _ = take_nbt_string(payload, 0)
+            self.on_chat(client, text)
+        elif packet_id == S2C_SET_ACTION_BAR_TEXT:
+            text, _ = take_nbt_string(payload, 0)
+            client.action_bar.append(text)
+            client.log("<- action bar: %s" % text)
+        elif packet_id == S2C_ADD_ENTITY:
+            # `ClientboundAddEntityPacket`, from
+            # crates/hyperion-minecraft-proto/src/packets/play/entity.rs. Only
+            # the id and the position are read; the rest is skipped rather than
+            # decoded because nothing here asks what a mob looks like.
+            entity_id, offset = take_var_int(payload)
+            offset += 16  # uuid
+            kind, offset = take_var_int(payload, offset)
+            x, y, z = struct.unpack_from(">ddd", payload, offset)
+            client.entities[entity_id] = ((x, y, z), self.kinds.get(kind, "<type %d>" % kind))
+        elif packet_id == S2C_LEVEL_CHUNK_WITH_LIGHT:
+            _at, blocks = decode_chunk(payload, (60, 70))
+            client.blocks.update(blocks)
+        elif packet_id == S2C_SECTION_BLOCKS_UPDATE:
+            _at, changes = decode_section_blocks_update(payload)
+            for position, state in changes:
+                client.blocks[position] = state
+        elif packet_id == S2C_DISCONNECT:
+            text, _ = take_nbt_string(payload, 0)
+            client.log("<- DISCONNECTED: %s" % text)
+            client.gone = True
+
+    def on_chat(self, client, text):
+        if text.startswith(PODIUM_PREFIX):
+            client.podiums.append(json.loads(text[len(PODIUM_PREFIX) :]))
+            return
+        if text.startswith(PODIUM_END_PREFIX):
+            client.podiums_expected = int(text[len(PODIUM_END_PREFIX) :])
+            return
+        client.log("<- chat: %s" % text)
+        if text.startswith("Kit set to "):
+            client.kit = text[len("Kit set to ") :].rstrip(".")
+            return
+        if "The game starts shortly" in text:
+            self.phase = "countdown"
+        elif "Get ready" in text:
+            self.phase = "preparing"
+        elif text.strip().endswith("Go!"):
+            self.phase = "playing"
+            self.log("== the match is running ==")
+        elif "Game over" in text:
+            self.phase = "ended"
+
+    # --- reading the world ----------------------------------------------
+
+    def ask_podiums(self, client):
+        """What the server says the ring is, right now."""
+        client.podiums = []
+        client.podiums_expected = None
+        client.command("podiums")
+        got = self.wait_until(
+            lambda: client.podiums_expected is not None
+            and len(client.podiums) >= client.podiums_expected,
+            15.0,
+            "the server to answer /podiums",
+        )
+        if not got:
+            return []
+        return client.podiums
+
+    @staticmethod
+    def offer(podiums, kit):
+        for entry in podiums:
+            if entry["kit"] == kit:
+                return entry
+        return None
+
+    @staticmethod
+    def click_at(entry):
+        return (entry["x"], entry["y"], entry["z"])
+
+    @staticmethod
+    def base_at(entry):
+        return (entry["x"], entry["base_y"], entry["z"])
+
+    def mob_of(self, client, entry):
+        """The entity id of the mob standing on that podium, as this client
+        has been told about it.
+
+        Matched on position, because that is the only thing the two sides
+        share: `/podiums` says which block the mob stands in and `add_entity`
+        says where each entity is. The server puts a mob in the middle of its
+        block, so the match is against the block the entity's position falls
+        in rather than against the position itself.
+        """
+        wanted = self.click_at(entry)
+        for entity_id, (at, _kind) in client.entities.items():
+            if (
+                math.floor(at[0]) == wanted[0]
+                and math.floor(at[1]) == wanted[1]
+                and math.floor(at[2]) == wanted[2]
+            ):
+                return entity_id
+        return None
+
+    def kind_of(self, client, entry):
+        """What the client was told the podium's mob is."""
+        entity_id = self.mob_of(client, entry)
+        if entity_id is None:
+            return None
+        return client.entities[entity_id][1]
+
+    def wool_seen_by(self, client, entry):
+        """The block the client has actually been sent for that podium's wool."""
+        state = client.blocks.get(self.base_at(entry))
+        if state is None:
+            return None
+        return self.names.name(state)
+
+    def approach(self, client, entry):
+        """Walk to the podium, so the click comes from somewhere a player is."""
+        x, y, z = self.click_at(entry)
+        stand = (x + 1.5, float(y) - 1.0, z + 1.5)
+        client.walk(stand)
+        self.wait_until(client.arrived, 20.0)
+        client.look_at((x, y, z))
+        self.settle(0.2)
+
+    def pick(self, client, entry):
+        """Right-click the podium's mob, which is how a player picks a kit.
+
+        The mob is the surface this whole feature is about, so the gate uses
+        it, and a run where no mob ever arrived is a failure rather than a
+        quiet fall back to the wool. The wool is clicked anyway afterwards so
+        the rest of the script still has something to check, but the run has
+        already been marked failed by then.
+        """
+        self.approach(client, entry)
+        client.action_bar.clear()
+        entity_id = self.mob_of(client, entry)
+        if entity_id is None:
+            self.fail(
+                "%s was never sent a mob standing on the %s podium at %s, so "
+                "there was nothing to right-click"
+                % (client.name, entry["kit"], self.click_at(entry))
+            )
+            client.right_click(self.click_at(entry), "(%s, wool)" % entry["kit"])
+            return
+        client.right_click_mob(entity_id, "(the %s)" % entry["kit"])
+    # --- the script -----------------------------------------------------
+
+    def run(self):
+        # Three, which is one short of `min_players`, so the lobby stays in
+        # `Waiting` for as long as these checks take. A fourth client here
+        # would start a countdown underneath them and every later assertion
+        # would be racing it.
+        one, two, three = self.connect(3)
+        if not self.wait_until(
+            lambda: all(client.joined for client in self.clients),
+            60.0,
+            "three clients to reach the world",
+        ):
+            return self.report()
+
+        self.the_ring_exists(one)
+        taken = self.a_click_picks_the_mob(one)
+        if taken is None:
+            return self.report()
+        self.the_wool_turns_red(one, two, taken)
+        self.a_taken_mob_is_refused(two, taken, one.name)
+        self.a_free_mob_is_not(two, taken)
+        self.a_holder_who_leaves_frees_it(one, two, three, taken)
+        self.selection_survives_the_countdown()
+        return self.report()
+
+    def the_ring_exists(self, client):
+        podiums = self.ask_podiums(client)
+        if not podiums:
+            self.fail("the server named no podiums at all")
+            return
+        free = [entry for entry in podiums if entry["held_by"] is None]
+        if len(free) != len(podiums):
+            self.fail("somebody already holds a mob in an empty lobby: %r" % podiums)
+            return
+        wools = {entry["wool"] for entry in podiums}
+        if wools != {FREE_BLOCK}:
+            self.fail("a free podium is not %s: %r" % (FREE_BLOCK, wools))
+            return
+
+        # The blocks the server said are there against the blocks it sent.
+        # Everything below reads the manifest; this is the one check that the
+        # manifest describes the world a player is standing in.
+        #
+        # Waited for rather than asserted: the hub arrives as an empty chunk
+        # and then seventy-odd thousand block changes layered on top of it, so
+        # a podium is briefly air on a client that has only just joined.
+        self.wait_until(
+            lambda: all(
+                self.wool_seen_by(client, entry) == FREE_BLOCK for entry in podiums
+            ),
+            30.0,
+        )
+        mismatched = []
+        for entry in podiums:
+            seen = self.wool_seen_by(client, entry)
+            if seen != FREE_BLOCK:
+                mismatched.append(
+                    "%s at %s is %s" % (entry["kit"], self.base_at(entry), seen)
+                )
+        if mismatched:
+            self.fail(
+                "the podiums the server described are not the blocks it sent: %s"
+                % "; ".join(mismatched)
+            )
+            return
+
+        # And a real mob standing on each of them, which is the whole feature:
+        # a player picks a kit by right-clicking the mob, so a ring of wool
+        # with nothing on it is a ring nobody can use.
+        self.wait_until(
+            lambda: all(self.mob_of(client, entry) is not None for entry in podiums),
+            30.0,
+        )
+        empty = [
+            entry["kit"] for entry in podiums if self.mob_of(client, entry) is None
+        ]
+        if empty:
+            self.fail("these podiums have no mob standing on them: %s" % ", ".join(empty))
+            return
+
+        # And the mob the kit says it is. Fifteen armour stands would satisfy
+        # every check above and would not be the feature.
+        wrong = [
+            "%s stands on a %s" % (entry["kit"], self.kind_of(client, entry))
+            for entry in podiums
+            if self.kind_of(client, entry) != entry["mob"]
+        ]
+        if wrong:
+            self.fail("the wrong mob is standing on these podiums: %s" % "; ".join(wrong))
+            return
+
+        self.prove(
+            "the hub has a podium per mob, with that mob standing on it",
+            "%d podiums, every one free, every one standing on %s in the chunks "
+            "the client was sent, and each one carrying the entity its kit names "
+            "(%s)"
+            % (
+                len(podiums),
+                FREE_BLOCK,
+                ", ".join(sorted(entry["mob"] for entry in podiums)),
+            ),
+        )
+
+    def a_click_picks_the_mob(self, client):
+        podiums = self.ask_podiums(client)
+        if not podiums:
+            return None
+        entry = podiums[0]
+        self.pick(client, entry)
+
+        if not self.wait_until(
+            lambda: client.kit == entry["kit"],
+            10.0,
+            "%s to be playing the %s" % (client.name, entry["kit"]),
+        ):
+            return None
+        told = [line for line in client.action_bar if entry["kit"] in line]
+        if not told:
+            self.fail(
+                "%s picked the %s and the action bar never said so: %r"
+                % (client.name, entry["kit"], client.action_bar)
+            )
+        self.prove(
+            "a right-click on a podium picks that mob",
+            "%s right-clicked %s and the server answered %r"
+            % (client.name, self.click_at(entry), told or client.action_bar),
+        )
+        return entry
+
+    def the_wool_turns_red(self, holder, watcher, entry):
+        base = self.base_at(entry)
+        if not self.wait_until(
+            lambda: self.wool_seen_by(watcher, entry) == TAKEN_BLOCK,
+            10.0,
+            "the wool under the %s to go red for %s" % (entry["kit"], watcher.name),
+        ):
+            self.log(
+                "%s sees %s at %s"
+                % (watcher.name, self.wool_seen_by(watcher, entry), base)
+            )
+            return
+        # Only that one. A repaint that reddened the whole ring would pass a
+        # check that looked at one block.
+        podiums = self.ask_podiums(watcher)
+        red = [
+            other["kit"]
+            for other in podiums
+            if self.wool_seen_by(watcher, other) == TAKEN_BLOCK
+        ]
+        if red != [entry["kit"]]:
+            self.fail("one mob was taken and these podiums are red: %r" % red)
+            return
+        self.prove(
+            "a taken mob is red without anybody reading anything",
+            "%s took the %s and %s was sent %s at %s, the only red podium in "
+            "the ring" % (holder.name, entry["kit"], watcher.name, TAKEN_BLOCK, base),
+        )
+
+    def a_taken_mob_is_refused(self, client, entry, holder):
+        self.pick(client, entry)
+        self.settle(1.0)
+
+        if client.kit is not None:
+            self.fail(
+                "%s clicked a mob %s already had and ended up playing %s"
+                % (client.name, holder, client.kit)
+            )
+            return
+        told = [
+            line
+            for line in client.action_bar
+            if entry["kit"] in line and holder in line
+        ]
+        if not told:
+            self.fail(
+                "%s was refused the %s and never told who has it: %r"
+                % (client.name, entry["kit"], client.action_bar)
+            )
+            return
+        self.prove(
+            "a mob somebody else has is refused, by name",
+            "%s clicked the %s and was told %r" % (client.name, entry["kit"], told[0]),
+        )
+
+    def a_free_mob_is_not(self, client, taken):
+        podiums = self.ask_podiums(client)
+        free = [entry for entry in podiums if entry["held_by"] is None]
+        if not free:
+            self.fail("every mob is taken with one player holding one")
+            return
+        entry = free[0]
+        self.pick(client, entry)
+        if not self.wait_until(
+            lambda: client.kit == entry["kit"],
+            10.0,
+            "%s to be playing the %s" % (client.name, entry["kit"]),
+        ):
+            return
+        self.prove(
+            "the refusal is about that mob and not about clicking",
+            "%s was refused the %s and then took the %s from the next podium "
+            "along" % (client.name, taken["kit"], entry["kit"]),
+        )
+    def a_holder_who_leaves_frees_it(self, holder, watcher, spare, entry):
+        """The claim is the holder's `(Playing, kit)` edge and nothing else.
+
+        Nothing in the server frees a mob on disconnect, because there is
+        nothing to free: destroying the player destroys the edge that was the
+        claim. This is the check that says so from outside, where a forgotten
+        cleanup handler would be visible as a mob nobody can ever take again.
+        """
+        holder.leave()
+
+        if not self.wait_until(
+            lambda: self.wool_seen_by(watcher, entry) == FREE_BLOCK,
+            20.0,
+            "the %s to go back to %s after %s left" % (entry["kit"], FREE_BLOCK, holder.name),
+        ):
+            return
+        podiums = self.ask_podiums(watcher)
+        again = self.offer(podiums, entry["kit"])
+        if again is None or again["held_by"] is not None:
+            self.fail(
+                "%s left and the %s is still held by %r"
+                % (holder.name, entry["kit"], again and again["held_by"])
+            )
+            return
+
+        self.pick(spare, entry)
+        if not self.wait_until(
+            lambda: spare.kit == entry["kit"],
+            10.0,
+            "%s to take the mob %s left behind" % (spare.name, holder.name),
+        ):
+            return
+        self.prove(
+            "a holder who disconnects frees their mob at once",
+            "%s left, the podium went back to %s, and %s took the %s"
+            % (holder.name, FREE_BLOCK, spare.name, entry["kit"]),
+        )
+
+    def selection_survives_the_countdown(self):
+        """Fill the lobby, let it commit, and see whether the picks held.
+
+        `full_players` rather than `min_players` because the countdown at a
+        full lobby is the shortest one the config will run, and a gate should
+        not spend a minute of wall clock proving something a ten-second one
+        proves.
+        """
+        joining = FULL_PLAYERS - len(self.live())
+        if joining > 0:
+            self.connect(joining)
+        if not self.wait_until(
+            lambda: all(client.joined for client in self.live()),
+            60.0,
+            "a full lobby",
+        ):
+            return
+
+        # Everybody who has not picked yet takes a different free mob.
+        #
+        # Assigned from one reading of the manifest and then walked and clicked
+        # all at once, rather than a client at a time. Both halves of that
+        # matter. Asking each client in turn what is free races the one before
+        # it, whose claim may not have landed yet, and two clients then go for
+        # the same mob. And doing it in series costs a second and a half of
+        # walking each, which is most of the ten-second countdown a full lobby
+        # runs: the first version of this had the eighth player still choosing
+        # when the match committed, and was refused by the game, correctly.
+        waiting = [client for client in self.live() if client.kit is None]
+        podiums = self.ask_podiums(self.live()[0])
+        free = [entry for entry in podiums if entry["held_by"] is None]
+        if len(free) < len(waiting):
+            self.fail(
+                "a lobby of %d has only %d free mobs left"
+                % (len(self.live()), len(free))
+            )
+            return
+
+        assigned = list(zip(waiting, free))
+        wanted = {client.name: entry["kit"] for client, entry in assigned}
+        for client, entry in assigned:
+            x, y, z = self.click_at(entry)
+            client.walk((x + 1.5, float(y) - 1.0, z + 1.5))
+        self.wait_until(
+            lambda: all(client.arrived() for client, _ in assigned), 20.0
+        )
+        for client, entry in assigned:
+            client.look_at(self.click_at(entry))
+        self.settle(0.2)
+
+        for client, entry in assigned:
+            client.action_bar.clear()
+            entity_id = self.mob_of(client, entry)
+            if entity_id is None:
+                self.fail(
+                    "%s was never sent the %s mob, so there was nothing to click"
+                    % (client.name, entry["kit"])
+                )
+                return
+            client.right_click_mob(entity_id, "(the %s)" % entry["kit"])
+
+        if not self.wait_until(
+            lambda: all(client.kit is not None for client in self.live()),
+            20.0,
+            "every client to be playing something",
+        ):
+            missing = [
+                "%s (wanted the %s)" % (c.name, wanted.get(c.name, "?"))
+                for c in self.live()
+                if c.kit is None
+            ]
+            self.log("still without a mob: %s" % ", ".join(missing))
+            return
+
+        before = {client.name: client.kit for client in self.live()}
+        distinct = set(before.values())
+        if len(distinct) != len(before):
+            self.fail("a full lobby ended up sharing mobs: %r" % before)
+            return
+        self.prove(
+            "a full lobby holds one mob each",
+            "; ".join("%s=%s" % pair for pair in sorted(before.items())),
+        )
+
+        if not self.wait_until(
+            lambda: self.phase == "playing",
+            180.0,
+            "the countdown to finish and the match to start",
+        ):
+            return
+
+        after = {client.name: client.kit for client in self.live()}
+        changed = {
+            name: (before[name], after.get(name))
+            for name in before
+            if before.get(name) != after.get(name)
+        }
+        if changed:
+            self.fail("the countdown changed somebody's mob: %r" % changed)
+            return
+        self.prove(
+            "a selection made in the hub survives the countdown",
+            "%d clients started the match on the mob they clicked for in the "
+            "lobby" % len(after),
+        )
+
+        # And once it has committed, the podiums stop answering. This is the
+        # rule that makes the claim last the whole match without anything
+        # having to say so.
+        client = self.live()[0]
+        podiums = self.ask_podiums(client)
+        other = next(
+            (entry for entry in podiums if entry["kit"] != client.kit), None
+        )
+        if other is None:
+            self.fail("the roster has one kit in it, so this proves nothing")
+            return
+        held = client.kit
+        client.action_bar.clear()
+        # From the arena, several hundred blocks from the hub. hyperion does
+        # not check that a clicked block is within reach, and this check is
+        # about the phase rule rather than about reach, so the click is sent
+        # from wherever the scatter put the player.
+        client.right_click(self.click_at(other), "(%s, mid-match)" % other["kit"])
+        self.settle(1.0)
+        if client.kit != held:
+            self.fail(
+                "%s clicked a podium mid-match and changed from %s to %s"
+                % (client.name, held, client.kit)
+            )
+            return
+        told = [line for line in client.action_bar if "cannot change kit" in line]
+        if not told:
+            self.fail(
+                "a mid-match click was ignored rather than refused: %r"
+                % client.action_bar
+            )
+            return
+        self.prove(
+            "a click after the match commits is refused",
+            "%s clicked the %s while playing the %s and was told %r"
+            % (client.name, other["kit"], held, told[0]),
+        )
+
+    # --- the verdict ----------------------------------------------------
+
+    def report(self):
+        for client in self.live():
+            client.leave()
+        print("")
+        print("=" * 78)
+        for claim, evidence in self.proved:
+            print("PASS  %-52s %s" % (claim, evidence))
+        for why in self.failures:
+            print("FAIL  %s" % why)
+        print("=" * 78)
+        if self.failures:
+            print("RESULT: %d checks failed" % len(self.failures))
+            return 1
+        if len(self.proved) < 7:
+            print(
+                "RESULT: only %d of 7 checks reported, so something stopped "
+                "early" % len(self.proved)
+            )
+            return 1
+        print("RESULT: the kit selector works, on the wire")
+        return 0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=25565)
+    args = parser.parse_args()
+    return Run(args).run()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Right-clicking a mob in the middle of the lobby is how you pick a kit now. `/kit`
still works.

## What is in the hub

A ring of fifteen podiums around the middle of the lobby, one per kit, each a
block of wool with that kit's own mob standing on it. You walk up, right-click
the mob, and you are that mob. The wool under a mob somebody has already taken
is red instead of green.

The ring is generated from the roster at boot rather than written into
`maps/hub.map`, because it has to have exactly as many podiums as there are
registered kits and a map file has no way to ask. Its radius comes from the kit
count and a constant gap, so adding a kit widens the ring rather than eventually
putting two podiums in one block. It stands at radius 8, between the hub's spawn
points at 6 and its pillars at 13, which puts a podium a couple of blocks in
front of wherever a player lands.

## What Mineplex did, and where this differs

The Mineplex Wiki describes the SSM waiting lobby's centrepiece as "mobs ...
standing atop pedestals of coloured wool and stone brick slabs, allowing you to
click/right-click on them to select kits", with each individual mob rather than
the stand-in zombies other games used, and it records what the wool was for: the
colour said what you had to do to unlock the kit. That is the whole shape
reproduced here, with the colour repurposed from "can you afford this" to "has
somebody taken this", which is the question a player in a filling lobby is
actually asking.

**One player per mob is ours, not theirs.** Nothing found says whether Mineplex
reserved a kit. Neither the wiki's kit and waiting-lobby pages nor the SSM forum
threads mention a reservation in either direction, and since kits were bought
per account with gems it would be a strange rule to have shipped. Stated as a
choice in the module docs rather than as a reconstruction.

## The exclusivity rule

A claim lasts the rest of the match, and it is enforced in exactly one place:
`lobby::choose`, which both the podium click and `/kit` go through, so the two
surfaces cannot come to different answers. Nothing says "for the rest of the
match" anywhere, because nothing has to: `choose` already refuses any kit change
once the match commits, so past `Phase::Countdown` the claim is frozen for free.

A holder who disconnects frees their mob immediately, and there is no disconnect
handler doing it. That is the point of deriving the answer.

## Nothing stores who has what

`player.add((Playing, kit))` already existed and already *was* the selection.
"Is this mob taken" is a query for any player with `(Playing, thatKit)`, walked
on every call by `kit::claims`. There is no `taken` flag on a kit and no set of
claims on the side, because a second copy of that answer is a thing that can
disagree with the first, and the disagreement that matters is the one nobody
notices: a player who disconnects is destroyed and takes their edge with them.

Two more relations carry the rest of it. A podium *is* its `(Offers, kit)` edge,
and a mob *is* its `(StandsOn, podium)` edge, so a click that arrives naming an
entity becomes a kit in two hops with no table keyed on entity id or block
position. `StandsOn` is declared `(OnDeleteTarget, Delete)`, which is what makes
`selector::build` a rebuild rather than a leak: tearing the ring down takes its
mobs with it, with no teardown loop for anybody to forget to extend.

## The engine change this needed

hyperion routed no entity-interaction packet at all. `minecraft:interact`
reached the dispatch table in `simulation/handlers.rs` and fell straight
through, so a right-click on an entity arrived as nothing. It is routed now, as
`event::EntityInteract`; since 26.2 split attacking out into `minecraft:attack`
that packet means a right-click and nothing else.

Its body is hand-written in `packets/play/entity.rs`. `protocol.json` models the
field list from Mojang's own class but marks the packet `complete: false` over
one unmodelled statement inside the `Vec3` LP codec, which this crate already
has and which the body uses, so the generator's refusal costs the whole packet
rather than the one field it could not follow. The field list is the
extractor's, not a reading of a wiki.

`EntityKind` gained a name-to-kind lookup, which needed a list of every variant.
The enum and the list are now declared by one macro so the list cannot fall
behind it.

## How a player is told a mob is taken

The wool. It goes green to red the moment somebody takes the mob, and back to
green when they leave. That is the only channel that works in the last seconds
of a countdown, when nobody is reading chat, and it says *which* mob is gone
rather than only that something was refused. The action bar line
("Skeleton is already taken by S1.") explains a refusal that has already
happened; it is not how the news arrives.

No sound. A refusal cue would be a real improvement, and now that #1003 has
landed there is a proper place for one: kits hang their voice off the prefab as
`(PlaysOnHurt, sound)` and a refusal would be the same shape. It is a follow-up
rather than something bolted on here, and this branch leaves the sound module
alone.

The colours are recomputed from the live claims every tick and written only
where they disagree with the world. A poll rather than an observer because the
thing that frees a mob most often is a player disconnecting, which is an entity
being destroyed rather than an edge anybody here could watch.

## `/kit` and `/kits` stay

They are the surface a screen reader uses and the one every gate that is not
testing the selector reaches for. `/podiums` is new: one JSON object per podium
saying which kit, where its mob stands, what colour its wool is and who holds
it. It exists so the gate below can right-click a podium without recomputing the
ring in Python, which would be a second copy of the geometry that kept passing
after the real one moved.

## Tests

`nix run .#smash-selector-e2e`, and `checks.smash-selector-e2e`, boot the stack
and drive real clients through it. Nothing in it knows where a podium is; it
asks the server and clicks what it is told, and it clicks the mob, not the
block.

```
 0.85s PROVED the hub has a podium per mob, with that mob standing on it
       15 podiums, every one free, every one standing on minecraft:lime_wool in
       the chunks the client was sent, and each one carrying the entity its kit
       names (blaze, chicken, cow, creeper, enderman, guardian, iron_golem,
       skeleton, slime, snow_golem, spider, squid, wither_skeleton, wolf,
       zombie)
 2.15s PROVED a right-click on a podium picks that mob
       S1 right-clicked (8, 66, 0) and the server answered
       ['You are the Skeleton.']
 2.28s PROVED a taken mob is red without anybody reading anything
       S1 took the Skeleton and S2 was sent minecraft:red_wool at (8, 65, 0),
       the only red podium in the ring
 4.50s PROVED a mob somebody else has is refused, by name
       S2 clicked the Skeleton and was told 'Skeleton is already taken by S1.'
 5.30s PROVED the refusal is about that mob and not about clicking
       S2 was refused the Skeleton and then took the Iron Golem
 6.62s PROVED a holder who disconnects frees their mob at once
       S1 left, the podium went back to minecraft:lime_wool, and S3 took the
       Skeleton
10.09s PROVED a full lobby holds one mob each
       S2=Iron Golem; S3=Skeleton; S4=Spider; S5=Slime; S6=Enderman;
       S7=Sky Squid; S8=Creeper; S9=Wolf
27.02s PROVED a selection made in the hub survives the countdown
       8 clients started the match on the mob they clicked for in the lobby
28.09s PROVED a click after the match commits is refused
       S2 clicked the Skeleton while playing the Iron Golem and was told
       'You cannot change kit once the game has started.'
RESULT: the kit selector works, on the wire
```

The full-lobby phase caught something in the gate itself worth keeping. Picking
for eight clients one at a time cost a second and a half of walking each, and
the eighth was still choosing when the ten-second countdown committed; the
server refused it, correctly. The picks are assigned from one reading of the
manifest and then walked and clicked all at once now, which also closes a race
where two clients asked what was free before the first one's claim had landed.

The wool colours are read out of the chunk and block-update packets the client
was actually sent, using `smash-map-check.py`'s decoders, and the mob types out
of `add_entity` against the generated entity-type table. A run where the mobs
never arrived fails rather than quietly falling back to clicking the wool.

The pure parts are unit tested the way `scoreboard::render` is: 24 tests in
`events/smash/tests/selector.rs` covering the ring geometry against the hub map
file (no podium on a spawn point, none inside the glass wall, none on the
raised centre), the relation walking, and every rule through both surfaces.

## The gate this broke, and why that is the interesting part

`tools/smash-match.py` swept every ability by putting all three clients on the
kit under test. One player per mob forbids that, so the sweep now gives the
attacker the kit and the victims their own, and it has to hand them out in an
order that works: a client still standing on the mob the next one was assigned
refuses it.

The first version asked whoever was free each pass and went round again, which
is not enough, and the gate said so rather than my noticing: moving from the Sky
Squid to the Creeper leaves the attacker on the mob a victim wants and the
victim on the mob the attacker wants, and nobody can go first. One of them now
steps aside onto a mob nobody in the plan wants. `every declared ability did
what it declared, 51 abilities` is green again, and the sweep also got faster,
because the victims are a constant now instead of changing with every kit.

## One thing the rebase broke, in the tools

#1004's component API means a coloured message is an NBT compound on the wire
rather than the bare `Tag::String` a plain one collapses to.
`smash-match.py`'s reader only handled the bare form, so every styled line
arrived at both gates as `<nbt tag type 0x0A, not a string>`. It is shared, so
it is fixed there: the reader now walks a compound's `text` and `extra` and
discards the styling, which is what the server's own `Component::plain` does
and what the Rust tests already assert against.

Worth naming because of how it showed up. My gate asserts on the words a player
is told, so it failed loudly. A gate that only asserted something arrived would
have gone green while reporting that the server said `<nbt tag type 0x0A>`.

## Verified

- `nix run .#lint` clean.
- `cargo test -p smash`: 188 passed, 24 of them the selector's.
- `nix run .#smash-selector-e2e`: the transcript above, 28 seconds.
- `nix run .#smash-e2e`: a whole match at protocol 776, no ability failures.
- `nix run .#completions-e2e`: still green, since this touches both files
  #1002 touched.
- `nix run .#doc` and `nix run .#unused-deps` clean.

Rebased onto #1002, #1003 and #1004. The action bar lines and the refusal go
through the new `Text` component API rather than legacy section-sign codes,
`/kit` keeps the tab completion #1002 gave it, and the podium mobs sit
alongside the kit voices #1003 added rather than touching them.

## What a reviewer should not assume

**No vanilla client has looked at this.** Every assertion is a scripted client
reading real bytes. That the fifteen mobs *render*, stand where they should and
are pleasant to click is reasoned from hyperion's own spawn path and has not
been seen by a human. The mobs have no AI and no server-side physics, which is
what makes them stand still; whether a client tries to animate them is not
checked.

**The sandboxed `checks.smash-selector-e2e` has been evaluated, not built here,
and CI will not build it either.** Every one of hyperion's nine CI jobs runs on
a hosted ubuntu runner and the only job that builds the flake checks is
`continue-on-error: true`, so the nix gates have never actually run in CI
(ENG-10817). The app form of the same driver is what passed, locally, and that
is the whole of the verification this got. It is the same `mkCheck` shape as
`smash-e2e` and needs no seeded world.

**The repaint runs every tick and rebuilds two flecs queries doing it.** Fifteen
podiums, so it is nothing next to a tick, but it is a poll and it is written as
one on purpose. If it ever matters, the fix is to gate it on the lobby phase.

**A refusal has no sound**, deliberately, and that is a worse experience than it
could be.

Written by Claude (Opus 4.5) driving the repository's own gates.
