### PR TITLE
ci: enforce the flake checks, by name, instead of exempting all of them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,13 @@ on:
 jobs:
   # Each check is the same flake app a contributor runs locally, so CI cannot
   # drift from `nix run .#ci`.
-  # Job names are fixed by the merge queue ruleset on main, which requires
-  # these exact contexts. The app each one runs is the same one a contributor
-  # runs locally.
+  #
+  # A previous version of this comment said the job names were fixed by the
+  # merge queue ruleset, "which requires these exact contexts". It does not:
+  # ruleset 566717 on main carries no `required_status_checks` rule and the
+  # branch has no classic protection either, so today nothing here is a
+  # required context and a red job does not block a merge on its own. Renaming
+  # a job is therefore safe and enforcement is weaker than it reads. ENG-10827.
   check:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -55,23 +59,43 @@ jobs:
           cache-on-failure: "true"
       - run: nix run --accept-flake-config .#${{ matrix.app }}
 
-  # Builds every flake app, which is what proves each one passes shellcheck and
-  # that its tools resolve.
+  # Every flake check, built, and no longer advisory: a failure fails the run.
+  # It is not literally a required context, because this repository has none;
+  # see the note on `check` above and ENG-10827.
   #
-  # Reported, not enforced, for the same reason as the audit jobs above: it also
-  # builds `packages`, which cannot succeed yet. cargoUnit cannot vendor a lock
-  # holding one crate at one version from two git sources, which this lock does
-  # via tools/packet-inspector. A fix is in flight in the index repo. Main's
-  # `nix build` is broken today anyway, on a divan hash that matches no git
-  # dependency, so nothing regresses by landing this first.
+  # What it enforces and what it does not is nix/ci/flake-gate.nix, by name,
+  # and an excluded check is rebuilt here and required to still fail, so an
+  # exception cannot outlive its defect. This job used to be
+  # `continue-on-error: true` behind a paragraph of prose; ENG-10817 has the
+  # measurement of what that cost.
+  #
+  # runs-on is a hosted runner and the house rule says fleet self-hosted. The
+  # fleet cannot serve this repo: ix `crates/ci/dispatcher/src/config.rs` holds
+  # `GithubApp.org` as one `String`, and `github.rs` registers every JIT runner
+  # at `orgs/{org}` with org = indexable-inc, so a hyperion-mc job is never
+  # offered one. ENG-10824 tracks making the dispatcher multi-org. Until it
+  # lands, `nix build .#checks.x86_64-linux.<name>` is the same command here as
+  # on the fleet, so nothing about the gate has to change when it does.
   flake:
     name: Flake
     runs-on: ubuntu-latest
-    continue-on-error: true
+    # A runner-level guard, not a target. The gate builds every check serially
+    # from a cold hosted store; the bedwars binary alone measured 620 to 670
+    # seconds across four runs on 2026-07-28 and everything else is minutes.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
-      - run: nix flake check --accept-flake-config
+        with:
+          # The DAEMON is what decides whether a content-addressed derivation
+          # can be realised, and cargoUnit content-addresses every crate unit.
+          # `extra-experimental-features` in the flake's nixConfig or in
+          # NIX_CONFIG reaches the client only: measured on run 30341528713,
+          # both of those leave a CA build failing while extra-conf here
+          # succeeds. The gate re-checks this itself and says so if it is lost.
+          extra-conf: |
+            extra-experimental-features = ca-derivations
+      - run: nix run --accept-flake-config .#flake-gate
 
   coverage:
     name: Code Coverage

--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ Every command is a flake app, so nix is the only thing you need installed.
 | `nix run .#proxy` | Proxy alone, release-full |
 | `nix run .#bedwars` | Game server alone, release-full |
 | `nix run .#bots -- <ip> <count>` | Connect bots to a running server |
-| `nix run .#ci` | Everything CI runs |
+| `nix run .#ci` | The cargo half of CI: format, lint, test, doc, deny, machete |
+| `nix run .#flake-gate` | The nix half: builds every flake check CI enforces |
 | `nix run .#fmt` | `cargo fmt`; add `-- --check` to verify only |
 | `nix run .#lint` | Clippy, warnings denied |
 | `nix run .#lint-fix` | Clippy with `--fix` |
@@ -282,9 +283,14 @@ Every command is a flake app, so nix is the only thing you need installed.
 | `nix run .#smash-e2e` | The same on smash: four clients, a whole match |
 | `nix run .#real-client -- <host:port>` | Joins with the actual game and says whether a player reached the world |
 
-`nix build .#bedwars` builds a release binary, and `nix flake check` builds every
-app. If you would rather use cargo directly, `nix develop` gives you a shell with
-the pinned toolchain and the cargo subcommands the apps use.
+`nix build .#bedwars` builds a release binary. `nix run .#flake-gate` is the
+whole nix gate: it builds every check the flake exposes, which is every app
+(proving each passes shellcheck and its tools resolve) plus the sandboxed
+end-to-end gates and the generated-source comparisons. Which of those CI
+enforces, and the named exceptions with the evidence behind each, is
+`nix/ci/flake-gate.nix`. If you would rather use cargo directly, `nix develop`
+gives you a shell with the pinned toolchain and the cargo subcommands the apps
+use.
 
 ## Features
 

--- a/flake.nix
+++ b/flake.nix
@@ -738,60 +738,10 @@
             hyperion-proxy = named "hyperion-proxy" workspace.binaries.hyperion-proxy;
           };
 
-        in
-        {
-          devShells.default = pkgs.mkShell {
-            nativeBuildInputs = nativeBuildInputs ++ cargoTools ++ [ rustToolchain ];
-            RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
-          };
-
-          apps = lib.mapAttrs
-            (_: script: {
-              type = "app";
-              program = lib.getExe script;
-            })
-            (scripts // {
-              default = scripts.dev;
-              update-minecraft-data = minecraft.updateScript;
-              sync-minecraft-proto = minecraft.syncScript;
-              sync-minecraft-registry-data = minecraft.syncRegistryDataScript;
-              sync-minecraft-tag-data = minecraft.syncTagDataScript;
-              sync-minecraft-block-states = minecraft.syncBlockStatesScript;
-              sync-minecraft-entity-types = minecraft.syncEntityTypesScript;
-              # Re-records the golden traces `crates/hyperion/tests/differential.rs`
-              # compares against. See docs/differential-testing.md.
-              record-differential-traces = differential.syncScript;
-              extract-minecraft-protocol = minecraft.extractor;
-              # `nix run .#minecraft-encode -- fixtures out.json` prints bytes
-              # from the server's own codecs, so a new codec can be checked
-              # against Mojang rather than against a reading of Mojang.
-              minecraft-encode = minecraft.vanillaEncoder;
-            });
-
-          packages = {
-            default = gameBinaries.bedwars;
-            inherit (gameBinaries) bedwars smash hyperion-proxy;
-            rust-mc-bot = named "rust-mc-bot" workspace.binaries.rust-mc-bot;
-
-            minecraft-server-jar = minecraft.serverJar;
-            minecraft-data = minecraft.generatedData;
-            minecraft-decompiled = minecraft.decompiledSources;
-            minecraft-protocol = minecraft.protocolJson;
-            minecraft-proto-rust = minecraft.generatedRust;
-            minecraft-encoder-fixtures = minecraft.encoderFixtures;
-            minecraft-registry-contents = minecraft.registryContents;
-            minecraft-tag-contents = minecraft.tagContents;
-            minecraft-registry-data-rust = minecraft.generatedRegistryData;
-            minecraft-tag-data-rust = minecraft.generatedTagData;
-            differential-recorder = differential.recorder;
-            differential-traces = differential.recordedTraces;
-            minecraft-block-states-rust = minecraft.generatedBlockStates;
-            minecraft-entity-types-rust = minecraft.generatedEntityTypes;
-          };
-
           # `nix flake check` builds every app, which is what proves each one
-          # passes shellcheck and that its tools resolve.
-          checks = scripts // {
+          # passes shellcheck and that its tools resolve. What CI enforces of
+          # this set, and the named exceptions, live in nix/ci/flake-gate.nix.
+          baseChecks = scripts // {
             # The two gates that read the wire the way a player does, as
             # derivations: nix builds the binaries, the sandbox boots them on
             # loopback, and the scripted client's verdict is the build result.
@@ -900,7 +850,113 @@
             # committed traces behind, or the Rust test passes against a
             # recording of a server nobody runs any more.
             differential-traces = differential.tracesUpToDate;
+
+            # Pins the command line the two modules build, so a renamed option
+            # or a reordered argument is caught here rather than on a host.
+            #
+            # The store paths are context-stripped on purpose. Keeping the
+            # context would make this check depend on the binaries, and a
+            # module check should run everywhere in seconds rather than
+            # compile a server. What a module gets wrong is the spelling of a
+            # flag or the order of the arguments, and that is what this reads.
+            nixos-modules =
+              let
+                units = self.nixosConfigurations.module-smoke-test.config.systemd.services;
+                argv = unit: builtins.unsafeDiscardStringContext units.${unit}.serviceConfig.ExecStart;
+              in
+              pkgs.runCommand "hyperion-nixos-modules" { } ''
+                cat > argv <<'ARGV'
+                ${argv "hyperion-game-server"}
+                ${argv "hyperion-proxy"}
+                ARGV
+
+                expect() {
+                  grep -qF -- "$1" argv || {
+                    echo "hyperion NixOS module argv lost: $1" >&2
+                    echo "what the modules built:" >&2
+                    cat argv >&2
+                    exit 1
+                  }
+                }
+
+                expect "/bin/bedwars --ip :: --port 35565"
+                expect "/bin/hyperion-proxy '[::]:25565' --server hyperion-game.internal:35565"
+                expect "--root-ca-cert /var/lib/hyperion-pki/root_ca.crt --cert /var/lib/hyperion-pki/game.crt --private-key /var/lib/hyperion-pki/game_private_key.pem"
+                expect "--root-ca-cert /var/lib/hyperion-pki/root_ca.crt --cert /var/lib/hyperion-pki/proxy.crt --private-key /var/lib/hyperion-pki/proxy_private_key.pem"
+
+                touch $out
+              '';
           };
+
+          # Self-referential on purpose: the gate is told every name in
+          # `checks`, including its own, so a check added later is enforced
+          # without anyone editing a list. `builtins.attrNames` reads the keys
+          # of an attrset without forcing its values, which is what keeps this
+          # from looping.
+          checks = baseChecks // {
+            flake-gate = import ./nix/ci/flake-gate.nix {
+              inherit lib system;
+              inherit (pkgs) writeShellApplication;
+              names = builtins.attrNames checks;
+            };
+          };
+
+        in
+        {
+          devShells.default = pkgs.mkShell {
+            nativeBuildInputs = nativeBuildInputs ++ cargoTools ++ [ rustToolchain ];
+            RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+          };
+
+          apps = lib.mapAttrs
+            (_: script: {
+              type = "app";
+              program = lib.getExe script;
+            })
+            (scripts // {
+              default = scripts.dev;
+              # What CI runs. A contributor can run the same one command and
+              # see the same verdict, which is what stops the two drifting.
+              inherit (checks) flake-gate;
+              update-minecraft-data = minecraft.updateScript;
+              sync-minecraft-proto = minecraft.syncScript;
+              sync-minecraft-registry-data = minecraft.syncRegistryDataScript;
+              sync-minecraft-tag-data = minecraft.syncTagDataScript;
+              sync-minecraft-block-states = minecraft.syncBlockStatesScript;
+              sync-minecraft-entity-types = minecraft.syncEntityTypesScript;
+              # Re-records the golden traces `crates/hyperion/tests/differential.rs`
+              # compares against. See docs/differential-testing.md.
+              record-differential-traces = differential.syncScript;
+              extract-minecraft-protocol = minecraft.extractor;
+              # `nix run .#minecraft-encode -- fixtures out.json` prints bytes
+              # from the server's own codecs, so a new codec can be checked
+              # against Mojang rather than against a reading of Mojang.
+              minecraft-encode = minecraft.vanillaEncoder;
+            });
+
+          packages = {
+            default = gameBinaries.bedwars;
+            inherit (gameBinaries) bedwars smash hyperion-proxy;
+            rust-mc-bot = named "rust-mc-bot" workspace.binaries.rust-mc-bot;
+
+            minecraft-server-jar = minecraft.serverJar;
+            minecraft-data = minecraft.generatedData;
+            minecraft-decompiled = minecraft.decompiledSources;
+            minecraft-protocol = minecraft.protocolJson;
+            minecraft-proto-rust = minecraft.generatedRust;
+            minecraft-encoder-fixtures = minecraft.encoderFixtures;
+            minecraft-registry-contents = minecraft.registryContents;
+            minecraft-tag-contents = minecraft.tagContents;
+            minecraft-registry-data-rust = minecraft.generatedRegistryData;
+            minecraft-tag-data-rust = minecraft.generatedTagData;
+            differential-recorder = differential.recorder;
+            differential-traces = differential.recordedTraces;
+            minecraft-block-states-rust = minecraft.generatedBlockStates;
+            minecraft-entity-types-rust = minecraft.generatedEntityTypes;
+          };
+
+          # What CI enforces of this set is nix/ci/flake-gate.nix.
+          inherit checks;
 
         };
     in
@@ -965,50 +1021,7 @@
       };
 
       apps = forAllSystems (system: (mkSystem system).apps);
-      checks = forAllSystems (
-        system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-        in
-        (mkSystem system).checks
-        // {
-          # Pins the command line the two modules build, so a renamed option
-          # or a reordered argument is caught here rather than on a host.
-          #
-          # The store paths are context-stripped on purpose. Keeping the
-          # context would make this check depend on the binaries, and a module
-          # check should run everywhere in seconds rather than compile a
-          # server. What a module gets wrong is the spelling of a flag or the
-          # order of the arguments, and that is what this reads.
-          nixos-modules =
-            let
-              units = self.nixosConfigurations.module-smoke-test.config.systemd.services;
-              argv = unit: builtins.unsafeDiscardStringContext units.${unit}.serviceConfig.ExecStart;
-            in
-            pkgs.runCommand "hyperion-nixos-modules" { } ''
-              cat > argv <<'ARGV'
-              ${argv "hyperion-game-server"}
-              ${argv "hyperion-proxy"}
-              ARGV
-
-              expect() {
-                grep -qF -- "$1" argv || {
-                  echo "hyperion NixOS module argv lost: $1" >&2
-                  echo "what the modules built:" >&2
-                  cat argv >&2
-                  exit 1
-                }
-              }
-
-              expect "/bin/bedwars --ip :: --port 35565"
-              expect "/bin/hyperion-proxy '[::]:25565' --server hyperion-game.internal:35565"
-              expect "--root-ca-cert /var/lib/hyperion-pki/root_ca.crt --cert /var/lib/hyperion-pki/game.crt --private-key /var/lib/hyperion-pki/game_private_key.pem"
-              expect "--root-ca-cert /var/lib/hyperion-pki/root_ca.crt --cert /var/lib/hyperion-pki/proxy.crt --private-key /var/lib/hyperion-pki/proxy_private_key.pem"
-
-              touch $out
-            '';
-        }
-      );
+      checks = forAllSystems (system: (mkSystem system).checks);
       devShells = forAllSystems (system: (mkSystem system).devShells);
       packages = forAllSystems (system: (mkSystem system).packages);
     };

--- a/nix/ci/flake-gate.nix
+++ b/nix/ci/flake-gate.nix
@@ -1,0 +1,156 @@
+# Which flake checks CI enforces, and the named exceptions.
+#
+# Enforcement is subtractive: every attribute of `checks` is built and must
+# pass, except the names listed in `excluded`. A check added tomorrow is
+# enforced the day it lands rather than the day someone remembers to add it
+# here, which is the failure this file exists to prevent. See ENG-10817: the
+# job that would have built these sat behind `continue-on-error: true`, so
+# every gate landed in that window was believed to be running when it was not.
+#
+# An exclusion is not a comment. `nix run .#flake-gate` builds each excluded
+# check as well and requires it to STILL FAIL. The day one starts passing, the
+# gate goes red and names the entry to delete, so an exception cannot outlive
+# the defect it was written for.
+{
+  lib,
+  writeShellApplication,
+  system,
+  # Every name in `checks`, rather than the derivations: the gate shells out to
+  # `nix build .#checks.<system>.<name>` and needs no more than the name.
+  names,
+}:
+let
+  # Empty, and that is the interesting part. ENG-10817 exempted the whole set
+  # on the belief that most of it could not pass. Measured per check on
+  # ubuntu-latest instead of as one all-or-nothing job (run 30341722090, 41
+  # checks), 38 passed and the 3 that failed were the sandboxed e2e gates,
+  # failing on a missing trust store rather than on the runner. nix/e2e.nix
+  # names the CA bundle now, so nothing is left to exempt.
+  #
+  # `differential-traces` is the one worth remembering: it failed on run
+  # 30341066882 and then passed four times (30341722090, plus three
+  # independent repeats in 30342250503). The only difference was whether the
+  # daemon could realise a content-addressed derivation, so it was the store
+  # and not the check, and it is enforced.
+  #
+  # An entry here is `name = <the evidence>`, never a justification. The gate
+  # prints that text, builds the check anyway, and fails if it passes, so an
+  # exception cannot outlive the defect it was written for. Anything you cannot
+  # write as an observation carrying a date and a run id does not belong here.
+  # Fix the check or delete it instead.
+  excluded = { };
+
+  excludedNames = lib.attrNames excluded;
+
+  # A renamed or deleted check must not leave a dead exclusion behind, reading
+  # as though it exempts something while exempting nothing.
+  stale = lib.subtractLists names excludedNames;
+
+  enforced = lib.subtractLists excludedNames names;
+
+  quote = xs: lib.concatMapStringsSep " " lib.escapeShellArg xs;
+
+  # The recorded evidence is printed by the gate, not left in this file for
+  # someone to go and read. An exception nobody sees is an exception nobody
+  # revisits.
+  reasonArms = lib.concatStrings (
+    lib.mapAttrsToList (
+      name: why: "${lib.escapeShellArg name}) printf '%s' ${lib.escapeShellArg why} ;;\n    "
+    ) excluded
+  );
+
+  gate = writeShellApplication {
+    name = "flake-gate";
+    text = ''
+      flake="''${1:-.}"
+
+      # cargoUnit content-addresses every crate unit, so a store that cannot
+      # realise a content-addressed derivation cannot build most of this flake.
+      # Checked here rather than assumed because the failure it produces
+      # otherwise is `store path '...bedwars-0.1.0.drv' does not exist`, which
+      # points nowhere near the cause and cost ENG-10817 months of a green-
+      # looking CI. Note the client setting is not enough: the DAEMON's
+      # /etc/nix/nix.conf is what decides, so `extra-experimental-features` in
+      # a flake's nixConfig or in NIX_CONFIG reads as accepted and still fails.
+      # `$out` below is the builder's variable, not this shell's, so the
+      # single quotes are the point.
+      # shellcheck disable=SC2016
+      if ! nix build --no-link --quiet --expr 'derivation {
+             name = "ca-derivations-probe";
+             system = "${system}";
+             builder = "/bin/sh";
+             args = [ "-c" "echo probe > $out" ];
+             __contentAddressed = true;
+             outputHashMode = "recursive";
+             outputHashAlgo = "sha256";
+           }'; then
+        {
+          echo "this nix store cannot build content-addressed derivations."
+          echo "add to the DAEMON config (/etc/nix/nix.conf, then restart it):"
+          echo "  extra-experimental-features = ca-derivations"
+          echo "on GitHub Actions that is the nix-installer-action 'extra-conf' input."
+        } >&2
+        exit 1
+      fi
+
+      enforced=(${quote enforced})
+      excluded=(${quote excludedNames})
+
+      reason() {
+        case "$1" in
+          ${reasonArms}esac
+      }
+
+      build() {
+        nix build --accept-flake-config --no-link --print-build-logs \
+          "$flake#checks.${system}.$1"
+      }
+
+      status=0
+      failed=()
+
+      # Every failure is reported rather than the first one only, so a single
+      # push can fix all of them.
+      for name in "''${enforced[@]}"; do
+        if build "$name"; then
+          echo "ok        $name"
+        else
+          echo "FAILED    $name"
+          failed+=("$name")
+          status=1
+        fi
+      done
+
+      for name in "''${excluded[@]}"; do
+        if build "$name"; then
+          echo "STALE     $name"
+          {
+            echo "checks.${system}.$name is excluded from CI but now builds."
+            echo "nix/ci/flake-gate.nix excluded it on this evidence:"
+            reason "$name"
+            echo "Delete the entry; CI enforces the check from then on."
+          } >&2
+          status=1
+        else
+          echo "excluded  $name (still failing, on the evidence recorded for it)"
+          reason "$name"
+        fi
+      done
+
+      if [ "''${#failed[@]}" -gt 0 ]; then
+        {
+          echo ""
+          echo "enforced checks that failed: ''${failed[*]}"
+          echo "reproduce one with: nix build .#checks.${system}.<name> -L"
+        } >&2
+      fi
+
+      exit "$status"
+    '';
+  };
+in
+lib.throwIf (stale != [ ]) ''
+  nix/ci/flake-gate.nix excludes checks that do not exist: ${lib.concatStringsSep ", " stale}
+  Delete them, or spell them the way `checks.${system}` does.
+''
+  gate

--- a/nix/e2e.nix
+++ b/nix/e2e.nix
@@ -306,6 +306,16 @@ let
           pkgs.python3
           driver
         ];
+        # The game server builds a reqwest client at startup, before it knows
+        # whether it will ever make a request, and reqwest refuses to construct
+        # one without a trust store. A darwin build finds the keychain and a
+        # NixOS host often leaks /etc/ssl into the sandbox, so this check only
+        # looked green on the machines it was written on: on a stock Linux
+        # store it dies with `No CA certificates were loaded from the system`
+        # before the server opens its port. Measured on ubuntu-latest, GitHub
+        # Actions run 30341722090, where all three e2e gates failed this way
+        # and nothing else. Naming the bundle turns a leak into an input.
+        SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
         # Without this a darwin build gets no loopback at all and the proxy
         # cannot reach the game server. Linux ignores it and uses the sandbox's
         # own network namespace, which already has loopback up.


### PR DESCRIPTION
Closes ENG-10817.

## What was wrong

`nix flake check` ran under `continue-on-error: true`. No nix gate this
repository has landed had ever been built by CI. The last green-looking run on
main, [30340104855](https://github.com/hyperion-mc/hyperion/actions/runs/30340104855),
reported **0 of 41** checks passing and the job was still advisory.

## Why nothing built, measured

The daemon decides whether a content-addressed derivation can be realised, and
cargoUnit content-addresses every crate unit.
[Run 30341528713](https://github.com/hyperion-mc/hyperion/actions/runs/30341528713)
built a one-line CA derivation under three configurations:

| config | result |
| --- | --- |
| baseline | `CA-BUILD-FAIL` |
| `NIX_CONFIG: experimental-features = ... ca-derivations` | `CA-BUILD-FAIL` |
| nix-installer-action `extra-conf: extra-experimental-features = ca-derivations` | `CA-BUILD-OK` |

The flake's own `nixConfig` and a workflow `NIX_CONFIG` reach the client only,
which is why the failure read as `store path '...bedwars-0.1.0.drv' does not
exist`. The gate re-checks this itself and prints what to set.

## Real versus environmental

Per check rather than as one all-or-nothing job,
[run 30341722090](https://github.com/hyperion-mc/hyperion/actions/runs/30341722090),
41 checks:

- **38 pass**, including every `minecraft-*` up-to-date check, `nixos-modules`,
  `genmap-url-pinned` and `differential-traces`.
- **3 fail**: `e2e`, `smash-e2e`, `completions-e2e`, all on the same line.

```
hyperion-e2e> the game server exited before opening 127.0.0.1:60917
hyperion-e2e> Client::new(): reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") }
```

Real, not the runner. The server builds a reqwest client at startup and reqwest
will not construct one without a trust store; a darwin build finds the keychain
and a NixOS host often leaks `/etc/ssl` into the sandbox, so these gates only
ever looked green on the machines they were written on. `SSL_CERT_FILE` in
`nix/e2e.nix` makes the bundle an input.

`differential-traces` is the one that looked ambiguous: it failed on run
30341066882 and then passed four times (30341722090 plus three independent
repeats in
[30342250503](https://github.com/hyperion-mc/hyperion/actions/runs/30342250503)).
The only difference was ca-derivations. Environmental, and enforced.

Every package builds, 19 of 19 in each of three runs. The prose this replaces
said `packages` "cannot succeed yet" and that cargoUnit could not vendor this
lock. `nix flake check` never built packages at all, it prints
`(build skipped)` for each, and they build.

## What the first real run caught

[Run 30342733873](https://github.com/hyperion-mc/hyperion/actions/runs/30342733873)
is the first time `smash-e2e` has ever run to completion in CI. It failed, on
47 of 47 abilities:

```
COOLDOWN FAILED Blaze / Firefly has a 9.0s cooldown and let a second use through
...
 280.23s         NOT PROVED  cooldowns refused a second use
 280.23s       RESULT: 1 of 12 steps did not happen
```

The action bar had become an NBT compound when the component API landed in
#1004, and `tools/smash-match.py` read only `Tag::String`, so it logged
`<- action bar: <nbt tag type 0x0A, not a string>` and never saw the refusal.
It was red on main for two commits and nothing reported it. #1006 fixed the
reader; ENG-10838 has the write-up and the remaining gap.

## What is enforced now

`nix/ci/flake-gate.nix`, subtractive: every attribute of `checks` is built
unless named in `excluded`, so a check added tomorrow is enforced the day it
lands. `nixos-modules` moved into the per-system set so nothing sits outside
the gate's view, and the gate reads its own names with `builtins.attrNames`,
which is how three checks that landed in sibling PRs while this branch was open
(`smash-text-no-legacy-formatting`, `smash-selector-e2e`,
`smash-selector-e2e-app`) became enforced with no edit.

**45 enforced. Exclusion list empty.**

## Watching the guards fire

Three guards, none of them trusted on reading alone.

**An exclusion that starts passing turns the gate red.** Run 30342733873 still
had `differential-traces` excluded while it in fact passed:

```
STALE     differential-traces
checks.x86_64-linux.differential-traces is excluded from CI but now builds.
Delete it from nix/ci/flake-gate.nix; CI enforces it after that.

enforced checks that failed: smash-e2e
##[error]Process completed with exit code 1.
```

**Breaking something only a newly enforced check protects turns the job red.**
PR #1008 reordered `--port` ahead of `--ip` in the game server module. No cargo
job can see that: Formatting, Clippy, Documentation, Tests, deny, unused-deps
and Code Coverage all read rust.
[Job 90222622214](https://github.com/hyperion-mc/hyperion/actions/runs/30344559040)
went red with the message intended:

```
FAILED    nixos-modules
hyperion-nixos-modules> hyperion NixOS module argv lost: /bin/bedwars --ip :: --port 35565
hyperion-nixos-modules> what the modules built:
hyperion-nixos-modules> ...bin/bedwars --port 35565 --ip :: --root-ca-cert ...
```

Reverted immediately.

**A misspelled exclusion throws at evaluation.**

```
$ nix eval .#checks.aarch64-darwin.flake-gate.drvPath
error: nix/ci/flake-gate.nix excludes checks that do not exist: differential-tracez
       Delete them, or spell them the way `checks.aarch64-darwin` does.
```

And the ca-derivations preflight, run against a store without it:

```
$ NIX_CONFIG="experimental-features = nix-command flakes" flake-gate .
this nix store cannot build content-addressed derivations.
add to the DAEMON config (/etc/nix/nix.conf, then restart it):
  extra-experimental-features = ca-derivations
on GitHub Actions that is the nix-installer-action 'extra-conf' input.
```

## Not done, and tracked

`runs-on` stays `ubuntu-latest` against the house rule. The fleet cannot serve
this org: ix `crates/ci/dispatcher/src/config.rs` holds `GithubApp.org` as one
`String` and `github.rs` registers every JIT runner at `orgs/{org}` with
`org = indexable-inc`, so a `hyperion-mc` job is never offered one. Pointing
`runs-on` at an `ix-ci-run-*` label today would hang until timeout, which is
strictly worse than a hosted runner that works. **ENG-10824**. The gate is the
same `nix build .#checks.x86_64-linux.<name>` either way, so the migration is
one line when it lands.

No CI job here is a required status check, and the comment on the `check` job
claimed the opposite. Corrected in this PR; **ENG-10827** proposes adding the
rule, not done here because four agents had PRs in flight and turning eight
jobs into required contexts mid-flight would have blocked all of them.

Authored by an AI agent (Claude Opus 4.5 via Claude Code).
