### PR TITLE
test(smash): kill the four mutants the sound change let through

### DIFF
--- a/events/smash/src/module/kit.rs
+++ b/events/smash/src/module/kit.rs
@@ -25,7 +25,7 @@ use crate::{
         player::{Energy, Health, JumpsLeft},
         sound::{self, Levels, PlaysOnCast, PlaysOnDeath, PlaysOnHurt},
     },
-    server::{HotbarItem, SoundCategory},
+    server::HotbarItem,
 };
 
 /// Tag on kit prefabs.
@@ -259,12 +259,7 @@ impl<'w> KitBuilder<'w> {
     /// name to do it.
     #[must_use]
     pub fn sounds(self, sounds: KitSounds) -> Self {
-        let voice = Levels {
-            // A kit is a mob, and a mob's voice belongs under the slider a
-            // player uses to turn mobs down.
-            category: SoundCategory::Hostile,
-            ..Levels::default()
-        };
+        let voice = Levels::default();
         self.kit
             .add((PlaysOnHurt, sound::intern(self.world, sounds.hurt, voice)));
         self.kit
@@ -339,16 +334,12 @@ impl<'w> KitBuilder<'w> {
         // declaration reaches that instance is `module/sound.rs`'s business.
         if !spec.sound.is_empty() {
             let sound = sound::intern(self.world, spec.sound, Levels {
-                // Every kit is a combatant whatever mob it is skinned as, so
-                // they all belong under one slider and a player who turns
-                // monsters down turns the whole roster down evenly. The two
-                // categories that are deliberately not this are the impact of
-                // a hit, which is `Players`, and the countdown, which is `Ui`.
-                category: SoundCategory::Hostile,
                 // An ultimate carries further, and volume is range: see
                 // `hyperion::net::agnostic::RANGE_PER_VOLUME`. A Smash Crystal
                 // going off is the loudest thing in a match and should be heard
-                // by people who are not in it yet.
+                // by people who are not in it yet. Everything else about how it
+                // plays is `Levels::default`, which is where the reasoning for
+                // the category lives.
                 volume: if ultimate { ULTIMATE_VOLUME } else { 1.0 },
                 ..Levels::default()
             });

--- a/events/smash/src/module/lobby.rs
+++ b/events/smash/src/module/lobby.rs
@@ -327,11 +327,10 @@ fn tick_countdown(world: &WorldRef<'_>, before: Lobby, after: Lobby) {
     if !counts_down(after.phase) || before.phase != after.phase {
         return;
     }
-    let (was, now) = (before.timer.ceil(), after.timer.ceil());
-    if now >= was || now <= 0.0 || now > f32::from(sound::COUNTDOWN_AUDIBLE_SECONDS) {
+    let Some(seconds_left) = sound::countdown_second_crossed(before.timer, after.timer) else {
         return;
-    }
-    sound::play_to_everyone(*world, sound::countdown_tick(now));
+    };
+    sound::play_to_everyone(*world, sound::countdown_tick(seconds_left));
 }
 
 fn on_phase_change(world: &WorldRef<'_>, from: Phase, to: Phase) {

--- a/events/smash/src/module/sound.rs
+++ b/events/smash/src/module/sound.rs
@@ -57,6 +57,16 @@ pub struct Levels {
 }
 
 impl Default for Levels {
+    /// [`SoundCategory::Hostile`], and this is the only place that says so.
+    ///
+    /// Every kit is a combatant whatever mob it is skinned as, so they all
+    /// belong under one slider and a player who turns monsters down turns the
+    /// whole roster down evenly. Nothing declared through a relationship wants
+    /// a different category, so a caller that restates this one is writing a
+    /// line no test can distinguish from its absence. The two categories that
+    /// are deliberately not this belong to sounds that are not declared at all:
+    /// the impact of a hit is [`SoundCategory::Players`] and the countdown is
+    /// [`SoundCategory::Ui`].
     fn default() -> Self {
         Self {
             category: SoundCategory::Hostile,
@@ -118,6 +128,23 @@ pub const COUNTDOWN_AUDIBLE_SECONDS: u8 = 5;
 
 /// How much the pitch climbs with each second closer to the start.
 pub const COUNTDOWN_PITCH_STEP: f32 = 0.2;
+
+/// Whether a timer going from `before` to `after` seconds just crossed a whole
+/// second inside the audible window, and which second it landed on.
+///
+/// Pulled out of the lobby and made pure because it is four conditions with a
+/// boundary at each end, and a test that drives it through a whole match can
+/// only observe the ones that happen to fire. Driven directly, each edge is one
+/// line: a timer that has not crossed a boundary, one that crossed above the
+/// window, one that crossed into it, and one that ran out.
+#[must_use]
+pub fn countdown_second_crossed(before: f32, after: f32) -> Option<f32> {
+    let (was, now) = (before.ceil(), after.ceil());
+    if now >= was || now <= 0.0 || now > f32::from(COUNTDOWN_AUDIBLE_SECONDS) {
+        return None;
+    }
+    Some(now)
+}
 
 /// One countdown tick, rising as the wait runs out.
 ///

--- a/events/smash/tests/sound.rs
+++ b/events/smash/tests/sound.rs
@@ -459,14 +459,6 @@ fn the_countdown_ticks_once_a_second_and_then_the_match_starts() {
     game.advance(6.0, 120);
     assert_eq!(game.world.cloned::<&Lobby>().phase, Phase::Countdown);
 
-    // Every whole second inside the audible window, once each, rising. Built
-    // from the same function the game calls rather than from a literal, so this
-    // is a claim about the sequence and not a copy of the pitch table.
-    let mut wanted: Vec<f32> = (1..=sound::COUNTDOWN_AUDIBLE_SECONDS)
-        .map(|second| sound::countdown_tick(f32::from(second)).pitch)
-        .collect();
-    wanted.reverse();
-
     let ticks: Vec<f32> = game
         .server
         .sounds_to(listener)
@@ -474,9 +466,12 @@ fn the_countdown_ticks_once_a_second_and_then_the_match_starts() {
         .filter(|played| played.id == sound::COUNTDOWN_TICK)
         .map(|played| played.pitch)
         .collect();
+    // The literal sequence, not one derived from `countdown_tick`. Deriving it
+    // would compare the function against itself and pass for any pitch curve at
+    // all, including a flat one.
     assert_eq!(
         ticks,
-        wanted,
+        vec![1.0, 1.2, 1.4, 1.6, 1.8],
         "the countdown should tick once a second through its last {} and rise as it goes",
         sound::COUNTDOWN_AUDIBLE_SECONDS
     );
@@ -618,6 +613,93 @@ fn declaring_a_sound_twice_keeps_the_second() {
         declared.id, "minecraft:block.note_block.bell",
         "the first declaration outlived the one that replaced it"
     );
+}
+
+/// The countdown pitch, against the numbers the documentation quotes.
+///
+/// Absolute rather than relative, and that is the point: a test that builds its
+/// expectation by calling `countdown_tick` compares the function against itself
+/// and passes for any curve, flat included.
+#[test]
+fn a_countdown_tick_rises_a_fixed_step_a_second() {
+    assert!((sound::countdown_tick(5.0).pitch - 1.0).abs() < 1e-6);
+    assert!((sound::countdown_tick(1.0).pitch - 1.8).abs() < 1e-6);
+    // Outside the window in either direction, clamped rather than extrapolated,
+    // so nothing can hand the client a pitch it would flatten.
+    assert!((sound::countdown_tick(9.0).pitch - 1.0).abs() < 1e-6);
+    assert!((sound::countdown_tick(0.0).pitch - 2.0).abs() < 1e-6);
+}
+
+/// Which timer steps are a tick, one edge per line.
+///
+/// A whole match only exercises the edges it happens to reach, and the ones
+/// that matter here are the ones it does not: a step crossing a second above
+/// the audible window, and the step that takes the timer to zero. Both are
+/// silent, and neither shows up in a run that only counts the ticks it got.
+#[test]
+fn only_a_whole_second_inside_the_window_is_a_tick() {
+    let window = f32::from(sound::COUNTDOWN_AUDIBLE_SECONDS);
+
+    // Inside the window, crossing a boundary: a tick, named by the second it
+    // landed on.
+    assert_eq!(sound::countdown_second_crossed(5.01, 4.99), Some(5.0));
+    assert_eq!(sound::countdown_second_crossed(1.01, 0.99), Some(1.0));
+
+    // Inside the window and not crossing anything.
+    assert_eq!(sound::countdown_second_crossed(4.99, 4.90), None);
+
+    // Crossing, but above the window. Sixty seconds of metronome is what this
+    // rejects.
+    assert_eq!(
+        sound::countdown_second_crossed(window + 2.01, window + 1.99),
+        None
+    );
+    assert_eq!(
+        sound::countdown_second_crossed(window + 1.01, window + 0.99),
+        None
+    );
+
+    // The timer running out is the match starting, which has its own sound.
+    assert_eq!(sound::countdown_second_crossed(0.01, 0.0), None);
+    assert_eq!(sound::countdown_second_crossed(0.5, -0.5), None);
+
+    // A timer that went up, which is what a join filling the lobby does.
+    assert_eq!(sound::countdown_second_crossed(3.0, 4.0), None);
+}
+
+/// Two declarations of the same sound at the same levels are one node in the
+/// graph, so "which abilities play this" stays a query over the world.
+#[test]
+fn the_same_sound_at_the_same_levels_is_one_entity() {
+    let game = Game::new();
+    let first = sound::intern(
+        &game.world,
+        "minecraft:block.note_block.bell",
+        Levels::default(),
+    );
+    let again = sound::intern(
+        &game.world,
+        "minecraft:block.note_block.bell",
+        Levels::default(),
+    );
+    assert_eq!(
+        first.id(),
+        again.id(),
+        "interning the same sound twice made two entities"
+    );
+
+    // Different levels are a different node, because the levels are what an
+    // occasion reads back. Sharing one would hand the second caller the first
+    // one's volume with nothing anywhere reporting it.
+    let louder = sound::intern(&game.world, "minecraft:block.note_block.bell", Levels {
+        volume: 2.0,
+        ..Levels::default()
+    });
+    assert_ne!(first.id(), louder.id());
+    let volume = louder
+        .try_get::<&Levels>(|l| l.volume)
+        .expect("an interned sound carries its levels");
+    assert!((volume - 2.0).abs() < 1e-6);
 }
 
 /// Almost everything here is a sweep over the registry; the three checks that


### PR DESCRIPTION
## Four mutants survived #1003

`nix run .#mutants` holds `events/smash/src/module/*.rs` to a budget of zero
surviving mutants. A mutant that survives is a line the suite executes without
checking. #1003 left four, found by running the gate scoped to that diff:

```
events/smash/src/module/lobby.rs:296:33: replace || with && in tick_countdown
events/smash/src/module/sound.rs:131:25: replace - with / in countdown_tick
events/smash/src/module/sound.rs:228:5: replace lookup -> Option<EntityView<'w>> with None
events/smash/src/module/kit.rs:243:13: delete field category from struct Levels expression in KitBuilder<'w>::sounds
```

Three are checks that only looked like checks. The fourth is a line that could
not have been checked because it did nothing.

## The countdown compared itself against itself

The test built the pitch sequence it expected by calling `countdown_tick`, so
replacing that function's subtraction with a division changed both sides of the
comparison and the assertion still held. It would have passed for a flat curve,
which is exactly the thing the sequence exists to not be.

The sequence is written out now, and a separate test holds the two ends against
the numbers the doc comment quotes.

## The countdown's edges were only ever seen through a whole match

Four conditions decide whether a timer step is a tick, and a match reaches the
ones it happens to reach. Replacing an `||` with an `&&` among them survived.

They are now `sound::countdown_second_crossed`, a pure function over two timer
readings, and a table drives every edge one line at a time, including the two a
match does not produce: a second crossed above the audible window, and the step
that takes the timer to zero.

## Nothing checked that interning interns

`lookup` could return `None` unconditionally and the suite stayed green, which
means `intern` making a fresh entity every call was invisible. Two declarations
of one sound at one set of levels are now asserted to be one entity, and two at
different levels to be two.

## The fourth is not a test gap

`KitBuilder::sounds` wrote `category: SoundCategory::Hostile` into a `Levels`
whose `Default` is already `Hostile`, so deleting the field changed nothing and
no test could have caught it. Both call sites take the default now, and
`Levels::default` is the one place that names the category, with the reasoning
sitting on it rather than restated at each use.

## Verification

Each of the three surviving mutants was reintroduced by hand and the new tests
watched to fail, then restored:

```
=== M1: || -> && in countdown_second_crossed ===
test result: FAILED. 14 passed; 2 failed
=== M2: - -> / in countdown_tick ===
test result: FAILED. 14 passed; 2 failed
=== M3: lookup -> None ===
test result: FAILED. 15 passed; 1 failed
```

Gates, run locally, exit codes read from the logs:

```
$ nix run .#lint
rc=0
$ cargo fmt --all --check
rc=0
$ nix run .#test
     Summary [  49.417s] 622 tests run: 622 passed, 1 skipped
rc=0
```

And the gate that motivated this, run over this diff:

```
$ git diff --no-ext-diff origin/main...HEAD > /tmp/sound-indiff2.patch
$ MUTANT_OUTPUT=/tmp/sound-mutants-diff2 nix run .#mutants -- --in-diff /tmp/sound-indiff2.patch
Found 14 mutants to test
ok       Unmutated baseline in 41s build + 10s test
mutants: 12 killed, 0 survived (budget 0)
rc=0
```

`--in-diff` rather than the whole gate on purpose: the full sweep is 364 mutants
and around four hours on this machine, and everything outside the diff was
already at zero. That narrowing is worth knowing about, because it means the
number above is "this change adds no survivors" and not "the repo has none".

The `Flake` job is red here as it is on every branch right now, which is
ENG-10817 and ENG-10819 and not this change.

---

AI-authored: written by Claude (Opus 4.5) under human direction.
