### PR TITLE
feat(smash): a mob you can read, that answers when you pick it

### DIFF
--- a/crates/hyperion/src/egress/player_join/mod.rs
+++ b/crates/hyperion/src/egress/player_join/mod.rs
@@ -12,7 +12,7 @@ use flecs_ecs::prelude::*;
 mod list;
 pub use list::*;
 pub mod roster;
-pub use roster::{RosterModule, announce, entry_of};
+pub use roster::{RosterModule, announce, entry_of, wear};
 
 use crate::{
     simulation::command::{Command, ROOT_COMMAND},

--- a/crates/hyperion/src/egress/player_join/roster.rs
+++ b/crates/hyperion/src/egress/player_join/roster.rs
@@ -66,10 +66,7 @@ use crate::{
         metadata::show_all,
         player_join::{PlayerInfoActions, PlayerList, PlayerListEntry, SkinProperty},
     },
-    net::{
-        Channel, Compose, ConnectionId, DataBundle,
-        protocol::Clientbound,
-    },
+    net::{Channel, Compose, ConnectionId, DataBundle, protocol::Clientbound},
     simulation::{
         Name, Pitch, Position, Uuid, Velocity, Yaw, add_entity,
         entity_kind::EntityKind,

--- a/crates/hyperion/src/egress/player_join/roster.rs
+++ b/crates/hyperion/src/egress/player_join/roster.rs
@@ -24,6 +24,30 @@
 //! Verified against the 26.2 client jar (sha1 2dc72797acbc1b63fc16a11c4ac393605f453754)
 //! and authlib 9.0.75, which ships inside the server bundle this repository
 //! already pins.
+//!
+//! # A texture change never costs a player their world
+//!
+//! This module used to hand the wearer a `Respawn`, on the reasoning that
+//! rebuilding `LocalPlayer` is the only thing that clears the cached
+//! `PlayerInfo` in the third bullet above. It does, and it also throws away
+//! everything else the client had: `handleRespawn` replaces `ClientLevel`
+//! wholesale, so the player loses every chunk and every entity in one packet.
+//!
+//! Giving those back is not a matter of re-sending terrain. Chunks could be
+//! restreamed from here, but entities could not: which entities a client is
+//! subscribed to is the proxy's bookkeeping, keyed on position, and it has no
+//! reason to re-offer a subscription the client already holds. So a respawn
+//! left the wearer standing in an empty hub with no podiums, no mobs and
+//! nobody else in it, and the operator saw the terrain half of that as
+//! "Loading terrain..." forever.
+//!
+//! So [`refresh`] does not respawn. The wearer's profile entry is replaced,
+//! which is what the tab list reads, and every *other* client drops and
+//! re-adds their entity, which is what puts the new skin on the model that
+//! matters. What is deliberately not fixed is the wearer's own first-person
+//! view of themselves, which keeps the texture their `LocalPlayer` was built
+//! with until something rebuilds it. That is one pair of arms against every
+//! client's whole world, and it is the trade this file makes on purpose.
 
 use flecs_ecs::{macros::system, prelude::*};
 use hyperion_minecraft_proto::{
@@ -31,7 +55,7 @@ use hyperion_minecraft_proto::{
     generated::packet_id::play::clientbound::PacketId,
     packets::{
         play::clientbound::{PlayerInfoRemove, RemoveEntities},
-        play_login::{GameEvent, Respawn},
+        play_login::GameEvent,
     },
 };
 use hyperion_utils::EntityExt;
@@ -44,7 +68,7 @@ use crate::{
     },
     net::{
         Channel, Compose, ConnectionId, DataBundle,
-        protocol::{Clientbound, join},
+        protocol::Clientbound,
     },
     simulation::{
         Name, Pitch, Position, Uuid, Velocity, Yaw, add_entity,
@@ -113,7 +137,7 @@ fn skin_property(skin: &PlayerSkin) -> Option<SkinProperty> {
 /// ordering is load bearing: the profile has to be on the client before the
 /// first `AddEntity` naming it, and the joining player's own subscription to
 /// other players' channels starts the moment [`Channel`] is added at the end of
-/// [`join::enter_world`].
+/// [`crate::net::protocol::join::enter_world`].
 ///
 /// # Errors
 /// Returns an error when a packet fails to encode.
@@ -156,17 +180,39 @@ fn retire(compose: &Compose, uuid: uuid::Uuid) -> anyhow::Result<()> {
     compose.broadcast(clientbound).send()
 }
 
+/// Dress `entity` in `skin`, unless it is already wearing it.
+///
+/// The comparison is on the profile property the client would receive and not
+/// on the component, because those are not the same question. A player who
+/// joins with no [`PlayerSkin`] at all and a player wearing [`PlayerSkin::EMPTY`]
+/// publish exactly the same profile -- no `textures` property either way -- so
+/// writing the second over the first changes nothing a client can observe and
+/// must not be published as a change.
+///
+/// That distinction is the whole reason this function exists. `apply_skins`
+/// hands every real client an empty skin a moment after it joins, because a
+/// vanilla client sends its profile id and hyperion answers by asking Mojang
+/// for a skin that an offline uuid does not have. Left as a plain `set`, that
+/// no-op tripped [`refresh`] on every single join.
+pub fn wear(entity: EntityView<'_>, skin: PlayerSkin) {
+    let published = entity.try_get::<&PlayerSkin>(skin_property).flatten();
+    if published == skin_property(&skin) {
+        return;
+    }
+    entity.set(skin);
+}
+
 /// Re-send `entity`'s profile so a changed skin takes effect.
 ///
 /// Two different sequences, because the client treats itself differently from
 /// everyone else. Others are told to forget the profile and the entity and are
-/// handed both again. The player themselves cannot be told to forget their own
-/// entity, so they get a `Respawn`, which is what rebuilds `LocalPlayer` and
-/// with it the `PlayerInfo` reference `AbstractClientPlayer` had cached.
+/// handed both again, which is what puts the new texture on the model. The
+/// wearer is told to forget the profile and is handed it back, and that is all:
+/// see this module's own documentation for why they are deliberately not
+/// respawned and what that costs.
 ///
 /// # Errors
-/// Returns an error when a packet fails to encode or when the registries carry
-/// no overworld dimension type.
+/// Returns an error when a packet fails to encode.
 fn refresh(entity: EntityView<'_>, compose: &Compose) -> anyhow::Result<()> {
     let Some(entry) = entry_of(entity) else {
         return Ok(());
@@ -176,7 +222,6 @@ fn refresh(entity: EntityView<'_>, compose: &Compose) -> anyhow::Result<()> {
     };
     let uuid = entry.uuid;
     let minecraft_id = entity.minecraft_id();
-    let mode = gamemode::of(entity);
 
     let remove_info = PlayerInfoRemove(vec![ProtoUuid(uuid.as_u128())]);
     let add_info = PlayerList::initialize(vec![entry]);
@@ -187,18 +232,7 @@ fn refresh(entity: EntityView<'_>, compose: &Compose) -> anyhow::Result<()> {
         &remove_info,
     ))?;
     mine.add_packet(&add_info)?;
-    mine.add_packet(Clientbound::new(PacketId::Respawn.to_raw(), &Respawn {
-        spawn_info: join::spawn_info(mode.to_game_type())?,
-        // Both `KEEP_ATTRIBUTES` and `KEEP_ENTITY_DATA`. This respawn is a
-        // cosmetic refresh and not a death, so wiping either would make a skin
-        // change reset the player's speed and pose as a side effect.
-        data_to_keep: 0x03,
-    }))?;
     mine.unicast(connection_id)?;
-
-    // The respawn leaves the client at the dimension's default position, so
-    // where the server thinks the player is has to be restated.
-    join::send_position(entity, compose, connection_id)?;
 
     let mut theirs = DataBundle::new(compose);
     theirs.add_packet(Clientbound::new(
@@ -325,7 +359,7 @@ impl Module for RosterModule {
                     let Some(entity) = world.try_get_alive(by) else {
                         continue;
                     };
-                    entity.set(skin);
+                    wear(entity, skin);
                 }
             });
 

--- a/crates/hyperion/src/net/protocol/join.rs
+++ b/crates/hyperion/src/net/protocol/join.rs
@@ -247,7 +247,12 @@ impl Module for JoinModule {
                     if !world.is_alive(entity) {
                         continue;
                     }
-                    world.entity_from_id(entity).set(skin);
+                    // `wear` and not `set`, because this fires after the join
+                    // and the overwhelmingly common answer from the session
+                    // server is the empty skin the player already publishes.
+                    // A plain write would republish the profile of every
+                    // client on the server a second after it joined.
+                    roster::wear(world.entity_from_id(entity), skin);
                 }
             });
 

--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -46,9 +46,7 @@ use valence_nbt::{Compound, List, Value};
 
 use crate::{
     module::kit::{self, Playing},
-    server::{
-        Channel, Cue, HotbarItem, PlayerId, Server, SidebarLine, Sound, SoundCategory, Text,
-    },
+    server::{Channel, Cue, HotbarItem, PlayerId, Server, SidebarLine, Sound, SoundCategory, Text},
 };
 
 /// One deferred write.

--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, Mutex};
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 use hyperion::{
+    egress::player_join::roster,
     hyperion_minecraft_proto::{
         generated::packet_id::play::clientbound::PacketId,
         packets::play::{
@@ -244,10 +245,17 @@ impl Module for SmashAdapterModule {
                 let Some(skin) = kit::skin_of(player) else {
                     return;
                 };
-                player.set(PlayerSkin::new(
-                    skin.textures.trim().to_owned(),
-                    skin.signature.trim().to_owned(),
-                ));
+                // `wear` and not `set`: re-picking the mob you are already
+                // playing publishes nothing, so a player leaning on a podium
+                // does not send every other client a stream of profile
+                // rewrites and entity respawns.
+                roster::wear(
+                    player,
+                    PlayerSkin::new(
+                        skin.textures.trim().to_owned(),
+                        skin.signature.trim().to_owned(),
+                    ),
+                );
             });
 
         // PostUpdate rather than OnStore: hyperion's own inventory and entity

--- a/events/smash/src/command.rs
+++ b/events/smash/src/command.rs
@@ -246,7 +246,7 @@ fn podium(offer: &selector::Offer) -> String {
     let mut out = String::new();
     let _unused = write!(
         out,
-        r#"{{"kit":"{}","x":{},"y":{},"z":{},"base_y":{},"wool":"{}","mob":"{}","held_by":"#,
+        r#"{{"kit":"{}","x":{},"y":{},"z":{},"base_y":{},"wool":"{}","mob":"{}","label":"{}","select_sound":{},"held_by":"#,
         escape(offer.name),
         offer.click.x,
         offer.click.y,
@@ -254,6 +254,11 @@ fn podium(offer: &selector::Offer) -> String {
         offer.base.y,
         escape(offer.wool),
         escape(offer.mob),
+        escape(&offer.label),
+        offer.select_sound.map_or_else(
+            || "null".to_owned(),
+            |sound| format!(r#""{}""#, escape(sound)),
+        ),
     );
     match &offer.held_by {
         Some(who) => {

--- a/events/smash/src/module/kit.rs
+++ b/events/smash/src/module/kit.rs
@@ -23,7 +23,7 @@ use crate::{
         damage::Armor,
         knockback::KnockbackTaken,
         player::{Energy, Health, JumpsLeft},
-        sound::{self, Levels, PlaysOnCast, PlaysOnDeath, PlaysOnHurt},
+        sound::{self, Levels, PlaysOnCast, PlaysOnDeath, PlaysOnHurt, PlaysOnSelect},
     },
     server::HotbarItem,
 };
@@ -254,11 +254,23 @@ pub const ULTIMATE_VOLUME: f32 = 1.6;
 
 /// The voice of the mob a kit is.
 ///
-/// Two sounds and not three: what *landing* a hit sounds like is deliberately
-/// the same for every kit, so that its pitch and volume can mean how hard
-/// rather than who. See [`crate::module::sound::IMPACT`].
+/// Three sounds, and what is deliberately *not* among them is the noise a
+/// landed hit makes: that one is the same for every kit so that its pitch and
+/// volume can mean how hard rather than who. See
+/// [`crate::module::sound::IMPACT`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KitSounds {
+    /// Played to the player who just picked this mob off its podium, and to
+    /// nobody else. See [`crate::module::sound::PlaysOnSelect`].
+    ///
+    /// The mob's own greeting rather than a menu click: what a player has just
+    /// done is choose to *be* a skeleton, and the skeleton rattling back is
+    /// what says so without a line of text. Every one of these is the mob's
+    /// vanilla ambient sound where it has one, and `tests/sound.rs` holds all
+    /// fifteen against the generated `minecraft:sound_event` registry and
+    /// against each other, because a roster where two mobs answer alike is a
+    /// roster where the sound has stopped carrying which mob it was.
+    pub select: &'static str,
     /// Played on the victim when they are hurt, whoever hurt them.
     pub hurt: &'static str,
     /// Played where they died.
@@ -295,15 +307,20 @@ impl<'w> KitBuilder<'w> {
         self
     }
 
-    /// What this kit's mob sounds like when it is hurt and when it dies.
+    /// What this kit's mob sounds like when it is chosen, when it is hurt and
+    /// when it dies.
     ///
-    /// Hung off the kit prefab as `(PlaysOnHurt, sound)` and
-    /// `(PlaysOnDeath, sound)`, so the damage and death paths reach it through
-    /// the player's own `(Playing, kit)` edge and no subsystem learns a kit
-    /// name to do it.
+    /// Hung off the kit prefab as `(PlaysOnSelect, sound)`,
+    /// `(PlaysOnHurt, sound)` and `(PlaysOnDeath, sound)`, so the selector, the
+    /// damage path and the death path each reach it through the player's own
+    /// `(Playing, kit)` edge and no subsystem learns a kit name to do it.
     #[must_use]
     pub fn sounds(self, sounds: KitSounds) -> Self {
         let voice = Levels::default();
+        self.kit.add((
+            PlaysOnSelect,
+            sound::intern(self.world, sounds.select, voice),
+        ));
         self.kit
             .add((PlaysOnHurt, sound::intern(self.world, sounds.hurt, voice)));
         self.kit

--- a/events/smash/src/module/kits/blaze.rs
+++ b/events/smash/src/module/kits/blaze.rs
@@ -42,6 +42,7 @@ impl Module for Blaze {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            select: "minecraft:entity.blaze.ambient",
             hurt: "minecraft:entity.blaze.hurt",
             death: "minecraft:entity.blaze.death",
         })

--- a/events/smash/src/module/kits/chicken.rs
+++ b/events/smash/src/module/kits/chicken.rs
@@ -43,6 +43,7 @@ impl Module for Chicken {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            select: "minecraft:entity.chicken.ambient",
             hurt: "minecraft:entity.chicken.hurt",
             death: "minecraft:entity.chicken.death",
         })

--- a/events/smash/src/module/kits/cow.rs
+++ b/events/smash/src/module/kits/cow.rs
@@ -35,6 +35,7 @@ impl Module for Cow {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            select: "minecraft:entity.cow.ambient",
             hurt: "minecraft:entity.cow.hurt",
             death: "minecraft:entity.cow.death",
         })

--- a/events/smash/src/module/kits/creeper.rs
+++ b/events/smash/src/module/kits/creeper.rs
@@ -44,6 +44,11 @@ impl Module for Creeper {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            // A creeper has exactly three sounds and no ambient one, so the
+            // hiss is the only thing it can say that is not being hurt or
+            // dying. Sulphur Bomb below plays the same hiss on purpose: it is
+            // what a creeper sounds like, and there is not a second one.
+            select: "minecraft:entity.creeper.primed",
             hurt: "minecraft:entity.creeper.hurt",
             death: "minecraft:entity.creeper.death",
         })

--- a/events/smash/src/module/kits/enderman.rs
+++ b/events/smash/src/module/kits/enderman.rs
@@ -45,6 +45,7 @@ impl Module for Enderman {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            select: "minecraft:entity.enderman.ambient",
             hurt: "minecraft:entity.enderman.hurt",
             death: "minecraft:entity.enderman.death",
         })

--- a/events/smash/src/module/kits/guardian.rs
+++ b/events/smash/src/module/kits/guardian.rs
@@ -54,6 +54,7 @@ impl Module for Guardian {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            select: "minecraft:entity.guardian.ambient",
             hurt: "minecraft:entity.guardian.hurt",
             death: "minecraft:entity.guardian.death",
         })

--- a/events/smash/src/module/kits/iron_golem.rs
+++ b/events/smash/src/module/kits/iron_golem.rs
@@ -41,6 +41,11 @@ impl Module for IronGolem {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            // An iron golem has no ambient sound either. The heavy metal
+            // swing is the one thing it makes that everybody recognises, and
+            // it is the right promise for a kit whose blurb is "hit like a
+            // truck".
+            select: "minecraft:entity.iron_golem.attack",
             hurt: "minecraft:entity.iron_golem.hurt",
             death: "minecraft:entity.iron_golem.death",
         })

--- a/events/smash/src/module/kits/skeleton.rs
+++ b/events/smash/src/module/kits/skeleton.rs
@@ -45,6 +45,7 @@ impl Module for Skeleton {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            select: "minecraft:entity.skeleton.ambient",
             hurt: "minecraft:entity.skeleton.hurt",
             death: "minecraft:entity.skeleton.death",
         })

--- a/events/smash/src/module/kits/sky_squid.rs
+++ b/events/smash/src/module/kits/sky_squid.rs
@@ -39,6 +39,7 @@ impl Module for SkySquid {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            select: "minecraft:entity.squid.ambient",
             hurt: "minecraft:entity.squid.hurt",
             death: "minecraft:entity.squid.death",
         })

--- a/events/smash/src/module/kits/slime.rs
+++ b/events/smash/src/module/kits/slime.rs
@@ -50,6 +50,7 @@ impl Module for Slime {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            select: "minecraft:entity.slime.squish",
             hurt: "minecraft:entity.slime.hurt",
             death: "minecraft:entity.slime.death",
         })

--- a/events/smash/src/module/kits/snowman.rs
+++ b/events/smash/src/module/kits/snowman.rs
@@ -35,6 +35,7 @@ impl Module for Snowman {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            select: "minecraft:entity.snow_golem.ambient",
             hurt: "minecraft:entity.snow_golem.hurt",
             death: "minecraft:entity.snow_golem.death",
         })

--- a/events/smash/src/module/kits/spider.rs
+++ b/events/smash/src/module/kits/spider.rs
@@ -37,6 +37,7 @@ impl Module for Spider {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            select: "minecraft:entity.spider.ambient",
             hurt: "minecraft:entity.spider.hurt",
             death: "minecraft:entity.spider.death",
         })

--- a/events/smash/src/module/kits/wither_skeleton.rs
+++ b/events/smash/src/module/kits/wither_skeleton.rs
@@ -48,6 +48,7 @@ impl Module for WitherSkeleton {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            select: "minecraft:entity.wither_skeleton.ambient",
             hurt: "minecraft:entity.wither_skeleton.hurt",
             death: "minecraft:entity.wither_skeleton.death",
         })

--- a/events/smash/src/module/kits/wolf.rs
+++ b/events/smash/src/module/kits/wolf.rs
@@ -54,6 +54,7 @@ impl Module for Wolf {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            select: "minecraft:entity.wolf.ambient",
             hurt: "minecraft:entity.wolf.hurt",
             death: "minecraft:entity.wolf.death",
         })

--- a/events/smash/src/module/kits/zombie.rs
+++ b/events/smash/src/module/kits/zombie.rs
@@ -32,6 +32,7 @@ impl Module for Zombie {
             ..KitStats::default()
         })
         .sounds(KitSounds {
+            select: "minecraft:entity.zombie.ambient",
             hurt: "minecraft:entity.zombie.hurt",
             death: "minecraft:entity.zombie.death",
         })

--- a/events/smash/src/module/lobby.rs
+++ b/events/smash/src/module/lobby.rs
@@ -228,6 +228,14 @@ pub fn choose(world: &World, player: EntityView<'_>, chosen: EntityView<'_>) -> 
     let name = chosen.try_get::<&KitName>(|name| name.0).unwrap_or("");
     kit::apply(world, player, chosen);
 
+    // The kit that was chosen, not the kit the player is on: this runs inside a
+    // deferred world, where `apply`'s `(Playing, kit)` edge has been queued and
+    // not applied, so asking the player what they are playing answers with what
+    // they were playing before. See `sound::play_declared_to`. Nothing here
+    // names a kit or looks a sound up; the mob answers for itself, to the player
+    // who chose it and to nobody else.
+    sound::play_declared_to(world.into(), chosen, sound::PlaysOnSelect, player);
+
     if let Some(id) = player.try_get::<&PlayerId>(|p| *p) {
         let hotbar = kit::hotbar(player);
         world.get::<&ServerHandle>(|server| {

--- a/events/smash/src/module/selector.rs
+++ b/events/smash/src/module/selector.rs
@@ -58,9 +58,9 @@ use crate::{
     flecs_ext::EntityViewExt,
     module::{
         kit::{self, KitMob, KitName},
-        lobby,
+        lobby, sound,
     },
-    server::{Channel, NamedColor, PlayerId, ServerHandle, Text},
+    server::{Channel, NamedColor, PlayerId, ServerHandle, Sound, SoundCategory, Text},
 };
 
 /// Tag on a selector podium.
@@ -133,6 +133,17 @@ pub const FREE_BLOCK: &str = "minecraft:lime_wool";
 
 /// The wool a taken podium stands on. See [`FREE_BLOCK`].
 pub const TAKEN_BLOCK: &str = "minecraft:red_wool";
+
+/// The colour a free mob's nameplate is drawn in, and a taken one's.
+///
+/// The same pair as [`FREE_BLOCK`] and [`TAKEN_BLOCK`], on purpose: the wool
+/// and the nameplate are one signal drawn at two heights rather than two facts
+/// that can drift, and both are computed from [`kit::claims`] by the two
+/// functions below. What the second height buys is reach. Wool is at a
+/// player's feet in the middle of a lobby people are standing around in, and a
+/// nameplate renders over whatever is in front of it from anywhere in the hub.
+pub const FREE_COLOR: NamedColor = NamedColor::Green;
+pub const TAKEN_COLOR: NamedColor = NamedColor::Red;
 
 /// The y of a podium's wool, in the hub's local coordinates.
 ///
@@ -278,6 +289,41 @@ pub fn plinths(world: &World) -> Vec<(IVec3, &'static str)> {
         .collect()
 }
 
+/// What one podium's mob is called, and in what colour. Pure.
+///
+/// The kit's name and nothing else. Not the holder's, though the holder is
+/// known here and `taken_message` already formats one: fifteen mobs each
+/// captioned with somebody's IGN is a paragraph strung across the middle of
+/// the hub, and it answers a question a player only asks after they have been
+/// refused. The colour carries the claim in no characters at all, which is
+/// what keeps a ring of fifteen readable. Whose it is stays where it was, on
+/// the action bar of the click that was refused.
+#[must_use]
+pub fn nameplate(kit: &str, taken: bool) -> Text {
+    Text::text(kit.to_owned()).color(if taken { TAKEN_COLOR } else { FREE_COLOR })
+}
+
+/// What the mob on each podium should currently be called.
+///
+/// Derived from the live claims on every call and returned rather than
+/// written, exactly as [`plinths`] is and for the same reason: the rule is
+/// then testable with no Minecraft world anywhere near it, and the host is
+/// what compares this against the names the mobs are wearing.
+#[must_use]
+pub fn nameplates(world: &World) -> Vec<(Entity, Text)> {
+    let claims = kit::claims(world);
+    podiums(world)
+        .into_iter()
+        .filter_map(|(podium, _, kit)| {
+            let name = world
+                .entity_from_id(kit)
+                .try_get::<&KitName>(|name| name.0)?;
+            let taken = claims.iter().any(|claim| claim.kit == kit);
+            Some((podium, nameplate(name, taken)))
+        })
+        .collect()
+}
+
 /// Which mob stands on each podium, and where.
 ///
 /// Names rather than anything typed, because the game half must not know what
@@ -315,6 +361,21 @@ pub struct Offer {
     pub wool: &'static str,
     /// The mob standing on it, by vanilla entity id.
     pub mob: &'static str,
+    /// The name the mob is wearing over its head, as plain text.
+    ///
+    /// The rendered string and not the component, because what a gate can
+    /// read off the wire is a name and a colour, and the colour is
+    /// [`wool`](Self::wool)'s question already. A client checks this against
+    /// the `custom_name` in the mob's entity metadata.
+    pub label: String,
+    /// The vanilla sound event picking this mob plays, read off the kit's own
+    /// `(PlaysOnSelect, sound)` edge.
+    ///
+    /// Published so that a gate can hold the sound it hears against the
+    /// server's own declaration rather than against a table of fifteen strings
+    /// copied into Python, which would be a second registry and would go on
+    /// passing after the first one changed.
+    pub select_sound: Option<&'static str>,
     /// Whoever is playing this mob, by name. Derived from `(Playing, kit)`.
     pub held_by: Option<String>,
 }
@@ -343,6 +404,9 @@ pub fn manifest(world: &World) -> Vec<Offer> {
                 mob: entry
                     .try_get::<&KitMob>(|mob| mob.0)
                     .unwrap_or(kit::DEFAULT_MOB),
+                label: nameplate(name, taken).plain(),
+                select_sound: sound::declared(entry, sound::PlaysOnSelect)
+                    .map(|declared| declared.id),
                 held_by: claims
                     .iter()
                     .find(|claim| claim.kit == kit)
@@ -417,13 +481,18 @@ fn take(world: &World, player: EntityView<'_>, kit: Entity) {
 /// under the mob was already red before the click, so this explains a refusal
 /// rather than delivering the news.
 ///
-/// No sound. A refusal cue would be a real improvement and it belongs with the
-/// rest of the audio work rather than bolted on here.
+/// And a sound, which is the first-line answer: a player whose click did
+/// nothing learns that from their ears before they have read anything. It is
+/// [`sound::SELECTION_REFUSED`] and not the mob's own voice, because hearing
+/// the Wolf when you failed to become the Wolf is the wrong answer said
+/// confidently. To the clicker alone, for the same reason the selection sound
+/// is.
 fn refuse(world: &World, player: EntityView<'_>, reason: &str) {
     let Some(id) = player.try_get::<&PlayerId>(|id| *id) else {
         return;
     };
     world.get::<&ServerHandle>(|server| {
+        server.play_sound_to(id, Sound::new(sound::SELECTION_REFUSED, SoundCategory::Ui));
         server.send_message(
             id,
             Channel::ActionBar,

--- a/events/smash/src/module/sound.rs
+++ b/events/smash/src/module/sound.rs
@@ -7,14 +7,16 @@
 //! itself, reached the same way everything else about an ability is reached, so
 //! there is one registry and it is the world.
 //!
-//! Three relationships, named for the occasion rather than for the sound:
+//! Four relationships, named for the occasion rather than for the sound:
 //!
 //! * `(PlaysOnCast, sound)` on an ability -- what firing it sounds like.
+//! * `(PlaysOnSelect, sound)` on a kit -- what the mob says when you pick it
+//!   off its podium.
 //! * `(PlaysOnHurt, sound)` on a kit -- what the mob you are playing says when
 //!   it is hit.
 //! * `(PlaysOnDeath, sound)` on a kit -- and when it dies.
 //!
-//! All three are `Exclusive`, because an occasion has one sound and a second
+//! All four are `Exclusive`, because an occasion has one sound and a second
 //! declaration is a correction rather than an addition. Without it a kit that
 //! redeclares gets both edges and [`declared`] answers with whichever was added
 //! first, which is a silently stale sound and no error anywhere.
@@ -80,6 +82,20 @@ impl Default for Levels {
 #[derive(Component, Debug)]
 pub struct PlaysOnCast;
 
+/// Relationship: `(PlaysOnSelect, sound)` on a kit.
+///
+/// The mob answering a right-click on its podium. Heard by the player who
+/// clicked and by nobody else, which is [`play_declared_to`] rather than
+/// [`play_kit_voice`], and the reason is the ring: fifteen podiums fit inside
+/// a radius of eight blocks and a sound at volume 1.0 carries sixteen, so a
+/// positioned selection sound is audible at every other podium in the hub. A
+/// filling lobby of eight people browsing mobs would be a wall of noise in
+/// which nobody could tell their own click from anybody else's. It is feedback
+/// about a click and not an event in the world, which is the same reading that
+/// makes [`RANGED_HITMARKER`] a unicast.
+#[derive(Component, Debug)]
+pub struct PlaysOnSelect;
+
 /// Relationship: `(PlaysOnHurt, sound)` on a kit.
 #[derive(Component, Debug)]
 pub struct PlaysOnHurt;
@@ -115,6 +131,21 @@ pub const PROJECTILE_HIT: &str = "minecraft:entity.arrow.hit";
 /// can connect forty blocks away, where a positioned sound is inaudible and the
 /// shooter learns nothing.
 pub const RANGED_HITMARKER: &str = "minecraft:entity.arrow.hit_player";
+
+/// The answer to a click on a mob somebody else is already playing.
+///
+/// A constant and not a relationship, which is the distinction this module
+/// draws everywhere else: a kit's voice belongs to the kit, but a refusal
+/// belongs to the *rule*, and the rule is the lobby's one-player-per-mob
+/// claim. Giving each kit its own refusal sound would say the Creeper refuses
+/// differently from the Wolf, which is not true and is not what a player needs
+/// to hear. What they need is the one noise vanilla already means "no" with,
+/// so that it reads as a refusal the first time rather than as a mob they
+/// might have selected.
+///
+/// This closes the thread `crate::module::selector::refuse` left open when it
+/// dropped `Cue::Denied`.
+pub const SELECTION_REFUSED: &str = "minecraft:entity.villager.no";
 
 /// One second closer to the start of the match.
 pub const COUNTDOWN_TICK: &str = "minecraft:block.note_block.hat";
@@ -345,6 +376,44 @@ pub fn play_kit_voice(
     play_declared(world, kit, occasion, at);
 }
 
+/// Play whatever `subject` declares for `occasion`, to `player` alone, at their
+/// own ears.
+///
+/// `subject` is passed in rather than found through the player's
+/// `(Playing, kit)` edge, and that is not a style choice. Every caller of this
+/// reaches it from inside a flecs system or observer, where the world is
+/// deferred: an `add` made a line earlier has been *queued* and not applied, so
+/// `player.target(Playing, 0)` answers with the kit the player had before. On a
+/// first selection that is nothing and the mob is silent; on a later one it is
+/// the previous mob's voice, which is worse. The mock-seam tests could not see
+/// either, because a test calls `choose` directly and nothing is deferred;
+/// `tools/smash-selector.py` is what found it, and
+/// `choosing_a_kit_plays_that_kit_s_voice_to_the_chooser_alone` now runs inside
+/// `World::defer` so a Rust test would too.
+///
+/// The sound is still declared as a relationship on the kit and still reached by
+/// following it. What is dropped is only the hop from the player to the kit, in
+/// the one case where the caller is holding the kit already.
+pub fn play_declared_to(
+    world: WorldRef<'_>,
+    subject: EntityView<'_>,
+    occasion: impl IntoEntity,
+    player: EntityView<'_>,
+) {
+    let Some(sound) = declared(subject, occasion) else {
+        return;
+    };
+    play_to(world, player, sound);
+}
+
+/// Play `sound` to `player` alone, at their own ears.
+pub fn play_to(world: WorldRef<'_>, player: EntityView<'_>, sound: Sound) {
+    let Some(id) = player.try_get::<&PlayerId>(|id| *id) else {
+        return;
+    };
+    world.get::<&ServerHandle>(|server| server.play_sound_to(id, sound));
+}
+
 /// Play `sound` at `at`, for everyone close enough to hear it.
 pub fn play_at(world: WorldRef<'_>, at: Vec3, sound: Sound) {
     world.get::<&ServerHandle>(|server| server.play_sound(at, sound));
@@ -364,6 +433,7 @@ impl Module for SoundModule {
         // and, for one of them, what it does not.
         for relationship in [
             world.component::<PlaysOnCast>().id(),
+            world.component::<PlaysOnSelect>().id(),
             world.component::<PlaysOnHurt>().id(),
             world.component::<PlaysOnDeath>().id(),
         ] {

--- a/events/smash/src/terrain.rs
+++ b/events/smash/src/terrain.rs
@@ -17,16 +17,22 @@
 use flecs_ecs::prelude::*;
 use glam::{I16Vec2, IVec3, Vec3};
 use hyperion::{
-    BlockKind, BlockState,
+    BlockKind, BlockState, Prev,
     net::Channel as EntityChannel,
     runtime::AsyncRuntime,
     simulation::{
-        Pitch, Position as MobPosition, Spawn, Uuid, Velocity, Yaw, blocks::Blocks,
+        Pitch, Position as MobPosition, Spawn, Uuid, Velocity, Yaw,
+        blocks::Blocks,
         entity_kind::EntityKind,
+        metadata::{
+            MetadataChanges,
+            entity::{CustomName, CustomNameVisible},
+        },
     },
 };
 
 use crate::{
+    flecs_ext::EntityViewExt,
     map::{self, MapSpec, parse},
     module::{
         arena::Arena,
@@ -34,7 +40,7 @@ use crate::{
         player::Player,
         selector,
     },
-    server::{PlayerId, ServerHandle},
+    server::{PlayerId, ServerHandle, Text},
 };
 
 /// Blocks between one region's centre and the next.
@@ -262,6 +268,44 @@ impl Module for MapModule {
                 }
             });
 
+        // The nameplates, recomputed from who is playing what and written only
+        // where they disagree with the mob that is wearing one.
+        //
+        // A poll beside `smash::render_podiums` rather than an observer, for
+        // the same reason that one is: a mob is freed most often by its holder
+        // disconnecting, which destroys an entity rather than removing an edge
+        // anything here could watch. `selector::nameplates` is the only place
+        // that says what a mob should be called, and this writes the
+        // difference.
+        world
+            .system_named::<()>("smash::render_nameplates")
+            .run(|mut it| {
+                while it.next() {
+                    let world = it.world();
+                    let wanted: std::collections::HashMap<_, _> =
+                        selector::nameplates(&world).into_iter().collect();
+                    world
+                        .query::<()>()
+                        .with((selector::StandsOn, id::<flecs::Wildcard>()))
+                        .build()
+                        .each_entity(|mob, ()| {
+                            let Some(podium) = mob.find_target(selector::StandsOn, |_| true) else {
+                                return;
+                            };
+                            let Some(label) = wanted.get(&podium.id()) else {
+                                return;
+                            };
+                            let current = mob
+                                .try_get::<&CustomName>(|name| (**name).clone())
+                                .unwrap_or_default();
+                            if current.as_ref() == Some(label) {
+                                return;
+                            }
+                            mob.set(CustomName::new(Some(label.clone())));
+                        });
+                }
+            });
+
         // Back to the hub when the results screen is over. The game half ends a
         // match by resetting lives and health; where players physically go is a
         // hosting question, so it is answered here.
@@ -301,6 +345,25 @@ fn stamp_podiums(blocks: &mut Blocks, world: &World) {
     }
 }
 
+/// Dress one podium mob in the name its kit declares.
+///
+/// Four writes and not one, because a metadata field only reaches a client
+/// that is already watching if the entity is set up to notice it changing.
+/// `CustomName` alone is enough for the subscribe packet, which is what a
+/// player walking up to the ring receives; the `(Prev, CustomName)` pair and
+/// `MetadataChanges` are what hyperion's `exchange_` system and
+/// `entity_metadata_sync` need to broadcast a *later* change, which is what
+/// makes the name go red the moment somebody takes the mob.
+///
+/// `Prev` starts equal to the name rather than at its default, so standing the
+/// ring up does not queue fifteen changes nobody has subscribed to yet.
+fn label_mob(mob: EntityView<'_>, label: Text) {
+    mob.set_pair::<Prev, _>(CustomName::new(Some(label.clone())));
+    mob.set(CustomName::new(Some(label)));
+    mob.set(CustomNameVisible::new(true));
+    mob.add(id::<MetadataChanges>());
+}
+
 /// Stand a real mob on each podium.
 ///
 /// The half of the selector the game cannot build for itself: `selector` says
@@ -318,6 +381,7 @@ fn stamp_podiums(blocks: &mut Blocks, world: &World) {
 /// a block that is not a block: a podium with nothing on it is a kit nobody
 /// can pick, and the hole would be the only report.
 fn stand_mobs(world: &World) {
+    let labels: std::collections::HashMap<_, _> = selector::nameplates(world).into_iter().collect();
     for (podium, at, name) in selector::mobs(world) {
         let kind = EntityKind::named(name).unwrap_or_else(|| panic!("{name:?} is not a mob"));
         #[expect(
@@ -325,7 +389,7 @@ fn stand_mobs(world: &World) {
             reason = "hub-local coordinates, tens of blocks"
         )]
         let position = Vec3::new(at.x as f32 + 0.5, at.y as f32, at.z as f32 + 0.5);
-        world
+        let mob = world
             .entity()
             .add_enum(kind)
             .set(MobPosition::new(position.x, position.y, position.z))
@@ -335,8 +399,17 @@ fn stand_mobs(world: &World) {
             .set(Pitch::new(0.0))
             .set(Velocity::new(0.0, 0.0, 0.0))
             .add(id::<EntityChannel>())
-            .add((selector::StandsOn, podium))
-            .add(id::<Spawn>());
+            .add((selector::StandsOn, podium));
+
+        // Before `Spawn`, which is the tag whose observer sends `AddEntity`.
+        // A name written afterwards would still reach anybody who subscribes
+        // later, because the subscribe path re-reads the components, but
+        // anybody already in range would get the mob first and its name in a
+        // second packet.
+        if let Some(label) = labels.get(&podium) {
+            label_mob(mob, label.clone());
+        }
+        mob.add(id::<Spawn>());
     }
 }
 

--- a/events/smash/tests/selector.rs
+++ b/events/smash/tests/selector.rs
@@ -9,6 +9,8 @@
 
 mod harness;
 
+use std::collections::BTreeMap;
+
 use flecs_ecs::prelude::*;
 use glam::{IVec3, Vec3};
 use harness::Game;
@@ -22,7 +24,7 @@ use smash::{
             self, FREE_BLOCK, MAX_RADIUS, MIN_RADIUS, PLINTH_Y, Plinth, StandsOn, TAKEN_BLOCK,
         },
     },
-    server::{Channel, PlayerId, mock::Call},
+    server::{Channel, PlayerId, Text, mock::Call},
 };
 
 /// The hub's glass wall, from `maps/hub.map`.
@@ -186,6 +188,94 @@ fn every_mob_and_block_the_ring_is_made_of_is_real() {
             "{mob} is not a mob, so the server would panic while building the hub"
         );
     }
+}
+
+/// A ring of unnamed mobs is a ring you have to click to read, which is what
+/// the operator hit in a real client.
+///
+/// Every podium, because the failure this catches is one mob quietly having no
+/// name: fourteen readable tags and one blank creature nobody dares click.
+#[test]
+fn every_mob_in_the_ring_is_captioned_with_its_kit() {
+    let game = Game::new();
+    selector::build(&game.world, IVec3::ZERO);
+
+    let plates = selector::nameplates(&game.world);
+    let podiums = selector::podiums(&game.world);
+    assert_eq!(
+        plates.len(),
+        podiums.len(),
+        "{} podiums and {} nameplates",
+        podiums.len(),
+        plates.len()
+    );
+
+    let by_podium: BTreeMap<Entity, Text> = plates.into_iter().collect();
+    for (podium, _, kit) in podiums {
+        let name = game
+            .world
+            .entity_from_id(kit)
+            .try_get::<&KitName>(|name| name.0)
+            .expect("a registered kit has a name");
+        let plate = by_podium
+            .get(&podium)
+            .unwrap_or_else(|| panic!("the podium offering {name} has no nameplate"));
+        assert_eq!(
+            plate.plain(),
+            name,
+            "the podium offering {name} is captioned {:?}",
+            plate.plain()
+        );
+    }
+}
+
+/// The caption says whether the mob is free, in the colour the wool under it
+/// is, and that is the whole of the difference between the two states.
+///
+/// Held against `plinths` rather than against a literal, because the claim is
+/// that the two readouts are one signal: a change that recoloured the wool and
+/// left the tag alone would pass a test that only read the tag.
+#[test]
+fn a_taken_mob_is_captioned_in_the_same_colour_as_its_wool() {
+    let mut game = lobby_with_podiums();
+    let player = game.player("Holder", Vec3::ZERO);
+    let wolf = kit::by_name(&game.world, "Wolf").expect("the registry has Wolf");
+
+    let free = selector::nameplate("Wolf", false);
+    let taken = selector::nameplate("Wolf", true);
+    assert_ne!(
+        free.style.color, taken.style.color,
+        "free and taken read identically, so the colour says nothing"
+    );
+    assert_eq!(free.plain(), taken.plain(), "the words should not change");
+
+    let plate_for = |game: &Game| {
+        let podium = selector::podiums(&game.world)
+            .into_iter()
+            .find(|(_, _, offered)| *offered == wolf.id())
+            .expect("Wolf has a podium");
+        selector::nameplates(&game.world)
+            .into_iter()
+            .find(|(entity, _)| *entity == podium.0)
+            .map(|(_, plate)| plate)
+            .expect("Wolf's podium has a nameplate")
+    };
+
+    assert_eq!(plate_for(&game).style.color, free.style.color);
+    assert_eq!(
+        plinth_block(&game, podium_for(&game, "Wolf").base),
+        FREE_BLOCK
+    );
+
+    lobby::choose(&game.world, game.world.entity_from_id(player), wolf)
+        .expect("an empty lobby refuses nothing");
+
+    assert_eq!(plate_for(&game).style.color, taken.style.color);
+    assert_eq!(
+        plinth_block(&game, podium_for(&game, "Wolf").base),
+        TAKEN_BLOCK,
+        "the wool and the caption disagree about who has the Wolf"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/events/smash/tests/sound.rs
+++ b/events/smash/tests/sound.rs
@@ -17,7 +17,7 @@ mod harness;
 use std::collections::BTreeMap;
 
 use flecs_ecs::prelude::*;
-use glam::Vec3;
+use glam::{IVec3, Vec3};
 use harness::Game;
 use hyperion::hyperion_minecraft_proto::generated::registry::SOUND_EVENT;
 use smash::{
@@ -27,9 +27,10 @@ use smash::{
         kit::{self, KitName},
         knockback::Knockback,
         lives::{self, DeathCause, Eliminated, Lives},
-        lobby::{Lobby, LobbyConfig, Phase},
+        lobby::{self, Lobby, LobbyConfig, Phase},
         player::{Energy, Health, OnGround, Position},
-        sound::{self, Levels, PlaysOnCast, PlaysOnDeath, PlaysOnHurt},
+        selector,
+        sound::{self, Levels, PlaysOnCast, PlaysOnDeath, PlaysOnHurt, PlaysOnSelect},
     },
     server::{PlayerId, Sound},
 };
@@ -119,6 +120,7 @@ fn every_sound_id_is_one_a_vanilla_client_owns() {
         let kit = game.world.entity_from_id(kit);
         let name = kit.try_get::<&KitName>(|n| n.0).unwrap_or("<unnamed>");
         for (occasion, declared) in [
+            ("select", sound::declared(kit, PlaysOnSelect)),
             ("hurt", sound::declared(kit, PlaysOnHurt)),
             ("death", sound::declared(kit, PlaysOnDeath)),
         ] {
@@ -134,6 +136,7 @@ fn every_sound_id_is_one_a_vanilla_client_owns() {
     }
 
     for (what, id) in [
+        ("selection refused", sound::SELECTION_REFUSED),
         ("impact", sound::IMPACT),
         ("projectile hit", sound::PROJECTILE_HIT),
         ("ranged hitmarker", sound::RANGED_HITMARKER),
@@ -169,6 +172,7 @@ fn every_kit_declares_a_voice() {
         let kit = game.world.entity_from_id(kit);
         let name = kit.try_get::<&KitName>(|n| n.0).unwrap_or("<unnamed>");
         for (occasion, declared) in [
+            ("select", sound::declared(kit, PlaysOnSelect)),
             ("hurt", sound::declared(kit, PlaysOnHurt)),
             ("death", sound::declared(kit, PlaysOnDeath)),
         ] {
@@ -178,6 +182,171 @@ fn every_kit_declares_a_voice() {
         }
     }
     assert!(mute.is_empty(), "{}", mute.join("\n"));
+}
+
+/// Fifteen mobs that all answer alike are one mob as far as a player's ears go.
+///
+/// The failure this exists for is a kit added by copying its neighbour's file:
+/// the sound is present, `is_vanilla` passes, the declaration sweep passes, and
+/// the new mob greets you in somebody else's voice. Only comparing them to each
+/// other finds that.
+#[test]
+fn no_two_kits_answer_a_click_alike() {
+    let game = Game::new();
+    let mut by_sound: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for kit in kit::registry(&game.world) {
+        let kit = game.world.entity_from_id(kit);
+        let name = kit.try_get::<&KitName>(|n| n.0).unwrap_or("<unnamed>");
+        let Some(declared) = sound::declared(kit, PlaysOnSelect) else {
+            continue;
+        };
+        by_sound.entry(declared.id).or_default().push(name);
+    }
+
+    let shared: Vec<_> = by_sound
+        .iter()
+        .filter(|(_, kits)| kits.len() > 1)
+        .map(|(sound, kits)| format!("{sound} is the voice of {kits:?}"))
+        .collect();
+    assert!(
+        shared.is_empty(),
+        "these kits answer a click with the same sound: {}",
+        shared.join("; ")
+    );
+}
+
+/// Picking a kit plays that kit's voice, to the player who picked and to
+/// nobody else.
+///
+/// The sweep that a declaration cannot pass, and the one that pins the
+/// relationship rather than the data: `choose` never names a kit or a sound, so
+/// the only thing that carries the right noise to the right player is the
+/// `(Playing, kit)` edge followed to `(PlaysOnSelect, sound)`. A wrong
+/// traversal here is silence with nothing failing anywhere else.
+///
+/// Every kit in the registry, because the failure mode the charter names is one
+/// kit quietly having none.
+#[test]
+fn choosing_a_kit_plays_that_kit_s_voice_to_the_chooser_alone() {
+    let mut game = Game::new();
+    let chooser = game.player("Chooser", Vec3::ZERO);
+    let bystander = game.player("Bystander", Vec3::new(1.0, 0.0, 0.0));
+    let chooser_id = game
+        .world
+        .entity_from_id(chooser)
+        .try_get::<&PlayerId>(|id| *id)
+        .expect("a player has an id");
+    let bystander_id = game
+        .world
+        .entity_from_id(bystander)
+        .try_get::<&PlayerId>(|id| *id)
+        .expect("a player has an id");
+
+    let kits = kit::registry(&game.world);
+    assert!(
+        kits.len() >= 15,
+        "the registry only found {} kits",
+        kits.len()
+    );
+
+    let mut failures = Vec::new();
+    for kit in kits {
+        let kit = game.world.entity_from_id(kit);
+        let name = kit.try_get::<&KitName>(|n| n.0).unwrap_or("<unnamed>");
+        let declared = sound::declared(kit, PlaysOnSelect)
+            .unwrap_or_else(|| panic!("{name} declares no selection sound"));
+
+        let _discarded = game.server.take();
+        // Inside `defer`, which is the condition the real caller runs under and
+        // the one this test used to miss. `selector::click_mob` is reached from
+        // a flecs system, so `kit::apply`'s `(Playing, kit)` edge is queued
+        // rather than applied while `choose` is still running. A `choose` that
+        // asked the player what they were playing in order to find the sound
+        // answered with the previous kit, which is silence on a first selection
+        // and the wrong mob's voice on every one after. Called directly, as this
+        // test did before, nothing is deferred and the bug is invisible; it took
+        // `tools/smash-selector.py` and a real client to find it.
+        game.world.defer(|| {
+            lobby::choose(&game.world, game.world.entity_from_id(chooser), kit)
+                .unwrap_or_else(|reason| panic!("{name} was refused in an empty lobby: {reason}"));
+        });
+
+        let heard = game.server.sounds_to(chooser_id);
+        if !heard.iter().any(|sound| sound.id == declared.id) {
+            failures.push(format!(
+                "{name} declares {} and choosing it played {heard:?}",
+                declared.id
+            ));
+        }
+        let overheard = game.server.sounds_to(bystander_id);
+        if !overheard.is_empty() {
+            failures.push(format!(
+                "choosing {name} was audible to somebody who did not choose it: {overheard:?}"
+            ));
+        }
+        let positioned = game.server.sounds();
+        if !positioned.is_empty() {
+            failures.push(format!(
+                "choosing {name} put a sound in the world rather than at the chooser's ears: \
+                 {positioned:?}"
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// A click on a mob somebody else has says no, out loud, and not in that mob's
+/// voice.
+///
+/// The second half matters as much as the first: hearing the Wolf when the Wolf
+/// is exactly what you failed to get is a confident wrong answer, and it is the
+/// shape this would take if the refusal reached for the kit's own relationship.
+#[test]
+fn a_refused_click_says_no_and_does_not_answer_in_the_mob_s_voice() {
+    let mut game = Game::new();
+    let holder = game.player("Holder", Vec3::ZERO);
+    let latecomer = game.player("Latecomer", Vec3::new(1.0, 0.0, 0.0));
+    let latecomer_id = game
+        .world
+        .entity_from_id(latecomer)
+        .try_get::<&PlayerId>(|id| *id)
+        .expect("a player has an id");
+
+    // The ring is stood up by the host at boot, which no test has; `build` is
+    // the same call `terrain.rs` makes and is what gives `click` a podium to
+    // resolve.
+    selector::build(&game.world, IVec3::ZERO);
+
+    let wolf = kit::by_name(&game.world, "Wolf").expect("the registry lost Wolf");
+    lobby::choose(&game.world, game.world.entity_from_id(holder), wolf)
+        .expect("an empty lobby refuses nothing");
+    let voice = sound::declared(wolf, PlaysOnSelect).expect("Wolf declares a selection sound");
+
+    let _discarded = game.server.take();
+    let refused = lobby::choose(&game.world, game.world.entity_from_id(latecomer), wolf);
+    assert!(refused.is_err(), "a taken mob was handed out twice");
+    selector::click(
+        &game.world,
+        game.world.entity_from_id(latecomer),
+        selector::podiums(&game.world)
+            .into_iter()
+            .find(|(_, _, kit)| *kit == wolf.id())
+            .expect("Wolf has a podium")
+            .1
+            .base,
+    );
+
+    let heard = game.server.sounds_to(latecomer_id);
+    assert!(
+        heard
+            .iter()
+            .any(|sound| sound.id == sound::SELECTION_REFUSED),
+        "a refused click made no noise; the log is {heard:?}"
+    );
+    assert!(
+        !heard.iter().any(|sound| sound.id == voice.id),
+        "a refused click answered in the mob's own voice: {heard:?}"
+    );
 }
 
 /// The sweep that a declaration alone cannot pass: fire every ability in the

--- a/flake.nix
+++ b/flake.nix
@@ -360,6 +360,61 @@
           gameServerPort = 35565;
           proxyPort = 25565;
 
+          # How far each end to end gate's default ports sit above those two.
+          #
+          # One attribute set rather than a number written into each gate's
+          # script, because two gates claiming one offset is invisible where the
+          # numbers are apart: `completions-e2e` and `smash-selector-e2e` both
+          # said 4000 for weeks (ENG-10834), and on darwin, where a build shares
+          # the host's loopback, the loser of that race fails with "address
+          # already in use" from a gate it has nothing to do with. Collected
+          # here, `e2ePortsDistinct` below can say so at eval time.
+          e2eOffsets = {
+            e2e = 1000;
+            smash-e2e = 2000;
+            smash-map-e2e = 3000;
+            smash-selector-e2e = 4000;
+            smash-identity-e2e = 5000;
+            completions-e2e = 6000;
+          };
+
+          # Two gates on one offset, as a build failure rather than as a race.
+          #
+          # An eval-time check and not a runtime one: the failure it catches is a
+          # number, it costs nothing to look at, and the alternative is finding
+          # out from whichever unlucky gate lost the port. The names are reported
+          # rather than only the count, because "two gates collide" is not
+          # actionable and "these two gates collide" is.
+          e2ePortsDistinct =
+            let
+              offsets = lib.attrValues e2eOffsets;
+              duplicated = lib.filter (
+                offset: lib.length (lib.filter (other: other == offset) offsets) > 1
+              ) offsets;
+              colliding = lib.filter (name: lib.elem e2eOffsets.${name} duplicated) (
+                lib.attrNames e2eOffsets
+              );
+            in
+            pkgs.runCommand "hyperion-e2e-ports-distinct" { } (
+              if duplicated == [ ] then
+                ''
+                  echo "ok: ${toString (lib.length offsets)} end to end gates, ${
+                    toString (lib.length offsets)
+                  } distinct port offsets"
+                  touch "$out"
+                ''
+              else
+                ''
+                  echo "FAIL: these gates claim the same port offset: ${
+                    lib.concatStringsSep ", " colliding
+                  }" >&2
+                  echo "Every gate in e2eOffsets needs its own number, or two of" >&2
+                  echo "them running at once fight over one port and the loser" >&2
+                  echo "fails with address already in use." >&2
+                  exit 1
+                ''
+            );
+
           # Generated rather than committed as YAML: the ports and cert paths
           # then have one source of truth shared with the standalone apps above.
           # Commands are single-line: a backslash continuation is literal in a
@@ -562,8 +617,8 @@
                 # a fresh clone runs this without a setup step first.
                 export HYPERION_E2E_CERTS="${e2e.certs}"
 
-                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + 1000)}}"
-                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + 1000)}}"
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.e2e)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.e2e)}}"
 
                 exec hyperion-e2e-driver "$@"
               '';
@@ -581,8 +636,8 @@
               text = ''
                 export HYPERION_EVENT=smash
                 export HYPERION_E2E_CLIENT=tools/smash-match.py
-                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + 2000)}}"
-                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + 2000)}}"
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.smash-e2e)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.smash-e2e)}}"
                 exec "${lib.getExe runners.e2e}" "$@"
               '';
             };
@@ -601,8 +656,8 @@
               text = ''
                 export HYPERION_EVENT=smash
                 export HYPERION_E2E_CLIENT=tools/smash-selector.py
-                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + 4000)}}"
-                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + 4000)}}"
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.smash-selector-e2e)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.smash-selector-e2e)}}"
                 exec "${lib.getExe runners.e2e}" "$@"
               '';
             };
@@ -626,8 +681,8 @@
               text = ''
                 export HYPERION_EVENT=smash
                 export HYPERION_E2E_CLIENT=tools/smash-map-check.py
-                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + 3000)}}"
-                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + 3000)}}"
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.smash-map-e2e)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.smash-map-e2e)}}"
                 exec "${lib.getExe runners.e2e}" "$@"
               '';
             };
@@ -638,15 +693,22 @@
             # `smash-e2e` and `smash-map-e2e` both prove things about a world.
             # This one never leaves the hub: it reads the command graph the
             # server sends on join and then presses tab, which is the whole of
-            # the completion path and touches nothing else. Its ports default
-            # off `smash-map-e2e`'s so all four gates can run at once.
+            # the completion path and touches nothing else.
+            #
+            # +6000 and not +4000, which is what it claimed until ENG-10834:
+            # `smash-selector-e2e` claims that offset too, so running the two
+            # side by side had one of them lose the port to the other. On darwin
+            # a build shares the host's loopback, so the loser fails with
+            # "address already in use" from a gate it has nothing to do with.
+            # Every offset in this file is now distinct, which the check below
+            # is what says.
             completions-e2e = {
               deps = [ pkgs.git ];
               text = ''
                 export HYPERION_EVENT=smash
                 export HYPERION_E2E_CLIENT=tools/completions-check.py
-                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + 4000)}}"
-                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + 4000)}}"
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.completions-e2e)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.completions-e2e)}}"
                 exec "${lib.getExe runners.e2e}" "$@"
               '';
             };
@@ -664,8 +726,8 @@
               text = ''
                 export HYPERION_EVENT=smash
                 export HYPERION_E2E_CLIENT=tools/identity-check.py
-                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + 5000)}}"
-                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + 5000)}}"
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.smash-identity-e2e)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.smash-identity-e2e)}}"
                 exec "${lib.getExe runners.e2e}" "$@"
               '';
             };
@@ -881,6 +943,9 @@
 
             # The pinned world URL still has to be the one the server asks for.
             genmap-url-pinned = e2e.genMapUrlPinned;
+
+            # No two end to end gates may claim one port. See `e2eOffsets`.
+            e2e-ports-distinct = e2ePortsDistinct;
 
             # A colour reaches a client as a component field or not at all.
             smash-text-no-legacy-formatting = textGate;

--- a/tools/identity-check.py
+++ b/tools/identity-check.py
@@ -182,7 +182,19 @@ class Probe(match.MatchClient):
             actions, entries = parse_player_info_update(payload)
             for entry in entries:
                 known = self.roster.setdefault(entry["uuid"], {"properties": {}})
-                known.update(entry)
+                # Field by field, and the properties merged rather than
+                # replaced. A `PlayerInfoUpdate` that carries only a gamemode
+                # says nothing about a profile's properties, and every entry
+                # this parser builds starts with an empty `properties`, so a
+                # wholesale update forgets the texture the client was told about
+                # a moment earlier. The skin check below then reads `None` and
+                # reports a skin that never arrived, which was luck rather than
+                # design every time this gate passed.
+                for key, value in entry.items():
+                    if key == "properties":
+                        known["properties"].update(value)
+                    else:
+                        known[key] = value
             self.log(
                 "<- PlayerInfoUpdate actions=0x%02X %s"
                 % (

--- a/tools/smash-selector.py
+++ b/tools/smash-selector.py
@@ -6,7 +6,7 @@ before it: can a player walk up to the ring of podiums in the middle of the hub,
 right-click a mob and be playing it, and does the game answer honestly when the
 mob is already somebody else's.
 
-Four claims, and each one is checked against what a client was actually sent
+Nine claims, and each one is checked against what a client was actually sent
 rather than against a return value:
 
   1. a right-click on a podium picks that mob;
@@ -15,7 +15,31 @@ rather than against a return value:
   3. the wool under the mob goes green to red on the wire when it is taken, and
      back to green when the holder disconnects, which frees the mob;
   4. a selection made in the hub survives the countdown, and a click after the
-     match commits is refused.
+     match commits is refused;
+  5. every mob in the ring arrives wearing its kit's name, always visible, so a
+     player does not have to click one to learn what it is;
+  6. a click plays the mob's own declared sound, to the player who clicked;
+  7. and to that player alone, so fifteen people browsing the ring is not a
+     wall of noise;
+  8. all fifteen mobs answer in different voices, swept by clicking every one of
+     them, because the failure mode is one kit quietly having none;
+  9. the OTHER player sees the selecting player's skin change on the wire, and
+     the selecting player is not respawned to make that happen.
+
+Claim 9 is the one that reaches furthest outside this file. A skin change used
+to be published to the wearer as `PlayerInfoRemove`, `PlayerInfoUpdate` and a
+`Respawn`, and the respawn is what left a real client on "Loading terrain..."
+forever: `handleRespawn` puts `ReceivingLevelScreen` back up and only a second
+`LEVEL_CHUNKS_LOAD_START` takes it down. So this gate asserts both directions.
+No respawn is sent, and if one ever is, terrain and that game event must follow
+it. A test that counted chunk packets would have passed the bug.
+
+Claim 9 also needs a client that behaves like a real one in a way no other
+scripted client here does: a vanilla client puts its own profile id in
+`ServerboundHelloPacket`, and hyperion answers that by asking Mojang for a skin
+which arrives after the join. Every other tool in this directory sends sixteen
+zero bytes and takes a different branch, which is exactly why the hang shipped
+through five green gates. `--real-profile` is the default here.
 
 Nothing here knows where a podium is. The ring is generated from the roster at
 boot, so the server is asked: `/podiums` answers with one JSON object per
@@ -39,6 +63,7 @@ import re
 import struct
 import sys
 import time
+import uuid
 
 TOOLS = pathlib.Path(__file__).resolve().parent
 
@@ -82,6 +107,40 @@ S2C_PLAYER_POSITION = world.S2C_PLAYER_POSITION
 S2C_ADD_ENTITY = 0x01
 S2C_SET_ACTION_BAR_TEXT = 0x57
 S2C_SYSTEM_CHAT = 0x79
+S2C_SET_ENTITY_DATA = 0x63
+S2C_SOUND = match.S2C_SOUND
+S2C_PLAYER_INFO_REMOVE = 0x45
+S2C_PLAYER_INFO_UPDATE = 0x46
+S2C_RESPAWN = 0x52
+S2C_GAME_EVENT = 0x26
+
+# `ClientboundGameEventPacket.LEVEL_CHUNKS_LOAD_START`, which is what takes
+# `ReceivingLevelScreen` down. See the module docstring.
+LEVEL_CHUNKS_LOAD_START = 13
+
+# `PlayerInfoActions`, the same bit order as
+# `ClientboundPlayerInfoUpdatePacket.Action`.
+ADD_PLAYER = 1 << 0
+INITIALIZE_CHAT = 1 << 1
+UPDATE_GAME_MODE = 1 << 2
+UPDATE_LISTED = 1 << 3
+UPDATE_LATENCY = 1 << 4
+UPDATE_DISPLAY_NAME = 1 << 5
+UPDATE_LIST_ORDER = 1 << 6
+UPDATE_HAT = 1 << 7
+
+# `net.minecraft.world.entity.Entity`'s field indices, from
+# crates/hyperion/src/simulation/metadata/entity.rs, and the serializer ids
+# those two fields were declared with, from `EntityDataSerializer`. The client
+# rejects a value whose serializer disagrees, so reading them back is a check on
+# both halves.
+DATA_CUSTOM_NAME = 2
+DATA_CUSTOM_NAME_VISIBLE = 3
+SERIALIZER_OPTIONAL_COMPONENT = 6
+SERIALIZER_BOOLEAN = 8
+
+# `ClientboundSetEntityDataPacket.EOF_MARKER`.
+METADATA_EOF = 0xFF
 
 # events/smash/src/command.rs.
 PODIUM_PREFIX = "smash-podium "
@@ -96,6 +155,12 @@ TAKEN_BLOCK = "minecraft:red_wool"
 # `full_players`, which is the shortest countdown the lobby will run and so the
 # cheapest way to reach a committed match.
 FULL_PLAYERS = 8
+
+# How many lines a complete run reports. More than the nine claims, because two
+# of the checks answer several: the roster sweep proves the sound, its audience
+# and its distinctness, and the skin check proves both what the other client
+# sees and what the wearer was spared.
+CLAIMS = 13
 
 ON_GROUND = 1
 # `smash-match.py`'s numbers: how far a step may carry a client and how often
@@ -130,6 +195,122 @@ def stamp(started):
     return "%7.2fs" % (time.time() - started)
 
 
+# The committed skins, which are the only thing a texture property on the wire
+# can honestly be checked against: the server reads these files with
+# `include_str!`, so comparing against them is comparing against the same bytes
+# rather than against a description of them.
+SKINS = ROOT / "events" / "smash" / "skins"
+
+
+def skin_payload(kit):
+    """The committed `(textures, signature)` pair for a kit, or `None`.
+
+    Keyed on the kit name lowercased with spaces squashed, which is how
+    `kit_skin!("iron_golem")` names its files. `None` rather than an exception
+    so a roster that grows a kit with no skin yet fails with the gate's own
+    wording.
+    """
+    stem = kit.lower().replace(" ", "_")
+    value = SKINS / (stem + ".value")
+    signature = SKINS / (stem + ".sig")
+    if not value.exists() or not signature.exists():
+        return None
+    return value.read_text().strip(), signature.read_text().strip()
+
+
+def take_optional_string(payload, offset):
+    present = payload[offset]
+    offset += 1
+    if not present:
+        return None, offset
+    return base.take_string(payload, offset)
+
+
+def parse_player_info_update(payload):
+    """Every entry in one `PlayerInfoUpdate`, as far as the actions describe.
+
+    Nothing in the body says how long an entry is, so a reader that stops
+    understanding a field loses the rest of the packet. Raising rather than
+    returning what was read so far is deliberate: a half-read packet is a
+    disagreement about the wire format, not a shorter list of players.
+    """
+    actions = payload[0]
+    count, offset = take_var_int(payload, 1)
+    entries = []
+    for _ in range(count):
+        entry = {"uuid": payload[offset : offset + 16].hex(), "properties": {}}
+        offset += 16
+        if actions & ADD_PLAYER:
+            entry["name"], offset = base.take_string(payload, offset)
+            properties, offset = take_var_int(payload, offset)
+            for _ in range(properties):
+                name, offset = base.take_string(payload, offset)
+                value, offset = base.take_string(payload, offset)
+                signature, offset = take_optional_string(payload, offset)
+                entry["properties"][name] = (value, signature)
+        if actions & INITIALIZE_CHAT:
+            raise ValueError("this server does not sign chat, so it cannot send a session")
+        if actions & UPDATE_GAME_MODE:
+            entry["game_mode"], offset = take_var_int(payload, offset)
+        if actions & UPDATE_LISTED:
+            entry["listed"] = bool(payload[offset])
+            offset += 1
+        if actions & UPDATE_LATENCY:
+            _, offset = take_var_int(payload, offset)
+        if actions & UPDATE_DISPLAY_NAME:
+            present = payload[offset]
+            offset += 1
+            if present:
+                raise ValueError("PlayerInfoUpdate carried a display name")
+        if actions & UPDATE_LIST_ORDER:
+            _, offset = take_var_int(payload, offset)
+        if actions & UPDATE_HAT:
+            offset += 1
+        entries.append(entry)
+    if offset != len(payload):
+        raise ValueError(
+            "PlayerInfoUpdate has %d trailing byte(s); the action set and this "
+            "reader disagree" % (len(payload) - offset)
+        )
+    return actions, entries
+
+
+def decode_entity_metadata(payload):
+    """The two `Entity`-level fields this gate reads, out of one SetEntityData.
+
+    Only the two, and every other entry is skipped by its serializer rather
+    than decoded: a reader that had to understand all forty serializers to see
+    a name would be a second copy of the protocol, and the entries this gate
+    cares about are always the same two. An entry whose serializer is not one
+    of the ones handled below ends the read, because the run is
+    self-delimiting only if every length is known.
+    """
+    entity_id, offset = take_var_int(payload)
+    fields = {}
+    while offset < len(payload):
+        index = payload[offset]
+        offset += 1
+        if index == METADATA_EOF:
+            break
+        serializer, offset = take_var_int(payload, offset)
+        if serializer == SERIALIZER_OPTIONAL_COMPONENT:
+            present = payload[offset]
+            offset += 1
+            if present:
+                text, offset = take_nbt_string(payload, offset)
+            else:
+                text = None
+            fields[index] = text
+        elif serializer == SERIALIZER_BOOLEAN:
+            fields[index] = bool(payload[offset])
+            offset += 1
+        else:
+            # Anything else is a field this gate does not read, and the run
+            # cannot be walked past a length it does not know.
+            break
+    return entity_id, fields
+
+
 def block_pos(at):
     """`BlockPos.asLong`: x in the top 26 bits, z in the next 26, y in the low 12."""
     x, y, z = at
@@ -160,11 +341,73 @@ class Client(base.Client):
         # How the gate finds a podium's mob: the server says where a podium is
         # and the mob standing there is the entity at that block.
         self.entities = {}
+        # Entity id -> the `Entity`-level metadata fields this gate reads,
+        # accumulated because a client is told a name in whichever packet the
+        # server chose, at spawn or later.
+        self.metadata = {}
+        # Profile id -> the tab list entry, so a client can be asked what it
+        # believes another player looks like. Merged rather than replaced: a
+        # `PlayerInfoUpdate` that carries only a gamemode says nothing about a
+        # profile's properties, and overwriting would forget a texture the
+        # client still has.
+        self.roster = {}
+        self.sounds = []
+        # The ordering evidence for claim 9. `respawns` counts them; the two
+        # lists record what arrived after the most recent one, which is the only
+        # thing that distinguishes a repaired respawn from a client stuck on a
+        # loading screen with a full world behind it.
+        self.respawns = 0
+        self.chunks_since_respawn = 0
+        self.level_loads_since_respawn = 0
         self.last_position_sent = 0.0
         self.gone = False
 
     def _log(self, line):
         print("%s [%-3s] %s" % (stamp(self.started), self.name, line), flush=True)
+
+    def login(self):
+        """`Hello` carrying a profile id, the way a vanilla client does.
+
+        Overridden rather than inherited because `client-26.2.py` sends sixteen
+        zero bytes, which puts hyperion on the branch that hands the player an
+        empty skin synchronously. A real id sends it to the Mojang session
+        server instead and the answer lands after the join, which is the branch
+        that used to publish a `Respawn` at every real client and is therefore
+        the only branch worth testing here. See the module docstring.
+        """
+        self.claimed = uuid.uuid4()
+        self.log("-> Hello name=%s profile=%s" % (self.name, self.claimed))
+        self.send(base.C2S_HELLO, mc_string(self.name) + self.claimed.bytes)
+        while True:
+            packet_id, payload = self.recv()
+            if packet_id == base.S2C_LOGIN_COMPRESSION:
+                self.threshold, _ = take_var_int(payload)
+            elif packet_id == base.S2C_LOGIN_FINISHED:
+                self.profile_id = payload[:16].hex()
+                self.log("<- LoginFinished profile=%s" % self.profile_id)
+                self.send(base.C2S_LOGIN_ACKNOWLEDGED)
+                return
+            elif packet_id == base.S2C_LOGIN_DISCONNECT:
+                reason, _ = base.take_string(payload)
+                raise SystemExit("login refused: %s" % reason)
+
+    def texture_of(self, profile_id):
+        """The `textures` property this client believes `profile_id` wears."""
+        return self.roster.get(profile_id, {}).get("properties", {}).get("textures")
+
+    def name_over(self, entity_id):
+        """The always-visible name this client sees over `entity_id`, if any.
+
+        `None` when there is no name, and `None` when there is one the client
+        has been told not to draw: a `custom_name` without
+        `custom_name_visible` renders only when the crosshair is on the mob,
+        which is the failure the operator reported and would otherwise pass a
+        check that read the name alone.
+        """
+        fields = self.metadata.get(entity_id, {})
+        if not fields.get(DATA_CUSTOM_NAME_VISIBLE):
+            return None
+        return fields.get(DATA_CUSTOM_NAME)
 
     def enter_play(self):
         self.sock.settimeout(0.02)
@@ -396,7 +639,46 @@ class Run:
             kind, offset = take_var_int(payload, offset)
             x, y, z = struct.unpack_from(">ddd", payload, offset)
             client.entities[entity_id] = ((x, y, z), self.kinds.get(kind, "<type %d>" % kind))
+        elif packet_id == S2C_SET_ENTITY_DATA:
+            entity_id, fields = decode_entity_metadata(payload)
+            client.metadata.setdefault(entity_id, {}).update(fields)
+        elif packet_id == S2C_SOUND:
+            heard = match.take_sound(payload)
+            if heard is None:
+                self.fail(
+                    "a sound arrived as a registry id; hyperion sends no id "
+                    "table, so a client would resolve it against the wrong "
+                    "registry"
+                )
+            else:
+                client.sounds.append(heard)
+                client.log("<- sound %s" % heard[0])
+        elif packet_id == S2C_PLAYER_INFO_UPDATE:
+            try:
+                _actions, entries = parse_player_info_update(payload)
+            except ValueError as error:
+                self.fail("could not read a PlayerInfoUpdate: %s" % error)
+            else:
+                for entry in entries:
+                    known = client.roster.setdefault(entry["uuid"], {"properties": {}})
+                    # Merged field by field rather than wholesale, so a packet
+                    # that carries only a gamemode does not erase the texture
+                    # the client was told about earlier.
+                    for key, value in entry.items():
+                        if key == "properties":
+                            known["properties"].update(value)
+                        else:
+                            known[key] = value
+        elif packet_id == S2C_RESPAWN:
+            client.respawns += 1
+            client.chunks_since_respawn = 0
+            client.level_loads_since_respawn = 0
+            client.log("<- RESPAWN (the client has just discarded its world)")
+        elif packet_id == S2C_GAME_EVENT:
+            if payload and payload[0] == LEVEL_CHUNKS_LOAD_START:
+                client.level_loads_since_respawn += 1
         elif packet_id == S2C_LEVEL_CHUNK_WITH_LIGHT:
+            client.chunks_since_respawn += 1
             _at, blocks = decode_chunk(payload, (60, 70))
             client.blocks.update(blocks)
         elif packet_id == S2C_SECTION_BLOCKS_UPDATE:
@@ -541,6 +823,12 @@ class Run:
             return self.report()
 
         self.the_ring_exists(one)
+        self.every_mob_wears_its_name(one)
+        # Before anything is claimed, because the sweep clicks all fifteen and
+        # every later check wants a ring nobody has touched. `two` watches, so
+        # the skin half is answered by a client that is not the one selecting.
+        self.every_mob_answers_in_its_own_voice(one, two)
+        self.a_skin_change_costs_nobody_their_world(one, two)
         taken = self.a_click_picks_the_mob(one)
         if taken is None:
             return self.report()
@@ -550,6 +838,255 @@ class Run:
         self.a_holder_who_leaves_frees_it(one, two, three, taken)
         self.selection_survives_the_countdown()
         return self.report()
+
+    def every_mob_wears_its_name(self, client):
+        """Claim 5: a player can read the ring without clicking any of it.
+
+        Every podium, because the failure is one blank mob among fourteen
+        labelled ones. The expected string is the server's own
+        `Offer::label`, so this is a check that the name the client renders is
+        the name the game decided, and not a check against fifteen kit names
+        copied into Python.
+        """
+        podiums = self.ask_podiums(client)
+        if not podiums:
+            self.fail("the server named no podiums, so no mob could wear a name")
+            return
+
+        # Waited for rather than asserted: a mob's metadata rides on the
+        # subscribe packets the proxy asks for when the client comes into range,
+        # which is a tick or two after the chunk it stands in.
+        self.wait_until(
+            lambda: all(
+                client.name_over(self.mob_of(client, entry)) is not None
+                for entry in podiums
+                if self.mob_of(client, entry) is not None
+            )
+            and all(self.mob_of(client, entry) is not None for entry in podiums),
+            30.0,
+        )
+
+        wrong = []
+        for entry in podiums:
+            mob = self.mob_of(client, entry)
+            if mob is None:
+                wrong.append("%s has no mob at %s" % (entry["kit"], self.click_at(entry)))
+                continue
+            seen = client.name_over(mob)
+            if seen is None:
+                fields = client.metadata.get(mob, {})
+                wrong.append(
+                    "%s's mob wears no always-visible name; its metadata is %r"
+                    % (entry["kit"], fields)
+                )
+            elif seen != entry["label"]:
+                wrong.append(
+                    "%s's mob is captioned %r and the server said %r"
+                    % (entry["kit"], seen, entry["label"])
+                )
+        if wrong:
+            self.fail("the ring is not readable without clicking it: %s" % "; ".join(wrong))
+            return
+        self.prove(
+            "every mob wears its kit's name, always visible",
+            "%d of %d, e.g. %r over the %s"
+            % (
+                len(podiums),
+                len(podiums),
+                podiums[0]["label"],
+                podiums[0]["mob"],
+            ),
+        )
+
+    def every_mob_answers_in_its_own_voice(self, chooser, bystander):
+        """Claims 6, 7 and 8: the sweep over the whole roster.
+
+        One client can hold every mob in turn, because `lobby::choose` only
+        refuses a mob *somebody else* has, so fifteen clicks by one player is a
+        legal sequence and is the cheapest way to hear all fifteen voices on a
+        real wire.
+
+        Each sound is held against the `select_sound` the server published for
+        that podium rather than against a table here, so this cannot pass by
+        agreeing with a copy of the roster that has gone stale.
+        """
+        podiums = self.ask_podiums(chooser)
+        if not podiums:
+            self.fail("the server named no podiums, so no mob could answer")
+            return
+
+        missing = [entry["kit"] for entry in podiums if not entry["select_sound"]]
+        if missing:
+            self.fail("these kits declare no selection sound: %r" % missing)
+            return
+
+        heard_for = {}
+        overheard = []
+        for entry in podiums:
+            self.approach(chooser, entry)
+            mob = self.mob_of(chooser, entry)
+            if mob is None:
+                self.fail("no mob stands on the %s podium" % entry["kit"])
+                return
+            chooser.sounds = []
+            bystander.sounds = []
+            chooser.right_click_mob(mob, "sweep %s" % entry["kit"])
+            wanted = entry["select_sound"]
+            self.wait_until(
+                lambda wanted=wanted: any(sound[0] == wanted for sound in chooser.sounds),
+                6.0,
+            )
+            ids = [sound[0] for sound in chooser.sounds]
+            if wanted not in ids:
+                self.fail(
+                    "clicking the %s declares %s and played %r"
+                    % (entry["kit"], wanted, ids)
+                )
+                return
+            heard_for[entry["kit"]] = wanted
+            if bystander.sounds:
+                overheard.append(
+                    "%s was audible to %s: %r"
+                    % (entry["kit"], bystander.name, [s[0] for s in bystander.sounds])
+                )
+
+        self.prove(
+            "a click plays the mob's own declared sound",
+            "%d of %d kits answered, e.g. %s from the %s"
+            % (
+                len(heard_for),
+                len(podiums),
+                heard_for[podiums[0]["kit"]],
+                podiums[0]["kit"],
+            ),
+        )
+
+        if overheard:
+            self.fail(
+                "a selection was heard by somebody who did not make it, which a "
+                "lobby of eight people browsing the ring would turn into a wall "
+                "of noise: %s" % "; ".join(overheard)
+            )
+        else:
+            self.prove(
+                "and only the player who clicked hears it",
+                "%s heard none of %d selections" % (bystander.name, len(podiums)),
+            )
+
+        duplicates = {}
+        for kit, sound in heard_for.items():
+            duplicates.setdefault(sound, []).append(kit)
+        shared = {
+            sound: kits for sound, kits in duplicates.items() if len(kits) > 1
+        }
+        if shared:
+            self.fail("these kits answer a click alike: %r" % shared)
+        else:
+            self.prove(
+                "all fifteen mobs answer in different voices",
+                "%d distinct sounds over %d kits" % (len(duplicates), len(heard_for)),
+            )
+
+    def a_skin_change_costs_nobody_their_world(self, chooser, watcher):
+        """Claim 9: the other client sees the new skin, and nobody respawns.
+
+        The skin is the point of the feature and the respawn is the bug that
+        shipped with it. Both are read off `watcher` and `chooser` rather than
+        inferred: a texture property in somebody else's tab list entry is the
+        only evidence that a change reached the client that renders the model,
+        and a respawn count is the only evidence that it did not cost that
+        client its terrain.
+        """
+        # Any free mob except the first podium, which the checks after this one
+        # take for themselves. Leaving `chooser` already holding that mob would
+        # make the next check a no-op: it clicks and waits for the kit to
+        # change, which it never does, and reads an action bar that was never
+        # written. That is a fault in the order these checks run in and not in
+        # the game, but it reads exactly like one.
+        podiums = self.ask_podiums(chooser)
+        free = [
+            entry
+            for entry in podiums
+            if entry["held_by"] is None and entry["kit"] != podiums[0]["kit"]
+        ]
+        if not free:
+            self.fail("no mob is free, so no skin could change")
+            return
+        entry = free[0]
+
+        before = watcher.texture_of(chooser.profile_id)
+        chooser_respawns = chooser.respawns
+
+        self.approach(chooser, entry)
+        mob = self.mob_of(chooser, entry)
+        if mob is None:
+            self.fail("no mob stands on the %s podium" % entry["kit"])
+            return
+        chooser.right_click_mob(mob, "dress as %s" % entry["kit"])
+
+        self.wait_until(
+            lambda: watcher.texture_of(chooser.profile_id) not in (None, before),
+            20.0,
+            "%s to be told what %s now looks like" % (watcher.name, chooser.name),
+        )
+        after = watcher.texture_of(chooser.profile_id)
+        if after is None or after == before:
+            self.fail(
+                "%s picked the %s and %s was never told: the texture it holds is "
+                "still %r" % (chooser.name, entry["kit"], watcher.name, before)
+            )
+            return
+
+        value, signature = after
+        expected = skin_payload(entry["kit"])
+        if expected is None:
+            self.fail("no committed skin for the %s, so nothing could be checked" % entry["kit"])
+            return
+        if value != expected[0]:
+            self.fail(
+                "%s sees a texture that is not the one committed for the %s"
+                % (watcher.name, entry["kit"])
+            )
+            return
+        if signature != expected[1]:
+            self.fail(
+                "the texture %s sees carries %s, and without the committed Mojang "
+                "signature the client would show it to nobody but its wearer"
+                % (watcher.name, "no signature" if signature is None else "a different signature")
+            )
+            return
+        self.prove(
+            "the other player sees the new skin on the wire",
+            "%s now holds the committed %s payload for %s, signed"
+            % (watcher.name, entry["kit"], chooser.name),
+        )
+
+        # The ordering claim. Both halves, because a respawn is legitimate as
+        # long as it is repaired, and the failure that shipped was a respawn
+        # nobody repaired.
+        self.settle(1.5)
+        if chooser.respawns == chooser_respawns:
+            self.prove(
+                "and it did not cost the wearer its world",
+                "%s was sent no Respawn while its skin changed" % chooser.name,
+            )
+        elif chooser.level_loads_since_respawn and chooser.chunks_since_respawn:
+            self.prove(
+                "and the respawn it took gave the world back",
+                "%d chunk columns and %d LEVEL_CHUNKS_LOAD_START after the respawn"
+                % (chooser.chunks_since_respawn, chooser.level_loads_since_respawn),
+            )
+        else:
+            self.fail(
+                "a skin change respawned %s and left it there: %d chunk columns "
+                "and %d LEVEL_CHUNKS_LOAD_START arrived afterwards, so a real "
+                "client sits on ReceivingLevelScreen forever"
+                % (
+                    chooser.name,
+                    chooser.chunks_since_respawn,
+                    chooser.level_loads_since_respawn,
+                )
+            )
 
     def the_ring_exists(self, client):
         podiums = self.ask_podiums(client)
@@ -926,10 +1463,13 @@ class Run:
         if self.failures:
             print("RESULT: %d checks failed" % len(self.failures))
             return 1
-        if len(self.proved) < 7:
+        # A count, because a check that returned early without failing is a
+        # check that proved nothing and said nothing, and the run would
+        # otherwise read as a pass.
+        if len(self.proved) < CLAIMS:
             print(
-                "RESULT: only %d of 7 checks reported, so something stopped "
-                "early" % len(self.proved)
+                "RESULT: only %d of %d checks reported, so something stopped "
+                "early" % (len(self.proved), CLAIMS)
             )
             return 1
         print("RESULT: the kit selector works, on the wire")


### PR DESCRIPTION
## What this is

Three things the operator asked for after playing the kit selector, and one
bug that turned up while building the first of them and was blocking them from
joining at all.

Written by Claude (Anthropic), an AI agent, driven by an operator. Every claim
below was measured against a running server, not reasoned about.

## The join hang, first, because it is what was blocking play

A real client was stuck on "Loading terrain..." forever and could not join.

Measured on the wire against unmodified `origin/main`, with a scripted client
that announces a real profile id in `Hello` the way a vanilla client does:

    0.27s Login
    0.29s GameEvent 13 LEVEL_CHUNKS_LOAD_START
    0.29s PlayerInfoRemove
    0.29s PlayerInfoUpdate
    0.29s RESPAWN
    0.29s PlayerPosition
    ... 3696 chunk columns follow ...

Terrain is not what goes missing. Three thousand six hundred and ninety six
columns arrive after that respawn. What never arrives is a second
`LEVEL_CHUNKS_LOAD_START`. `handleRespawn` calls `startWaitingForNewLevel`,
which puts `ReceivingLevelScreen` back up, and only that game event takes it
down, so the player sits on a loading screen with a fully built world behind
it.

The trigger was not kit selection. A vanilla client puts its own profile id in
`ServerboundHelloPacket`; hyperion answers by asking Mojang for a skin; the
offline uuid has none; and `apply_skins` wrote `PlayerSkin::EMPTY` over the
empty profile the player already published, a moment after the join finished.
That redundant write tripped the `OnSet` observer and its `refresh` on every
single real join. Every scripted gate in this repository sends sixteen zero
bytes as its profile id and takes a different branch, which is why five green
gates shipped it.

Two changes, neither a patch over the symptom.

`roster::wear` replaces the three bare `.set()` calls on `PlayerSkin`. It
compares the profile property a client would receive rather than the component,
so an absent skin and `PlayerSkin::EMPTY` are the same thing, and a write that
changes nothing publishes nothing.

`refresh` no longer respawns the wearer at all. Repairing a respawn would mean
giving back terrain and entities both, and the entity half cannot be done from
the server: which entities a client is subscribed to is the proxy's
bookkeeping, keyed on position, and it will not re-offer a subscription it
believes is held. A mid-game respawn would have left a player standing in an
empty hub with no podiums and no mobs in it. Deleting the respawn deletes the
bug class rather than patching an instance of it.

**What that costs, stated plainly.** The wearer's own first-person view of
themselves keeps the texture their `LocalPlayer` was built with, because
`AbstractClientPlayer` caches its `PlayerInfo` and only rebuilding `LocalPlayer`
clears it. Every other client still drops and re-adds the entity and sees the
new skin, which is the half that was actually asked for. One pair of arms
against every client's whole world. Filed as a follow-up rather than left
unsaid.

## Skins already worked, and that is worth writing down

The brief assumed a texture change after join did not propagate. It does.
Measured before changing anything, two clients, one clicking a podium:

    Alice: Chat, ActionBar, PlayerInfoRemove, PlayerInfoUpdate(484-byte signed
           textures), Respawn
    Bob:   PlayerInfoRemove, PlayerInfoUpdate(same), RemoveEntities, AddEntity,
           SetEntityData x2

#1005's remove-and-re-add was correct. What was missing was any acknowledgement
a player could perceive, plus the respawn above. Repeated changes propagate
too: Skeleton to Slime to Wolf each produced a fresh signed payload of a
different length.

## Nametags

Fifteen mobs stood on wool with nothing over their heads, so the only way to
learn which was which was to click one. Each now wears its kit's name, always
visible, green while free and red once taken. The colour is the wool's colour,
from the same `kit::claims` call, so the two are one signal drawn at two
heights rather than two facts that can disagree; the tag is the one that
renders over a crowd from across the hub.

Not the holder's name, though it is known there. Fifteen IGNs is a paragraph
strung across the middle of the lobby, and whose mob it is is a question you
only ask after being refused, which is where the action bar already answers it.
The name comes through the podium's `(Offers, kit)` edge and the text is
#1004's `Text` with a `NamedColor`, never a raw string.

## A voice

`(PlaysOnSelect, sound)` joins `(PlaysOnCast, sound)`, `(PlaysOnHurt, sound)`
and `(PlaysOnDeath, sound)` on the kit prefab: same `Exclusive`, same
`Inherit`, same intern table, no match statement anywhere. Fifteen vanilla
ambient sounds, all distinct, all held against the generated
`minecraft:sound_event` registry. The Creeper and the Iron Golem have no
ambient sound in vanilla and say why they use what they use.

**Heard by the clicker alone.** The ring's radius is eight blocks and a sound at
volume 1.0 carries sixteen, so a positioned selection sound is audible at every
other podium in the hub; eight people browsing mobs would be a wall of noise in
which nobody could pick out their own click. It is feedback about a click rather
than an event in the world, which is the reading that already makes the ranged
hitmarker a unicast.

**A refused click says no**, which closes the `Cue::Denied` thread #1006 left
open. A constant and not a relationship: a refusal belongs to the rule, not to
the mob, and answering in the Wolf's voice when the Wolf is exactly what you
failed to get is a confident wrong answer.

## The bug the wire test found that the mock tests could not

The selection sound did not work at all in its first form, and every mock-seam
Rust test passed it. `choose` runs inside a deferred flecs world, so
`kit::apply`'s `(Playing, kit)` edge is queued rather than applied, and reading
the sound back through that edge answers with the kit the player had *before*:
silence on a first selection, the previous mob's voice on every one after. A
Rust test that calls `choose` directly defers nothing and cannot see it.

The sound is now read off the kit that was chosen, and the Rust test runs inside
`World::defer` so it reproduces the bug when the old shape is put back:

    Iron Golem declares entity.iron_golem.attack
    and choosing it played [entity.skeleton.ambient]

## Gates, extended rather than duplicated

`tools/smash-selector.py` went from four claims to nine, all read off the wire:

    PROVED every mob wears its kit's name, always visible   15 of 15
    PROVED a click plays the mob's own declared sound       15 of 15 kits answered
    PROVED and only the player who clicked hears it         S2 heard none of 15
    PROVED all fifteen mobs answer in different voices      15 distinct sounds
    PROVED the other player sees the new skin on the wire   signed, committed payload
    PROVED and it did not cost the wearer its world         no Respawn

The sound sweep clicks all fifteen podiums, which one player may legally do
because `choose` only refuses a mob somebody *else* holds. Each sound is held
against the `select_sound` the server publishes in `/podiums`, so it cannot pass
by agreeing with a stale copy of the roster.

The ordering claim is asserted both ways: no respawn is sent, and **if one ever
is, terrain and `LEVEL_CHUNKS_LOAD_START` must follow it**. A test that counted
chunk packets would have passed the hang.

That gate also announces a real profile id, which no scripted client here did.

`tests/sound.rs` sweeps every kit for a declared selection sound, checks all
fifteen against the vanilla registry and against each other, and drives `choose`
for the whole roster under `defer`. `tests/selector.rs` holds every podium's
caption against its kit and the caption's colour against the wool's.

**Every guard was broken and watched to fail before being trusted**, including
the ones that were nearly right: the nametag guard reports
`wears no always-visible name; its metadata is {2: 'Skeleton'}`, which is the
exact distinction between a name and a name you can see.

## ENG-10834, since a gate was being added next to it

Every end to end gate's port offset now comes from one `e2eOffsets` set, and
`checks.e2e-ports-distinct` fails the build when two claim a number.
`completions-e2e` moves off `smash-selector-e2e`'s 4000 to 6000. Watched to
fail:

    FAIL: these gates claim the same port offset:
      completions-e2e, smash-selector-e2e

## Also

`identity-check.py`'s roster reader merged a `PlayerInfoUpdate` wholesale, so a
gamemode-only packet erased the texture it had been told about a moment earlier.
It was passing on timing rather than on design.

## What was run

    nix run .#fmt                              rc=0
    nix run .#lint                             rc=0
    nix run .#test                             rc=0   653 passed
    nix build .#checks.*.smash-selector-e2e    rc=0
    nix build .#checks.*.smash-identity-e2e    rc=0
    nix build .#checks.*.completions-e2e       rc=0
    nix build .#checks.*.e2e-ports-distinct    rc=0
    nix build .#checks.*.kit-skins-signed      rc=0

Plus the live two-client run above, on a private port, against a real proxy.

## What was not done

No human has looked at the fifteen skin images; selection was by colour
histogram and `skins/README.md` names guardian, spider, sky_squid and wolf as
the weakest matches. Nothing in this change improves them, and I did not
eyeball them either, so that claim is unchanged.

The wearer's own first-person view is the known gap described above.

A red `Flake` job in CI is pre-existing: hyperion's nix gates have never run on
hosted runners (ENG-10817), so the local runs above are the only real
verification.
