### PR TITLE
fix(hot-reload): the no-migration stub is const, as clippy asks

### DIFF
--- a/crates/hyperion-hot-reload/demo/module/src/lib.rs
+++ b/crates/hyperion-hot-reload/demo/module/src/lib.rs
@@ -65,7 +65,7 @@ fn migrations() -> Vec<hyperion_hot_reload::Migration> {
 }
 
 #[cfg(not(feature = "migration"))]
-fn migrations() -> Vec<hyperion_hot_reload::Migration> {
+const fn migrations() -> Vec<hyperion_hot_reload::Migration> {
     Vec::new()
 }
 


### PR DESCRIPTION
fix(hot-reload): the no-migration stub is const, as clippy asks

`cargo clippy --workspace --all-targets` fails on main:

    error: this could be a `const fn`
      --> crates/hyperion-hot-reload/demo/module/src/lib.rs:68:1
    68 | fn migrations() -> Vec<hyperion_hot_reload::Migration> {

`Vec::new()` is const, so the stub can be. The `migration`-feature variant
builds a vector with a closure and cannot be, which is why only one of the
pair changes. Callers are unaffected either way.

Reported by a sibling agent as ENG-10848 and reproduced here on a pristine
detached origin/main. The other half of that ticket, a `cargo fmt` failure in
`net/intermediate.rs`, no longer reproduces and needs no change.

Verified:

  cargo clippy -p hyperion-hot-reload-demo-module --all-targets   rc=0, 0 errors

Closes ENG-10848

Assisted-by: Claude Opus 4.5 via Claude Code
