### PR TITLE
feat(smash): a screen that says what the game already knows

### DIFF
--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -21,11 +21,16 @@ use glam::Vec3;
 use hyperion::{
     egress::player_join::roster,
     hyperion_minecraft_proto::{
+        Uuid,
         generated::packet_id::play::clientbound::PacketId,
         packets::play::{
             chunk::{LevelParticles, Particle},
-            clientbound::{SetActionBarText, SetDisplayObjective, SetHealth, SetTitleText},
+            clientbound::{
+                SetActionBarText, SetDisplayObjective, SetExperience, SetHealth, SetSubtitleText,
+                SetTitleText, SetTitlesAnimation,
+            },
             player::{
+                BossBarColor, BossBarOverlay, BossBarProperties, BossEvent, BossEventOperation,
                 DisplaySlot, NumberFormat, ObjectiveDisplay, ObjectiveRenderType, SetObjective,
                 SetScore,
             },
@@ -46,7 +51,10 @@ use valence_nbt::{Compound, List, Value};
 
 use crate::{
     module::kit::{self, Playing},
-    server::{Channel, Cue, HotbarItem, PlayerId, Server, SidebarLine, Sound, SoundCategory, Text},
+    server::{
+        BarColour, BossBar, Channel, Cue, Experience, HotbarItem, PlayerId, Server, SidebarLine,
+        Sound, SoundCategory, Text, Title,
+    },
 };
 
 /// One deferred write.
@@ -100,6 +108,21 @@ enum Op {
     PlaySoundTo {
         player: Entity,
         sound: Sound,
+    },
+    SetExperience {
+        player: Entity,
+        experience: Experience,
+    },
+    SetBossBar {
+        player: Entity,
+        bar: BossBar,
+    },
+    ShowTitle {
+        player: Entity,
+        title: Title,
+    },
+    BroadcastTitle {
+        title: Title,
     },
 }
 
@@ -202,6 +225,31 @@ impl Server for HyperionServer {
             player: entity_of(player),
             sound,
         });
+    }
+
+    fn set_experience(&self, player: PlayerId, experience: Experience) {
+        self.push(Op::SetExperience {
+            player: entity_of(player),
+            experience,
+        });
+    }
+
+    fn set_boss_bar(&self, player: PlayerId, bar: BossBar) {
+        self.push(Op::SetBossBar {
+            player: entity_of(player),
+            bar,
+        });
+    }
+
+    fn show_title(&self, player: PlayerId, title: Title) {
+        self.push(Op::ShowTitle {
+            player: entity_of(player),
+            title,
+        });
+    }
+
+    fn broadcast_title(&self, title: Title) {
+        self.push(Op::BroadcastTitle { title });
     }
 }
 
@@ -406,7 +454,140 @@ fn apply(world: WorldRef<'_>, compose: &Compose, op: Op) {
                 tracing::warn!("dropping a smash sound: {error}");
             }
         }
+        Op::SetExperience { player, experience } => {
+            let Some(connection) = connection_of(world, player) else {
+                return;
+            };
+            let packet = SetExperience {
+                experience_progress: experience.progress,
+                experience_level: experience.level,
+                // Never read by the client's HUD, which draws the bar from
+                // `experience_progress` and the number from `experience_level`.
+                // It is the value `/xp query points` would answer with, and
+                // this game has no points to answer about.
+                total_experience: 0,
+            };
+            let _unused = protocol::send(
+                compose,
+                connection,
+                PacketId::SetExperience.to_raw(),
+                &packet,
+            );
+        }
+        Op::SetBossBar { player, bar } => {
+            let Some(connection) = connection_of(world, player) else {
+                return;
+            };
+            boss_bar(compose, connection, bar_id(player), &bar);
+        }
+        Op::ShowTitle { player, title } => {
+            let Some(connection) = connection_of(world, player) else {
+                return;
+            };
+            show_title(compose, &title, Some(connection));
+        }
+        Op::BroadcastTitle { title } => show_title(compose, &title, None),
     }
+}
+
+/// The connection behind a player, or nothing when they have left.
+fn connection_of(world: WorldRef<'_>, player: Entity) -> Option<ConnectionId> {
+    let entity = world.entity_from_id(player);
+    if !entity.is_alive() {
+        return None;
+    }
+    entity.try_get::<&ConnectionId>(|id| *id)
+}
+
+/// The high half of every boss bar id this game invents.
+///
+/// A bar is addressed by a UUID the *server* chooses and reuses across every
+/// update to it, so the id has to be stable for a player and distinct between
+/// them. The player's own entity id is both, so it is the low half and this is
+/// a namespace that keeps those ids away from any other bar a host might run.
+const BAR_NAMESPACE: u128 = 0x736d_6173_685f_6261_7200_0000_0000_0000;
+
+fn bar_id(player: Entity) -> Uuid {
+    Uuid(BAR_NAMESPACE | u128::from(player.0))
+}
+
+/// Push one player's boss bar.
+///
+/// `Add` every time rather than `Add` once and `UpdateProgress` after, which
+/// would need this file to remember which players already have a bar. It does
+/// not need to: the client's `BossHealthOverlay.add` is a `put` into a
+/// `LinkedHashMap` keyed on the id, so a second `Add` under the same id
+/// replaces the bar in place and keeps its slot on screen. What is lost is the
+/// client-side lerp between two progress values, and that is not wanted here:
+/// the number on this bar is a percentage that steps when somebody is hit, and
+/// sliding it smoothly would be an animation of something that did not happen
+/// smoothly.
+fn boss_bar(compose: &Compose, to: ConnectionId, id: Uuid, bar: &BossBar) {
+    let packet = BossEvent {
+        id,
+        operation: BossEventOperation::Add {
+            name: bar.title.clone(),
+            progress: bar.progress.clamp(0.0, 1.0),
+            color: colour(bar.colour),
+            overlay: BossBarOverlay::Progress,
+            // No fog, no darkened sky and no boss music. Every one of them is
+            // a change to how the arena looks or sounds, and this bar is a
+            // readout rather than an event.
+            properties: BossBarProperties::NONE,
+        },
+    };
+    let _unused = compose.unicast(Clientbound::new(PacketId::BossEvent.to_raw(), &packet), to);
+}
+
+const fn colour(colour: BarColour) -> BossBarColor {
+    match colour {
+        BarColour::Green => BossBarColor::Green,
+        BarColour::Yellow => BossBarColor::Yellow,
+        BarColour::Red => BossBarColor::Red,
+        BarColour::Blue => BossBarColor::Blue,
+    }
+}
+
+/// Put a title on screen: the timing, then the line under it, then the line
+/// itself.
+///
+/// That order is the whole reason [`Title`] is one value. The subtitle packet
+/// only stores a line; the title packet is what draws both and restarts the
+/// animation, so a subtitle written after its title is a line the player sees
+/// under the *next* one. The empty subtitle is sent rather than skipped for
+/// the same reason in reverse: the client keeps the last one it was given, so
+/// a title with nothing under it would otherwise inherit whatever the previous
+/// one said.
+fn show_title(compose: &Compose, title: &Title, to: Option<ConnectionId>) {
+    let animation = SetTitlesAnimation {
+        fade_in: title.times.fade_in,
+        stay: title.times.stay,
+        fade_out: title.times.fade_out,
+    };
+    dispatch(
+        compose,
+        Clientbound::new(PacketId::SetTitlesAnimation.to_raw(), &animation),
+        to,
+    );
+
+    let blank = Text::text("");
+    let subtitle = SetSubtitleText {
+        text: title.subtitle.as_ref().unwrap_or(&blank).to_tag(),
+    };
+    dispatch(
+        compose,
+        Clientbound::new(PacketId::SetSubtitleText.to_raw(), &subtitle),
+        to,
+    );
+
+    let text = SetTitleText {
+        text: title.title.to_tag(),
+    };
+    dispatch(
+        compose,
+        Clientbound::new(PacketId::SetTitleText.to_raw(), &text),
+        to,
+    );
 }
 
 /// Turn the game's sound into hyperion's.
@@ -468,16 +649,6 @@ fn send(compose: &Compose, channel: Channel, text: Text, to: Option<ConnectionId
             dispatch(
                 compose,
                 Clientbound::new(PacketId::SetActionBarText.to_raw(), &packet),
-                to,
-            );
-        }
-        Channel::Title => {
-            let packet = SetTitleText {
-                text: text.to_tag(),
-            };
-            dispatch(
-                compose,
-                Clientbound::new(PacketId::SetTitleText.to_raw(), &packet),
                 to,
             );
         }

--- a/events/smash/src/input.rs
+++ b/events/smash/src/input.rs
@@ -230,8 +230,20 @@ impl Module for InputModule {
 
 /// Which of the nine hotbar slots the player is holding.
 fn held_slot(player: EntityView<'_>) -> Option<u8> {
-    let absolute = player.try_get::<&PlayerInventory>(PlayerInventory::get_cursor_index)?;
-    u8::try_from(absolute.checked_sub(PlayerInventory::HOTBAR_START_SLOT)?).ok()
+    hotbar_slot(player.try_get::<&PlayerInventory>(PlayerInventory::get_cursor_index)?)
+}
+
+/// The hotbar slot an inventory cursor index names, if it names one at all.
+///
+/// `ClientboundContainerSetSlot` and `PlayerInventory` both number the whole
+/// inventory; everything else in this game means one of the nine slots a
+/// player can see. Two places do that subtraction -- the input path, which
+/// asks the host what is held at the moment a right-click arrives, and the
+/// mirror, which copies it onto a component once a tick -- so it is written
+/// once here rather than twice with a chance of disagreeing about the bounds.
+pub(crate) fn hotbar_slot(cursor: u16) -> Option<u8> {
+    let slot = u8::try_from(cursor.checked_sub(PlayerInventory::HOTBAR_START_SLOT)?).ok()?;
+    (slot < 9).then_some(slot)
 }
 
 /// The attacker's kit's melee damage, plus whatever their kit has stacked onto

--- a/events/smash/src/lib.rs
+++ b/events/smash/src/lib.rs
@@ -25,10 +25,10 @@ use hyperion::{Crypto, GameServerEndpoint, HyperionCore};
 use hyperion_clap::hyperion_command::CommandRegistry;
 
 use crate::module::{
-    ability::AbilityModule, arena::ArenaModule, damage::DamageModule, kit::KitModule,
-    kits::StockKits, knockback::KnockbackModule, lives::LivesModule, lobby::LobbyModule,
-    player::PlayerModule, projectile::ProjectileModule, scoreboard::ScoreboardModule,
-    selector::SelectorModule, sound::SoundModule,
+    ability::AbilityModule, arena::ArenaModule, damage::DamageModule, hud::HudModule,
+    kit::KitModule, kits::StockKits, knockback::KnockbackModule, lives::LivesModule,
+    lobby::LobbyModule, player::PlayerModule, projectile::ProjectileModule,
+    scoreboard::ScoreboardModule, selector::SelectorModule, sound::SoundModule,
 };
 
 /// The whole game.
@@ -61,6 +61,7 @@ impl Module for SmashModule {
         world.import::<ProjectileModule>();
         world.import::<LobbyModule>();
         world.import::<ScoreboardModule>();
+        world.import::<HudModule>();
         world.import::<SelectorModule>();
         world.import::<StockKits>();
     }

--- a/events/smash/src/mirror.rs
+++ b/events/smash/src/mirror.rs
@@ -9,8 +9,12 @@
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 use hyperion::simulation::{MovementTracking, Pitch, Yaw};
+use hyperion_inventory::PlayerInventory;
 
-use crate::module::player::{Facing, OnGround, Player, Position, Velocity};
+use crate::{
+    input::hotbar_slot,
+    module::player::{Facing, OnGround, Player, Position, SelectedSlot, Velocity},
+};
 
 #[derive(Component)]
 pub struct MirrorModule;
@@ -25,15 +29,28 @@ impl Module for MirrorModule {
                 &Yaw,
                 &Pitch,
                 &MovementTracking,
+                &PlayerInventory,
                 &mut Position,
                 &mut Facing,
                 &mut OnGround,
                 &mut Velocity,
+                &mut SelectedSlot,
             )>("smash::mirror_player_state")
             .kind(id::<flecs::pipeline::OnLoad>())
             .with(Player::id())
             .each(
-                |(source, yaw, pitch, tracking, position, facing, ground, velocity)| {
+                |(
+                    source,
+                    yaw,
+                    pitch,
+                    tracking,
+                    inventory,
+                    position,
+                    facing,
+                    ground,
+                    velocity,
+                    selected,
+                )| {
                     position.0 = **source;
                     facing.0 = look_vector(**yaw, **pitch);
                     ground.0 = tracking.was_on_ground;
@@ -43,6 +60,13 @@ impl Module for MirrorModule {
                     // and it is what abilities that scale with speed -- Block
                     // Toss, Iron Hook -- are asking for.
                     velocity.0 = tracking.server_velocity.as_vec3();
+                    // A cursor outside the hotbar leaves the last slot standing
+                    // rather than resetting to zero: the alternative reads as
+                    // "you are holding slot 0" and would put slot 0's cooldown
+                    // on the experience bar of somebody holding nothing.
+                    if let Some(slot) = hotbar_slot(inventory.get_cursor_index()) {
+                        selected.0 = slot;
+                    }
                 },
             );
     }

--- a/events/smash/src/module.rs
+++ b/events/smash/src/module.rs
@@ -1,6 +1,7 @@
 pub mod ability;
 pub mod arena;
 pub mod damage;
+pub mod hud;
 pub mod kit;
 pub mod kits;
 pub mod knockback;

--- a/events/smash/src/module/hud.rs
+++ b/events/smash/src/module/hud.rs
@@ -1,0 +1,591 @@
+//! What the screen says while a match runs.
+//!
+//! Three surfaces, and one rule behind all of them: the game already knows
+//! everything a player needs, and until now it only said so in words, after
+//! the fact, on a channel that scrolls.
+//!
+//! * The **experience bar** is the recharge of whatever ability is in the slot
+//!   you are holding. Cooldowns were already enforced and the only feedback
+//!   was a line of red text *after* a press had been refused, which is the
+//!   wrong end of the interaction: a gauge answers "can I" before you commit,
+//!   and a refusal only answers "you could not" once you already have.
+//! * The **bar across the top** is your knockback percentage during a match,
+//!   and whatever the lobby is waiting on outside one. Percentage is the read
+//!   Super Smash Mobs is played on and no client draws it: hearts say how much
+//!   damage you have left, and percent says what the next hit will do with it.
+//!   See [`crate::module::knockback::percent`].
+//! * The **titles** punctuate the match. The countdown gets a number, the
+//!   start gets a word, the end gets the winner's name, and a death gets the
+//!   name of whoever did it.
+//!
+//! Everything that decides content is a pure function of a small struct, and
+//! everything that decides *when* lives in a system or in the lobby's own
+//! state machine. That split is what makes `tests/hud.rs` able to pin the
+//! exact bar, number and wording for every state the game has, including the
+//! ones a scripted match would have to be lucky to reach.
+//!
+//! # Nothing is sent twice
+//!
+//! Each of these is a packet per player, and the bar and the meter both change
+//! continuously. [`Shown`] is what the client was last told, initialised to
+//! the state a fresh client is already in -- an empty experience bar and no
+//! boss bar -- so the first push is the first real change and every tick after
+//! that sends nothing until the value moves. The experience bar is also
+//! quantised to [`METER_STEPS`], which is what keeps a seven second cooldown
+//! to sixty-four packets rather than a hundred and forty.
+
+use flecs_ecs::prelude::*;
+
+use crate::{
+    module::{
+        ability::{self, Cooldown, CooldownSpec},
+        knockback::{self, KnockbackModel},
+        lives::{self, DeathCause, Eliminated, Lives},
+        lobby::{self, Lobby, LobbyConfig, Phase},
+        player::{Health, Player, SelectedSlot},
+    },
+    server::{
+        BarColour, BossBar, Experience, NamedColor, PlayerId, ServerHandle, Text, Title, TitleTimes,
+    },
+};
+
+/// How many steps the experience bar is quantised to.
+///
+/// The bar is 182 pixels wide, so a step is under three pixels and no player
+/// can see the difference between one step and the tick that produced it. What
+/// the quantisation buys is the other direction: a cooldown otherwise sends a
+/// packet every tick for its whole length, and this cuts a seven second one
+/// from a hundred and forty to at most sixty-four.
+pub const METER_STEPS: u16 = 64;
+
+/// The cooldown of one ability, as the experience bar needs it.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Recharge {
+    /// Seconds still to wait.
+    pub remaining: f32,
+    /// Seconds the wait is in total.
+    pub full: f32,
+}
+
+/// The experience bar for a player holding an ability in `recharge`.
+///
+/// Three states, told apart by the two numbers together rather than by either
+/// alone:
+///
+/// | in the slot | bar | number |
+/// | --- | --- | --- |
+/// | an ability that is ready | full | none |
+/// | an ability recharging | filling from empty | whole seconds left |
+/// | nothing | empty | none |
+///
+/// **Filling, not draining.** Vanilla fills this bar left to right as
+/// experience accumulates, so a full bar already reads as "you have the thing"
+/// to anybody who has played Minecraft, and a player learns the mapping
+/// without being told. Draining would put the bar at its fullest at the exact
+/// moment the ability cannot be used, which inverts the one fact it is there
+/// to carry.
+///
+/// **The number is the seconds, rounded up.** The bar is the glanceable half
+/// and is deliberately imprecise; the number is for the other question, which
+/// is not "am I ready" but "how long until I am", and that is what a player
+/// counts down when they are deciding whether to take a fight now or back off
+/// for two seconds. Rounded up rather than down so it never says zero while
+/// the ability is still refusing.
+#[must_use]
+pub fn meter(recharge: Option<Recharge>) -> Experience {
+    /// A slot with nothing in it. Not a lie about being ready, and not a lie
+    /// about recharging either: an empty bar with no number is a state the
+    /// other two cannot produce.
+    const EMPTY: Experience = Experience {
+        progress: 0.0,
+        level: 0,
+    };
+    const READY: Experience = Experience {
+        progress: 1.0,
+        level: 0,
+    };
+
+    let Some(recharge) = recharge else {
+        return EMPTY;
+    };
+    // One division rather than three comparisons, so a zero-length cooldown
+    // (infinity), a finished one (zero) and a nonsensical one (NaN) all land
+    // on "ready" without a branch each.
+    let left = recharge.remaining / recharge.full;
+    if !left.is_finite() || left <= 0.0 {
+        return READY;
+    }
+    Experience {
+        progress: quantise(1.0 - left),
+        level: whole_seconds(recharge.remaining),
+    }
+}
+
+/// `fraction` snapped down to a whole [`METER_STEPS`] step.
+///
+/// Down and not to nearest, which is the property that matters for the
+/// experience bar: one that is still recharging never rounds up to full, so
+/// "the bar is full" and "the ability is ready" are the same statement rather
+/// than nearly the same one.
+///
+/// The boss bar goes through this too, for the other reason. Its progress is a
+/// continuous quantity in three of the five phases -- a countdown, a prepare
+/// timer, and health under a kit's regeneration -- so an exact fraction is a
+/// packet every tick per player forever. Measured on the wire by
+/// `nix run .#smash-hud-e2e`, which is eight clients through one countdown and
+/// into a match: 3,065 boss bar packets in thirty seconds before, 1,135 after,
+/// for a bar 182 pixels wide that cannot draw the difference.
+fn quantise(fraction: f32) -> f32 {
+    let steps = f32::from(METER_STEPS);
+    (fraction.clamp(0.0, 1.0) * steps).floor() / steps
+}
+
+/// Seconds rounded up, and never below one while there are any left.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "a cooldown is seconds, and the longest one in the roster is 30"
+)]
+fn whole_seconds(seconds: f32) -> i32 {
+    seconds.ceil().clamp(1.0, f32::from(i16::MAX)) as i32
+}
+
+/// The percentage at which the bar stops being green, and at which it turns
+/// red.
+///
+/// Read off the model rather than chosen for looks. `percent` is
+/// `(knockback_multiplier - 1) * 100`, so fifty is a hit that sends you half
+/// again as far as it would have at full health and a hundred is one that
+/// sends you twice as far. Twice is where a hit that was survivable stops
+/// being, which is the moment a player wants the bar to be shouting.
+pub const YELLOW_PERCENT: f32 = 50.0;
+pub const RED_PERCENT: f32 = 100.0;
+
+/// Which band a percentage falls in.
+#[must_use]
+pub fn percent_colour(percent: f32) -> BarColour {
+    if percent >= RED_PERCENT {
+        BarColour::Red
+    } else if percent >= YELLOW_PERCENT {
+        BarColour::Yellow
+    } else {
+        BarColour::Green
+    }
+}
+
+/// The colour a band's number is written in, so the text and the bar say the
+/// same thing.
+const fn ink(colour: BarColour) -> NamedColor {
+    match colour {
+        BarColour::Green => NamedColor::Green,
+        BarColour::Yellow => NamedColor::Yellow,
+        BarColour::Red => NamedColor::Red,
+        BarColour::Blue => NamedColor::Aqua,
+    }
+}
+
+/// Everything one player's bar is decided from.
+///
+/// A struct and not eight arguments because every field is a number and half
+/// of them are counts, which is the shape where an argument list silently
+/// swaps two of them.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct View<'a> {
+    pub phase: Phase,
+    /// Everyone connected.
+    pub players: u32,
+    /// Everyone still in the match.
+    pub alive: u32,
+    /// The fewest players a match can start with.
+    pub min_players: u32,
+    /// The lobby's own clock.
+    pub timer: f32,
+    /// What that clock started from, for the phases that count down. Zero for
+    /// the phases that do not.
+    pub span: f32,
+    /// This player is out of lives and watching.
+    pub eliminated: bool,
+    /// Their knockback percentage. See
+    /// [`crate::module::knockback::percent`].
+    pub percent: f32,
+    /// Their health, `0.0..=1.0`.
+    pub health: f32,
+    /// Who won, once anybody has.
+    pub winner: Option<&'a str>,
+}
+
+/// The bar across the top of one player's screen.
+///
+/// Total, so there is no state of the game in which the strip is blank. One
+/// bar rather than two, and what it carries is whatever the player should be
+/// watching at that moment: before the match, how many more people are needed
+/// and then how long is left; during it, the number the mode is about. A
+/// second permanent bar for the match clock was the alternative and was
+/// dropped, because a twenty minute timeout nobody has ever reached is not
+/// something a player acts on and it would have spent the other half of the
+/// only always-visible strip on the screen saying so.
+#[must_use]
+pub fn boss_bar(view: &View<'_>) -> BossBar {
+    match view.phase {
+        Phase::Waiting => BossBar {
+            title: Text::text(format!(
+                "Waiting for players  {}/{}",
+                view.players, view.min_players
+            ))
+            .color(NamedColor::Aqua),
+            progress: ratio(view.players, view.min_players),
+            colour: BarColour::Blue,
+        },
+        Phase::Countdown => BossBar {
+            title: Text::text(format!("Starting in {}s", whole_seconds(view.timer)))
+                .color(NamedColor::Yellow),
+            progress: fraction(view.timer, view.span),
+            colour: BarColour::Yellow,
+        },
+        Phase::Preparing => BossBar {
+            title: Text::text("Get ready").color(NamedColor::Yellow).bold(),
+            progress: fraction(view.timer, view.span),
+            colour: BarColour::Yellow,
+        },
+        // A spectator's own percentage is a number about a body that is no
+        // longer in the match, so the bar answers the question they do have
+        // instead: how much of it is left to watch.
+        Phase::Playing if view.eliminated => BossBar {
+            title: Text::text(format!("{} still in", view.alive)).color(NamedColor::Aqua),
+            progress: ratio(view.alive, view.players),
+            colour: BarColour::Blue,
+        },
+        Phase::Playing => {
+            let colour = percent_colour(view.percent);
+            BossBar {
+                // The number is the point, so it is the whole title and it is
+                // bold. The bar under it is the same fact drawn as a length,
+                // which is what makes it readable without being read.
+                title: Text::text(format!("{}%", round(view.percent)))
+                    .color(ink(colour))
+                    .bold(),
+                // Health and not the percentage, because a bar has to be
+                // bounded and a percentage is not: it rises with the kit's
+                // health pool and there is no full mark to draw it against.
+                // Health has one, and it drains as the percentage climbs,
+                // which is the direction a player already reads as bad.
+                //
+                // Quantised, because every kit regenerates health continuously
+                // and an exact fraction is a packet a tick for as long as
+                // anybody is below full.
+                progress: quantise(view.health),
+                colour,
+            }
+        }
+        Phase::Ended => view.winner.map_or_else(
+            || BossBar {
+                title: Text::text("Nobody was left standing").color(NamedColor::Aqua),
+                progress: 1.0,
+                colour: BarColour::Blue,
+            },
+            |winner| BossBar {
+                title: Text::text(format!("{winner} wins!"))
+                    .color(NamedColor::Gold)
+                    .bold(),
+                progress: 1.0,
+                colour: BarColour::Green,
+            },
+        ),
+    }
+}
+
+/// A count as a float. A lobby has fewer players than `u16::MAX`, which is
+/// what makes this exact rather than a lossy cast.
+fn count(value: u32) -> f32 {
+    f32::from(u16::try_from(value).unwrap_or(u16::MAX))
+}
+
+/// `part` out of `whole`, clamped, and zero rather than a division by zero.
+fn ratio(part: u32, whole: u32) -> f32 {
+    fraction(count(part), count(whole))
+}
+
+/// The same for two times, snapped to a step so a timer that moves every tick
+/// does not send a packet every tick. See [`quantise`].
+fn fraction(part: f32, whole: f32) -> f32 {
+    let value = part / whole;
+    if value.is_finite() {
+        quantise(value)
+    } else {
+        0.0
+    }
+}
+
+/// A percentage as a whole number.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "percent is non-negative by construction and bounded by the kit's health pool"
+)]
+const fn round(percent: f32) -> u32 {
+    percent.max(0.0).round() as u32
+}
+
+/// The last seconds of the countdown that get a number across the screen.
+///
+/// Three, where five get a sound. A digit in the middle of the screen is the
+/// most intrusive thing this file draws, so it earns its place only for the
+/// seconds a player is actually timing something against. The sound has no such
+/// cost and starts earlier.
+pub const COUNTDOWN_TITLE_SECONDS: f32 = 3.0;
+
+/// The number in the middle of the screen with `seconds` to go, if this is one
+/// of the seconds that gets one.
+///
+/// `Preparing` only, and not the lobby countdown, even though both phases count
+/// down and both tick out loud. Two phases run out in a row -- the lobby's
+/// clock into `Preparing`, and `Preparing`'s nine seconds into the match -- and
+/// a window on both is two "3, 2, 1" sequences back to back with a teleport
+/// between them. The wire gate caught exactly that: `['3', '2', '1', '3', '2',
+/// '1', 'GO!']`. Only the second sequence counts down to anything a player can
+/// act on, so only the second one gets digits; the lobby's wait is up to sixty
+/// seconds and belongs on the bar, which can say "Starting in 47s" without
+/// filling the screen.
+#[must_use]
+pub fn countdown_title(phase: Phase, seconds: f32) -> Option<Title> {
+    if phase != Phase::Preparing || seconds <= 0.0 || seconds > COUNTDOWN_TITLE_SECONDS {
+        return None;
+    }
+    Some(
+        Title::new(
+            Text::text(whole_seconds(seconds).to_string())
+                .color(NamedColor::Gold)
+                .bold(),
+        )
+        .under(Text::text("Get ready").color(NamedColor::Gray))
+        // Exactly one second, so each digit is replaced by the next rather
+        // than fading across it.
+        .timed(TitleTimes::TICK),
+    )
+}
+
+/// The title a phase change puts on screen, if it puts one there.
+///
+/// Two of the five phases do. `Countdown` and `Preparing` are covered by
+/// [`countdown_title`] and by the bar, and `Waiting` is the hub, where a title
+/// across the screen would be permanent furniture.
+#[must_use]
+pub fn phase_title(to: Phase, winner: Option<&str>) -> Option<Title> {
+    match to {
+        Phase::Playing => Some(
+            Title::new(Text::text("GO!").color(NamedColor::Green).bold())
+                .under(Text::text("Smash them off the map").color(NamedColor::Gray))
+                .timed(TitleTimes::TICK),
+        ),
+        Phase::Ended => Some(winner.map_or_else(
+            || {
+                Title::new(Text::text("Game over").color(NamedColor::Red).bold())
+                    .under(Text::text("Nobody was left standing").color(NamedColor::Gray))
+            },
+            |winner| {
+                Title::new(
+                    Text::text(format!("{winner} wins!"))
+                        .color(NamedColor::Gold)
+                        .bold(),
+                )
+                .under(Text::text("Last mob standing").color(NamedColor::Gray))
+            },
+        )),
+        Phase::Waiting | Phase::Countdown | Phase::Preparing => None,
+    }
+}
+
+/// What a player sees on their own screen when they die.
+///
+/// The subtitle is the point. The chat line naming both of you is broadcast
+/// and scrolls away behind the next one, and the middle of your own screen is
+/// where you are looking at the instant you are launched off the map: before
+/// this it carried a life count and no answer at all to the only question a
+/// player asks there, which is who did that. The credit is not new -- the
+/// damage pipeline has recorded `(LastHitBy, attacker)` all along -- it simply
+/// had nowhere to be read.
+#[must_use]
+pub fn death_title(lives_left: u8, killer: Option<&str>, cause: DeathCause) -> Title {
+    let heading = match lives_left {
+        0 => Text::text("GAME OVER").color(NamedColor::Red).bold(),
+        // Not "1 lives left". The line is read at the worst moment of a
+        // match and a grammatical error is exactly the sort of thing that
+        // makes a game feel unfinished.
+        1 => Text::text("1 life left!").color(NamedColor::Red),
+        left => Text::text(format!("{left} lives left!")).color(NamedColor::Gold),
+    };
+    let under = match (killer, cause) {
+        (Some(killer), _) => Text::text(format!("Smashed by {killer}")),
+        (None, DeathCause::Void) => Text::text("You fell out of the world"),
+        (None, DeathCause::Damage) => Text::text("Nobody to blame but yourself"),
+    };
+    Title::new(heading).under(under.color(NamedColor::Gray))
+}
+
+/// Who won, from everyone's remaining lives.
+///
+/// The last player standing in the ordinary case, where exactly one person has
+/// any lives left. A match that runs into the twenty minute timeout ends with
+/// several people alive and the honest answer there is whoever has the most,
+/// which is the same rule; when two are level there is no winner and the
+/// results screen says so rather than picking one of them.
+#[must_use]
+pub fn winner_of(standings: &[(String, u8)]) -> Option<&str> {
+    let best = standings
+        .iter()
+        .map(|(_, lives)| *lives)
+        .filter(|lives| *lives > 0)
+        .max()?;
+    let mut leaders = standings.iter().filter(|(_, lives)| *lives == best);
+    let (name, _) = leaders.next()?;
+    if leaders.next().is_some() {
+        return None;
+    }
+    Some(name)
+}
+
+/// Everyone's name and remaining lives, as [`winner_of`] wants them.
+#[must_use]
+pub fn standings(world: WorldRef<'_>) -> Vec<(String, u8)> {
+    let mut rows = Vec::new();
+    world
+        .query::<&Lives>()
+        .with(Player::id())
+        .build()
+        .each_entity(|player, lives| rows.push((player.name(), lives::remaining(player, *lives))));
+    rows
+}
+
+/// Who has won the match that is ending, if anybody has.
+#[must_use]
+pub fn winner(world: WorldRef<'_>) -> Option<String> {
+    let rows = standings(world);
+    winner_of(&rows).map(ToOwned::to_owned)
+}
+
+/// What this client was last told.
+///
+/// Initialised to the state a client is already in when it joins: a fresh
+/// client's experience bar is empty with no level, and it has no boss bar
+/// until something adds one. So the first tick compares against the truth
+/// rather than against a guess, and a player who joins gets exactly one push
+/// of each rather than none or two.
+#[derive(Component, Debug, Clone, PartialEq, Default)]
+struct Shown {
+    experience: Experience,
+    /// `None` before the first push, which is also the client's own state.
+    bar: Option<BossBar>,
+}
+
+/// One player's push, held until the query that computed it has finished.
+///
+/// The bar is boxed because it carries a text component and the meter carries
+/// two numbers, so an unboxed enum would size every element of the queue to the
+/// larger of the two.
+enum Push {
+    Experience(PlayerId, Experience),
+    Bar(PlayerId, Box<BossBar>),
+}
+
+/// What the phase's timer started from, so the bar can draw it as a fraction.
+fn span_of(config: &LobbyConfig, phase: Phase, players: u32) -> f32 {
+    match phase {
+        Phase::Countdown => config
+            .countdown_for(players)
+            .unwrap_or(config.countdown_at_min),
+        Phase::Preparing => config.prepare_seconds,
+        Phase::Ended => config.results_seconds,
+        Phase::Waiting | Phase::Playing => 0.0,
+    }
+}
+
+/// The cooldown state of one ability instance.
+fn recharge_of(ability: EntityView<'_>) -> Recharge {
+    Recharge {
+        remaining: ability
+            .try_get::<&Cooldown>(|cooldown| cooldown.remaining)
+            .unwrap_or(0.0),
+        full: ability
+            .try_get::<&CooldownSpec>(|spec| spec.0)
+            .unwrap_or(0.0),
+    }
+}
+
+#[derive(Component)]
+pub struct HudModule;
+
+impl Module for HudModule {
+    fn module(world: &World) {
+        world.module::<Self>("smash::Hud");
+
+        world.component::<Shown>();
+        // This module is what makes the two surfaces mean anything, so this
+        // module is what says every player has a record of what is on them.
+        world
+            .component::<Player>()
+            .add_trait::<(flecs::With, Shown)>();
+
+        world.system_named::<()>("smash::update_hud").run(|mut it| {
+            while it.next() {
+                let world = it.world();
+                let lobby = world.cloned::<&Lobby>();
+                let model = world.cloned::<&KnockbackModel>();
+                let players = lobby::player_count(&world);
+                let alive = lobby::alive_count(&world);
+                let (min_players, span) = world.get::<&LobbyConfig>(|config| {
+                    (config.min_players, span_of(config, lobby.phase, players))
+                });
+                // Only at the end, and once for the whole world rather than
+                // once per viewer: it is a query over every player, and the
+                // answer is the same on everybody's screen.
+                let champion = (lobby.phase == Phase::Ended)
+                    .then(|| winner(world))
+                    .flatten();
+
+                let mut pushes = Vec::new();
+                world
+                    .query::<(&PlayerId, &Health, &SelectedSlot, &mut Shown)>()
+                    .with(Player::id())
+                    .build()
+                    .each_entity(|player, (id, health, slot, shown)| {
+                        let experience =
+                            meter(ability::granted_in_slot(player, slot.0).map(recharge_of));
+                        let bar = boss_bar(&View {
+                            phase: lobby.phase,
+                            players,
+                            alive,
+                            min_players,
+                            timer: lobby.timer,
+                            span,
+                            eliminated: player.has(Eliminated::id()),
+                            percent: knockback::percent(model, *health),
+                            health: health.fraction(),
+                            winner: champion.as_deref(),
+                        });
+
+                        if shown.experience != experience {
+                            shown.experience = experience;
+                            pushes.push(Push::Experience(*id, experience));
+                        }
+                        if shown.bar.as_ref() != Some(&bar) {
+                            shown.bar = Some(bar.clone());
+                            pushes.push(Push::Bar(*id, Box::new(bar)));
+                        }
+                    });
+
+                if pushes.is_empty() {
+                    continue;
+                }
+                world.get::<&ServerHandle>(|server| {
+                    for push in pushes {
+                        match push {
+                            Push::Experience(id, experience) => {
+                                server.set_experience(id, experience);
+                            }
+                            Push::Bar(id, bar) => server.set_boss_bar(id, *bar),
+                        }
+                    }
+                });
+            }
+        });
+    }
+}

--- a/events/smash/src/module/knockback.rs
+++ b/events/smash/src/module/knockback.rs
@@ -136,6 +136,27 @@ pub fn strength(
     base * health_term * taken.0.max(0.0) * ability_multiplier
 }
 
+/// How much further this player is launched than a fresh one, as a percentage.
+///
+/// [`strength`]'s health term is `1 + health_scale_per_hp * missing_health`, so
+/// a player at half health is launched twice as far by an otherwise identical
+/// hit. This is that term with the one taken off and multiplied out: 0% at
+/// full health, 100% where a hit sends you twice as far, and about 190% on the
+/// last half-heart of a twenty-health kit.
+///
+/// It is the same number Super Smash Bros puts on screen, arrived at from the
+/// other direction. Smash accumulates damage and multiplies knockback by it;
+/// Mineplex subtracts health and multiplies knockback by what is missing.
+/// Written out as a percentage the two read identically, and the hearts a
+/// vanilla client draws do not: hearts say how much damage there is left to
+/// take, and this says what the next hit will do with it. Both are the same
+/// health, and only this one is the read the mode is played on.
+#[must_use]
+pub fn percent(model: KnockbackModel, health: Health) -> f32 {
+    let missing = (health.max - health.current).max(0.0);
+    model.health_scale_per_hp * missing * 100.0
+}
+
 /// Turn a strength into the velocity to add to the victim.
 ///
 /// Mineplex scaled a unit trajectory by `0.6 * strength`, read its length back

--- a/events/smash/src/module/lives.rs
+++ b/events/smash/src/module/lives.rs
@@ -12,7 +12,7 @@ use crate::{
     module::{
         arena::Arena,
         damage::{KILL_CREDIT_WINDOW, LastHitAt, LastHitBy, MatchClock},
-        kit,
+        hud, kit,
         player::{self, Health, JumpsLeft, Player, Position},
         sound::{self, PlaysOnDeath},
     },
@@ -333,6 +333,7 @@ impl Module for LivesModule {
             .observer_named::<Died, (&mut Lives, &PlayerId, &mut Health)>("smash::on_death")
             .with(Player::id())
             .each_iter(|it, index, (lives, player, health)| {
+                let cause = it.param().cause;
                 let victim = it.entity(index);
                 if victim.has(Eliminated::id()) {
                     return;
@@ -347,6 +348,7 @@ impl Module for LivesModule {
 
                 let name = victim.name();
                 let killer = killer_of(victim, clock);
+                let killer_name = killer.map(|killer| world.entity_from_id(killer).name());
                 let at = sound::position_of(victim);
                 // The kit's last word, where it fell. Reached through the
                 // player's own `(Playing, kit)` edge, so this module still does
@@ -355,36 +357,27 @@ impl Module for LivesModule {
 
                 world.get::<&ServerHandle>(|server| {
                     server.cue(at, Cue::Death);
-                    match killer {
-                        Some(killer) => {
-                            let killer_name = world.entity_from_id(killer).name();
-                            server.broadcast(
-                                Channel::Chat,
-                                Text::text(format!("{name} was smashed by {killer_name}!")),
-                            );
-                        }
-                        None => {
-                            server.broadcast(
-                                Channel::Chat,
-                                Text::text(format!("{name} fell out of bounds!")),
-                            );
-                        }
+                    match killer_name.as_deref() {
+                        Some(killer_name) => server.broadcast(
+                            Channel::Chat,
+                            Text::text(format!("{name} was smashed by {killer_name}!")),
+                        ),
+                        None => server.broadcast(
+                            Channel::Chat,
+                            Text::text(format!("{name} fell out of bounds!")),
+                        ),
                     }
                     server.set_spectating(*player, true);
 
-                    if lives.0 == 0 {
-                        server.send_message(
-                            *player,
-                            Channel::Title,
-                            Text::text("GAME OVER: you ran out of lives!").color(NamedColor::Red),
-                        );
-                    } else {
-                        server.send_message(
-                            *player,
-                            Channel::Title,
-                            Text::text(format!("{} lives left!", lives.0)),
-                        );
-                    }
+                    // The victim's own screen, where the subtitle is what
+                    // finally spends the kill credit this module has been
+                    // recording all along: the chat line above names both
+                    // players and is read by everybody except the one person
+                    // who most wants it.
+                    server.show_title(
+                        *player,
+                        hud::death_title(lives.0, killer_name.as_deref(), cause),
+                    );
                 });
 
                 if lives.0 == 0 {

--- a/events/smash/src/module/lobby.rs
+++ b/events/smash/src/module/lobby.rs
@@ -11,12 +11,15 @@
 //! seconds, three-quarters full thirty, minimum sixty, and dropping back below
 //! the minimum cancels.
 
+use std::borrow::Cow;
+
 use flecs_ecs::prelude::*;
 
 use crate::{
     module::{
         arena::Arena,
         damage::MatchClock,
+        hud,
         kit::{self, KitName},
         lives::{Eliminated, InvulnerableUntil, Lives, Placement, RespawnAt},
         player::{Health, Player, Position},
@@ -339,9 +342,25 @@ fn tick_countdown(world: &WorldRef<'_>, before: Lobby, after: Lobby) {
         return;
     };
     sound::play_to_everyone(*world, sound::countdown_tick(seconds_left));
+    // The same boundary drives the number on screen, so the digit and the tick
+    // that goes with it cannot come from two clocks and disagree. Which of
+    // those seconds gets a digit is `hud`'s to say, and it is fewer of them than
+    // get a sound: both phases here tick out loud and only one of them shows a
+    // number.
+    if let Some(title) = hud::countdown_title(after.phase, seconds_left) {
+        world.get::<&ServerHandle>(|server| server.broadcast_title(title));
+    }
 }
 
 fn on_phase_change(world: &WorldRef<'_>, from: Phase, to: Phase) {
+    // Read before the transition's own side effects, because `reset` is one of
+    // them and it is what puts everybody's lives back.
+    let champion = if to == Phase::Ended {
+        hud::winner(*world)
+    } else {
+        None
+    };
+
     match to {
         Phase::Countdown => announce(world, "Enough players. The game starts shortly."),
         Phase::Preparing => {
@@ -357,10 +376,24 @@ fn on_phase_change(world: &WorldRef<'_>, from: Phase, to: Phase) {
             );
         }
         Phase::Ended => {
-            announce(world, "Game over.");
+            // Chat is the record, so it carries the result and not just the
+            // fact that there was one. A player who was reading the panel when
+            // the last hit landed can scroll back to this line; the title that
+            // goes with it is gone in five seconds.
+            match champion.as_deref() {
+                Some(winner) => announce(world, format!("Game over. {winner} wins!")),
+                None => announce(world, "Game over. Nobody was left standing."),
+            }
             sound::play_to_everyone(*world, Sound::new(sound::MATCH_END, SoundCategory::Ui));
         }
         Phase::Waiting => reset(world),
+    }
+
+    // After the announcement and the sound, so the three arrive in the order a
+    // player reads them: the chat line is the record, the noise is the cue,
+    // and the title is the thing they are looking at.
+    if let Some(title) = hud::phase_title(to, champion.as_deref()) {
+        world.get::<&ServerHandle>(|server| server.broadcast_title(title));
     }
 
     world
@@ -370,7 +403,13 @@ fn on_phase_change(world: &WorldRef<'_>, from: Phase, to: Phase) {
         .emit(&PhaseChanged { from, to });
 }
 
-fn announce(world: &WorldRef<'_>, text: &'static str) {
+/// One line to everybody's chat.
+///
+/// `Cow` rather than `&'static str` so the results line can name the winner.
+/// Deliberately unstyled: `Channel::Chat` cannot carry a style at all, and the
+/// adapter logs a warning for anything that tries, so a colour here would be a
+/// silent no-op with a log line nobody reads. ENG-10796 is the fix.
+fn announce(world: &WorldRef<'_>, text: impl Into<Cow<'static, str>>) {
     world.get::<&ServerHandle>(|server| server.broadcast(Channel::Chat, Text::text(text)));
 }
 

--- a/events/smash/src/module/player.rs
+++ b/events/smash/src/module/player.rs
@@ -119,6 +119,22 @@ impl Energy {
 #[derive(Component, Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct JumpsLeft(pub u8);
 
+/// Mirror of which of the nine hotbar slots the player is holding.
+///
+/// A mirror in the same sense as [`Position`]: the host owns it, the adapter
+/// copies it in once a tick, and the game reads it as a plain component. What
+/// reads it is the experience bar, which has to answer "how far along is the
+/// ability in the slot you are holding" for every player twenty times a
+/// second, and a call across the seam per player per tick is exactly the cost
+/// the mirrors in this module exist to avoid.
+///
+/// It is deliberately not what *fires* an ability. A right-click is a packet
+/// and the slot it means is the one the host knows at the instant the packet
+/// arrives, which is the same tick a client may have changed it in; the input
+/// layer therefore reads the host directly and this stays a display input.
+#[derive(Component, Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct SelectedSlot(pub u8);
+
 /// Registers the mirrored components and the systems that maintain them.
 #[derive(Component)]
 pub struct PlayerModule;
@@ -135,6 +151,7 @@ impl Module for PlayerModule {
         world.component::<Health>();
         world.component::<Energy>();
         world.component::<JumpsLeft>();
+        world.component::<SelectedSlot>();
 
         // A player is never meaningfully without these, and forgetting one is
         // the kind of bug that shows up as a silently non-matching query three
@@ -146,7 +163,8 @@ impl Module for PlayerModule {
             .add_trait::<(flecs::With, Facing)>()
             .add_trait::<(flecs::With, OnGround)>()
             .add_trait::<(flecs::With, Health)>()
-            .add_trait::<(flecs::With, JumpsLeft)>();
+            .add_trait::<(flecs::With, JumpsLeft)>()
+            .add_trait::<(flecs::With, SelectedSlot)>();
 
         world
             .system_named::<(&OnGround, &mut JumpsLeft)>("smash::restore_double_jump")

--- a/events/smash/src/server.rs
+++ b/events/smash/src/server.rs
@@ -184,11 +184,139 @@ impl Sound {
 }
 
 /// Where a message goes on screen.
+///
+/// The middle of the screen is deliberately absent. A title there is not a
+/// line of text but a pair of them with an animation, and the protocol makes
+/// the halves separable in a way that is a trap; [`Title`] is that shape and
+/// [`Server::show_title`] is the only way to reach it.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Channel {
     Chat,
     ActionBar,
-    Title,
+}
+
+/// The experience bar, and the number over it.
+///
+/// Super Smash Mobs has no experience to spend, so the bar the client already
+/// draws above the hotbar is free real estate, and the mode used it for
+/// ability recharge. This is that bar, as the two numbers the client takes.
+///
+/// Level zero draws no number at all -- `Gui.renderExperienceLevel` is guarded
+/// by `experienceLevel > 0` -- which is what makes "nothing to count down"
+/// expressible rather than something that has to be drawn as a zero.
+///
+/// [`Default`] is the state a client is in before anything is sent to it: an
+/// empty bar and no number.
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub struct Experience {
+    /// How full the bar is, `0.0..=1.0`.
+    pub progress: f32,
+    /// The number in the green box, or zero to draw none.
+    pub level: i32,
+}
+
+/// How a boss bar is tinted.
+///
+/// The game's own vocabulary, like [`Cue`]: four bands and not the client's
+/// seven colours, because what the game means is "fine", "getting dangerous",
+/// "the next hit ends you" and "this is not about you". Which Minecraft colour
+/// each becomes is a hosting decision and lives in the adapter.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum BarColour {
+    Green,
+    Yellow,
+    Red,
+    /// Informational: a countdown, a lobby, a result. Not a warning.
+    Blue,
+}
+
+/// The bar across the top of one player's screen.
+///
+/// Per player and not per world, which is the whole reason it can carry a
+/// number that is only true of the person reading it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BossBar {
+    /// Drawn centred above the bar.
+    pub title: Text,
+    /// How full it is, `0.0..=1.0`.
+    pub progress: f32,
+    pub colour: BarColour,
+}
+
+/// How long a title spends fading in, on screen, and fading out, in ticks.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct TitleTimes {
+    pub fade_in: i32,
+    pub stay: i32,
+    pub fade_out: i32,
+}
+
+impl TitleTimes {
+    /// Vanilla's own, which is what a client uses when nothing says otherwise.
+    pub const DEFAULT: Self = Self {
+        fade_in: 10,
+        stay: 70,
+        fade_out: 20,
+    };
+    /// Exactly one second, with no fade at either end.
+    ///
+    /// For a sequence: a countdown digit that faded out over twenty ticks
+    /// would still be on screen when the next one arrived, and the two would
+    /// cross-fade into an unreadable smear right at the moment the number
+    /// matters.
+    pub const TICK: Self = Self {
+        fade_in: 0,
+        stay: 20,
+        fade_out: 0,
+    };
+}
+
+impl Default for TitleTimes {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Big text across the middle of the screen, and the smaller line under it.
+///
+/// One value rather than two channels, because the protocol makes the halves
+/// separable and the separation is a trap. `ClientboundSetSubtitleTextPacket`
+/// does not draw anything: it stores a line, and the *next* title is what puts
+/// both on screen. Two independent sends therefore have an order that matters,
+/// and a subtitle nobody cleared outlives the title it was written for and
+/// reappears under an unrelated one. Carrying them together lets the adapter
+/// always write the subtitle first and always write one, empty included, so
+/// neither mistake is expressible here.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Title {
+    pub title: Text,
+    pub subtitle: Option<Text>,
+    pub times: TitleTimes,
+}
+
+impl Title {
+    /// A title with no line under it, shown for vanilla's own duration.
+    #[must_use]
+    pub const fn new(title: Text) -> Self {
+        Self {
+            title,
+            subtitle: None,
+            times: TitleTimes::DEFAULT,
+        }
+    }
+
+    /// The smaller line under it.
+    #[must_use]
+    pub fn under(mut self, subtitle: Text) -> Self {
+        self.subtitle = Some(subtitle);
+        self
+    }
+
+    #[must_use]
+    pub const fn timed(mut self, times: TitleTimes) -> Self {
+        self.times = times;
+        self
+    }
 }
 
 /// Everything the game asks the host server to do.
@@ -233,6 +361,21 @@ pub trait Server: Send + Sync + 'static {
     /// countdown tick has no position, and playing one in the world would make
     /// it quieter for whoever happened to be furthest from the origin.
     fn play_sound_to(&self, player: PlayerId, sound: Sound);
+
+    /// Move `player`'s experience bar. See [`Experience`].
+    fn set_experience(&self, player: PlayerId, experience: Experience);
+
+    /// Put the bar across the top of `player`'s screen, replacing whatever is
+    /// there. There is no way to take it away, because there is no state of
+    /// the game with nothing worth putting on it: see
+    /// [`crate::module::hud::boss_bar`].
+    fn set_boss_bar(&self, player: PlayerId, bar: BossBar);
+
+    /// Put a title across the middle of `player`'s screen.
+    fn show_title(&self, player: PlayerId, title: Title);
+
+    /// The same, for everyone.
+    fn broadcast_title(&self, title: Title);
 }
 
 /// Singleton holding the live [`Server`].

--- a/events/smash/src/server/mock.rs
+++ b/events/smash/src/server/mock.rs
@@ -9,7 +9,10 @@ use std::sync::Mutex;
 
 use glam::Vec3;
 
-use super::{Channel, Cue, HotbarItem, PlayerId, Server, SidebarLine, Sound, Text};
+use super::{
+    BossBar, Channel, Cue, Experience, HotbarItem, PlayerId, Server, SidebarLine, Sound, Text,
+    Title,
+};
 
 /// One thing the game asked the server to do.
 #[derive(Debug, Clone, PartialEq)]
@@ -27,6 +30,10 @@ pub enum Call {
     Sound(Vec3, Sound),
     /// A sound only one player hears.
     SoundTo(PlayerId, Sound),
+    Experience(PlayerId, Experience),
+    BossBar(PlayerId, BossBar),
+    Title(PlayerId, Title),
+    BroadcastTitle(Title),
 }
 
 #[derive(Default)]
@@ -108,6 +115,54 @@ impl MockServer {
             .collect()
     }
 
+    /// Every experience bar pushed to `player`, oldest first.
+    #[must_use]
+    pub fn experience_of(&self, player: PlayerId) -> Vec<Experience> {
+        self.calls()
+            .iter()
+            .filter_map(|call| match call {
+                Call::Experience(id, experience) if *id == player => Some(*experience),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Every boss bar pushed to `player`, oldest first.
+    #[must_use]
+    pub fn boss_bars_of(&self, player: PlayerId) -> Vec<BossBar> {
+        self.calls()
+            .iter()
+            .filter_map(|call| match call {
+                Call::BossBar(id, bar) if *id == player => Some(bar.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Every title shown to `player` alone.
+    #[must_use]
+    pub fn titles_to(&self, player: PlayerId) -> Vec<Title> {
+        self.calls()
+            .iter()
+            .filter_map(|call| match call {
+                Call::Title(id, title) if *id == player => Some(title.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Every title shown to everyone.
+    #[must_use]
+    pub fn broadcast_titles(&self) -> Vec<Title> {
+        self.calls()
+            .iter()
+            .filter_map(|call| match call {
+                Call::BroadcastTitle(title) => Some(title.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
     #[must_use]
     pub fn broadcasts(&self) -> Vec<String> {
         self.calls()
@@ -163,5 +218,21 @@ impl Server for MockServer {
 
     fn play_sound_to(&self, player: PlayerId, sound: Sound) {
         self.push(Call::SoundTo(player, sound));
+    }
+
+    fn set_experience(&self, player: PlayerId, experience: Experience) {
+        self.push(Call::Experience(player, experience));
+    }
+
+    fn set_boss_bar(&self, player: PlayerId, bar: BossBar) {
+        self.push(Call::BossBar(player, bar));
+    }
+
+    fn show_title(&self, player: PlayerId, title: Title) {
+        self.push(Call::Title(player, title));
+    }
+
+    fn broadcast_title(&self, title: Title) {
+        self.push(Call::BroadcastTitle(title));
     }
 }

--- a/events/smash/tests/contract.rs
+++ b/events/smash/tests/contract.rs
@@ -30,6 +30,7 @@ use smash::{
         ability::AbilityModule,
         arena::{Arena, ArenaModule},
         damage::{Armor, DamageKind, DamageModule, Damaged, hurt},
+        hud::HudModule,
         kit::{self, KitModule, KitStats},
         kits::StockKits,
         knockback::{Knockback, KnockbackModel, KnockbackModule, KnockbackTaken, Smashed},
@@ -313,6 +314,46 @@ fn contracts() -> Vec<Contract> {
             ],
             runtime_requires: &[],
             exercise: |world, _player| {
+                world.progress_time(0.05);
+            },
+        },
+        Contract {
+            name: "Hud",
+            import: |world| {
+                world.import::<HudModule>();
+            },
+            // Everything its one system names in a query term or reads as a
+            // singleton: the player's health and held slot, the ability in that
+            // slot, the lobby's phase and config, and the knockback model the
+            // percentage is derived from.
+            requires: &[
+                "Player",
+                "Knockback",
+                "Damage",
+                "Ability",
+                "Kit",
+                "Arena",
+                "Lives",
+                "Lobby",
+            ],
+            runtime_requires: &[],
+            exercise: |world, player| {
+                // A held slot with an ability in it, so the tick walks the
+                // whole path rather than the empty one: the mirror is the
+                // host's and does not exist here, so the slot is set directly.
+                kit::define(world, "HudContract", KitStats::default())
+                    .ability(smash::module::kit::AbilitySpec {
+                        name: "HudContract",
+                        cooldown: 5.0,
+                        proves: &[smash::module::ability::Observable::HurtsTarget],
+                        ..smash::module::kit::AbilitySpec::DEFAULT
+                    })
+                    .register();
+                let chosen = kit::by_name(world, "HudContract").expect("just defined");
+                kit::apply(world, player, chosen);
+                // The kit's only ability, so the first slot along.
+                player.set(smash::module::player::SelectedSlot(0));
+                world.progress_time(0.05);
                 world.progress_time(0.05);
             },
         },

--- a/events/smash/tests/game_flow.rs
+++ b/events/smash/tests/game_flow.rs
@@ -124,11 +124,11 @@ fn losing_the_last_life_eliminates_you_permanently() {
     assert!(player.try_get::<&Placement>(|p| p.0).is_some());
     assert!(
         game.server
-            .messages_to(PlayerId(1))
+            .titles_to(PlayerId(1))
             .iter()
-            .any(|line| line.contains("GAME OVER")),
+            .any(|title| title.title.plain().contains("GAME OVER")),
         "{:?}",
-        game.server.messages_to(PlayerId(1))
+        game.server.titles_to(PlayerId(1))
     );
 
     // Further deaths do nothing.

--- a/events/smash/tests/hud.rs
+++ b/events/smash/tests/hud.rs
@@ -1,0 +1,1220 @@
+//! What the screen says, pinned exactly.
+//!
+//! Almost everything here drives a pure function, because almost everything in
+//! `module/hud.rs` is one. That is deliberate and it is what makes this file
+//! able to say anything: the interesting states of a heads-up display are the
+//! boundaries -- the tick a cooldown finishes on, the second a countdown digit
+//! appears, the percentage a bar turns red at, a match that ends with two
+//! players level -- and a test that plays a match reaches those by luck if at
+//! all.
+//!
+//! The last section drives a whole world instead, and it checks something the
+//! pure functions cannot: that the numbers reach the seam, that they follow the
+//! slot the player is actually holding, and that an unchanged screen sends
+//! nothing.
+
+mod harness;
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use harness::Game;
+use smash::{
+    module::{
+        ability::{self, Cooldown, Grants, Slot},
+        damage::{DamageKind, Damaged, hurt},
+        hud::{
+            METER_STEPS, RED_PERCENT, Recharge, View, YELLOW_PERCENT, boss_bar, countdown_title,
+            death_title, meter, percent_colour, phase_title, winner_of,
+        },
+        kit,
+        knockback::{Knockback, KnockbackModel, KnockbackTaken, percent, strength},
+        lives::{DeathCause, Eliminated, Lives, kill},
+        lobby::{Lobby, LobbyConfig, Phase},
+        player::{Health, SelectedSlot},
+    },
+    server::{BarColour, Experience, NamedColor, PlayerId, TextColor, TitleTimes, mock::Call},
+};
+
+const EPS: f32 = 1e-5;
+
+/// The finest the experience bar and the boss bar are allowed to move, which is
+/// therefore the tolerance every check on either of them gets.
+fn step() -> f32 {
+    1.0 / f32::from(METER_STEPS)
+}
+
+/// A view with every field at a value that makes no claim, so a test can set
+/// only the fields its own claim is about.
+const fn view() -> View<'static> {
+    View {
+        phase: Phase::Playing,
+        players: 4,
+        alive: 4,
+        min_players: 4,
+        timer: 0.0,
+        span: 0.0,
+        eliminated: false,
+        percent: 0.0,
+        health: 1.0,
+        winner: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The experience bar
+// ---------------------------------------------------------------------------
+
+/// A ready ability is a full bar and no number.
+///
+/// Both halves. A full bar alone would be indistinguishable from a bar that
+/// has finished filling but still carries a stale count beside it, which is
+/// what a level nobody cleared would look like.
+#[test]
+fn a_ready_ability_fills_the_bar_and_shows_no_number() {
+    let ready = meter(Some(Recharge {
+        remaining: 0.0,
+        full: 8.0,
+    }));
+    assert!((ready.progress - 1.0).abs() < EPS, "{ready:?}");
+    assert_eq!(ready.level, 0, "{ready:?}");
+}
+
+/// An empty slot is an empty bar and no number, which is neither of the other
+/// two states.
+///
+/// The state that has to exist and cannot be conflated: reporting "ready" for
+/// a slot holding nothing would promise an ability that is not there, and
+/// reporting "recharging" would promise one that is coming.
+#[test]
+fn an_empty_slot_is_an_empty_bar_and_no_number() {
+    let empty = meter(None);
+    assert_eq!(empty, Experience {
+        progress: 0.0,
+        level: 0
+    });
+
+    // And it is not the same value as either of the others, which is the whole
+    // claim rather than a restatement of the line above.
+    let ready = meter(Some(Recharge {
+        remaining: 0.0,
+        full: 8.0,
+    }));
+    let recharging = meter(Some(Recharge {
+        remaining: 4.0,
+        full: 8.0,
+    }));
+    assert_ne!(empty, ready);
+    assert_ne!(empty, recharging);
+    assert_ne!(ready, recharging);
+}
+
+/// The bar fills as the cooldown runs down, and the number counts the seconds.
+#[test]
+fn a_recharging_ability_fills_from_empty_and_counts_the_seconds() {
+    // A ten second cooldown, sampled at each whole second left.
+    let at = |remaining: f32| {
+        meter(Some(Recharge {
+            remaining,
+            full: 10.0,
+        }))
+    };
+
+    // Just after the press: nothing filled, ten seconds to wait.
+    let fresh = at(10.0);
+    assert!(fresh.progress < EPS, "{fresh:?}");
+    assert_eq!(fresh.level, 10);
+
+    // Half way.
+    let half = at(5.0);
+    assert!((half.progress - 0.5).abs() < step(), "{half:?}");
+    assert_eq!(half.level, 5);
+
+    // The bar only ever goes up and the number only ever goes down. Stepped in
+    // whole ticks, counted as integers, so the sweep is the same on every
+    // machine rather than depending on how a float accumulates.
+    let mut previous = at(10.0);
+    for tick in 1..=200_u16 {
+        let remaining = f32::from(200 - tick) * 0.05;
+        let now = at(remaining);
+        assert!(
+            now.progress >= previous.progress,
+            "the bar went backwards at {remaining}s: {previous:?} then {now:?}"
+        );
+        assert!(
+            now.level <= previous.level,
+            "the number went up at {remaining}s: {previous:?} then {now:?}"
+        );
+        previous = now;
+    }
+}
+
+/// A bar that is still recharging never reads full, at any point in any
+/// cooldown the roster uses.
+///
+/// This is the property the quantisation exists to preserve and the one a
+/// rounding to nearest would break: at the last tick of a ten second cooldown
+/// the fraction left is 0.005, which rounds to a full bar and tells the player
+/// they may press a button that will refuse them.
+#[test]
+fn a_recharging_bar_never_reads_full() {
+    for cooldown in [1_u16, 5, 7, 8, 16, 30] {
+        let full = f32::from(cooldown);
+        // Every tick from the press to the last one that still refuses.
+        for tick in 1..=cooldown * 20 {
+            let remaining = f32::from(cooldown * 20 - tick + 1) * 0.05;
+            let shown = meter(Some(Recharge { remaining, full }));
+            assert!(
+                shown.progress < 1.0,
+                "a {full}s cooldown read as full with {remaining}s left"
+            );
+            assert!(
+                shown.level >= 1,
+                "a {full}s cooldown showed no number with {remaining}s left"
+            );
+        }
+    }
+}
+
+/// An ability whose cooldown is zero is always ready, and never divides by it.
+#[test]
+fn a_zero_length_cooldown_is_always_ready() {
+    for remaining in [0.0_f32, 1.0, f32::NAN] {
+        let shown = meter(Some(Recharge {
+            remaining,
+            full: 0.0,
+        }));
+        assert!(
+            (shown.progress - 1.0).abs() < EPS,
+            "{remaining} -> {shown:?}"
+        );
+        assert_eq!(shown.level, 0);
+    }
+}
+
+/// The bar is quantised, so a cooldown costs steps rather than ticks.
+///
+/// The number is the point of the quantisation and a test that only checked
+/// monotonicity would pass at one packet per tick.
+#[test]
+fn a_cooldown_sends_at_most_one_packet_per_step() {
+    const TICKS: u16 = 200;
+    let mut seen: Vec<f32> = Vec::new();
+    for tick in 0..TICKS {
+        let shown = meter(Some(Recharge {
+            remaining: f32::from(TICKS - tick) * 0.05,
+            full: 10.0,
+        }));
+        if seen.last() != Some(&shown.progress) {
+            seen.push(shown.progress);
+        }
+    }
+    // Two hundred ticks in a ten second cooldown, and the bar takes at most as
+    // many distinct values as it has steps, which is what turns two hundred
+    // packets into sixty-four.
+    let steps = usize::from(METER_STEPS);
+    assert!(
+        seen.len() <= steps,
+        "a ten second cooldown produced {} distinct bars against {steps} steps",
+        seen.len()
+    );
+    assert!(
+        seen.len() > usize::from(TICKS) / 8,
+        "the bar barely moved: {} values",
+        seen.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The percentage
+// ---------------------------------------------------------------------------
+
+/// The percentage really is the knockback multiplier, minus one.
+///
+/// Not a restatement of `percent`'s own arithmetic: it solves the claim against
+/// [`strength`], which is the function the whole game is balanced on. A hit on
+/// a player at p% has to be `1 + p/100` times the same hit on a fresh one, and
+/// if either function's health term is changed without the other this is what
+/// fails.
+#[test]
+fn a_percentage_is_how_much_further_the_next_hit_sends_you() {
+    let model = KnockbackModel::default();
+    let full = Health::full(20.0);
+    let baseline = strength(model, 6.0, full, KnockbackTaken::default(), 1.0);
+    assert!(
+        (percent(model, full)).abs() < EPS,
+        "a fresh player is at 0%"
+    );
+
+    for current in [18.0_f32, 15.0, 10.0, 5.0, 1.0, 0.0] {
+        let hurt = Health { current, max: 20.0 };
+        let p = percent(model, hurt);
+        let launched = strength(model, 6.0, hurt, KnockbackTaken::default(), 1.0);
+        let expected = baseline * (1.0 + p / 100.0);
+        assert!(
+            (launched - expected).abs() < 1e-4,
+            "at {current} health the percentage says {p}% but the model launched {launched} \
+             against {expected}"
+        );
+    }
+
+    // The end of the scale, for a twenty health kit.
+    assert!(
+        (percent(model, Health {
+            current: 0.0,
+            max: 20.0
+        }) - 200.0)
+            .abs()
+            < EPS
+    );
+    // Overhealed is not a negative percentage.
+    assert!(
+        percent(model, Health {
+            current: 30.0,
+            max: 20.0
+        })
+        .abs()
+            < EPS
+    );
+}
+
+/// The bar changes colour exactly at the multipliers the constants name.
+#[test]
+fn the_bar_reddens_at_the_multiplier_the_bands_name() {
+    assert_eq!(percent_colour(0.0), BarColour::Green);
+    assert_eq!(percent_colour(YELLOW_PERCENT - 0.01), BarColour::Green);
+    assert_eq!(percent_colour(YELLOW_PERCENT), BarColour::Yellow);
+    assert_eq!(percent_colour(RED_PERCENT - 0.01), BarColour::Yellow);
+    assert_eq!(percent_colour(RED_PERCENT), BarColour::Red);
+    assert_eq!(percent_colour(500.0), BarColour::Red);
+}
+
+// ---------------------------------------------------------------------------
+// The bar across the top
+// ---------------------------------------------------------------------------
+
+/// The lobby's bar says how many more players are needed.
+#[test]
+fn the_lobby_bar_counts_the_players_it_is_waiting_for() {
+    let bar = boss_bar(&View {
+        phase: Phase::Waiting,
+        players: 3,
+        min_players: 4,
+        ..view()
+    });
+    assert_eq!(bar.title.plain(), "Waiting for players  3/4");
+    // Three quarters is a whole number of steps, so quantising leaves it exact.
+    assert!((bar.progress - 0.75).abs() < EPS, "{}", bar.progress);
+    assert_eq!(bar.colour, BarColour::Blue);
+
+    // An empty lobby is an empty bar rather than a division by zero.
+    let none = boss_bar(&View {
+        phase: Phase::Waiting,
+        players: 0,
+        min_players: 0,
+        ..view()
+    });
+    assert!(none.progress.is_finite() && none.progress.abs() < EPS);
+}
+
+/// The countdown's bar drains, and says the seconds out loud.
+#[test]
+fn the_countdown_bar_drains_towards_the_start() {
+    let bar = boss_bar(&View {
+        phase: Phase::Countdown,
+        timer: 7.5,
+        span: 10.0,
+        ..view()
+    });
+    assert_eq!(bar.title.plain(), "Starting in 8s");
+    assert!((bar.progress - 0.75).abs() < EPS, "{}", bar.progress);
+    assert_eq!(bar.colour, BarColour::Yellow);
+
+    // Rounded up, so the bar never says zero while there is still a wait.
+    let last = boss_bar(&View {
+        phase: Phase::Countdown,
+        timer: 0.05,
+        span: 10.0,
+        ..view()
+    });
+    assert_eq!(last.title.plain(), "Starting in 1s");
+}
+
+/// During a match the bar is the player's own percentage, and the bar under it
+/// is their health.
+#[test]
+fn the_match_bar_is_the_percentage_and_drains_with_health() {
+    let bar = boss_bar(&View {
+        phase: Phase::Playing,
+        percent: 140.0,
+        health: 0.3,
+        ..view()
+    });
+    assert_eq!(bar.title.plain(), "140%");
+    // Within a step, because the bar is quantised: see `quantise`.
+    assert!((bar.progress - 0.3).abs() <= step(), "{}", bar.progress);
+    assert_eq!(bar.colour, BarColour::Red);
+    assert_eq!(
+        bar.title.runs()[0].color(),
+        Some(TextColor::Named(NamedColor::Red)),
+        "the number and the bar have to agree"
+    );
+
+    let fresh = boss_bar(&View {
+        phase: Phase::Playing,
+        percent: 0.0,
+        health: 1.0,
+        ..view()
+    });
+    assert_eq!(fresh.title.plain(), "0%");
+    assert_eq!(fresh.colour, BarColour::Green);
+}
+
+/// A player who is out watches the match instead of their own body.
+///
+/// Their percentage is a fact about a corpse: health is zero, so it reads at
+/// the top of the scale for the rest of the match and would be the loudest
+/// thing on the screen of the one person it cannot happen to.
+#[test]
+fn a_spectator_sees_how_much_of_the_match_is_left() {
+    let bar = boss_bar(&View {
+        phase: Phase::Playing,
+        eliminated: true,
+        players: 8,
+        alive: 2,
+        percent: 200.0,
+        health: 0.0,
+        ..view()
+    });
+    assert_eq!(bar.title.plain(), "2 still in");
+    assert!((bar.progress - 0.25).abs() < EPS, "{}", bar.progress);
+    assert_eq!(bar.colour, BarColour::Blue);
+}
+
+/// The results bar names the winner, and says so when there is not one.
+#[test]
+fn the_results_bar_names_the_winner() {
+    let won = boss_bar(&View {
+        phase: Phase::Ended,
+        winner: Some("Andrew"),
+        ..view()
+    });
+    assert_eq!(won.title.plain(), "Andrew wins!");
+    assert_eq!(won.colour, BarColour::Green);
+
+    let drawn = boss_bar(&View {
+        phase: Phase::Ended,
+        winner: None,
+        ..view()
+    });
+    assert_eq!(drawn.title.plain(), "Nobody was left standing");
+    assert_eq!(drawn.colour, BarColour::Blue);
+}
+
+/// Every phase puts something on the bar, and no two phases put the same thing.
+///
+/// The claim the module documents is that the strip is never blank and never
+/// stale. A per-phase test proves the first; this proves the second, which is
+/// what a copy-pasted arm would break.
+#[test]
+fn every_phase_says_something_and_no_two_say_the_same() {
+    let phases = [
+        Phase::Waiting,
+        Phase::Countdown,
+        Phase::Preparing,
+        Phase::Playing,
+        Phase::Ended,
+    ];
+    let mut titles = Vec::new();
+    for phase in phases {
+        let bar = boss_bar(&View {
+            phase,
+            timer: 5.0,
+            span: 10.0,
+            ..view()
+        });
+        assert!(!bar.title.plain().is_empty(), "{phase:?} said nothing");
+        assert!(
+            (0.0..=1.0).contains(&bar.progress),
+            "{phase:?} asked for a bar at {}",
+            bar.progress
+        );
+        titles.push(bar.title.plain());
+    }
+    let mut unique = titles.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(
+        unique.len(),
+        titles.len(),
+        "two phases read alike: {titles:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Titles
+// ---------------------------------------------------------------------------
+
+/// Only the last three seconds get a number, and each is its own digit.
+#[test]
+fn only_the_last_three_seconds_of_the_countdown_get_a_number() {
+    assert!(countdown_title(Phase::Preparing, 5.0).is_none());
+    assert!(countdown_title(Phase::Preparing, 4.0).is_none());
+    assert!(countdown_title(Phase::Preparing, 3.0001).is_none());
+    assert!(countdown_title(Phase::Preparing, 0.0).is_none());
+    assert!(countdown_title(Phase::Preparing, -1.0).is_none());
+
+    for second in [3.0_f32, 2.0, 1.0] {
+        let title = countdown_title(Phase::Preparing, second).expect("inside the window");
+        assert_eq!(title.title.plain(), format!("{second:.0}"));
+        assert_eq!(
+            title.subtitle.as_ref().map(smash::server::Component::plain),
+            Some("Get ready".to_owned())
+        );
+        assert_eq!(
+            title.times,
+            TitleTimes::TICK,
+            "a countdown digit has to be gone before the next one arrives"
+        );
+    }
+}
+
+/// The lobby's own countdown gets no digits, only the prepare timer does.
+///
+/// Two phases count down in a row and both tick out loud, so a window on both
+/// draws "3, 2, 1" twice with a teleport in the middle. The wire gate found
+/// exactly that before this rule existed.
+#[test]
+fn only_the_prepare_timer_gets_digits() {
+    for second in [3.0_f32, 2.0, 1.0] {
+        for phase in [
+            Phase::Waiting,
+            Phase::Countdown,
+            Phase::Playing,
+            Phase::Ended,
+        ] {
+            assert!(
+                countdown_title(phase, second).is_none(),
+                "{phase:?} put a {second} on screen"
+            );
+        }
+        assert!(countdown_title(Phase::Preparing, second).is_some());
+    }
+}
+
+/// The start and the end get a title. Nothing else does.
+#[test]
+fn the_start_and_the_end_get_a_title_and_nothing_else_does() {
+    assert!(phase_title(Phase::Waiting, None).is_none());
+    assert!(phase_title(Phase::Countdown, None).is_none());
+    assert!(phase_title(Phase::Preparing, None).is_none());
+
+    let go = phase_title(Phase::Playing, None).expect("the match starting is worth a word");
+    assert_eq!(go.title.plain(), "GO!");
+    assert_eq!(go.times, TitleTimes::TICK);
+
+    let won = phase_title(Phase::Ended, Some("Andrew")).expect("a result is worth a title");
+    assert_eq!(won.title.plain(), "Andrew wins!");
+    assert_eq!(
+        won.subtitle.as_ref().map(smash::server::Component::plain),
+        Some("Last mob standing".to_owned())
+    );
+
+    let drawn = phase_title(Phase::Ended, None).expect("so is the absence of one");
+    assert_eq!(drawn.title.plain(), "Game over");
+    assert_eq!(
+        drawn.subtitle.as_ref().map(smash::server::Component::plain),
+        Some("Nobody was left standing".to_owned())
+    );
+}
+
+/// A death says what it cost, and who did it.
+#[test]
+fn a_death_names_the_killer_under_the_life_count() {
+    let title = death_title(2, Some("Andrew"), DeathCause::Damage);
+    assert_eq!(title.title.plain(), "2 lives left!");
+    assert_eq!(
+        title.subtitle.as_ref().map(smash::server::Component::plain),
+        Some("Smashed by Andrew".to_owned()),
+        "the whole point of the subtitle"
+    );
+
+    // The last life, and the credit still arrives.
+    let last = death_title(0, Some("Andrew"), DeathCause::Void);
+    assert_eq!(last.title.plain(), "GAME OVER");
+    assert_eq!(
+        last.subtitle.as_ref().map(smash::server::Component::plain),
+        Some("Smashed by Andrew".to_owned())
+    );
+
+    // Nobody to credit, and the two ways that happens read differently.
+    let fell = death_title(1, None, DeathCause::Void);
+    assert_eq!(
+        fell.subtitle.as_ref().map(smash::server::Component::plain),
+        Some("You fell out of the world".to_owned())
+    );
+    let starved = death_title(1, None, DeathCause::Damage);
+    assert_eq!(
+        starved
+            .subtitle
+            .as_ref()
+            .map(smash::server::Component::plain),
+        Some("Nobody to blame but yourself".to_owned())
+    );
+}
+
+/// One life left is one life, not one lives.
+///
+/// A trivial line, and the reason it has a test is that it is read at the worst
+/// moment of a match: a grammatical error there is exactly the kind of thing
+/// that makes a finished game feel unfinished.
+#[test]
+fn one_life_left_is_not_pluralised() {
+    assert_eq!(
+        death_title(1, None, DeathCause::Void).title.plain(),
+        "1 life left!"
+    );
+    assert_eq!(
+        death_title(2, None, DeathCause::Void).title.plain(),
+        "2 lives left!"
+    );
+    assert_eq!(
+        death_title(3, None, DeathCause::Void).title.plain(),
+        "3 lives left!"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Who won
+// ---------------------------------------------------------------------------
+
+/// The last player standing wins.
+#[test]
+fn the_last_player_standing_wins() {
+    let standings = [
+        ("out".to_owned(), 0u8),
+        ("alive".to_owned(), 2u8),
+        ("also_out".to_owned(), 0u8),
+    ];
+    assert_eq!(winner_of(&standings), Some("alive"));
+}
+
+/// A match that times out is won by whoever has the most lives.
+#[test]
+fn a_timed_out_match_goes_to_the_most_lives() {
+    let standings = [
+        ("ahead".to_owned(), 4u8),
+        ("behind".to_owned(), 2u8),
+        ("out".to_owned(), 0u8),
+    ];
+    assert_eq!(winner_of(&standings), Some("ahead"));
+}
+
+/// Two players level is not a winner, and neither is nobody.
+///
+/// Picking one of them would be inventing a result the game does not have, and
+/// a results screen that names a winner is what a player believes.
+#[test]
+fn a_tie_has_no_winner() {
+    let level = [("one".to_owned(), 3u8), ("two".to_owned(), 3u8)];
+    assert_eq!(winner_of(&level), None);
+
+    let nobody = [("one".to_owned(), 0u8), ("two".to_owned(), 0u8)];
+    assert_eq!(winner_of(&nobody), None);
+
+    let empty: [(String, u8); 0] = [];
+    assert_eq!(winner_of(&empty), None);
+}
+
+// ---------------------------------------------------------------------------
+// In a world
+// ---------------------------------------------------------------------------
+
+/// Give `player` a kit and hold `slot`, returning the ability instance there.
+fn hold(game: &Game, player: EntityView<'_>, kit_name: &str, slot: u8) -> Entity {
+    kit::apply(
+        &game.world,
+        player,
+        kit::by_name(&game.world, kit_name).expect("a stock kit"),
+    );
+    player.set(SelectedSlot(slot));
+    let mut found = None;
+    player.each_target(Grants, |ability| {
+        if ability.try_get::<&Slot>(|s| s.0 == slot) == Some(true) {
+            found = Some(ability.id());
+        }
+    });
+    found.expect("the kit grants an ability in that slot")
+}
+
+/// The last experience bar the server pushed to a player.
+fn bar_of(game: &Game, player: PlayerId) -> Option<Experience> {
+    game.server.experience_of(player).last().copied()
+}
+
+/// The experience bar follows the cooldown of the slot being held.
+///
+/// The whole feature, end to end through the seam: full before the press, then
+/// filling with a number beside it, then full again with the number gone, and
+/// the ability's own cooldown component agreeing at each step.
+#[test]
+fn the_experience_bar_follows_the_cooldown_of_the_slot_being_held() {
+    let mut game = Game::new();
+    let player = game.player("p", Vec3::ZERO);
+    let player = game.world.entity_from_id(player);
+    // Slot 2 is Seismic Slam at seven seconds. Abilities take the slots in the
+    // order the kit declares them, so this is the third `.ability` call in
+    // `kits/iron_golem.rs` and the assertion below is what says so.
+    let ability = hold(&game, player, "Iron Golem", 2);
+    let cooldown = game
+        .world
+        .entity_from_id(ability)
+        .cloned::<&smash::module::ability::CooldownSpec>()
+        .0;
+    assert!((cooldown - 7.0).abs() < EPS, "the kit changed: {cooldown}s");
+
+    game.advance(0.05, 1);
+    assert_eq!(
+        bar_of(&game, PlayerId(1)),
+        Some(Experience {
+            progress: 1.0,
+            level: 0
+        }),
+        "a ready ability is a full bar"
+    );
+
+    game.server.take();
+    assert_eq!(ability::activate(player, 2, 1.0), Ok(()));
+    game.advance(0.05, 1);
+    let fired = bar_of(&game, PlayerId(1)).expect("the press moved the bar");
+    assert!(fired.progress < 2.0 * step(), "{fired:?}");
+    assert_eq!(fired.level, 7, "the number is the seconds left");
+
+    // Two seconds in: five to go, and the bar is a bit over two sevenths.
+    game.advance(2.0, 40);
+    let part = bar_of(&game, PlayerId(1)).expect("the bar kept moving");
+    assert_eq!(part.level, 5, "{part:?}");
+    assert!((part.progress - 2.0 / 7.0).abs() < 2.0 * step(), "{part:?}");
+
+    // Out the other side.
+    game.advance(5.5, 110);
+    assert!(
+        game.world
+            .entity_from_id(ability)
+            .cloned::<&Cooldown>()
+            .remaining
+            .abs()
+            < EPS,
+        "the cooldown has not finished, so this test is measuring the wrong thing"
+    );
+    assert_eq!(
+        bar_of(&game, PlayerId(1)),
+        Some(Experience {
+            progress: 1.0,
+            level: 0
+        }),
+        "a finished cooldown is a full bar and no number again"
+    );
+}
+
+/// Changing which slot is held changes which cooldown the bar shows.
+///
+/// The bar is not "the last ability you used", which is the shape a naive
+/// implementation lands on and which reads identically until a player holds a
+/// different item.
+#[test]
+fn changing_the_held_slot_changes_which_cooldown_the_bar_shows() {
+    let mut game = Game::new();
+    let player = game.player("p", Vec3::ZERO);
+    let player = game.world.entity_from_id(player);
+    hold(&game, player, "Iron Golem", 2);
+    player.set(smash::module::player::OnGround(true));
+
+    assert_eq!(ability::activate(player, 2, 1.0), Ok(()));
+    game.advance(0.05, 1);
+    let firing = bar_of(&game, PlayerId(1)).expect("a bar");
+    assert!(firing.level > 0, "the fired slot is recharging: {firing:?}");
+
+    // Slot 1 is Iron Hook, untouched.
+    player.set(SelectedSlot(1));
+    game.advance(0.05, 1);
+    assert_eq!(
+        bar_of(&game, PlayerId(1)),
+        Some(Experience {
+            progress: 1.0,
+            level: 0
+        }),
+        "holding an untouched slot shows that slot"
+    );
+
+    // Slot 5 holds nothing at all.
+    player.set(SelectedSlot(5));
+    game.advance(0.05, 1);
+    assert_eq!(
+        bar_of(&game, PlayerId(1)),
+        Some(Experience {
+            progress: 0.0,
+            level: 0
+        }),
+        "holding an empty slot is an empty bar"
+    );
+}
+
+/// An unchanged screen sends nothing.
+///
+/// Both surfaces are a packet per player and the cheapest possible bug here is
+/// a redraw every tick, which costs twenty packets a second per player and is
+/// invisible in play. The lobby is the state that changes least, so it is where
+/// the claim is testable.
+#[test]
+fn an_unchanged_screen_sends_nothing() {
+    let mut game = Game::new();
+    game.player("p", Vec3::new(0.0, 100.0, 0.0));
+    // One player against a minimum of four, so the lobby stays in Waiting and
+    // nothing else moves.
+    game.advance(1.0, 20);
+
+    let hud_calls = |game: &Game| {
+        game.server
+            .calls()
+            .into_iter()
+            .filter(|call| matches!(call, Call::Experience(..) | Call::BossBar(..)))
+            .count()
+    };
+    // One, not two. A player with no kit holds an empty slot, whose meter is
+    // the empty bar a fresh client already draws, so there is nothing to
+    // correct; the boss bar is the only thing the client does not already have.
+    assert_eq!(
+        hud_calls(&game),
+        1,
+        "a joining player with no kit needs one push: {:?}",
+        game.server.calls()
+    );
+
+    game.server.take();
+    game.advance(5.0, 100);
+    let after = hud_calls(&game);
+    assert_eq!(after, 0, "a hundred idle ticks sent {after} HUD packets");
+}
+
+/// A hit moves the percentage on the victim's own bar.
+#[test]
+fn a_hit_moves_the_percentage_on_the_victims_bar() {
+    let mut game = Game::new();
+    // Well above the arena's kill plane, because setting the phase by hand
+    // skips the scatter that would otherwise have put them on a platform.
+    let attacker = game.player("attacker", Vec3::new(0.0, 100.0, 0.0));
+    let victim = game.player("victim", Vec3::new(2.0, 100.0, 0.0));
+    let victim_view = game.world.entity_from_id(victim);
+    game.world.set(Lobby {
+        phase: Phase::Playing,
+        timer: 1.0,
+    });
+    game.advance(0.05, 1);
+
+    let before = game
+        .server
+        .boss_bars_of(PlayerId(2))
+        .last()
+        .cloned()
+        .expect("a bar during a match");
+    assert_eq!(before.title.plain(), "0%");
+    assert_eq!(before.colour, BarColour::Green);
+
+    // Ten of twenty health, which the model says is exactly 100%.
+    hurt(victim_view, Damaged {
+        attacker: Some(attacker),
+        amount: 10.0,
+        knockback: Knockback::from(Vec3::ZERO),
+        kind: DamageKind::Environment,
+    });
+    game.advance(0.05, 1);
+
+    let after = game
+        .server
+        .boss_bars_of(PlayerId(2))
+        .last()
+        .cloned()
+        .expect("the hit moved the bar");
+    assert_eq!(after.title.plain(), "100%");
+    assert_eq!(after.colour, BarColour::Red);
+    assert!((after.progress - 0.5).abs() < EPS, "{}", after.progress);
+}
+
+/// A death puts the killer's name on the victim's own screen.
+///
+/// The credit relation has existed since the damage pipeline was written and
+/// until now it only ever reached the broadcast chat line, which is read by
+/// everybody except the person it happened to.
+#[test]
+fn a_death_puts_the_killers_name_on_the_victims_screen() {
+    let mut game = Game::new();
+    let attacker = game.player("Andrew", Vec3::ZERO);
+    let victim = game.player("victim", Vec3::new(2.0, 0.0, 0.0));
+    let victim_view = game.world.entity_from_id(victim);
+
+    hurt(victim_view, Damaged {
+        attacker: Some(attacker),
+        amount: 1.0,
+        knockback: Knockback::from(Vec3::ZERO),
+        kind: DamageKind::Melee,
+    });
+    game.server.take();
+    kill(victim_view, DeathCause::Void);
+
+    let titles = game.server.titles_to(PlayerId(2));
+    assert_eq!(titles.len(), 1, "{titles:?}");
+    assert_eq!(titles[0].title.plain(), "3 lives left!");
+    assert_eq!(
+        titles[0]
+            .subtitle
+            .as_ref()
+            .map(smash::server::Component::plain),
+        Some("Smashed by Andrew".to_owned())
+    );
+}
+
+/// The end of a match names the winner on every screen and in the chat.
+#[test]
+fn the_end_of_a_match_names_the_winner() {
+    let mut game = Game::new();
+    game.world.set(LobbyConfig {
+        min_players: 2,
+        full_players: 2,
+        countdown_at_full: 0.1,
+        countdown_at_three_quarters: 0.1,
+        countdown_at_min: 0.1,
+        prepare_seconds: 0.1,
+        match_timeout_seconds: 60.0,
+        results_seconds: 5.0,
+    });
+    let doomed = game.player("doomed", Vec3::ZERO);
+    game.player("survivor", Vec3::new(30.0, 0.0, 0.0));
+    let doomed = game.world.entity_from_id(doomed);
+
+    // Into the match.
+    game.advance(1.0, 20);
+    assert_eq!(game.world.cloned::<&Lobby>().phase, Phase::Playing);
+
+    // Out of lives, which is what ends it.
+    for _ in 0..smash::module::lives::MAX_LIVES {
+        kill(doomed, DeathCause::Void);
+        doomed.remove(smash::module::lives::RespawnAt::id());
+        doomed.get::<&mut Health>(|health| health.current = health.max);
+    }
+    assert!(doomed.has(Eliminated::id()));
+
+    game.server.take();
+    game.advance(0.5, 10);
+    assert_eq!(game.world.cloned::<&Lobby>().phase, Phase::Ended);
+
+    let titles = game.server.broadcast_titles();
+    assert!(
+        titles
+            .iter()
+            .any(|title| title.title.plain() == "survivor wins!"),
+        "{titles:?}"
+    );
+    assert!(
+        game.server
+            .broadcasts()
+            .iter()
+            .any(|line| line == "Game over. survivor wins!"),
+        "{:?}",
+        game.server.broadcasts()
+    );
+}
+
+/// A player still in the match is never told somebody else's bar.
+///
+/// One system pushes every player's bar in one pass, so the failure worth
+/// guarding against is a loop that computes one view and sends it to everybody.
+#[test]
+fn each_player_gets_their_own_percentage() {
+    let mut game = Game::new();
+    let attacker = game.player("attacker", Vec3::new(0.0, 100.0, 0.0));
+    let victim = game.player("victim", Vec3::new(2.0, 100.0, 0.0));
+    game.world.set(Lobby {
+        phase: Phase::Playing,
+        timer: 1.0,
+    });
+    hurt(game.world.entity_from_id(victim), Damaged {
+        attacker: Some(attacker),
+        amount: 10.0,
+        knockback: Knockback::from(Vec3::ZERO),
+        kind: DamageKind::Environment,
+    });
+    game.advance(0.05, 2);
+
+    let hit = game.server.boss_bars_of(PlayerId(2));
+    let untouched = game.server.boss_bars_of(PlayerId(1));
+    assert_eq!(
+        hit.last().map(|bar| bar.title.plain()),
+        Some("100%".to_owned())
+    );
+    assert_eq!(
+        untouched.last().map(|bar| bar.title.plain()),
+        Some("0%".to_owned())
+    );
+}
+
+/// The countdown's last three seconds reach every screen, exactly once.
+///
+/// Both counting phases are run through, which is the point: a four second
+/// lobby countdown followed by a four second prepare timer crosses three, two
+/// and one twice, and only the second crossing is a countdown to something a
+/// player can act on.
+#[test]
+fn the_countdown_puts_a_number_on_every_screen_exactly_once() {
+    let mut game = Game::new();
+    game.world.set(LobbyConfig {
+        min_players: 2,
+        full_players: 2,
+        countdown_at_full: 4.0,
+        countdown_at_three_quarters: 4.0,
+        countdown_at_min: 4.0,
+        prepare_seconds: 4.0,
+        match_timeout_seconds: 60.0,
+        results_seconds: 1.0,
+    });
+    game.player("one", Vec3::new(0.0, 100.0, 0.0));
+    game.player("two", Vec3::new(4.0, 100.0, 0.0));
+
+    // Through the lobby countdown and the prepare timer both.
+    game.advance(9.0, 180);
+    assert_eq!(game.world.cloned::<&Lobby>().phase, Phase::Playing);
+
+    let shown: Vec<String> = game
+        .server
+        .broadcast_titles()
+        .into_iter()
+        .map(|title| title.title.plain())
+        .collect();
+    let digits: Vec<&String> = shown.iter().filter(|text| text.len() == 1).collect();
+    assert_eq!(digits, vec!["3", "2", "1"], "{shown:?}");
+    assert!(shown.contains(&"GO!".to_owned()), "{shown:?}");
+}
+
+/// Every player in the world is on the panel and the bar, including one who
+/// joins mid-match.
+///
+/// `Shown` arrives with the player through a `With` trait, so a player created
+/// after the module has been running still gets a first push rather than
+/// silently having no record and never being compared.
+#[test]
+fn a_player_who_joins_late_gets_a_screen() {
+    let mut game = Game::new();
+    game.player("early", Vec3::new(0.0, 100.0, 0.0));
+    game.advance(1.0, 20);
+
+    let late = game.player("late", Vec3::new(4.0, 100.0, 0.0));
+    let late = game.world.entity_from_id(late);
+    hold(&game, late, "Iron Golem", 2);
+    game.server.take();
+    game.advance(0.05, 1);
+
+    assert!(
+        !game.server.boss_bars_of(PlayerId(2)).is_empty(),
+        "the late joiner got no bar"
+    );
+    assert_eq!(
+        game.server.experience_of(PlayerId(2)).last().copied(),
+        Some(Experience {
+            progress: 1.0,
+            level: 0
+        }),
+        "the late joiner got no experience bar"
+    );
+    // And the early one is not resent anything by somebody else's arrival: the
+    // lobby's own bar changed when the count went from one to two, so the check
+    // is that nothing beyond that one push happened.
+    assert_eq!(
+        game.server.experience_of(PlayerId(1)).len(),
+        0,
+        "the early player's experience bar was rewritten for somebody else's arrival"
+    );
+}
+
+/// Lives and elimination are not what the bar reads during a match, and a
+/// spectator is not a live player with a strange percentage.
+#[test]
+fn elimination_switches_the_bar_to_spectating() {
+    let mut game = Game::new();
+    let doomed = game.player("doomed", Vec3::new(0.0, 100.0, 0.0));
+    // Two survivors and not one, so the match does not end on the elimination
+    // and the bar this test is about is still the one on screen.
+    game.player("second", Vec3::new(30.0, 100.0, 0.0));
+    game.player("third", Vec3::new(60.0, 100.0, 0.0));
+    let doomed = game.world.entity_from_id(doomed);
+    game.world.set(Lobby {
+        phase: Phase::Playing,
+        timer: 1.0,
+    });
+
+    for _ in 0..smash::module::lives::MAX_LIVES {
+        kill(doomed, DeathCause::Void);
+        doomed.remove(smash::module::lives::RespawnAt::id());
+        doomed.get::<&mut Health>(|health| health.current = health.max);
+    }
+    assert_eq!(doomed.cloned::<&Lives>().0, 0);
+    assert!(doomed.has(Eliminated::id()));
+    game.advance(0.05, 2);
+    assert_eq!(game.world.cloned::<&Lobby>().phase, Phase::Playing);
+
+    let bar = game
+        .server
+        .boss_bars_of(PlayerId(1))
+        .last()
+        .cloned()
+        .expect("a bar");
+    assert_eq!(bar.title.plain(), "2 still in");
+    assert!(
+        (bar.progress - 2.0 / 3.0).abs() <= step(),
+        "{}",
+        bar.progress
+    );
+    assert_eq!(bar.colour, BarColour::Blue);
+}
+
+// ---------------------------------------------------------------------------
+// In a deferred world, which is the only kind the running server has
+// ---------------------------------------------------------------------------
+
+/// The bar catches up with a kit chosen inside a deferred world.
+///
+/// Every path a player actually reaches runs inside a flecs system, so the
+/// world is deferred and a `(Grants, ability)` edge written there is *queued*:
+/// a reader in the same frame sees the state before the change. A test that
+/// calls `choose` directly defers nothing and cannot see that window at all,
+/// which is how a sibling change shipped a sound that played the previous kit's
+/// voice with a green suite behind it.
+///
+/// What saves this module from the same bug is not luck but the shape of it:
+/// the meter is recomputed and diffed every tick, so a queued edge costs one
+/// tick of staleness and the next tick corrects it. That is a claim worth
+/// pinning rather than assuming, because it is what makes a stale read
+/// harmless here and fatal for a one-shot event.
+#[test]
+fn a_kit_chosen_in_a_deferred_world_reaches_the_bar() {
+    let mut game = Game::new();
+    let player = game.player("p", Vec3::new(0.0, 100.0, 0.0));
+    let player = game.world.entity_from_id(player);
+    player.set(SelectedSlot(2));
+    game.advance(0.05, 1);
+    game.server.take();
+
+    // Exactly what `/kit` does: `lobby::choose` from inside a system, where
+    // every add it makes is queued rather than applied.
+    game.world.defer(|| {
+        smash::module::lobby::choose(
+            &game.world,
+            player,
+            kit::by_name(&game.world, "Iron Golem").expect("a stock kit"),
+        )
+        .expect("the hub allows a kit change");
+    });
+
+    game.advance(0.05, 2);
+    assert_eq!(
+        bar_of(&game, PlayerId(1)),
+        Some(Experience {
+            progress: 1.0,
+            level: 0
+        }),
+        "the bar never noticed the kit: {:?}",
+        game.server.experience_of(PlayerId(1))
+    );
+
+    // And firing it in a deferred world moves the bar the same way.
+    game.server.take();
+    game.world.defer(|| {
+        assert_eq!(ability::activate(player, 2, 1.0), Ok(()));
+    });
+    game.advance(0.05, 2);
+    let fired = bar_of(&game, PlayerId(1)).expect("the press moved the bar");
+    assert_eq!(fired.level, 7, "{fired:?}");
+    assert!(fired.progress < 0.1, "{fired:?}");
+}
+
+/// A death in a deferred world still names the killer.
+///
+/// The credit is a relation the damage pipeline writes, so it is subject to the
+/// same queueing. The hit and the death it causes are always separate ticks in
+/// this game -- knockback carries a victim off the map over dozens of them --
+/// so the edge has merged by the time the death reads it, and this drives the
+/// two through separate deferred windows to say so rather than assuming it.
+#[test]
+fn a_death_in_a_deferred_world_still_names_the_killer() {
+    let mut game = Game::new();
+    let attacker = game.player("Andrew", Vec3::new(0.0, 100.0, 0.0));
+    let victim = game.player("victim", Vec3::new(2.0, 100.0, 0.0));
+    let victim_view = game.world.entity_from_id(victim);
+
+    game.world.defer(|| {
+        hurt(victim_view, Damaged {
+            attacker: Some(attacker),
+            amount: 1.0,
+            knockback: Knockback::from(Vec3::ZERO),
+            kind: DamageKind::Melee,
+        });
+    });
+    game.advance(0.05, 1);
+    game.server.take();
+
+    game.world.defer(|| kill(victim_view, DeathCause::Void));
+
+    let titles = game.server.titles_to(PlayerId(2));
+    assert_eq!(titles.len(), 1, "{titles:?}");
+    assert_eq!(
+        titles[0]
+            .subtitle
+            .as_ref()
+            .map(smash::server::Component::plain),
+        Some("Smashed by Andrew".to_owned()),
+        "the credit did not survive the merge"
+    );
+}
+
+/// The whole roster's cooldowns are readable on the bar.
+///
+/// Enumerated rather than sampled, because the failure this catches is one
+/// ability quietly having no cooldown declared: it would read as permanently
+/// ready and nothing else in the suite would notice, since `tests/abilities.rs`
+/// checks the refusal rather than the display.
+#[test]
+fn every_ability_in_the_roster_has_a_readable_meter() {
+    let game = Game::new();
+    let mut checked = 0;
+    for declared in ability::manifest(&game.world) {
+        let fresh = meter(Some(Recharge {
+            remaining: declared.cooldown,
+            full: declared.cooldown,
+        }));
+        let ready = meter(Some(Recharge {
+            remaining: 0.0,
+            full: declared.cooldown,
+        }));
+        assert!(
+            (ready.progress - 1.0).abs() < EPS && ready.level == 0,
+            "{} / {} does not read as ready",
+            declared.kit,
+            declared.name
+        );
+        if declared.cooldown > 0.0 {
+            assert!(
+                fresh.progress < 1.0 && fresh.level >= 1,
+                "{} / {} has a {}s cooldown that reads as ready the moment it fires",
+                declared.kit,
+                declared.name,
+                declared.cooldown
+            );
+        } else {
+            assert_eq!(
+                fresh, ready,
+                "{} / {} has no cooldown and should always read ready",
+                declared.kit, declared.name
+            );
+        }
+        checked += 1;
+    }
+    assert!(checked >= 50, "only {checked} abilities were enumerated");
+}

--- a/events/smash/tests/verification.rs
+++ b/events/smash/tests/verification.rs
@@ -514,18 +514,19 @@ fn a_death_tells_the_player_what_it_cost_them() {
         kill(player, DeathCause::Void);
         player.remove(RespawnAt::id());
         player.get::<&mut Health>(|health| health.current = health.max);
-        said.push(game.server.messages_to(PlayerId(1)));
+        said.push(
+            game.server
+                .titles_to(PlayerId(1))
+                .into_iter()
+                .map(|title| title.title.plain())
+                .collect::<Vec<_>>(),
+        );
     }
 
     assert_eq!(said[0], vec!["3 lives left!".to_owned()], "{:?}", said[0]);
     assert_eq!(said[1], vec!["2 lives left!".to_owned()], "{:?}", said[1]);
-    assert_eq!(said[2], vec!["1 lives left!".to_owned()], "{:?}", said[2]);
-    assert_eq!(said[3].len(), 1, "{:?}", said[3]);
-    assert!(
-        said[3][0].contains("GAME OVER"),
-        "the last death said {:?}",
-        said[3][0]
-    );
+    assert_eq!(said[2], vec!["1 life left!".to_owned()], "{:?}", said[2]);
+    assert_eq!(said[3], vec!["GAME OVER".to_owned()], "{:?}", said[3]);
 }
 
 /// A respawn is immune for exactly the documented window and no longer.

--- a/flake.nix
+++ b/flake.nix
@@ -376,6 +376,8 @@
             smash-selector-e2e = 4000;
             smash-identity-e2e = 5000;
             completions-e2e = 6000;
+            smash-hotbar-e2e = 7000;
+            smash-hud-e2e = 8000;
           };
 
           # Two gates on one offset, as a build failure rather than as a race.
@@ -750,8 +752,35 @@
               text = ''
                 export HYPERION_EVENT=smash
                 export HYPERION_E2E_CLIENT=tools/hotbar-check.py
-                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + 6000)}}"
-                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + 6000)}}"
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.smash-hotbar-e2e)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.smash-hotbar-e2e)}}"
+                exec "${lib.getExe runners.e2e}" "$@"
+              '';
+            };
+
+            # The same gate again, driving a client that reads the screen rather
+            # than the world: the experience bar as an ability recharges, the
+            # boss bar through every phase, and the titles a match punctuates
+            # itself with. Three of those packets were sent zero times by this
+            # server before the HUD landed, so nothing else here can tell a
+            # regression from the way it always was.
+            #
+            # Its ports come from `e2eOffsets`, which is also where
+            # `smash-hotbar-e2e` has just been moved to: it was written with a
+            # literal 6000, which is `completions-e2e`'s, and a literal is
+            # exactly what `e2ePortsDistinct` cannot see. Two gates on one
+            # offset is a race for a socket on darwin, and the guard only works
+            # if every gate is in the table it reads.
+            smash-hud-e2e = {
+              deps = [
+                pkgs.git
+                pkgs.python3
+              ];
+              text = ''
+                export HYPERION_EVENT=smash
+                export HYPERION_E2E_CLIENT=tools/hud-check.py
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.smash-hud-e2e)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.smash-hud-e2e)}}"
                 exec "${lib.getExe runners.e2e}" "$@"
               '';
             };
@@ -908,6 +937,18 @@
               timeout = 300;
             };
 
+            # The screen, on a real connection. Eight clients rather than four,
+            # because `full_players` is what makes the lobby run its ten second
+            # countdown instead of its sixty second one, and the countdown is
+            # half of what this reads.
+            smash-hud-e2e = e2e.mkCheck {
+              name = "hyperion-smash-hud-e2e";
+              gameServer = gameBinaries.smash;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "hud-check.py";
+              timeout = 420;
+            };
+
             # `checks.e2e` above took the names the two app wrappers used to
             # hold, and those wrappers still have to pass shellcheck.
             e2e-app = scripts.e2e;
@@ -916,6 +957,7 @@
             smash-selector-e2e-app = scripts.smash-selector-e2e;
             smash-identity-e2e-app = scripts.smash-identity-e2e;
             smash-hotbar-e2e-app = scripts.smash-hotbar-e2e;
+            smash-hud-e2e-app = scripts.smash-hud-e2e;
 
             # Every kit's skin, checked offline against Mojang's committed
             # public keys. A derivation rather than only an app, because the

--- a/tools/hud-check.py
+++ b/tools/hud-check.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""The heads-up display, read off the wire.
+
+Everything the server draws on a player's screen is a packet, and three of the
+packets this asks about were sent zero times by this server until now:
+`ClientboundSetExperiencePacket`, `ClientboundBossEventPacket` and
+`ClientboundSetSubtitleTextPacket`. A Rust test can prove the game *decided* to
+draw something; only a client can say whether it arrived, under the id a 26.2
+client reads, carrying the numbers the game meant.
+
+Two halves, because they need different numbers of players.
+
+  1. One client in the hub. It picks a kit, holds each of three slots in turn,
+     and reads the experience bar back: full with no number for an ability that
+     is ready, filling from empty with the seconds beside it for one that is
+     recharging, empty with no number for a slot holding nothing. It also fires
+     the ability and follows the bar all the way back to full, which is the
+     claim the whole feature rests on and the one that a bar wired to the wrong
+     slot would still pass half of.
+
+  2. Eight clients, which is `full_players`, so the lobby runs its shortest
+     countdown rather than its sixty second one. That gets the phase machine
+     through Countdown, Preparing and into Playing inside twenty seconds, and
+     the titles, subtitles and the percentage bar with it.
+
+Exits non-zero on the first thing that is not true, after printing what it saw.
+"""
+
+import argparse
+import importlib.util
+import math
+import pathlib
+import re
+import struct
+import sys
+import time
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+
+
+def _load(name, filename):
+    """Import a sibling tool whose file name is not a Python identifier."""
+    spec = importlib.util.spec_from_file_location(name, TOOLS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+match = _load("smash_match", "smash-match.py")
+take_var_int = match.take_var_int
+var_int = match.var_int
+
+# crates/hyperion-minecraft-proto/src/generated/packet_id.rs, protocol 776.
+S2C_BOSS_EVENT = 0x09
+S2C_SET_EXPERIENCE = 0x67
+S2C_SET_SUBTITLE_TEXT = 0x70
+S2C_SET_TITLES_ANIMATION = 0x73
+
+# `BossEventOperation::type_id`.
+BOSS_ADD = 0
+# `BossBarColor`, as ordinals.
+BOSS_COLOURS = ["pink", "blue", "red", "green", "yellow", "purple", "white"]
+
+# A kit's abilities take the hotbar slots in the order it declares them, so for
+# the Iron Golem slot 2 is Seismic Slam at seven seconds, slot 1 is Iron Hook at
+# eight, and slot 5 holds nothing. Named here rather than read off `/abilities`
+# because the point of this gate is the *display*, and a fixed cooldown is what
+# makes the number beside the bar predictable; `smash-hotbar-e2e` is the gate
+# that holds the layout itself.
+KIT = "Iron Golem"
+FIRED_SLOT = 2
+FIRED_COOLDOWN = 7.0
+IDLE_SLOT = 1
+EMPTY_SLOT = 5
+
+# events/smash/src/module/hud.rs: `METER_STEPS`. One step is the finest the bar
+# is allowed to move, so it is also the tolerance every progress check here
+# gets.
+METER_STEPS = 64.0
+STEP = 1.0 / METER_STEPS
+
+# events/smash/src/module/hud.rs: `COUNTDOWN_TITLE_SECONDS`.
+COUNTDOWN_DIGITS = ["3", "2", "1"]
+
+
+class Screen(match.MatchClient):
+    """A scripted player that remembers what was drawn on it."""
+
+    def __init__(self, host, port, name, started):
+        super().__init__(host, port, name, started)
+        # Every experience bar, boss bar and title in the order they arrived, so
+        # a check can ask about the last one or about the whole sequence.
+        self.experience = []
+        self.bars = []
+        self.titles = []
+        self.subtitles = []
+        self.animations = []
+        # The three title packets in arrival order, which is the only place the
+        # ordering they have to arrive in is observable at all.
+        self.screen = []
+
+    def absorb(self, packet_id, payload):
+        if packet_id == match.S2C_LOGIN:
+            self.entity_id = struct.unpack(">i", payload[:4])[0]
+            self.joined = True
+            self.log("** in the world ** entity_id=%d" % self.entity_id)
+        elif packet_id == match.S2C_PLAYER_POSITION:
+            teleport_id, offset = take_var_int(payload)
+            x, y, z = struct.unpack(">ddd", payload[offset : offset + 24])
+            self.position = (x, y, z)
+            self.send(match.C2S_ACCEPT_TELEPORTATION, var_int(teleport_id))
+            self.log("<- teleported to (%.1f, %.1f, %.1f)" % (x, y, z))
+        elif packet_id == match.S2C_KEEP_ALIVE:
+            self.send(match.C2S_KEEP_ALIVE, payload[:8])
+        elif packet_id == match.S2C_SYSTEM_CHAT:
+            text, _ = match.take_nbt_string(payload, 0)
+            self.log("<- chat: %s" % text)
+            if text.startswith("Kit set to "):
+                self.kit = text[len("Kit set to ") :].rstrip(".")
+        elif packet_id == match.S2C_CONTAINER_SET_SLOT:
+            self.absorb_slot(payload)
+        elif packet_id == match.S2C_DISCONNECT:
+            text, _ = match.take_nbt_string(payload, 0)
+            self.log("<- DISCONNECTED: %s" % text)
+            self.alive = False
+        elif packet_id == S2C_SET_EXPERIENCE:
+            (progress,) = struct.unpack(">f", payload[:4])
+            level, offset = take_var_int(payload, 4)
+            total, _ = take_var_int(payload, offset)
+            self.experience.append({"progress": progress, "level": level, "total": total})
+            self.log("<- experience bar %.4f full, level %d" % (progress, level))
+        elif packet_id == S2C_BOSS_EVENT:
+            bar = decode_boss_event(payload)
+            if bar is not None:
+                self.bars.append(bar)
+                self.log(
+                    "<- boss bar %r %.3f full, %s"
+                    % (bar["title"], bar["progress"], bar["colour"])
+                )
+        elif packet_id == match.S2C_SET_TITLE_TEXT:
+            text, _ = match.take_nbt_string(payload, 0)
+            self.titles.append(text)
+            self.screen.append(("title", text))
+            self.log("<- title: %r" % text)
+        elif packet_id == S2C_SET_SUBTITLE_TEXT:
+            text, _ = match.take_nbt_string(payload, 0)
+            self.subtitles.append(text)
+            self.screen.append(("subtitle", text))
+            self.log("<- subtitle: %r" % text)
+        elif packet_id == S2C_SET_TITLES_ANIMATION:
+            # Three plain big-endian ints, not varints: the generated
+            # `SetTitlesAnimation` carries no `#[proto(varint)]`. Reading them as
+            # varints decodes without complaining and reports rubbish, which is
+            # why this comment names the layout it was checked against.
+            fade_in, stay, fade_out = struct.unpack(">iii", payload[:12])
+            self.animations.append((fade_in, stay, fade_out))
+            self.screen.append(("times", (fade_in, stay, fade_out)))
+
+    def absorb_slot(self, payload):
+        """Only enough of `ContainerSetSlot` to know the hotbar has arrived."""
+        _container, offset = take_var_int(payload)
+        _state, offset = take_var_int(payload, offset)
+        (slot,) = struct.unpack_from(">h", payload, offset)
+        offset += 2
+        slot -= match.HOTBAR_START_SLOT
+        if not 0 <= slot < 9:
+            return
+        count, offset = take_var_int(payload, offset)
+        if count <= 0:
+            self.hotbar.pop(slot, None)
+        else:
+            item, _ = take_var_int(payload, offset)
+            self.hotbar[slot] = item
+
+    def carry(self, slot):
+        """Hold a slot without using it.
+
+        The distinction this gate exists to check: `use_slot` changes the held
+        item *and* right-clicks, so a bar wired to "the last ability you fired"
+        would be indistinguishable from one wired to "the slot you are holding"
+        if nothing ever only held.
+        """
+        self.log("-> hold hotbar slot %d" % slot)
+        self.send(match.C2S_SET_CARRIED_ITEM, struct.pack(">h", slot))
+
+
+def decode_boss_event(payload):
+    """One `ClientboundBossEventPacket`, or `None` for an operation this does
+    not read.
+
+    Only `Add` is decoded, because it is the only one the server sends: see the
+    note on `adapter::boss_bar` for why every update is a fresh `Add`.
+    """
+    operation, offset = take_var_int(payload, 16)
+    if operation != BOSS_ADD:
+        return None
+    title, offset = match.take_nbt_string(payload, offset)
+    (progress,) = struct.unpack_from(">f", payload, offset)
+    offset += 4
+    colour, offset = take_var_int(payload, offset)
+    overlay, offset = take_var_int(payload, offset)
+    flags = payload[offset]
+    return {
+        "uuid": payload[:16].hex(),
+        "title": title,
+        "progress": progress,
+        "colour": BOSS_COLOURS[colour] if colour < len(BOSS_COLOURS) else colour,
+        "overlay": overlay,
+        "flags": flags,
+    }
+
+
+class Run:
+    """The clients, the checks and the verdict."""
+
+    def __init__(self, args):
+        self.args = args
+        self.started = time.time()
+        self.clients = []
+        self.failures = []
+
+    def log(self, line):
+        print("%s %-5s %s" % (match.stamp(self.started), "", line), flush=True)
+
+    def check(self, ok, message):
+        print(
+            "%s %s %s" % (match.stamp(self.started), "PASS" if ok else "FAIL", message),
+            flush=True,
+        )
+        if not ok:
+            self.failures.append(message)
+        return ok
+
+    def connect(self, count):
+        for _ in range(count):
+            name = "H%d" % (len(self.clients) + 1)
+            client = Screen(self.args.host, self.args.port, name, self.started)
+            client.handshake(self.args.host, self.args.port, 2)
+            client.login()
+            client.configuration()
+            client.enter_play()
+            self.clients.append(client)
+            client.log("configuration acknowledged")
+
+    def pump(self, seconds):
+        deadline = time.time() + seconds
+        while True:
+            for client in self.clients:
+                if not client.alive:
+                    continue
+                for packet_id, payload in client.drain():
+                    client.absorb(packet_id, payload)
+                if client.joined:
+                    client.repeat_position()
+            if time.time() >= deadline:
+                return
+            time.sleep(0.01)
+
+    def until(self, predicate, seconds, what):
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            self.pump(0.05)
+            if predicate():
+                return True
+        self.log("TIMED OUT waiting for %s" % what)
+        return False
+
+    # --- the experience bar --------------------------------------------
+
+    def experience_check(self):
+        client = self.clients[0]
+
+        # The bar is pushed on the first tick after the player exists, which is
+        # a tick after the Login packet this has already read.
+        self.until(
+            lambda: any("Waiting for players" in bar["title"] for bar in client.bars),
+            10.0,
+            "the hub's boss bar",
+        )
+        self.check(
+            any("Waiting for players" in bar["title"] for bar in client.bars),
+            "the hub puts a boss bar up saying what it is waiting for: %s"
+            % [bar["title"] for bar in client.bars],
+        )
+        lobby = [bar for bar in client.bars if "Waiting for players" in bar["title"]]
+        if lobby:
+            self.check(
+                lobby[0]["colour"] == "blue" and lobby[0]["title"].endswith("1/4"),
+                "and it counts how many more it needs: %s" % lobby[0],
+            )
+
+        client.command("kit %s" % KIT)
+        if not self.until(lambda: len(client.hotbar) >= 2, 30.0, "the kit's hotbar"):
+            self.check(False, "the kit reached the hotbar")
+            return
+
+        # Every step below is a *transition*, and that is not incidental: the
+        # server sends nothing when the bar would not change, so a check that
+        # holds a slot reading the same thing as the last one waits for a packet
+        # that is correctly never sent. A kit's first ability sits in slot 0,
+        # which is where a hand already rests, so the bar is full the moment the
+        # kit lands and the empty slot has to come first for anything to move.
+
+        # 1. An empty slot is an empty bar and no number.
+        client.experience.clear()
+        client.carry(EMPTY_SLOT)
+        empty = self.until(
+            lambda: any(
+                bar["progress"] < 1e-6 and bar["level"] == 0 for bar in client.experience
+            ),
+            10.0,
+            "an empty bar for an empty slot",
+        )
+        self.check(
+            empty,
+            "holding a slot with no ability in it is an empty bar and no number: %s"
+            % client.experience,
+        )
+
+        # 2. A ready ability is a full bar and no number.
+        client.experience.clear()
+        client.carry(FIRED_SLOT)
+        ready = self.until(
+            lambda: any(
+                bar["progress"] > 1.0 - 1e-6 and bar["level"] == 0
+                for bar in client.experience
+            ),
+            10.0,
+            "a full experience bar for a ready ability",
+        )
+        self.check(
+            ready,
+            "holding a ready ability is a full bar and no number: %s" % client.experience,
+        )
+
+        # 3. Firing it empties the bar and puts the seconds beside it.
+        client.experience.clear()
+        client.use_slot(FIRED_SLOT, "(the ability whose recharge the bar shows)")
+        fired = self.until(
+            lambda: any(bar["level"] > 0 for bar in client.experience),
+            5.0,
+            "the bar to start recharging",
+        )
+        if not self.check(fired, "firing an ability starts the bar refilling"):
+            return
+        first = next(bar for bar in client.experience if bar["level"] > 0)
+        self.check(
+            first["level"] == round(FIRED_COOLDOWN),
+            "the number beside the bar is the whole seconds left, %d of %.0f: %s"
+            % (first["level"], FIRED_COOLDOWN, first),
+        )
+        self.check(
+            first["progress"] < 3.0 * STEP,
+            "and the bar starts near empty rather than near full: %.4f" % first["progress"],
+        )
+
+        # 4. It fills, monotonically, and never reads full while it is still
+        #    recharging. That last clause is the whole reason the server floors
+        #    the fraction rather than rounding it.
+        self.pump(FIRED_COOLDOWN + 1.5)
+        recharging = [bar for bar in client.experience if bar["level"] > 0]
+        rose = all(
+            later["progress"] >= earlier["progress"] - 1e-6
+            for earlier, later in zip(recharging, recharging[1:])
+        )
+        self.check(rose, "the bar only ever fills, never drains: %d samples" % len(recharging))
+        self.check(
+            all(bar["progress"] < 1.0 for bar in recharging),
+            "and never reads full while the ability is still refusing: %s"
+            % [bar for bar in recharging if bar["progress"] >= 1.0],
+        )
+        counted = [bar["level"] for bar in recharging]
+        self.check(
+            counted == sorted(counted, reverse=True) and counted[-1] >= 1,
+            "the number counts down and never reaches zero early: %s" % counted,
+        )
+        self.check(
+            client.experience[-1]["progress"] > 1.0 - 1e-6
+            and client.experience[-1]["level"] == 0,
+            "and the finished cooldown is a full bar with the number gone: %s"
+            % client.experience[-1],
+        )
+
+        # 5. The bar follows the slot being held, not the last thing fired: a
+        #    different, untouched ability reads full even though the one just
+        #    used is the last thing this player did.
+        client.experience.clear()
+        client.carry(EMPTY_SLOT)
+        self.until(lambda: client.experience, 5.0, "the bar to notice the empty slot")
+        client.experience.clear()
+        client.carry(IDLE_SLOT)
+        idle = self.until(
+            lambda: any(
+                bar["progress"] > 1.0 - 1e-6 and bar["level"] == 0
+                for bar in client.experience
+            ),
+            5.0,
+            "a full bar for an untouched slot",
+        )
+        self.check(
+            idle,
+            "and holding a different, untouched ability is full again: %s" % client.experience,
+        )
+
+    # --- the match ------------------------------------------------------
+
+    def match_check(self):
+        narrator = self.clients[0]
+        narrator.titles.clear()
+        narrator.subtitles.clear()
+        narrator.bars.clear()
+
+        self.connect(self.args.clients - len(self.clients))
+        if not self.until(
+            lambda: all(client.joined for client in self.clients), 90.0, "every client in play"
+        ):
+            self.check(False, "%d clients reached the world" % self.args.clients)
+            return
+
+        counting = self.until(
+            lambda: any(bar["title"].startswith("Starting in") for bar in narrator.bars),
+            90.0,
+            "the countdown to appear on the boss bar",
+        )
+        self.check(
+            counting,
+            "a full lobby puts the countdown on the boss bar: %s"
+            % [bar["title"] for bar in narrator.bars][-3:],
+        )
+        counting_bars = [bar for bar in narrator.bars if bar["title"].startswith("Starting in")]
+        if counting_bars:
+            self.check(
+                all(bar["colour"] == "yellow" for bar in counting_bars),
+                "and it is yellow, not the lobby's blue: %s"
+                % sorted({bar["colour"] for bar in counting_bars}),
+            )
+
+        # The last three seconds, then the word that starts the match.
+        started = self.until(lambda: "GO!" in narrator.titles, 120.0, "the match to start")
+        if not self.check(started, "the start of the match is a title: %s" % narrator.titles):
+            return
+
+        # The bar drains, checked over the whole countdown now that it has run
+        # out. Only the tail after the last reset: every join shortens the
+        # countdown and hands it a fresh full bar, which is the lobby doing its
+        # job rather than the bar going backwards.
+        counting_bars = [bar for bar in narrator.bars if bar["title"].startswith("Starting in")]
+        full = [
+            index for index, bar in enumerate(counting_bars) if bar["progress"] > 1.0 - 1e-6
+        ]
+        tail = counting_bars[(full[-1] if full else 0) :]
+        drained = [bar["progress"] for bar in tail]
+        self.check(
+            len(drained) > 4 and drained == sorted(drained, reverse=True) and drained[-1] < 0.3,
+            "the countdown bar drains towards the start rather than filling: %s"
+            % [round(value, 3) for value in drained],
+        )
+
+        digits = [text for text in narrator.titles if text in COUNTDOWN_DIGITS]
+        self.check(
+            digits == COUNTDOWN_DIGITS,
+            "the countdown's last three seconds are titles, in order: %s" % digits,
+        )
+        self.check(
+            "Get ready" in narrator.subtitles,
+            "each digit carries a subtitle, which this server had never sent: %s"
+            % narrator.subtitles,
+        )
+        self.check(
+            "Smash them off the map" in narrator.subtitles,
+            "and so does the start: %s" % narrator.subtitles,
+        )
+        # A title's own animation, which is what keeps one digit from fading
+        # across the next.
+        self.check(
+            (0, 20, 0) in narrator.animations,
+            "the countdown digits are timed to exactly one second: %s" % narrator.animations,
+        )
+
+        # The ordering, which is the whole reason the game carries a title and
+        # its subtitle as one value. `ClientboundSetSubtitleTextPacket` only
+        # stores a line; the title packet is what draws both and restarts the
+        # animation. A subtitle sent after its title therefore appears under the
+        # *next* one, and a title sent with no subtitle at all inherits whatever
+        # was left over. This is the only place either mistake is visible: from
+        # the server both look identical to doing it right.
+        kinds = [kind for kind, _ in narrator.screen]
+        triples = [
+            narrator.screen[index - 2 : index + 1]
+            for index, kind in enumerate(kinds)
+            if kind == "title" and index >= 2
+        ]
+        wrong = [
+            triple
+            for triple in triples
+            if [kind for kind, _ in triple] != ["times", "subtitle", "title"]
+        ]
+        self.check(
+            triples and not wrong,
+            "every title arrives as times, then its subtitle, then itself: "
+            "%d title(s), %d out of order %s" % (len(triples), len(wrong), wrong[:2]),
+        )
+
+        percent = self.until(
+            lambda: any(re.fullmatch(r"\d+%", bar["title"]) for bar in narrator.bars),
+            30.0,
+            "the percentage to reach the boss bar",
+        )
+        self.check(
+            percent,
+            "during a match the boss bar is the player's knockback percentage: %s"
+            % [bar["title"] for bar in narrator.bars][-4:],
+        )
+        readings = [bar for bar in narrator.bars if re.fullmatch(r"\d+%", bar["title"])]
+        if readings:
+            fresh = readings[0]
+            self.check(
+                fresh["title"] == "0%" and fresh["colour"] == "green",
+                "a fresh player reads 0%% and is green: %s" % fresh,
+            )
+            self.check(
+                math.isclose(fresh["progress"], 1.0, abs_tol=1e-6),
+                "with a full bar under it, because the bar is the health the "
+                "percentage is derived from: %.3f" % fresh["progress"],
+            )
+            self.check(
+                fresh["flags"] == 0,
+                "and it darkens nothing, plays nothing and fogs nothing: flags=%d"
+                % fresh["flags"],
+            )
+
+    def run(self):
+        self.connect(1)
+        if not self.until(lambda: self.clients[0].joined, 90.0, "the first client in play"):
+            self.check(False, "a client reached the world")
+            return self.report()
+        self.experience_check()
+        self.match_check()
+        return self.report()
+
+    def report(self):
+        print("", flush=True)
+        self.log(
+            "RESULT: %s (%d check(s) failed)"
+            % ("ok" if not self.failures else "failure", len(self.failures))
+        )
+        for failure in self.failures:
+            print("  failed: %s" % failure, file=sys.stderr)
+        return 1 if self.failures else 0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=25565)
+    parser.add_argument(
+        "--clients",
+        type=int,
+        default=8,
+        help="`LobbyConfig::full_players`, which is what makes the countdown ten "
+        "seconds rather than sixty",
+    )
+    args = parser.parse_args()
+    return Run(args).run()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Super Smash Mobs enforced ability cooldowns, recorded who smashed whom and ran a
five-phase match, and a player could see almost none of it. The cooldown existed
only as a line of red text after a press had already been refused. The kill
credit reached a broadcast chat line read by everybody except the person it
happened to. `BossEvent` and `SetSubtitleText` were sent zero times by this
server.

Three surfaces, one rule: the game already knows, so say so before it matters
rather than after.

## The experience bar is the recharge of the slot you are holding

Full with no number when the ability is ready, filling from empty with the whole
seconds beside it while it is not, and empty with no number for a slot holding
nothing. Those two numbers together are what make the third state expressible:
neither of the others can produce an empty bar with no count.

Filling and not draining. Vanilla fills that bar as experience accumulates, so a
full bar already reads as "you have the thing" to anybody who has played
Minecraft. Draining would put it at its fullest at the exact moment the ability
cannot be used, which inverts the one fact it is there to carry.

It follows a mirrored `SelectedSlot` and not the last ability fired, which reads
identically until a player holds a different item, and it floors rather than
rounds so a bar that reads full and an ability that is ready are the same
statement rather than nearly the same one.

The level number is the whole seconds left, rounded up. The bar is the
glanceable half and is deliberately imprecise; the number answers the other
question, which is not "am I ready" but "how long until I am".

## The bar across the top is the knockback percentage

The signature read of the mode, and no client draws it: hearts say how much
damage you have left to take, percent says what the next hit will do with it.

It is not invented. `knockback::strength`'s health term is
`1 + 0.1 * missing_health`, so the percentage is that term with the one taken
off and multiplied out: 0% fresh, 100% where a hit sends you twice as far. A
test solves the claim against `strength` rather than restating `percent`'s own
arithmetic, so changing one without the other fails. Green, yellow and red sit
at the multipliers those bands mean, not at numbers that felt right.

Outside a match the same bar carries whatever the player should be watching
instead: how many more people the lobby needs, then how long is left, then the
result. One bar rather than two. A match-clock bar was the alternative and was
dropped, because a twenty minute timeout nobody has reached is not something a
player acts on and it would have spent the other half of the only
always-visible strip on the screen saying so.

## Titles punctuate the match, and a death names the killer

The last three seconds of the prepare timer get a digit. The start gets a word.
The end names the winner, in the title, in the boss bar and in chat. A death
names the killer in the subtitle, which is the whole reason it is a title now:
until this, the middle of your own screen carried a life count and no answer at
all to the only question a player asks there. The credit is not new, it simply
had nowhere to be read.

A title and its subtitle travel as one value. The protocol makes them separable
and the separation is a trap: `ClientboundSetSubtitleTextPacket` only stores a
line and the next title is what draws both, so a subtitle written second appears
under the wrong title, and one nobody cleared outlives the title it was written
for. Carrying them together lets the adapter always write times, then subtitle,
then title, and `tools/hud-check.py` reads that order back off the wire, which
is the only place it is observable at all.

## What the wire gate found that no unit test could

Two "3, 2, 1" sequences back to back: `['3', '2', '1', '3', '2', '1', 'GO!']`.
Both counting phases cross those boundaries and both tick out loud, so a window
on both draws the digits twice with a teleport in the middle. Digits are now the
prepare timer's alone.

And 3,065 boss bar packets in thirty seconds for eight clients, because progress
is continuous in three of the five phases. Quantising both surfaces to
sixty-four steps, which is finer than a 182 pixel bar can draw, took it to
1,135.

## Deliberately left

Each for a reason rather than for time.

* **Nametags** carry no percentage and no last-life colour. That needs
  `SetPlayerTeam` plumbing a sibling change is already near, and the sidebar
  already colours a name by its life tier from the same table.
* **The sidebar** carries no percentage. Its own documentation is about not
  redrawing a panel that changes continuously, and a percentage moves under
  every kit's health regeneration; quantising it enough to stop the churn would
  put a number on screen that is not the number.
* **The experience bar** shows a cooldown and not a charge or an energy bar. One
  bar carries one quantity, and two that both read "filling towards go" cannot
  be told apart on it.
* **A match timer.** See above.

One gap in the brief turned out to be already closed: `lives.rs` has broadcast
`X was smashed by Y!` since the death path was written, and `smash-match.py`
reads it. What was missing was the *victim's own* screen, which is what the
subtitle is.

## Verified

Local only, per ENG-10817.

* `nix run .#test` -- 677 passed, 1 skipped
* `nix run .#lint` -- clean
* `nix run .#fmt` -- clean
* `nix run .#smash-hud-e2e` -- 25 checks, 0 failed, eight real clients through a
  whole countdown and into a match
* `nix run .#smash-e2e` -- `RESULT: a whole match ran at protocol 776`, rc=0

Every guard was broken and watched to fail before being trusted. Selected
output:

```
quantise now rounds to nearest
  a_recharging_bar_never_reads_full: a 7s cooldown read as full with 0.05s left

the meter now reads slot 3 whatever is held
  changing_the_held_slot_changes_which_cooldown_the_bar_shows:
    left: Some(Experience { progress: 0.0, level: 7 })  right: Some(Experience { progress: 1.0, level: 0 })

the diff that suppresses an unchanged screen is gone
  an_unchanged_screen_sends_nothing:  left: 40  right: 1

both counting phases get digits again
  the_countdown_puts_a_number_on_every_screen_exactly_once:
    left: ["3", "2", "1", "3", "2", "1"]  right: ["3", "2", "1"]

the death screen no longer names the killer
  a_death_names_the_killer_under_the_life_count:  left: None  right: Some("Smashed by Andrew")

percent is now plain damage taken, not the knockback multiplier
  a_percentage_is_how_much_further_the_next_hit_sends_you:
    at 18 health the percentage says 10% but the model launched 0.93378156 against 0.85596645

the title is now written before its subtitle
  FAIL every title arrives as times, then its subtitle, then itself:
    3 title(s), 3 out of order [[('subtitle', 'Get ready'), ('times', (0, 20, 0)), ('title', '2')], ...]
```

## Also filed

**ENG-10852**: `cargo test -p smash` segfaults about once in a hundred runs
inside `ecs_init`, because `cargo test` runs a thread per test and every test
opens a `World`. Pre-existing, measured at 1 in 160 on origin/main, and invisible
to `nix run .#test` because nextest forks per test. Ruling my own change out of
it cost about forty minutes.

One thing outside the feature came with it: `smash-hotbar-e2e` landed with a
literal port offset of 6000, which is `completions-e2e`'s, and a literal is
exactly what the new `e2ePortsDistinct` eval guard cannot see. Both it and this
gate are now in `e2eOffsets`.

---

Written by Claude (Opus 5) with human direction.
