### PR TITLE
feat(smash): two players start the countdown, four fill the lobby

### DIFF
--- a/events/smash/src/module/lobby.rs
+++ b/events/smash/src/module/lobby.rs
@@ -60,10 +60,19 @@ pub struct LobbyConfig {
 }
 
 impl Default for LobbyConfig {
+    /// Mineplex ran Super Smash Mobs at 4 to start and 8 for a full lobby.
+    /// We start at 2 and call 4 full, because the people playing this server
+    /// are the two or three developing it, and a threshold nobody can reach
+    /// is a game nobody can test.
+    ///
+    /// The three countdown lengths stay distinct at these numbers: 2 players
+    /// takes `countdown_at_min`, 3 satisfies the three-quarters rule, and 4
+    /// is full. Lowering `full_players` below 4 would collapse two of those
+    /// bands into one.
     fn default() -> Self {
         Self {
-            min_players: 4,
-            full_players: 8,
+            min_players: 2,
+            full_players: 4,
             countdown_at_min: 60.0,
             countdown_at_three_quarters: 30.0,
             countdown_at_full: 10.0,

--- a/events/smash/tests/lobby.rs
+++ b/events/smash/tests/lobby.rs
@@ -8,6 +8,22 @@ fn config() -> LobbyConfig {
     LobbyConfig::default()
 }
 
+/// The player count one short of starting a countdown.
+const fn below_min(config: &LobbyConfig) -> u32 {
+    config.min_players - 1
+}
+
+/// The smallest count that satisfies `countdown_at_three_quarters`, which
+/// `countdown_for` spells as `players * 4 >= full_players * 3`.
+const fn three_quarters(config: &LobbyConfig) -> u32 {
+    (config.full_players * 3).div_ceil(4)
+}
+
+// These name counts by what they mean to the config rather than by value. The
+// literals 3, 4, 6 and 8 used to appear here, which stated `LobbyConfig`'s
+// defaults a second time, so changing 4/8 to 2/4 broke six tests that were not
+// about those numbers.
+
 /// Run the machine until the phase changes or `limit` seconds pass.
 fn run_until_change(
     config: &LobbyConfig,
@@ -42,15 +58,21 @@ fn one_short_of_the_minimum_still_waits() {
 #[test]
 fn the_countdown_length_depends_on_how_full_the_lobby_is() {
     let config = config();
-    assert_eq!(config.countdown_for(3), None);
-    assert_eq!(config.countdown_for(4), Some(config.countdown_at_min));
+    assert_eq!(config.countdown_for(below_min(&config)), None);
     assert_eq!(
-        config.countdown_for(6),
+        config.countdown_for(config.min_players),
+        Some(config.countdown_at_min)
+    );
+    assert_eq!(
+        config.countdown_for(three_quarters(&config)),
         Some(config.countdown_at_three_quarters)
     );
-    assert_eq!(config.countdown_for(8), Some(config.countdown_at_full));
     assert_eq!(
-        config.countdown_for(20),
+        config.countdown_for(config.full_players),
+        Some(config.countdown_at_full)
+    );
+    assert_eq!(
+        config.countdown_for(config.full_players * 3),
         Some(config.countdown_at_full),
         "an over-full lobby is still a full lobby"
     );
@@ -59,7 +81,8 @@ fn the_countdown_length_depends_on_how_full_the_lobby_is() {
 #[test]
 fn reaching_the_minimum_starts_the_long_countdown() {
     let config = config();
-    let state = step(&config, Lobby::default(), 0.05, 4, 4);
+    let at_min = config.min_players;
+    let state = step(&config, Lobby::default(), 0.05, at_min, at_min);
     assert_eq!(state.phase, Phase::Countdown);
     assert!((state.timer - config.countdown_at_min).abs() < 1e-3);
 }
@@ -67,10 +90,11 @@ fn reaching_the_minimum_starts_the_long_countdown() {
 #[test]
 fn a_join_that_fills_the_lobby_shortens_the_countdown_immediately() {
     let config = config();
-    let state = step(&config, Lobby::default(), 0.05, 4, 4);
-    assert!(state.timer > 50.0);
+    let (at_min, full) = (config.min_players, config.full_players);
+    let state = step(&config, Lobby::default(), 0.05, at_min, at_min);
+    assert!(state.timer > config.countdown_at_three_quarters);
 
-    let state = step(&config, state, 0.05, 8, 8);
+    let state = step(&config, state, 0.05, full, full);
     assert_eq!(state.phase, Phase::Countdown);
     assert!(
         state.timer <= config.countdown_at_full,
@@ -83,18 +107,20 @@ fn a_join_that_fills_the_lobby_shortens_the_countdown_immediately() {
 #[test]
 fn the_countdown_never_lengthens_when_someone_leaves_but_stays_above_minimum() {
     let config = config();
-    let full = step(&config, Lobby::default(), 0.05, 8, 8);
-    let after_leaver = step(&config, full, 0.05, 6, 6);
+    let (count, fewer) = (config.full_players, three_quarters(&config));
+    let full = step(&config, Lobby::default(), 0.05, count, count);
+    let after_leaver = step(&config, full, 0.05, fewer, fewer);
     assert!(after_leaver.timer <= full.timer);
 }
 
 #[test]
 fn dropping_below_the_minimum_cancels_the_countdown_outright() {
     let config = config();
-    let state = step(&config, Lobby::default(), 0.05, 4, 4);
+    let (at_min, short) = (config.min_players, below_min(&config));
+    let state = step(&config, Lobby::default(), 0.05, at_min, at_min);
     assert_eq!(state.phase, Phase::Countdown);
 
-    let state = step(&config, state, 0.05, 3, 3);
+    let state = step(&config, state, 0.05, short, short);
     assert_eq!(state.phase, Phase::Waiting);
     assert!(
         state.timer.abs() < 1e-6,
@@ -105,12 +131,13 @@ fn dropping_below_the_minimum_cancels_the_countdown_outright() {
 #[test]
 fn the_full_path_from_waiting_to_results_and_back() {
     let config = config();
+    let full = config.full_players;
     let mut state = Lobby::default();
 
-    state = step(&config, state, 0.05, 8, 8);
+    state = step(&config, state, 0.05, full, full);
     assert_eq!(state.phase, Phase::Countdown);
 
-    let (state_after, elapsed) = run_until_change(&config, state, 8, 8);
+    let (state_after, elapsed) = run_until_change(&config, state, full, full);
     state = state_after;
     assert_eq!(state.phase, Phase::Preparing);
     assert!(
@@ -119,22 +146,22 @@ fn the_full_path_from_waiting_to_results_and_back() {
         config.countdown_at_full
     );
 
-    let (state_after, elapsed) = run_until_change(&config, state, 8, 8);
+    let (state_after, elapsed) = run_until_change(&config, state, full, full);
     state = state_after;
     assert_eq!(state.phase, Phase::Playing);
     assert!((elapsed - config.prepare_seconds).abs() < 0.2);
 
-    // Still eight alive, so the match keeps running.
-    let mid = step(&config, state, 1.0, 8, 8);
+    // Everyone still alive, so the match keeps running.
+    let mid = step(&config, state, 1.0, full, full);
     assert_eq!(mid.phase, Phase::Playing);
     assert!(mid.timer > state.timer, "the match clock counts up");
 
     // One left standing ends it.
-    state = step(&config, mid, 0.05, 8, 1);
+    state = step(&config, mid, 0.05, full, 1);
     assert_eq!(state.phase, Phase::Ended);
     assert!((state.timer - config.results_seconds).abs() < 1e-3);
 
-    let (state, _) = run_until_change(&config, state, 8, 1);
+    let (state, _) = run_until_change(&config, state, full, 1);
     assert_eq!(state.phase, Phase::Waiting);
 }
 
@@ -145,7 +172,8 @@ fn a_match_that_never_resolves_times_out() {
         phase: Phase::Playing,
         timer: config.match_timeout_seconds - 0.5,
     };
-    let state = step(&config, state, 1.0, 8, 8);
+    let full = config.full_players;
+    let state = step(&config, state, 1.0, full, full);
     assert_eq!(
         state.phase,
         Phase::Ended,
@@ -161,7 +189,10 @@ fn a_solo_lobby_that_somehow_starts_ends_at_once() {
         timer: 0.0,
     };
     assert_eq!(step(&config, state, 0.05, 1, 1).phase, Phase::Ended);
-    assert_eq!(step(&config, state, 0.05, 8, 0).phase, Phase::Ended);
+    assert_eq!(
+        step(&config, state, 0.05, config.full_players, 0).phase,
+        Phase::Ended
+    );
 }
 
 #[test]
@@ -219,13 +250,14 @@ fn a_phase_change_reaches_an_observer_that_names_lobby() {
             counted.fetch_add(1, Ordering::Relaxed);
         });
 
-    // Four players is `min_players`, so the first tick leaves Waiting.
+    // Four players is at or past `min_players`, so the first tick leaves
+    // Waiting.
     game.advance(0.05, 1);
 
     assert_eq!(
         game.world.cloned::<&Lobby>().phase,
         Phase::Countdown,
-        "four players is the minimum, so the countdown should have started"
+        "four players is enough to start, so the countdown should have started"
     );
     assert_eq!(
         by_lobby.load(Ordering::Relaxed),


### PR DESCRIPTION
## Effect

The countdown starts at 2 players instead of 4, and 4 players is a full lobby instead of 8. Requested by the operator so the match phases are reachable by the two or three people actually on this server.

## Why the defaults and not the state machine

`LobbyConfig` is already a singleton, and its own doc comment says it exists "so a server can run a two-player duels variant without touching the state machine". This uses that seam as designed. `step`, `countdown_for` and every phase transition are unchanged.

## The numbers still separate

`countdown_for` has three bands. At 2/4 they stay distinct:

| players | band |
|---|---|
| 1 | none, still Waiting |
| 2 | `countdown_at_min`, 60s |
| 3 | `countdown_at_three_quarters`, 30s |
| 4 | `countdown_at_full`, 10s |

Dropping `full_players` below 4 would collapse two bands into one. That reason is written next to the constant, so the next reader can tell the fence from a fossil.

## Why the diff is bigger than two lines

Six tests in `events/smash/tests/lobby.rs` broke that were not about these numbers. They spelled the counts as the literals 3, 4, 6 and 8, which stated `LobbyConfig::default` a second time. They now derive from the config through two named helpers, so the next threshold change moves the tests with it instead of breaking them.

## Checks

```
cargo fmt --check        rc=0
cargo clippy -p smash --tests -- -D warnings    rc=0
cargo test -p smash --test lobby --test hud     rc=0
  lobby: 35 passed, 0 failed
  hud:   12 passed, 0 failed
```

`tests/hud.rs`, `tests/sound.rs`, `tests/selector.rs`, `tests/verification.rs` and `tests/harness/mod.rs` all set `LobbyConfig` explicitly and were unaffected, which is the design working.