### PR TITLE
feat(proto): a raw `minecraft:` name in Rust is now a build failure

### DIFF
--- a/crates/hyperion-minecraft-proto/src/generated/registry/mod.rs
+++ b/crates/hyperion-minecraft-proto/src/generated/registry/mod.rs
@@ -18,8 +18,8 @@
 //! Nothing is curated: every registry the extractor reports has an enum, so
 //! there is no subset to fall outside of. The single exception is
 //! `minecraft:particle_type`, whose entries carry payloads this file's input
-//! cannot describe; `nix/generate-particles.py` owns that one and the reason
-//! is written at the top of the `particle_type` module here.
+//! cannot describe; its enum is generated from the decompiled codecs instead,
+//! and the reason is written at the top of the `particle_type` module here.
 //!
 //! # What is free and what is not
 //!

--- a/crates/hyperion-minecraft-proto/src/generated/registry/particle_type.rs
+++ b/crates/hyperion-minecraft-proto/src/generated/registry/particle_type.rs
@@ -3,7 +3,7 @@
 
 //! `minecraft:particle_type` -- names only. This registry deliberately has no enum here.
 //!
-//! Reason: its entries carry payloads that `protocol.json` cannot describe, so `nix/generate-particles.py` reads the decompiled codecs instead and owns the enum.
+//! Reason: 13 of its 125 entries carry payloads that `protocol.json` cannot describe, so the enum is generated from the decompiled codecs instead and lives outside this file.
 //!
 //! Every other registry in this module is an enum whether or not anything uses
 //! it, because a hand-picked subset is a gap waiting to be found. This one is
@@ -14,8 +14,8 @@
 //! never carry its block state, its colour or its flight time, while being the
 //! more discoverable of the two spellings.
 //!
-//! The table below stays, because it is what the real generator pins its ids
-//! against.
+//! The table below stays, because it is what the generator that does own the
+//! enum pins its ids against.
 
 /// Entry names in network-id order, so the index is the id.
 pub static NAMES_IN_ID_ORDER: [&str; 125] = [

--- a/crates/hyperion-minecraft-proto/src/packets/play/player.rs
+++ b/crates/hyperion-minecraft-proto/src/packets/play/player.rs
@@ -32,7 +32,7 @@
 use crate::{
     Decode, Encode, Error, Holder, Identifier, Reader, RegistryId, Result, Uuid, Writer,
     codec::{read_count, write_count},
-    generated::registry,
+    generated::registry::{self, CommandArgumentType},
     nbt,
     packets::play_login::GameType,
     text::Component,
@@ -596,9 +596,9 @@ pub enum StringArgumentKind {
 /// length-prefixed.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ArgumentType<'a> {
-    /// A type whose `ArgumentTypeInfo` writes no properties, held by its
-    /// network id in `minecraft:command_argument_type`.
-    Empty(RegistryId),
+    /// A type whose `ArgumentTypeInfo` writes no properties, held as its own
+    /// registry entry rather than as a number.
+    Empty(CommandArgumentType),
     /// `brigadier:double`, with optional bounds.
     Double {
         /// Lower bound; `None` is `Double.MIN_VALUE`.
@@ -638,8 +638,8 @@ pub enum ArgumentType<'a> {
     /// `resource_key`, `resource_or_tag`, `resource_or_tag_key` and
     /// `resource_selector`. Which one is the id; the payload is the registry.
     Registry {
-        /// Network id in `minecraft:command_argument_type`.
-        id: RegistryId,
+        /// Which of the five it is.
+        id: CommandArgumentType,
         /// Registry the argument names an element of, e.g. `minecraft:item`.
         registry: Identifier<'a>,
     },
@@ -662,42 +662,40 @@ const NUMBER_HAS_MIN: u8 = 1;
 /// See [`NUMBER_HAS_MIN`].
 const NUMBER_HAS_MAX: u8 = 2;
 
-/// The `minecraft:command_argument_type` network id of `name`.
-///
-/// # Errors
-/// Returns [`Error::InvalidIdentifier`] when the registry has no such entry,
-/// which means this crate's registry table and its argument-type list have
-/// drifted apart.
-fn argument_type_id(name: &str) -> Result<i32> {
-    let id = registry::COMMAND_ARGUMENT_TYPE
-        .id_of(name)
-        .ok_or_else(|| Error::InvalidIdentifier(name.to_owned()))?;
-    i32::try_from(id).map_err(|_| Error::InvalidIdentifier(name.to_owned()))
-}
-
 impl ArgumentType<'_> {
-    /// The network id this argument type is written under.
+    /// The registry entry this argument type is written as.
     ///
-    /// # Errors
-    /// See [`argument_type_id`].
-    pub fn to_id(&self) -> Result<i32> {
+    /// Infallible, and `const`. It used to look a name up in
+    /// `minecraft:command_argument_type` and return a `Result`, which meant
+    /// every command tree this server sends carried an error path for the
+    /// possibility that `brigadier:double` had stopped existing. It cannot
+    /// have: the name is a variant now, so a version that dropped it would
+    /// fail to build here instead.
+    #[must_use]
+    pub const fn to_type(&self) -> CommandArgumentType {
         match self {
-            Self::Empty(id) | Self::Registry { id, .. } => Ok(id.0),
-            Self::Double { .. } => argument_type_id("brigadier:double"),
-            Self::Entity { .. } => argument_type_id("minecraft:entity"),
-            Self::Float { .. } => argument_type_id("brigadier:float"),
-            Self::Integer { .. } => argument_type_id("brigadier:integer"),
-            Self::Long { .. } => argument_type_id("brigadier:long"),
-            Self::ScoreHolder { .. } => argument_type_id("minecraft:score_holder"),
-            Self::String(_) => argument_type_id("brigadier:string"),
-            Self::Time { .. } => argument_type_id("minecraft:time"),
+            Self::Empty(id) | Self::Registry { id, .. } => *id,
+            Self::Double { .. } => CommandArgumentType::BrigadierDouble,
+            Self::Entity { .. } => CommandArgumentType::Entity,
+            Self::Float { .. } => CommandArgumentType::BrigadierFloat,
+            Self::Integer { .. } => CommandArgumentType::BrigadierInteger,
+            Self::Long { .. } => CommandArgumentType::BrigadierLong,
+            Self::ScoreHolder { .. } => CommandArgumentType::ScoreHolder,
+            Self::String(_) => CommandArgumentType::BrigadierString,
+            Self::Time { .. } => CommandArgumentType::Time,
         }
+    }
+
+    /// The network id this argument type is written under.
+    #[must_use]
+    pub const fn to_id(&self) -> i32 {
+        self.to_type().id().0
     }
 
     /// Write the id and then the properties, as `ArgumentNodeStub.serializeCap`
     /// does.
     fn encode(&self, writer: &mut Writer) -> Result<()> {
-        writer.var_int(self.to_id()?);
+        writer.var_int(self.to_id());
         match self {
             Self::Empty(_) => {}
             Self::Float { min, max } => {
@@ -762,60 +760,60 @@ impl<'a> ArgumentType<'a> {
     /// properties would be read as the next node's fields.
     fn decode(reader: &mut Reader<'a>) -> Result<Self> {
         let raw = reader.var_int()?;
-        let name = usize::try_from(raw)
-            .ok()
-            .and_then(|id| registry::COMMAND_ARGUMENT_TYPE.get(id))
-            .ok_or(Error::InvalidEnum {
-                name: "minecraft:command_argument_type",
-                value: raw,
-            })?;
-        let id = RegistryId(raw);
-        Ok(match name {
-            "brigadier:float" => {
+        // The decode boundary, and the only place an argument type can fail to
+        // be one: the number came off the wire.
+        let id = CommandArgumentType::from_id(RegistryId(raw)).ok_or(Error::InvalidEnum {
+            name: "minecraft:command_argument_type",
+            value: raw,
+        })?;
+        Ok(match id {
+            CommandArgumentType::BrigadierFloat => {
                 let flags = reader.u8()?;
                 Self::Float {
                     min: read_if(flags & NUMBER_HAS_MIN != 0, reader, Reader::f32)?,
                     max: read_if(flags & NUMBER_HAS_MAX != 0, reader, Reader::f32)?,
                 }
             }
-            "brigadier:double" => {
+            CommandArgumentType::BrigadierDouble => {
                 let flags = reader.u8()?;
                 Self::Double {
                     min: read_if(flags & NUMBER_HAS_MIN != 0, reader, Reader::f64)?,
                     max: read_if(flags & NUMBER_HAS_MAX != 0, reader, Reader::f64)?,
                 }
             }
-            "brigadier:integer" => {
+            CommandArgumentType::BrigadierInteger => {
                 let flags = reader.u8()?;
                 Self::Integer {
                     min: read_if(flags & NUMBER_HAS_MIN != 0, reader, Reader::i32)?,
                     max: read_if(flags & NUMBER_HAS_MAX != 0, reader, Reader::i32)?,
                 }
             }
-            "brigadier:long" => {
+            CommandArgumentType::BrigadierLong => {
                 let flags = reader.u8()?;
                 Self::Long {
                     min: read_if(flags & NUMBER_HAS_MIN != 0, reader, Reader::i64)?,
                     max: read_if(flags & NUMBER_HAS_MAX != 0, reader, Reader::i64)?,
                 }
             }
-            "brigadier:string" => Self::String(StringArgumentKind::decode(reader)?),
-            "minecraft:entity" => {
+            CommandArgumentType::BrigadierString => {
+                Self::String(StringArgumentKind::decode(reader)?)
+            }
+            CommandArgumentType::Entity => {
                 let flags = reader.u8()?;
                 Self::Entity {
                     single: flags & 1 != 0,
                     players_only: flags & 2 != 0,
                 }
             }
-            "minecraft:score_holder" => Self::ScoreHolder {
+            CommandArgumentType::ScoreHolder => Self::ScoreHolder {
                 multiple: reader.u8()? & 1 != 0,
             },
-            "minecraft:time" => Self::Time { min: reader.i32()? },
-            "minecraft:resource_or_tag"
-            | "minecraft:resource_or_tag_key"
-            | "minecraft:resource"
-            | "minecraft:resource_key"
-            | "minecraft:resource_selector" => Self::Registry {
+            CommandArgumentType::Time => Self::Time { min: reader.i32()? },
+            CommandArgumentType::ResourceOrTag
+            | CommandArgumentType::ResourceOrTagKey
+            | CommandArgumentType::Resource
+            | CommandArgumentType::ResourceKey
+            | CommandArgumentType::ResourceSelector => Self::Registry {
                 id,
                 registry: Identifier::decode(reader)?,
             },

--- a/crates/hyperion/src/simulation/command.rs
+++ b/crates/hyperion/src/simulation/command.rs
@@ -13,15 +13,16 @@
 //! [`argument_type`] is the single place that vocabulary meets 776, and it is
 //! the piece to delete once callers name a
 //! [`hyperion_minecraft_proto::packets::play::player::ArgumentType`] directly.
-//! It resolves every id through `minecraft:command_argument_type` rather than
-//! writing numbers down, so a protocol bump moves the ids without touching
-//! this file. Two names did move between the two versions: 1.20.1's
-//! `minecraft:color` is 26.2's `minecraft:team_color`, and `minecraft:time`
-//! grew a minimum-duration property that 1.20.1 did not have.
+//! Every arm names a
+//! [`CommandArgumentType`] variant rather than a number or a string, so a
+//! protocol bump moves the ids without touching this file, and a bump that
+//! *renames* one stops this file compiling rather than sending an argument the
+//! client cannot parse. Two names did move between the two versions: 1.20.1's
+//! `color` is 26.2's `team_color`, and `time` grew a minimum-duration property
+//! that 1.20.1 did not have.
 
 use std::io::Write;
 
-use anyhow::Context as _;
 use flecs_ecs::{
     core::{
         Builder, Entity, EntityView, EntityViewGet, IdOperations, QueryAPI, QueryBuilderImpl,
@@ -30,8 +31,8 @@ use flecs_ecs::{
     macros::Component,
 };
 use hyperion_minecraft_proto::{
-    Identifier, RegistryId,
-    generated::{packet_id::play::clientbound::PacketId, registry},
+    Identifier,
+    generated::{packet_id::play::clientbound::PacketId, registry::CommandArgumentType},
     packets::play::player::{
         ArgumentType, CommandNode, CommandNodeStub, Commands, StringArgumentKind,
     },
@@ -186,26 +187,22 @@ impl Command {
 /// does not have, and every hyperion argument is server state.
 const ASK_SERVER: &str = "minecraft:ask_server";
 
-/// The `minecraft:command_argument_type` id of `name`.
-fn argument_type_id(name: &str) -> anyhow::Result<RegistryId> {
-    let id = registry::COMMAND_ARGUMENT_TYPE
-        .id_of(name)
-        .with_context(|| format!("no argument type named {name} in this protocol version"))?;
-    Ok(RegistryId(i32::try_from(id)?))
-}
-
-/// An argument type that writes no properties, by name.
-fn empty_argument(name: &str) -> anyhow::Result<ArgumentType<'static>> {
-    Ok(ArgumentType::Empty(argument_type_id(name)?))
+/// An argument type that writes no properties.
+///
+/// Infallible now that the type is a registry variant rather than a name to
+/// look up. It used to return `anyhow::Result` and every caller below carried
+/// a `?` for the possibility that `minecraft:block_pos` had stopped existing.
+const fn empty_argument(kind: CommandArgumentType) -> ArgumentType<'static> {
+    ArgumentType::Empty(kind)
 }
 
 /// A registry-scoped argument type, whose payload is the registry it scopes to.
-fn registry_argument<'a>(
-    name: &str,
-    scope: &'a valence_ident::Ident,
-) -> anyhow::Result<ArgumentType<'a>> {
+fn registry_argument(
+    kind: CommandArgumentType,
+    scope: &valence_ident::Ident,
+) -> anyhow::Result<ArgumentType<'_>> {
     Ok(ArgumentType::Registry {
-        id: argument_type_id(name)?,
+        id: kind,
         registry: Identifier::new(scope.as_str())?,
     })
 }
@@ -218,7 +215,7 @@ fn registry_argument<'a>(
 /// registry have drifted apart and the node cannot be sent at all.
 pub fn argument_type(parser: &Parser) -> anyhow::Result<ArgumentType<'_>> {
     Ok(match parser {
-        Parser::Bool => empty_argument("brigadier:bool")?,
+        Parser::Bool => empty_argument(CommandArgumentType::BrigadierBool),
         Parser::Float { min, max } => ArgumentType::Float {
             min: *min,
             max: *max,
@@ -255,51 +252,55 @@ pub fn argument_type(parser: &Parser) -> anyhow::Result<ArgumentType<'_>> {
         // `TimeArgument.time()` uses.
         Parser::Time => ArgumentType::Time { min: 0 },
         Parser::ResourceOrTag { registry } => {
-            registry_argument("minecraft:resource_or_tag", registry)?
+            registry_argument(CommandArgumentType::ResourceOrTag, registry)?
         }
         Parser::ResourceOrTagKey { registry } => {
-            registry_argument("minecraft:resource_or_tag_key", registry)?
+            registry_argument(CommandArgumentType::ResourceOrTagKey, registry)?
         }
-        Parser::Resource { registry } => registry_argument("minecraft:resource", registry)?,
-        Parser::ResourceKey { registry } => registry_argument("minecraft:resource_key", registry)?,
+        Parser::Resource { registry } => {
+            registry_argument(CommandArgumentType::Resource, registry)?
+        }
+        Parser::ResourceKey { registry } => {
+            registry_argument(CommandArgumentType::ResourceKey, registry)?
+        }
         // Everything below is a `SingletonArgumentInfo`, which writes its id
         // and stops.
-        Parser::GameProfile => empty_argument("minecraft:game_profile")?,
-        Parser::BlockPos => empty_argument("minecraft:block_pos")?,
-        Parser::ColumnPos => empty_argument("minecraft:column_pos")?,
-        Parser::Vec3 => empty_argument("minecraft:vec3")?,
-        Parser::Vec2 => empty_argument("minecraft:vec2")?,
-        Parser::BlockState => empty_argument("minecraft:block_state")?,
-        Parser::BlockPredicate => empty_argument("minecraft:block_predicate")?,
-        Parser::ItemStack => empty_argument("minecraft:item_stack")?,
-        Parser::ItemPredicate => empty_argument("minecraft:item_predicate")?,
+        Parser::GameProfile => empty_argument(CommandArgumentType::GameProfile),
+        Parser::BlockPos => empty_argument(CommandArgumentType::BlockPos),
+        Parser::ColumnPos => empty_argument(CommandArgumentType::ColumnPos),
+        Parser::Vec3 => empty_argument(CommandArgumentType::Vec3),
+        Parser::Vec2 => empty_argument(CommandArgumentType::Vec2),
+        Parser::BlockState => empty_argument(CommandArgumentType::BlockState),
+        Parser::BlockPredicate => empty_argument(CommandArgumentType::BlockPredicate),
+        Parser::ItemStack => empty_argument(CommandArgumentType::ItemStack),
+        Parser::ItemPredicate => empty_argument(CommandArgumentType::ItemPredicate),
         // Renamed in 1.20.5: what valence calls `Color` is a team colour.
-        Parser::Color => empty_argument("minecraft:team_color")?,
-        Parser::Component => empty_argument("minecraft:component")?,
-        Parser::Message => empty_argument("minecraft:message")?,
-        Parser::NbtCompoundTag => empty_argument("minecraft:nbt_compound_tag")?,
-        Parser::NbtTag => empty_argument("minecraft:nbt_tag")?,
-        Parser::NbtPath => empty_argument("minecraft:nbt_path")?,
-        Parser::Objective => empty_argument("minecraft:objective")?,
-        Parser::ObjectiveCriteria => empty_argument("minecraft:objective_criteria")?,
-        Parser::Operation => empty_argument("minecraft:operation")?,
-        Parser::Particle => empty_argument("minecraft:particle")?,
-        Parser::Angle => empty_argument("minecraft:angle")?,
-        Parser::Rotation => empty_argument("minecraft:rotation")?,
-        Parser::ScoreboardSlot => empty_argument("minecraft:scoreboard_slot")?,
-        Parser::Swizzle => empty_argument("minecraft:swizzle")?,
-        Parser::Team => empty_argument("minecraft:team")?,
-        Parser::ItemSlot => empty_argument("minecraft:item_slot")?,
-        Parser::ResourceLocation => empty_argument("minecraft:resource_location")?,
-        Parser::Function => empty_argument("minecraft:function")?,
-        Parser::EntityAnchor => empty_argument("minecraft:entity_anchor")?,
-        Parser::IntRange => empty_argument("minecraft:int_range")?,
-        Parser::FloatRange => empty_argument("minecraft:float_range")?,
-        Parser::Dimension => empty_argument("minecraft:dimension")?,
-        Parser::GameMode => empty_argument("minecraft:gamemode")?,
-        Parser::TemplateMirror => empty_argument("minecraft:template_mirror")?,
-        Parser::TemplateRotation => empty_argument("minecraft:template_rotation")?,
-        Parser::Uuid => empty_argument("minecraft:uuid")?,
+        Parser::Color => empty_argument(CommandArgumentType::TeamColor),
+        Parser::Component => empty_argument(CommandArgumentType::Component),
+        Parser::Message => empty_argument(CommandArgumentType::Message),
+        Parser::NbtCompoundTag => empty_argument(CommandArgumentType::NbtCompoundTag),
+        Parser::NbtTag => empty_argument(CommandArgumentType::NbtTag),
+        Parser::NbtPath => empty_argument(CommandArgumentType::NbtPath),
+        Parser::Objective => empty_argument(CommandArgumentType::Objective),
+        Parser::ObjectiveCriteria => empty_argument(CommandArgumentType::ObjectiveCriteria),
+        Parser::Operation => empty_argument(CommandArgumentType::Operation),
+        Parser::Particle => empty_argument(CommandArgumentType::Particle),
+        Parser::Angle => empty_argument(CommandArgumentType::Angle),
+        Parser::Rotation => empty_argument(CommandArgumentType::Rotation),
+        Parser::ScoreboardSlot => empty_argument(CommandArgumentType::ScoreboardSlot),
+        Parser::Swizzle => empty_argument(CommandArgumentType::Swizzle),
+        Parser::Team => empty_argument(CommandArgumentType::Team),
+        Parser::ItemSlot => empty_argument(CommandArgumentType::ItemSlot),
+        Parser::ResourceLocation => empty_argument(CommandArgumentType::ResourceLocation),
+        Parser::Function => empty_argument(CommandArgumentType::Function),
+        Parser::EntityAnchor => empty_argument(CommandArgumentType::EntityAnchor),
+        Parser::IntRange => empty_argument(CommandArgumentType::IntRange),
+        Parser::FloatRange => empty_argument(CommandArgumentType::FloatRange),
+        Parser::Dimension => empty_argument(CommandArgumentType::Dimension),
+        Parser::GameMode => empty_argument(CommandArgumentType::Gamemode),
+        Parser::TemplateMirror => empty_argument(CommandArgumentType::TemplateMirror),
+        Parser::TemplateRotation => empty_argument(CommandArgumentType::TemplateRotation),
+        Parser::Uuid => empty_argument(CommandArgumentType::Uuid),
     })
 }
 
@@ -703,15 +704,7 @@ mod tests {
         let CommandNodeStub::Argument { parser, .. } = decoded.nodes[2].stub else {
             panic!("third node should be the argument");
         };
-        assert_eq!(
-            parser.to_id().expect("argument type id"),
-            i32::try_from(
-                registry::COMMAND_ARGUMENT_TYPE
-                    .id_of("brigadier:string")
-                    .expect("brigadier:string is registered")
-            )
-            .expect("id fits an i32")
-        );
+        assert_eq!(parser.to_type(), CommandArgumentType::BrigadierString);
         assert!(decoded.nodes[2].executable);
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1031,6 +1031,7 @@
             minecraft-proto-generated = minecraft.generatedUpToDate;
             minecraft-proto-coverage = minecraft.coverageRatchet;
             tool-paths = minecraft.toolPaths;
+            minecraft-literals = minecraft.literalRatchet;
             minecraft-registry-data = minecraft.registryDataUpToDate;
             minecraft-tag-data = minecraft.tagDataUpToDate;
             minecraft-tags-load = minecraft.tagsLoadForClient;
@@ -1112,6 +1113,7 @@
               inherit (checks) flake-gate;
               update-minecraft-data = minecraft.updateScript;
               sync-minecraft-proto = minecraft.syncScript;
+              sync-minecraft-literals = minecraft.syncLiteralsScript;
               sync-minecraft-registry-data = minecraft.syncRegistryDataScript;
               sync-minecraft-tag-data = minecraft.syncTagDataScript;
               sync-minecraft-block-states = minecraft.syncBlockStatesScript;

--- a/nix/check-minecraft-literals.py
+++ b/nix/check-minecraft-literals.py
@@ -1,0 +1,223 @@
+"""Fail when a vanilla registry name appears as a raw string in Rust.
+
+A `"minecraft:..."` literal is an unproven claim. Nothing checks that the name
+exists, that this version still spells it that way, or that the registry it
+belongs to is the one being indexed, so a typo or a Mojang rename becomes a
+`None` on whichever tick that value was next needed -- or worse, a silent
+fallback. Every static registry is now a closed Rust enum, so the name can be a
+variant instead, and the compiler answers all three questions at the line that
+asked.
+
+This is what stops the class from growing back. It is deliberately not a
+regex over lines: `//! minecraft:pig` in a doc comment and `"minecraft:pig"` in
+code look identical to one, and this repo's doc comments name registry entries
+constantly. The scan below walks each file the way Rust lexes it and only ever
+looks inside string literals.
+
+Two kinds of exemption, and they are different on purpose.
+
+`ALLOWED` is a path with a reason: a file where these literals are correct and
+are expected to stay. It is short, and adding to it should feel like a decision.
+
+The baseline is a path with a *list*: literals that have not been migrated yet.
+It is debt with a name on it, it ratchets in both directions, and the intended
+end state is that it is empty and this script stops needing it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Namespaces a registry entry can carry. `brigadier:` is the six command
+# argument types Mojang did not move into their own namespace.
+NAMESPACE = re.compile(r"\b(?:minecraft|brigadier):[a-z0-9_./]+")
+
+# The generator's own output, recognised by the header every generator writes
+# rather than by a path list, so a new generated file is covered the day it
+# appears and a file that stops being generated stops being exempt.
+GENERATED_MARKER = "@generated"
+
+# Files where a raw registry name is the right thing, by path, with the reason.
+#
+# Not a pattern. A pattern loose enough to cover these would also cover the
+# next mistake.
+ALLOWED: dict[str, str] = {
+    "crates/hyperion/src/net/protocol/registries.rs": (
+        "the element names of the 29 *dynamic* registries, which protocol.json "
+        "does not carry and so have no enum. This file is a name table of the "
+        "same kind as generated output and its own header says it should be "
+        "deleted once the proto crate generates dynamic registry contents; "
+        "until then the names have to be written down somewhere"
+    ),
+    "crates/hyperion-minecraft-proto/tests/registry_enum.rs": (
+        "the test that proves the enums cover the registries has to name "
+        "entries as strings to check that the string form resolves, and names "
+        "deliberate non-entries to check that they do not"
+    ),
+}
+
+
+def literals(src: str):
+    """Yield (line, text) for every string literal in `src`.
+
+    Comments, char literals and lifetimes are stepped over. Raw strings keep
+    their contents verbatim, which is what a `r"minecraft:x"` needs.
+    """
+    i, n, line = 0, len(src), 1
+    while i < n:
+        char = src[i]
+        if char == "\n":
+            line += 1
+            i += 1
+            continue
+        if src.startswith("//", i):
+            end = src.find("\n", i)
+            i = n if end < 0 else end
+            continue
+        if src.startswith("/*", i):
+            depth, i = 1, i + 2
+            while i < n and depth:
+                if src.startswith("/*", i):
+                    depth, i = depth + 1, i + 2
+                elif src.startswith("*/", i):
+                    depth, i = depth - 1, i + 2
+                else:
+                    line += src[i] == "\n"
+                    i += 1
+            continue
+        raw = re.match(r'(b?r)(#*)"', src[i:])
+        if raw:
+            start = i + raw.end()
+            close = '"' + raw.group(2)
+            end = src.find(close, start)
+            end = n if end < 0 else end
+            yield line, src[start:end]
+            line += src.count("\n", i, end)
+            i = end + len(close)
+            continue
+        if char == '"':
+            j, out = i + 1, []
+            while j < n:
+                if src[j] == "\\":
+                    out.append(src[j:j + 2])
+                    j += 2
+                    continue
+                if src[j] == '"':
+                    break
+                out.append(src[j])
+                j += 1
+            text = "".join(out)
+            yield line, text
+            line += text.count("\n")
+            i = j + 1
+            continue
+        if char == "'":
+            i += 1
+            continue
+        i += 1
+
+
+def scan(root: Path) -> dict[str, list[str]]:
+    """Every registry name in a string literal, by file, excluding generated."""
+    listing = subprocess.run(
+        ["git", "ls-files", "-z", "*.rs"],
+        cwd=root, check=True, capture_output=True, text=True,
+    ).stdout
+    found: dict[str, list[str]] = {}
+    for name in listing.split("\0"):
+        if not name:
+            continue
+        path = root / name
+        try:
+            src = path.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        # The marker has to be near the top; a mention of the word further down
+        # is prose rather than a claim about the file.
+        if GENERATED_MARKER in src[:200]:
+            continue
+        if name in ALLOWED:
+            continue
+        hits = [
+            hit
+            for _, text in literals(src)
+            for hit in NAMESPACE.findall(text)
+        ]
+        if hits:
+            found[name] = sorted(hits)
+    return found
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--root", required=True, type=Path)
+    ap.add_argument("--baseline", required=True, type=Path)
+    ap.add_argument("--write", action="store_true", help="rewrite the baseline")
+    args = ap.parse_args()
+
+    found = scan(args.root)
+    total = sum(len(v) for v in found.values())
+
+    if args.write:
+        args.baseline.write_text(
+            json.dumps({"literals": found}, indent=2, sort_keys=True) + "\n"
+        )
+        print(
+            "{} raw registry names in {} files".format(total, len(found)),
+            file=sys.stderr,
+        )
+        return 0
+
+    baseline = json.loads(args.baseline.read_text())["literals"]
+    allowed_total = sum(len(v) for v in baseline.values())
+
+    print(
+        "{} raw registry names in Rust string literals, {} allowed by the "
+        "baseline".format(total, allowed_total),
+        file=sys.stderr,
+    )
+
+    added: list[tuple[str, str]] = []
+    removed: list[tuple[str, str]] = []
+    for name in sorted(set(found) | set(baseline)):
+        was = list(baseline.get(name, []))
+        now = list(found.get(name, []))
+        for hit in now:
+            if hit in was:
+                was.remove(hit)
+            else:
+                added.append((name, hit))
+        removed.extend((name, hit) for hit in was)
+
+    for name, hit in added:
+        print("NEW     {}  {}".format(name, hit), file=sys.stderr)
+    for name, hit in removed:
+        print("GONE    {}  {}".format(name, hit), file=sys.stderr)
+
+    if added:
+        print(
+            "\n{} raw registry name(s) that were not there before. Every static "
+            "registry is a closed enum in\nhyperion_minecraft_proto::generated::registry, "
+            "so name the variant instead: a typo or a\nMojang rename is then a compile "
+            "error here rather than a None at run time. If the name\nbelongs to a "
+            "dynamic registry and genuinely has no enum, add the file to ALLOWED in\n"
+            "nix/check-minecraft-literals.py with the reason.".format(len(added)),
+            file=sys.stderr,
+        )
+    if removed:
+        print(
+            "\n{} raw registry name(s) are gone, so the baseline is looser than the "
+            "code and has\nstopped bounding anything. Tighten it with: "
+            "nix run .#sync-minecraft-literals".format(len(removed)),
+            file=sys.stderr,
+        )
+    return 1 if added or removed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nix/generate-rust.py
+++ b/nix/generate-rust.py
@@ -283,20 +283,23 @@ WIDTH_BYTES = {"u8": 1, "u16": 2, "u32": 4}
 # An enum generated from this file would be id-only and structurally unable to
 # say that, while being the more discoverable of the two names.
 #
-# `nix/generate-particles.py` reads the decompiled codecs instead and emits
-# `crates/hyperion-minecraft-proto/src/particle.rs`, the same way
-# `nix/generate-entity-types.py` owns entity types. It follows the conventions
-# below -- discriminant is the network id, `const fn id`, `name()` off a static
-# table, `from_id`/`from_name` at the decode boundary only, closed, no
-# `Unknown` -- and pins its ids against `PARTICLE_TYPE` here, which is what
-# stops the two from drifting.
+# A separate generator reads the decompiled codecs instead, which is where the
+# payload shapes are. It follows the conventions below -- discriminant is the
+# network id, `const fn id`, `name()` off a static table, `from_id`/`from_name`
+# at the decode boundary only, closed, no `Unknown` -- and pins its ids against
+# `PARTICLE_TYPE` here, which is what stops the two from drifting.
 #
-# Do not add this back without deleting that generator first.
+# The name table below therefore stays even though the enum does not, because
+# it is what that generator pins against.
+#
+# Do not add this registry back without first deleting whatever generator owns
+# the particle enum. Two enums over one registry, with the poorer one being the
+# more discoverable name, is worse than either alone.
 NO_ENUM: dict[str, str] = {
     "minecraft:particle_type": (
-        "its entries carry payloads that `protocol.json` cannot describe, so "
-        "`nix/generate-particles.py` reads the decompiled codecs instead and "
-        "owns the enum"
+        "13 of its 125 entries carry payloads that `protocol.json` cannot "
+        "describe, so the enum is generated from the decompiled codecs instead "
+        "and lives outside this file"
     ),
 }
 
@@ -482,8 +485,8 @@ def emit_names_only(doc: dict, name: str, entries: list[str]) -> str:
 //! never carry its block state, its colour or its flight time, while being the
 //! more discoverable of the two spellings.
 //!
-//! The table below stays, because it is what the real generator pins its ids
-//! against.
+//! The table below stays, because it is what the generator that does own the
+//! enum pins its ids against.
 
 /// Entry names in network-id order, so the index is the id.
 pub static NAMES_IN_ID_ORDER: [&str; {count}] = [
@@ -527,8 +530,8 @@ def emit_registries(doc: dict) -> dict[str, str]:
 //! Nothing is curated: every registry the extractor reports has an enum, so
 //! there is no subset to fall outside of. The single exception is
 //! `minecraft:particle_type`, whose entries carry payloads this file's input
-//! cannot describe; `nix/generate-particles.py` owns that one and the reason
-//! is written at the top of the `particle_type` module here.
+//! cannot describe; its enum is generated from the decompiled codecs instead,
+//! and the reason is written at the top of the `particle_type` module here.
 //!
 //! # What is free and what is not
 //!

--- a/nix/minecraft-data.nix
+++ b/nix/minecraft-data.nix
@@ -325,6 +325,9 @@ let
   toolPathChecker = pkgs.writers.writePython3Bin "check-tool-paths" pythonWriterOptions
     (builtins.readFile ./check-tool-paths.py);
 
+  literalChecker = pkgs.writers.writePython3Bin "check-minecraft-literals" pythonWriterOptions
+    (builtins.readFile ./check-minecraft-literals.py);
+
   # The NBT blobs live next to the Rust that `include_bytes!`es them, so this
   # output is a whole directory rather than a single file.
   generatedRegistryData = pkgs.runCommand "hyperion-minecraft-registry-data-${pin.id}"
@@ -566,6 +569,20 @@ let
     '';
   };
 
+  # Rewrites the raw-literal baseline. The same command tightens it after a
+  # migration and records a deliberate new one, so the two cannot drift.
+  syncLiteralsScript = pkgs.writeShellApplication {
+    name = "sync-minecraft-literals";
+    runtimeInputs = [ pkgs.git literalChecker ];
+    text = ''
+      root=$(git rev-parse --show-toplevel)
+      check-minecraft-literals \
+        --root "$root" \
+        --baseline "$root/nix/minecraft-literal-baseline.json" \
+        --write
+    '';
+  };
+
   # The fixtures are committed so `cargo test` runs without nix. That only
   # stays honest if something notices when the jar stops producing them.
   fixturesUpToDate = pkgs.runCommand "check-minecraft-encoder-fixtures"
@@ -739,6 +756,46 @@ let
     ];
   };
 
+  # A raw `"minecraft:..."` in Rust is an unproven claim, and this is what
+  # stops the class from growing back.
+  #
+  # Every static registry is a closed enum now, so a name written as a string
+  # is a name nothing checks: a typo or a Mojang rename becomes a `None` at run
+  # time rather than a compile error. The checker walks each file the way Rust
+  # lexes it -- a regex over lines cannot tell `//! minecraft:pig` from
+  # `"minecraft:pig"`, and this repo's doc comments name registry entries
+  # constantly.
+  #
+  # A ratchet in both directions, like the coverage one. A new literal is a
+  # regression; a literal that has gone means the baseline has stopped bounding
+  # anything and should be tightened with `nix run .#sync-minecraft-literals`.
+  #
+  # The source is filtered to what the checker reads. Without that, every Rust
+  # edit anywhere in the tree rebuilds this.
+  literalRatchet = pkgs.runCommand "check-minecraft-literals"
+    {
+      nativeBuildInputs = [ literalChecker pkgs.git ];
+    }
+    ''
+      cp -r ${literalSource} source
+      chmod -R u+w source
+      cd source
+      git init -q .
+      git add -A
+      check-minecraft-literals \
+        --root . \
+        --baseline ${../nix/minecraft-literal-baseline.json}
+      touch $out
+    '';
+
+  # `git ls-files` is how the checker finds its inputs, so the copy it runs
+  # against has to be a git tree. Only Rust sources and the checker's own
+  # baseline matter, so nothing else is copied in.
+  literalSource = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.fileFilter (file: file.hasExt "rs") ../.;
+  };
+
   # protocol.json is the input build.rs reads, so a stale copy is a stale
   # packet struct in every build that does not go through nix. Guarding it is
   # what lets the structs live in OUT_DIR instead of in the tree.
@@ -785,6 +842,9 @@ in
     coverageRatchet
     toolPathChecker
     toolPaths
+    literalChecker
+    literalRatchet
+    syncLiteralsScript
     generatedUpToDate
     registryDataUpToDate
     tagDataUpToDate

--- a/nix/minecraft-literal-baseline.json
+++ b/nix/minecraft-literal-baseline.json
@@ -1,0 +1,433 @@
+{
+  "literals": {
+    "crates/hyperion-crafting/src/lib.rs": [
+      "minecraft:crafting_shapeless"
+    ],
+    "crates/hyperion-item/src/builder.rs": [
+      "minecraft:generic.attack_damage",
+      "minecraft:generic.attack_speed",
+      "minecraft:generic.max_health"
+    ],
+    "crates/hyperion-minecraft-proto/src/packets/configuration.rs": [
+      "minecraft:brand"
+    ],
+    "crates/hyperion-minecraft-proto/src/packets/play/chunk.rs": [
+      "minecraft:cloud",
+      "minecraft:crit",
+      "minecraft:dragon_breath",
+      "minecraft:explosion",
+      "minecraft:portal"
+    ],
+    "crates/hyperion-minecraft-proto/src/packets/play/player.rs": [
+      "minecraft:blank",
+      "minecraft:blank",
+      "minecraft:command_argument_type",
+      "minecraft:fixed",
+      "minecraft:fixed",
+      "minecraft:number_format_type",
+      "minecraft:number_format_type",
+      "minecraft:styled",
+      "minecraft:styled"
+    ],
+    "crates/hyperion-minecraft-proto/src/text/contents.rs": [
+      "minecraft:blocks"
+    ],
+    "crates/hyperion-minecraft-proto/tests/configuration.rs": [
+      "minecraft:banner_pattern",
+      "minecraft:block",
+      "minecraft:brand",
+      "minecraft:brand",
+      "minecraft:dimension_type",
+      "minecraft:overworld",
+      "minecraft:the_nether",
+      "minecraft:the_nether",
+      "minecraft:vanilla",
+      "minecraft:wool"
+    ],
+    "crates/hyperion-minecraft-proto/tests/inventory.rs": [
+      "minecraft:diamond_sword"
+    ],
+    "crates/hyperion-minecraft-proto/tests/play_combat.rs": [
+      "minecraft:hi"
+    ],
+    "crates/hyperion-minecraft-proto/tests/play_login.rs": [
+      "minecraft:overworld",
+      "minecraft:overworld",
+      "minecraft:overworld",
+      "minecraft:overworld",
+      "minecraft:overworld",
+      "minecraft:the_nether",
+      "minecraft:the_nether"
+    ],
+    "crates/hyperion-minecraft-proto/tests/play_player.rs": [
+      "minecraft:ask_server"
+    ],
+    "crates/hyperion-minecraft-proto/tests/registry_data.rs": [
+      "minecraft:chat",
+      "minecraft:chat",
+      "minecraft:chat_type",
+      "minecraft:dimension_type",
+      "minecraft:overworld",
+      "minecraft:overworld",
+      "minecraft:plains",
+      "minecraft:the_end",
+      "minecraft:the_nether",
+      "minecraft:worldgen/biome"
+    ],
+    "crates/hyperion-minecraft-proto/tests/tag_data.rs": [
+      "minecraft:block",
+      "minecraft:entity_type",
+      "minecraft:item"
+    ],
+    "crates/hyperion-minecraft-proto/tests/text.rs": [
+      "minecraft:alt",
+      "minecraft:blocks",
+      "minecraft:pig",
+      "minecraft:pig",
+      "minecraft:stone",
+      "minecraft:stone",
+      "minecraft:store"
+    ],
+    "crates/hyperion-minecraft-proto/tests/types.rs": [
+      "minecraft:block/stone"
+    ],
+    "crates/hyperion/src/net/protocol/join.rs": [
+      "minecraft:overworld"
+    ],
+    "crates/hyperion/src/net/protocol/pre_play.rs": [
+      "minecraft:brand",
+      "minecraft:vanilla"
+    ],
+    "crates/hyperion/src/simulation/blocks/loader/mod.rs": [
+      "minecraft:stone"
+    ],
+    "crates/hyperion/src/simulation/blocks/translate.rs": [
+      "minecraft:chest",
+      "minecraft:grass_block",
+      "minecraft:iron_chain",
+      "minecraft:plains",
+      "minecraft:plains",
+      "minecraft:plains",
+      "minecraft:short_grass",
+      "minecraft:stone"
+    ],
+    "crates/hyperion/src/simulation/command.rs": [
+      "minecraft:ask_server",
+      "minecraft:commands"
+    ],
+    "crates/hyperion/src/simulation/entity_kind.rs": [
+      "minecraft:entity_type"
+    ],
+    "crates/hyperion/src/simulation/inventory.rs": [
+      "minecraft:anvil",
+      "minecraft:beacon",
+      "minecraft:blast_furnace",
+      "minecraft:brewing_stand",
+      "minecraft:cartography_table",
+      "minecraft:crafting",
+      "minecraft:enchantment",
+      "minecraft:furnace",
+      "minecraft:generic_3x3",
+      "minecraft:generic_9x1",
+      "minecraft:generic_9x2",
+      "minecraft:generic_9x3",
+      "minecraft:generic_9x4",
+      "minecraft:generic_9x5",
+      "minecraft:generic_9x6",
+      "minecraft:grindstone",
+      "minecraft:hopper",
+      "minecraft:iron_chain",
+      "minecraft:lectern",
+      "minecraft:loom",
+      "minecraft:menu",
+      "minecraft:merchant",
+      "minecraft:short_grass",
+      "minecraft:shulker_box",
+      "minecraft:smithing",
+      "minecraft:smoker",
+      "minecraft:stonecutter",
+      "minecraft:turtle_scute"
+    ],
+    "crates/hyperion/src/simulation/metadata/block_display.rs": [
+      "minecraft:emerald_block",
+      "minecraft:emerald_block"
+    ],
+    "crates/hyperion/src/simulation/util.rs": [
+      "minecraft:worldgen/biome"
+    ],
+    "crates/hyperion/tests/protocol.rs": [
+      "minecraft:overworld",
+      "minecraft:overworld",
+      "minecraft:overworld",
+      "minecraft:overworld"
+    ],
+    "events/bedwars/src/module/attack.rs": [
+      "minecraft:armor",
+      "minecraft:armor",
+      "minecraft:entity.player.attack.crit",
+      "minecraft:entity.player.attack.knockback",
+      "minecraft:player_attack",
+      "minecraft:player_attack"
+    ],
+    "events/bedwars/src/module/damage.rs": [
+      "minecraft:entity.player.big_fall",
+      "minecraft:entity.player.small_fall",
+      "minecraft:fall",
+      "minecraft:fall"
+    ],
+    "events/smash/src/module/kit.rs": [
+      "minecraft:armor_stand",
+      "minecraft:stick"
+    ],
+    "events/smash/src/module/kits/blaze.rs": [
+      "minecraft:blaze",
+      "minecraft:entity.blaze.ambient",
+      "minecraft:entity.blaze.ambient",
+      "minecraft:entity.blaze.death",
+      "minecraft:entity.blaze.hurt",
+      "minecraft:entity.blaze.shoot",
+      "minecraft:entity.player.hurt_on_fire",
+      "minecraft:iron_axe",
+      "minecraft:iron_sword",
+      "minecraft:item.firecharge.use",
+      "minecraft:nether_star"
+    ],
+    "events/smash/src/module/kits/chicken.rs": [
+      "minecraft:chicken",
+      "minecraft:entity.chicken.ambient",
+      "minecraft:entity.chicken.ambient",
+      "minecraft:entity.chicken.death",
+      "minecraft:entity.chicken.egg",
+      "minecraft:entity.chicken.hurt",
+      "minecraft:entity.egg.throw",
+      "minecraft:iron_axe",
+      "minecraft:iron_sword",
+      "minecraft:nether_star"
+    ],
+    "events/smash/src/module/kits/cow.rs": [
+      "minecraft:cow",
+      "minecraft:entity.cow.ambient",
+      "minecraft:entity.cow.ambient",
+      "minecraft:entity.cow.death",
+      "minecraft:entity.cow.hurt",
+      "minecraft:entity.cow.milk",
+      "minecraft:entity.mooshroom.convert",
+      "minecraft:iron_axe",
+      "minecraft:iron_shovel",
+      "minecraft:nether_star"
+    ],
+    "events/smash/src/module/kits/creeper.rs": [
+      "minecraft:creeper",
+      "minecraft:entity.creeper.death",
+      "minecraft:entity.creeper.hurt",
+      "minecraft:entity.creeper.primed",
+      "minecraft:entity.creeper.primed",
+      "minecraft:entity.generic.explode",
+      "minecraft:entity.wither.spawn",
+      "minecraft:iron_axe",
+      "minecraft:iron_shovel",
+      "minecraft:nether_star"
+    ],
+    "events/smash/src/module/kits/enderman.rs": [
+      "minecraft:block.stone.place",
+      "minecraft:compass",
+      "minecraft:enderman",
+      "minecraft:entity.ender_dragon.flap",
+      "minecraft:entity.ender_pearl.throw",
+      "minecraft:entity.enderman.ambient",
+      "minecraft:entity.enderman.death",
+      "minecraft:entity.enderman.hurt",
+      "minecraft:entity.enderman.teleport",
+      "minecraft:iron_axe",
+      "minecraft:iron_sword",
+      "minecraft:nether_star"
+    ],
+    "events/smash/src/module/kits/guardian.rs": [
+      "minecraft:entity.elder_guardian.curse",
+      "minecraft:entity.generic.splash",
+      "minecraft:entity.guardian.ambient",
+      "minecraft:entity.guardian.attack",
+      "minecraft:entity.guardian.death",
+      "minecraft:entity.guardian.hurt",
+      "minecraft:entity.player.splash.high_speed",
+      "minecraft:guardian",
+      "minecraft:iron_axe",
+      "minecraft:iron_pickaxe",
+      "minecraft:iron_sword",
+      "minecraft:nether_star"
+    ],
+    "events/smash/src/module/kits/iron_golem.rs": [
+      "minecraft:block.chain.place",
+      "minecraft:block.deepslate.break",
+      "minecraft:entity.iron_golem.attack",
+      "minecraft:entity.iron_golem.attack",
+      "minecraft:entity.iron_golem.death",
+      "minecraft:entity.iron_golem.hurt",
+      "minecraft:entity.ravager.roar",
+      "minecraft:iron_axe",
+      "minecraft:iron_golem",
+      "minecraft:iron_pickaxe",
+      "minecraft:iron_shovel",
+      "minecraft:nether_star"
+    ],
+    "events/smash/src/module/kits/skeleton.rs": [
+      "minecraft:arrow",
+      "minecraft:block.bone_block.break",
+      "minecraft:bow",
+      "minecraft:entity.arrow.shoot",
+      "minecraft:entity.fishing_bobber.throw",
+      "minecraft:entity.skeleton.ambient",
+      "minecraft:entity.skeleton.death",
+      "minecraft:entity.skeleton.hurt",
+      "minecraft:iron_axe",
+      "minecraft:item.crossbow.shoot",
+      "minecraft:nether_star",
+      "minecraft:skeleton"
+    ],
+    "events/smash/src/module/kits/sky_squid.rs": [
+      "minecraft:entity.cod.flop",
+      "minecraft:entity.lightning_bolt.thunder",
+      "minecraft:entity.squid.ambient",
+      "minecraft:entity.squid.ambient",
+      "minecraft:entity.squid.death",
+      "minecraft:entity.squid.hurt",
+      "minecraft:entity.squid.squirt",
+      "minecraft:iron_axe",
+      "minecraft:iron_shovel",
+      "minecraft:iron_sword",
+      "minecraft:nether_star",
+      "minecraft:squid"
+    ],
+    "events/smash/src/module/kits/slime.rs": [
+      "minecraft:entity.slime.attack",
+      "minecraft:entity.slime.death",
+      "minecraft:entity.slime.hurt",
+      "minecraft:entity.slime.jump",
+      "minecraft:entity.slime.squish",
+      "minecraft:entity.slime.squish",
+      "minecraft:iron_axe",
+      "minecraft:iron_sword",
+      "minecraft:nether_star",
+      "minecraft:slime"
+    ],
+    "events/smash/src/module/kits/snowman.rs": [
+      "minecraft:block.snow.place",
+      "minecraft:entity.snow_golem.ambient",
+      "minecraft:entity.snow_golem.ambient",
+      "minecraft:entity.snow_golem.death",
+      "minecraft:entity.snow_golem.hurt",
+      "minecraft:entity.snow_golem.shoot",
+      "minecraft:entity.snowball.throw",
+      "minecraft:iron_axe",
+      "minecraft:iron_sword",
+      "minecraft:nether_star",
+      "minecraft:snow_block",
+      "minecraft:snow_golem"
+    ],
+    "events/smash/src/module/kits/spider.rs": [
+      "minecraft:block.cobweb.place",
+      "minecraft:entity.bee.sting",
+      "minecraft:entity.player.hurt_sweet_berry_bush",
+      "minecraft:entity.spider.ambient",
+      "minecraft:entity.spider.ambient",
+      "minecraft:entity.spider.death",
+      "minecraft:entity.spider.hurt",
+      "minecraft:iron_axe",
+      "minecraft:iron_sword",
+      "minecraft:nether_star",
+      "minecraft:spider"
+    ],
+    "events/smash/src/module/kits/wither_skeleton.rs": [
+      "minecraft:entity.illusioner.mirror_move",
+      "minecraft:entity.shulker.teleport",
+      "minecraft:entity.wither.shoot",
+      "minecraft:entity.wither_skeleton.ambient",
+      "minecraft:entity.wither_skeleton.death",
+      "minecraft:entity.wither_skeleton.hurt",
+      "minecraft:iron_axe",
+      "minecraft:iron_sword",
+      "minecraft:nether_star",
+      "minecraft:wither_skeleton"
+    ],
+    "events/smash/src/module/kits/wolf.rs": [
+      "minecraft:entity.baby_wolf.ambient",
+      "minecraft:entity.wolf.ambient",
+      "minecraft:entity.wolf.death",
+      "minecraft:entity.wolf.growl",
+      "minecraft:entity.wolf.hurt",
+      "minecraft:entity.wolf_angry.growl",
+      "minecraft:iron_axe",
+      "minecraft:iron_shovel",
+      "minecraft:nether_star",
+      "minecraft:wolf"
+    ],
+    "events/smash/src/module/kits/zombie.rs": [
+      "minecraft:bow",
+      "minecraft:entity.fishing_bobber.retrieve",
+      "minecraft:entity.witch.throw",
+      "minecraft:entity.zombie.ambient",
+      "minecraft:entity.zombie.ambient",
+      "minecraft:entity.zombie.death",
+      "minecraft:entity.zombie.hurt",
+      "minecraft:iron_axe",
+      "minecraft:nether_star",
+      "minecraft:zombie"
+    ],
+    "events/smash/src/module/selector.rs": [
+      "minecraft:lime_wool",
+      "minecraft:red_wool"
+    ],
+    "events/smash/src/module/sound.rs": [
+      "minecraft:block.beacon.deactivate",
+      "minecraft:block.note_block.hat",
+      "minecraft:entity.arrow.hit",
+      "minecraft:entity.arrow.hit_player",
+      "minecraft:entity.ender_dragon.growl",
+      "minecraft:entity.player.attack.strong",
+      "minecraft:entity.villager.no",
+      "minecraft:ui.toast.challenge_complete"
+    ],
+    "events/smash/tests/abilities.rs": [
+      "minecraft:entity.arrow.shoot"
+    ],
+    "events/smash/tests/contract.rs": [
+      "minecraft:block.note_block.hat",
+      "minecraft:creeper",
+      "minecraft:entity.player.hurt_on_fire"
+    ],
+    "events/smash/tests/maps.rs": [
+      "minecraft:stone",
+      "minecraft:stone",
+      "minecraft:stone",
+      "minecraft:stone",
+      "minecraft:stone",
+      "minecraft:stone",
+      "minecraft:stone",
+      "minecraft:stone",
+      "minecraft:stone",
+      "minecraft:stone",
+      "minecraft:stone"
+    ],
+    "events/smash/tests/modularity.rs": [
+      "minecraft:iron_axe",
+      "minecraft:iron_axe",
+      "minecraft:iron_shovel",
+      "minecraft:iron_sword",
+      "minecraft:nether_star"
+    ],
+    "events/smash/tests/sound.rs": [
+      "minecraft:block.note_block.bell",
+      "minecraft:block.note_block.bell",
+      "minecraft:block.note_block.bell",
+      "minecraft:block.note_block.bell",
+      "minecraft:block.note_block.bell",
+      "minecraft:block.note_block.hat"
+    ],
+    "events/smash/tests/verification.rs": [
+      "minecraft:bow",
+      "minecraft:stick",
+      "minecraft:stick",
+      "minecraft:stone"
+    ]
+  }
+}


### PR DESCRIPTION
feat(proto): a raw `minecraft:` name in Rust is now a build failure

## The gate first, the migration second

A `"minecraft:..."` string in Rust is an unproven claim. Nothing checks that
the name exists, that this version still spells it that way, or that the
registry it indexes is the one the caller meant, so a typo or a Mojang rename
becomes a `None` on whichever tick that value was next needed. Every static
registry is a closed enum since #1021, so the name can be a variant and the
compiler answers all three questions at the line that asked.

Fixing occurrences by hand does not stop the class. `nix flake check
.#minecraft-literals` does, and it is the point of this change; the migration
below is what it enabled, not what it is for.

## Counted from the source, not from a regex over lines

The brief warned about this and it was warranted. A regex cannot tell
`//! minecraft:pig` in a doc comment from `"minecraft:pig"` in code, and this
repo's doc comments name registry entries constantly -- `entity_kind.rs` alone
has dozens. `nix/check-minecraft-literals.py` walks each file the way Rust
lexes it: line comments, nested block comments, char literals and lifetimes are
stepped over, and raw strings (`r#"..."#`) keep their contents.

What that finds across every file in `git ls-files '*.rs'`:

| | files | literals |
| --- | --- | --- |
| generated, recognised by the `@generated` header | 102 | 10009 |
| hand-written | 56 | 765 |

765, against the 659 an earlier pass measured. I did not reconstruct how that
number was reached, so I cannot say which 106 it missed, only that a Rust-aware
scan finds more.

Generated files are exempted by their own header rather than by a path list, so
a new generated file is covered the day it appears and a file that stops being
generated stops being exempt.

## Two kinds of exemption, and they are different on purpose

`ALLOWED` is a path with a reason: a file where these literals are correct and
are expected to stay. Two entries, 430 names between them.

- `crates/hyperion/src/net/protocol/registries.rs` -- the element names of the
  29 **dynamic** registries. `protocol.json` does not carry those, so they have
  no enum. The file is a name table of the same kind as generated output and
  its own header already says it should be deleted once the proto crate
  generates dynamic registry contents.
- `crates/hyperion-minecraft-proto/tests/registry_enum.rs` -- the test proving
  the enums cover the registries has to name entries as strings to check that
  the string form resolves, and names deliberate non-entries to check that they
  do not.

The baseline is a path with a *list*: names that have not been migrated yet. It
is debt with a name on it, it ratchets in both directions, and the intended end
state is that it is empty and the baseline file is deleted. 386 at the start of
this change, 323 after the migration below, and 327 after rebasing onto a main
that had grown four more while this branch was open.

I chose a ratchet over a hard failure for the remainder because most of them are
in `events/smash/**` and `crates/hyperion/src/simulation/**`, where three other
agents have open branches tonight. Migrating those files now would conflict
with work in flight for no gain the gate does not already give: the gate refuses
the *next* one either way.

## What was migrated, and why this one

`minecraft:command_argument_type`, 63 names across two files, chosen because it
was the largest single cluster and because it fixes something the brief names
directly: **encoding could fail**.

```rust
-fn argument_type_id(name: &str) -> Result<i32> {
-    let id = registry::COMMAND_ARGUMENT_TYPE
-        .id_of(name)
-        .ok_or_else(|| Error::InvalidIdentifier(name.to_owned()))?;
-    i32::try_from(id).map_err(|_| Error::InvalidIdentifier(name.to_owned()))
-}
```

That was a linear scan over 57 entries, returning a `Result`, run for every
argument of every command in the tree, so that this server could discover at
run time whether `brigadier:double` still existed. `ArgumentType::to_id` is now
`const fn` and infallible, and `ArgumentType::Empty` and `ArgumentType::Registry`
hold a `CommandArgumentType` rather than a bare `RegistryId` -- so the id cannot
be one the registry does not have, rather than being checked against it.

`decode` changed in the same direction and is the interesting half: it used to
resolve the incoming id to a *name* and then match on string literals, which is
57 string comparisons in the worst case, and silently fell through to
`Self::Empty` for a name it did not recognise. It now resolves through
`CommandArgumentType::from_id` once -- the single decode boundary -- and matches
on variants.

`crates/hyperion/src/simulation/command.rs` lost its own duplicate
`argument_type_id`, and `empty_argument` went from `-> anyhow::Result<...>` to a
`const fn`, which deleted a `?` from 43 call sites.

Runtime validation sites on non-decode paths, by the command in the previous
PR's body: 26 before, 22 after. The four removed are the two `argument_type_id`
helpers and the two `id_of` calls inside them. The remaining 22 are enumerated
in the baseline and in that list; several are legitimate -- the anvil world
loader really is resolving a name it read out of a file -- and the worst is
`events/smash/src/adapter.rs:800`, `ItemKind::from_str(bare).unwrap_or(ItemKind::Stick)`,
which hands back a stick for a name nobody typed correctly. That file belongs
to another agent tonight.

## The gate, broken in every direction and watched

**A new raw name appears.** Added a second biome lookup to `translate.rs`:

```
387 raw registry names in Rust string literals, 386 allowed by the baseline
NEW     crates/hyperion/src/simulation/blocks/translate.rs  minecraft:sunflower_plains

1 raw registry name(s) that were not there before. Every static registry is a closed enum in
hyperion_minecraft_proto::generated::registry, so name the variant instead: a typo or a
Mojang rename is then a compile error here rather than a None at run time. If the name
belongs to a dynamic registry and genuinely has no enum, add the file to ALLOWED in
nix/check-minecraft-literals.py with the reason.
```

**Names disappear and the baseline stops bounding anything.** This is not a
hypothetical; it is what the command-argument migration produced before the
baseline was tightened:

```
323 raw registry names in Rust string literals, 386 allowed by the baseline
GONE    crates/hyperion-minecraft-proto/src/packets/play/player.rs  brigadier:double
GONE    crates/hyperion-minecraft-proto/src/packets/play/player.rs  brigadier:float
... 85 lines ...
63 raw registry name(s) are gone, so the baseline is looser than the code and has
stopped bounding anything. Tighten it with: nix run .#sync-minecraft-literals
```

**The claim about comments, tested rather than asserted.** Added a doc comment
naming `minecraft:block_pos` and `"minecraft:vec3"`, and a block comment
containing `"minecraft:item_stack"`, to `command.rs`. The count stayed at 323
and no `NEW` line appeared, which is the whole reason this is a lexer and not a
`rg` invocation. A line-based check would have reported three regressions there.

## The gate caught something before it even merged

While this branch was open, #1023 landed on `main`. Rebasing onto it, with no
prompting and no edit to the checker:

```
327 raw registry names in Rust string literals, 323 allowed by the baseline
NEW     events/smash/src/module/kits/blaze.rs  minecraft:entity.player.hurt_on_fire
NEW     events/smash/src/module/kits/spider.rs  minecraft:entity.player.hurt_sweet_berry_bush
NEW     events/smash/tests/abilities.rs         minecraft:entity.arrow.shoot
NEW     events/smash/tests/contract.rs          minecraft:entity.player.hurt_on_fire
```

Four sound names written as strings in a PR authored after the enums existed,
which is the class this is meant to stop and a fair demonstration that it does
not stop itself. They are in the baseline rather than migrated: those files
have work in flight against them tonight and the gate refuses the *next* one
either way. Had this check been on `main` an hour earlier, #1023 would have
been asked to write `SoundEvent::EntityPlayerHurtOnFire` and the four would not
exist.

## Gates

| gate | result |
| --- | --- |
| `nix build .#checks.aarch64-darwin.minecraft-literals` | rc=0, 327/327 |
| `nix eval .#checks.aarch64-darwin.flake-gate.drvPath` | rc=0 |
| `cargo clippy --workspace --all-targets` | rc=0 |
| `cargo fmt --all --check` | rc=0 |
| `cargo test --workspace` | rc=0 |
| `flake8 nix/check-minecraft-literals.py` | rc=0 |

Because #1007 made CI enforce the flake checks by name, `minecraft-literals`
runs in CI the day this merges with no edit to `nix/ci/flake-gate.nix`.

## What I did not do

**327 names are still raw.** Named above, bounded by the baseline, and left
deliberately rather than overlooked.

**The dynamic registries still have no enum.** 430 of the 765 hand-written
literals are the one file that lists them, and generating them properly means
teaching `nix/generate-registry-data.py` to emit enums the way
`generate-rust.py` now does. That would delete the largest `ALLOWED` entry and
is the obvious next step; it is not this PR. Filed as ENG-10887.

**The worst remaining fallback is filed rather than fixed.** ENG-10884 covers
`ItemKind::from_str(bare).unwrap_or(ItemKind::Stick)`, which is in another
agent's file this week.

**`nix flake check` was not run whole.** The three checks this change touches
were built individually and `flake-gate` was evaluated, but the full check set
compiles a server and I did not wait on it.

## Also in here: a stale reference in my own generator

`nix/generate-rust.py` explained the `particle_type` carve-out by saying the
particle enum is owned separately "the same way `nix/generate-entity-types.py`
owns entity types". #1024 -- mine, two commits earlier -- deleted that script.
So the comment justified a real decision by appealing to a precedent that no
longer existed, which leaves the next reader either hunting a missing file or
concluding the carve-out was arbitrary.

It also named `nix/generate-particles.py` and `src/particle.rs` as though they
were present. They are not on `main` yet. The reason for the carve-out is a
fact about the data and is true today; the ownership is an arrangement that
lands separately. The comment now says the first without asserting the second,
and the reciprocal note in the generated `registry/particle_type.rs` changed
with it, so the two cannot drift.

Worth naming the general shape, because a gate in this very PR nearly caught it
and did not. `tool-paths` only matches paths at the start of a string literal;
this one was inside backticks in the middle of a sentence. A comment can name a
file that does not exist and nothing anywhere objects. I have not widened the
pattern -- matching every path-shaped substring in every comment would flag
prose constantly -- so this stays a thing a reader catches, and one did.

## A note on what a green local clippy is worth

`cargo clippy --workspace --all-targets` reported this tree clean three times
while CI was failing, for two reasons that will recur. It does not pass
`-D warnings`, so an unused import is a warning locally and an error in CI. And
cargo caches per target, so a test target nobody touched is not re-checked and
a warning that arrived with somebody else's merge stays invisible. `touch`ing
the file made it appear at once.

CI's invocation is `cargo clippy --all-targets --all-features -- -D warnings`
(flake.nix:185). Anything less is not the same check, and this PR is verified
with that one. Filed as ENG-10894 along with the red it exposed, which #1029
has since fixed.

---

AI-authored (Claude) under human direction.
