### PR TITLE
feat(hyperion): a boss bar is an entity with an audience, and the host has two

### DIFF
--- a/crates/hyperion-clap/src/lib.rs
+++ b/crates/hyperion-clap/src/lib.rs
@@ -495,6 +495,40 @@ impl MinecraftCommand for PermissionCommand {
     }
 }
 
+/// `/serverload`: show or hide the host's own CPU and memory.
+///
+/// Admin, and opt in. Fifteen players in a lobby staring at server telemetry
+/// is a strange default, and three stacked bars is most of the strip; this way
+/// the operator who wants the numbers has them and nobody else pays for it.
+///
+/// Everything it does is one relationship. `egress::server_load::toggle` adds
+/// or removes `(ShownTo, caller)` on the two bars, and the `Add` packets, the
+/// `Remove` packets and the diffing in between are `egress::boss_bar`'s.
+#[derive(Parser, CommandPermission, Debug)]
+#[command(name = "serverload")]
+#[command_permission(group = "Admin")]
+pub struct ServerLoadCommand;
+
+impl MinecraftCommand for ServerLoadCommand {
+    fn execute(self, system: EntityView<'_>, caller: Entity) {
+        let world = system.world();
+        let showing = hyperion::egress::server_load::toggle(world, caller);
+        let message = if showing {
+            "§aServer load bars on."
+        } else {
+            "§7Server load bars off."
+        };
+        let chat = hyperion::net::agnostic::chat(message);
+        world.get::<&Compose>(|compose| {
+            caller.entity_view(world).get::<&ConnectionId>(|stream| {
+                if let Err(error) = compose.unicast(&chat, *stream) {
+                    tracing::warn!("dropping a /serverload reply: {error}");
+                }
+            });
+        });
+    }
+}
+
 impl Module for ClapCommandModule {
     fn module(world: &World) {
         world.import::<hyperion_command::CommandModule>();
@@ -505,6 +539,7 @@ impl Module for ClapCommandModule {
             // it is a clap `ValueEnum`, so registration already carried its
             // four values into the graph.
             PermissionCommand::register(registry, world).completes("player", Player::id());
+            ServerLoadCommand::register(registry, world);
         });
     }
 }

--- a/crates/hyperion/src/egress/boss_bar.rs
+++ b/crates/hyperion/src/egress/boss_bar.rs
@@ -1,0 +1,514 @@
+//! Boss bars: the strip across the top of a client's screen.
+//!
+//! # A bar is an entity and its audience is a set of edges
+//!
+//! ```ignore
+//! let bar = world
+//!     .entity()
+//!     .add(BossBar::id())
+//!     .set(Title(Text::text("CPU 240% of 1600%").color(NamedColor::Red)))
+//!     .set(Progress(0.15))
+//!     .add((ShownTo, operator));
+//! ```
+//!
+//! and later `bar.set(Progress(0.31))`, which sends one `UpdateProgress` to
+//! each viewer and nothing else. There is no packet in a caller anywhere.
+//!
+//! # Why the sent state is pair data and not a table
+//!
+//! [`Sent`] holds exactly what one client was last told, as the data on the
+//! `(Sent, viewer)` pair. That one choice is what makes the two cases that are
+//! usually bugs stop being code at all:
+//!
+//! * **Somebody joins mid-match.** They have no `(Sent, bar)` pair, so the
+//!   next tick sends them `Add` for every bar whose audience they are in.
+//!   Joining is the absence of state rather than a handler.
+//! * **Somebody leaves, or a bar is destroyed, or the audience shrinks.** All
+//!   three end with the pair going away -- flecs removes it itself for the
+//!   first two, under the `(OnDeleteTarget, Remove)` cleanup written down in
+//!   [`BossBarModule::module`] -- and one `OnRemove` observer on
+//!   `(Sent, Wildcard)` sends the `Remove`. Teardown cannot leak, because the
+//!   fact that says "this client has this bar" and the thing that gets cleaned
+//!   up are the same fact.
+//!
+//! # Nothing unchanged is resent
+//!
+//! The drive system compares each viewer's [`Sent`] against the bar's
+//! components and emits only the operations whose field moved. An unchanged
+//! bar sends nothing at all. That is not a micro-optimisation: hyperion#1018
+//! measured 3,065 boss bar packets in thirty seconds for eight clients from a
+//! bar that resent itself whenever its progress moved by any amount, against
+//! 1,135 once the game quantised what it asked for. A bar is a packet per
+//! viewer per change, and a caller that sets the same value every tick is the
+//! normal case rather than the exceptional one.
+
+use flecs_ecs::prelude::*;
+use hyperion_minecraft_proto::{
+    Uuid,
+    generated::packet_id::play::clientbound::PacketId,
+    packets::play::player::{
+        BossBarColor, BossBarOverlay, BossBarProperties, BossEvent, BossEventOperation,
+    },
+};
+use tracing::warn;
+
+use crate::{
+    ingress::PendingRemove,
+    net::{Compose, ConnectionId, protocol::Clientbound},
+};
+
+/// A boss bar's text.
+///
+/// A whole component and never a `String`, so a caller cannot smuggle a colour
+/// in as markup: writing `"§cCPU"` into a title is what hyperion#1004 existed
+/// to stop, and a type that only accepts components is the only version of
+/// that rule which cannot be forgotten.
+pub type Text = hyperion_minecraft_proto::text::Component<'static>;
+
+/// Tag: this entity is a boss bar.
+#[derive(Component, Debug)]
+pub struct BossBar;
+
+/// What the bar says, drawn centred above it.
+#[derive(Component, Debug, Clone, PartialEq)]
+pub struct Title(pub Text);
+
+/// How full the bar is, `0.0..=1.0`.
+///
+/// Anything outside that range, and anything not finite, is clamped on the way
+/// to the wire rather than rejected here: a bar is a readout and the fill is
+/// the least important half of it, so a caller with a bad number should still
+/// get their title on screen.
+#[derive(Component, Debug, Clone, Copy, PartialEq)]
+pub struct Progress(pub f32);
+
+/// How the bar is drawn.
+///
+/// The protocol's own enums rather than integers, so `overlay: 3` cannot be
+/// written where `Notched12` was meant and the set of legal values is the set
+/// the compiler will accept.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Style {
+    /// The bar's tint.
+    pub colour: BossBarColor,
+    /// One continuous bar, or six, ten, twelve or twenty notches.
+    pub overlay: BossBarOverlay,
+}
+
+/// What the bar does to the world around it: darken the sky, play boss music,
+/// close fog in.
+///
+/// Absent means [`BossBarProperties::NONE`], because every one of these
+/// changes how the game looks or sounds and a bar that is a readout should
+/// change neither.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Effects(pub BossBarProperties);
+
+/// Relationship: `(ShownTo, player)` on a bar. The audience, as edges.
+#[derive(Component, Debug)]
+pub struct ShownTo;
+
+/// Tag on a bar whose audience is every client in play.
+///
+/// Separate from [`ShownTo`] rather than an edge to a group entity, because
+/// "everyone" is a rule and not a list: a player who connects a minute from
+/// now is in it, and nothing has to be told about them.
+#[derive(Component, Debug)]
+pub struct ShownToEveryone;
+
+/// Relationship data: `(Sent, viewer)` on a bar, holding exactly what that
+/// client was last told.
+///
+/// Every field is the value that actually went on the wire, after clamping, so
+/// comparing against it answers "does this client already have this" rather
+/// than "did the caller ask for the same thing".
+#[derive(Component, Debug, Clone, PartialEq)]
+pub struct Sent {
+    title: Text,
+    progress: f32,
+    style: Style,
+    effects: Effects,
+}
+
+/// The high 64 bits of every boss bar id hyperion mints.
+///
+/// A bar is addressed by a UUID the *server* chooses and reuses for the life
+/// of the bar, so it has to be stable and it has to be distinct between bars.
+/// The bar's own entity id is both, for exactly as long as the bar exists, so
+/// it is the low half and this is a namespace keeping these ids away from any
+/// a game mints for itself. Derived and not stored, so there is no table that
+/// can fall out of step with entity deletion.
+const NAMESPACE: u64 = u64::from_be_bytes(*b"hyp_boss");
+
+/// The id `bar` is addressed by on the wire.
+#[must_use]
+pub const fn bar_uuid(bar: Entity) -> Uuid {
+    Uuid(((NAMESPACE as u128) << 64) | bar.0 as u128)
+}
+
+impl Sent {
+    /// What a bar's components say it should look like.
+    fn of(
+        title: &Title,
+        progress: Progress,
+        style: Option<&Style>,
+        effects: Option<&Effects>,
+    ) -> Self {
+        Self {
+            title: title.0.clone(),
+            progress: fill(progress.0),
+            style: style.copied().unwrap_or_default(),
+            effects: effects.copied().unwrap_or_default(),
+        }
+    }
+
+    /// Whether this client's fill is `other`'s.
+    ///
+    /// Bitwise, because the question is whether the same four bytes would go
+    /// on the wire again, which is exactly what a bit pattern answers and what
+    /// a float comparison only approximates.
+    const fn same_fill(&self, other: &Self) -> bool {
+        self.progress.to_bits() == other.progress.to_bits()
+    }
+}
+
+/// A caller's progress as the wire will carry it.
+///
+/// Not finite reads as empty rather than as a rejected bar: `f32::clamp`
+/// propagates `NaN`, and a `NaN` on the wire is a bar the client draws at an
+/// arbitrary width forever.
+const fn fill(progress: f32) -> f32 {
+    if progress.is_finite() {
+        progress.clamp(0.0, 1.0)
+    } else {
+        0.0
+    }
+}
+
+fn push(compose: &Compose, to: ConnectionId, id: Uuid, operation: BossEventOperation<'_>) {
+    let packet = BossEvent { id, operation };
+    if let Err(error) = compose.unicast(Clientbound::new(PacketId::BossEvent.to_raw(), &packet), to)
+    {
+        warn!("dropping a boss bar packet: {error}");
+    }
+}
+
+/// The connection to draw on, or nothing when there is nobody there any more.
+///
+/// [`PendingRemove`] and not only liveness: a disconnecting player is destroyed
+/// in `PostLoad`, and flecs runs the `(Sent, player)` removal that destruction
+/// causes while the entity is still alive and still carrying the
+/// [`ConnectionId`] it had. Sending a `Remove` down that is a packet written
+/// for a socket that has already gone.
+fn viewer_connection(viewer: EntityView<'_>) -> Option<ConnectionId> {
+    if !viewer.is_alive() || viewer.has(id::<PendingRemove>()) {
+        return None;
+    }
+    viewer.try_get::<&ConnectionId>(|id| *id)
+}
+
+/// Whether `viewer` is still in `bar`'s audience.
+fn in_audience(bar: EntityView<'_>, viewer: EntityView<'_>) -> bool {
+    if bar.has(id::<ShownToEveryone>()) {
+        return viewer.is_alive() && viewer.has(id::<ConnectionId>());
+    }
+    bar.has((id::<ShownTo>(), viewer.id()))
+}
+
+#[derive(Component)]
+pub struct BossBarModule;
+
+impl Module for BossBarModule {
+    fn module(world: &World) {
+        world.component::<BossBar>();
+        world.component::<Title>();
+        world.component::<Progress>();
+        world.component::<Style>();
+        world.component::<Effects>();
+        world.component::<ShownToEveryone>();
+
+        // Deleting a viewer removes what that viewer was told, and leaves the
+        // bar standing for everybody else still looking at it. This is flecs's
+        // default and it is spelled out because the teardown observer below is
+        // built on it: it is the difference between one player disconnecting
+        // and every player losing the bar.
+        world
+            .component::<ShownTo>()
+            .add_trait::<(flecs::OnDeleteTarget, flecs::Remove)>();
+        world
+            .component::<Sent>()
+            .add_trait::<(flecs::OnDeleteTarget, flecs::Remove)>();
+
+        // The whole of teardown. A bar stops being shown in three ways -- the
+        // bar is destroyed, the viewer disconnects, or the audience shrinks --
+        // and all three end here, because all three end with this pair going
+        // away.
+        //
+        // One term, deliberately. A second filter term turns an observer into
+        // a query-match observer, which fires on any table transition that
+        // still satisfies the query rather than on the removal itself.
+        world
+            .observer::<flecs::OnRemove, ()>()
+            .with((id::<Sent>(), id::<flecs::Wildcard>()))
+            .each_iter(|it, row, ()| {
+                let world = it.world();
+                let bar = it.entity(row);
+                let viewer = world.entity_from_id(it.pair(0).second_id().id());
+                let Some(connection) = viewer_connection(viewer) else {
+                    return;
+                };
+                world.get::<&Compose>(|compose| {
+                    push(
+                        compose,
+                        connection,
+                        bar_uuid(bar.id()),
+                        BossEventOperation::Remove,
+                    );
+                });
+            });
+
+        let bars = world
+            .query::<(&Title, &Progress, Option<&Style>, Option<&Effects>)>()
+            .with(id::<BossBar>())
+            .build();
+        let shown = world
+            .query::<(
+                &Title,
+                &Progress,
+                Option<&Style>,
+                Option<&Effects>,
+                &mut (Sent, flecs::Wildcard),
+            )>()
+            .with(id::<BossBar>())
+            .build();
+        let everyone = world.new_query::<&ConnectionId>();
+
+        world
+            .system_named::<&Compose>("boss_bar_sync")
+            .kind(id::<flecs::pipeline::OnStore>())
+            .each(move |compose| {
+                // First: anybody in an audience who has never been told. That
+                // set is the joiners, the bars created this tick, and the
+                // audiences that just grew, and none of the three has to be
+                // told apart from the others.
+                bars.each_entity(|bar, (title, progress, style, effects)| {
+                    let state = Sent::of(title, *progress, style, effects);
+                    if bar.has(id::<ShownToEveryone>()) {
+                        everyone.each_entity(|viewer, _| add_if_new(compose, bar, viewer, &state));
+                    } else {
+                        bar.each_target(id::<ShownTo>(), |viewer| {
+                            add_if_new(compose, bar, viewer, &state);
+                        });
+                    }
+                });
+
+                // Then: everybody who has been told something, compared
+                // against what the bar says now.
+                shown.each_iter(|it, row, (title, progress, style, effects, sent)| {
+                    let world = it.world();
+                    let bar = it.entity(row);
+                    let viewer = world.entity_from_id(it.pair(4).second_id().id());
+                    if !in_audience(bar, viewer) {
+                        // Which fires the observer above, which is what
+                        // actually takes the bar off the screen.
+                        bar.remove((id::<Sent>(), viewer.id()));
+                        return;
+                    }
+                    let Some(connection) = viewer_connection(viewer) else {
+                        return;
+                    };
+                    let now = Sent::of(title, *progress, style, effects);
+                    let Some(operation) = operation(sent, &now) else {
+                        return;
+                    };
+                    push(compose, connection, bar_uuid(bar.id()), operation);
+                    *sent = now;
+                });
+            });
+    }
+}
+
+/// Send `Add` to a viewer who has never seen this bar, and record it.
+///
+/// A viewer with no connection yet is skipped *without* recording anything, so
+/// the bar arrives on the tick they gain one rather than being counted as
+/// already delivered. That is the same rule as a mid-match joiner and it is
+/// the same line of code.
+fn add_if_new(compose: &Compose, bar: EntityView<'_>, viewer: EntityView<'_>, state: &Sent) {
+    if bar.has((id::<Sent>(), viewer.id())) {
+        return;
+    }
+    let Some(connection) = viewer_connection(viewer) else {
+        return;
+    };
+    push(compose, connection, bar_uuid(bar.id()), add(state));
+    bar.set_first(state.clone(), viewer.id());
+}
+
+/// The whole bar, in one packet.
+fn add(state: &Sent) -> BossEventOperation<'_> {
+    BossEventOperation::Add {
+        name: state.title.clone(),
+        progress: state.progress,
+        color: state.style.colour,
+        overlay: state.style.overlay,
+        properties: state.effects.0,
+    }
+}
+
+/// The one packet that takes a client from `sent` to `now`, if it needs one.
+///
+/// Exactly one field moved: the operation for that field, carrying nothing
+/// else. Nothing moved: no packet, which is the rule that took hyperion#1018's
+/// bar from 3,065 packets in thirty seconds to 1,135.
+///
+/// Several fields moved: a fresh `Add`, and not the run of updates it could be
+/// instead. Two reasons, pointing the same way.
+///
+/// It is **atomic**. Each operation is its own packet, so a run of them leaves
+/// the client holding a bar that is half one state and half the next, and
+/// there is no ordering that fixes it -- put the title last and a countdown
+/// ticking over shows the next second's fill under this second's number; put
+/// it first and a lobby bar becoming a countdown is a countdown drawn in the
+/// lobby's blue. `nix run .#smash-hud-e2e` caught the second of those as a
+/// real failure, which is how this arrived.
+///
+/// It is **smaller**. Every operation repeats the sixteen byte id, so two
+/// updates already cost more than the `Add` that carries all four fields, and
+/// the client is built for it: `BossHealthOverlay.add` is a `put` into a map
+/// keyed on the id, so a second `Add` replaces the bar in place and keeps its
+/// slot on screen.
+///
+/// What that gives up is the client-side lerp between two progress values,
+/// which none of these bars want: a knockback percentage steps when somebody
+/// is hit, and sliding it smoothly animates something that did not happen.
+fn operation<'a>(sent: &Sent, now: &'a Sent) -> Option<BossEventOperation<'a>> {
+    match (
+        sent.title != now.title,
+        !sent.same_fill(now),
+        sent.style != now.style,
+        sent.effects != now.effects,
+    ) {
+        (false, false, false, false) => None,
+        (true, false, false, false) => Some(BossEventOperation::UpdateName(now.title.clone())),
+        (false, true, false, false) => Some(BossEventOperation::UpdateProgress(now.progress)),
+        (false, false, true, false) => Some(BossEventOperation::UpdateStyle {
+            color: now.style.colour,
+            overlay: now.style.overlay,
+        }),
+        (false, false, false, true) => Some(BossEventOperation::UpdateProperties(now.effects.0)),
+        _ => Some(add(now)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state(progress: f32) -> Sent {
+        Sent {
+            title: Text::text("x"),
+            progress,
+            style: Style::default(),
+            effects: Effects::default(),
+        }
+    }
+
+    /// An id is a pure function of the bar and nothing else, so there is no
+    /// table to keep in step and two bars can never collide.
+    #[test]
+    fn a_bars_id_is_its_entity_under_one_namespace() {
+        assert_eq!(bar_uuid(Entity(7)), bar_uuid(Entity(7)));
+        assert_ne!(bar_uuid(Entity(7)), bar_uuid(Entity(8)));
+        // The low half is the entity and the high half is not, which is what
+        // keeps these away from ids a game mints for its own bars.
+        assert_eq!(bar_uuid(Entity(7)).0 & u128::from(u64::MAX), 7);
+        assert_eq!(bar_uuid(Entity(7)).0 >> 64, u128::from(NAMESPACE));
+    }
+
+    /// A fill nobody can draw is drawn as empty rather than sent as it is.
+    ///
+    /// `f32::clamp` propagates `NaN`, so the clamp alone is not enough: a
+    /// `NaN` on the wire is a bar the client draws at whatever width the
+    /// comparison happens to give, forever.
+    #[test]
+    fn a_fill_that_is_not_a_fraction_is_empty() {
+        assert!((fill(0.25) - 0.25).abs() < 1e-9);
+        assert!((fill(4.0) - 1.0).abs() < 1e-9);
+        assert!((fill(-1.0)).abs() < 1e-9);
+        assert!((fill(f32::NAN)).abs() < 1e-9);
+        assert!((fill(f32::INFINITY)).abs() < 1e-9);
+    }
+
+    /// Two clients on one bar are two rows of the drive query.
+    ///
+    /// The audience loop rests entirely on a `(Sent, *)` term producing one
+    /// result per target rather than one per entity, and if it produced one
+    /// per entity the second viewer's bar would silently never update. Nothing
+    /// else in this repo iterates a wildcard pair for its data, so the
+    /// assumption is pinned here rather than discovered in a match.
+    #[test]
+    fn a_wildcard_pair_term_visits_every_target_not_just_the_first() {
+        let world = World::new();
+        world.component::<Sent>();
+        world.component::<BossBar>();
+
+        let alice = world.entity();
+        let bob = world.entity();
+        let bar = world
+            .entity()
+            .add(id::<BossBar>())
+            .set_first(state(0.25), alice)
+            .set_first(state(0.75), bob);
+
+        let query = world
+            .query::<&mut (Sent, flecs::Wildcard)>()
+            .with(id::<BossBar>())
+            .build();
+
+        let mut seen = Vec::new();
+        query.each_iter(|it, row, sent| {
+            seen.push((
+                it.entity(row).id(),
+                it.pair(0).second_id().id(),
+                sent.progress,
+            ));
+        });
+        seen.sort_by_key(|(_, viewer, _)| *viewer);
+
+        assert_eq!(seen, vec![
+            (bar.id(), alice.id(), 0.25),
+            (bar.id(), bob.id(), 0.75)
+        ]);
+    }
+
+    /// Deleting a viewer takes away what that viewer was told and leaves
+    /// everybody else's bar alone.
+    ///
+    /// This is flecs's default cleanup and the whole teardown path is built on
+    /// it, so it is written down as a claim rather than assumed: the other
+    /// default, `Delete`, would mean one player quitting removed the bar from
+    /// every screen.
+    #[test]
+    fn a_viewer_leaving_removes_only_their_own_record() {
+        let world = World::new();
+        world
+            .component::<Sent>()
+            .add_trait::<(flecs::OnDeleteTarget, flecs::Remove)>();
+
+        let alice = world.entity();
+        let bob = world.entity();
+        let bar = world
+            .entity()
+            .set_first(state(0.25), alice)
+            .set_first(state(0.75), bob);
+
+        alice.destruct();
+
+        assert!(bar.is_alive(), "one viewer leaving destroyed the bar");
+        assert!(bar.has((id::<Sent>(), bob.id())));
+        let mut targets = 0;
+        bar.each_target(id::<Sent>(), |_| targets += 1);
+        assert_eq!(targets, 1, "the departed viewer's record outlived them");
+    }
+}

--- a/crates/hyperion/src/egress/mod.rs
+++ b/crates/hyperion/src/egress/mod.rs
@@ -13,15 +13,19 @@ use crate::{
     simulation::{Position, blocks::Blocks},
 };
 
+pub mod boss_bar;
 mod channel;
 pub mod metadata;
 pub mod player_join;
+pub mod server_load;
 mod stats;
 pub mod sync_chunks;
 mod sync_entity_state;
 
+use boss_bar::BossBarModule;
 use channel::ChannelModule;
 use player_join::PlayerJoinModule;
+use server_load::ServerLoadModule;
 use stats::StatsModule;
 use sync_chunks::SyncChunksModule;
 use sync_entity_state::EntityStateSyncModule;
@@ -41,6 +45,8 @@ impl Module for EgressModule {
         world.import::<SyncChunksModule>();
         world.import::<EntityStateSyncModule>();
         world.import::<ChannelModule>();
+        world.import::<BossBarModule>();
+        world.import::<ServerLoadModule>();
 
         system!("broadcast_chunk_deltas", world, &Compose, &mut Blocks,)
             .kind(id::<flecs::pipeline::OnUpdate>())

--- a/crates/hyperion/src/egress/server_load.rs
+++ b/crates/hyperion/src/egress/server_load.rs
@@ -1,0 +1,562 @@
+//! The host process's own CPU and memory, as two boss bars.
+//!
+//! Server telemetry is not a game concept, which is why it lives here and not
+//! in an event crate, and it is drawn on the one surface a player already has
+//! that can carry a number without covering anything up.
+//!
+//! # What a full bar means
+//!
+//! A boss bar is a fraction and neither of these quantities is one. A process
+//! can use more than one core's worth of CPU -- 200% is two cores' worth,
+//! which is what `top` says and what somebody asking "how loaded is the
+//! server" means -- and it can allocate until the machine refuses. So both
+//! bars are drawn against the point where the machine stops being able to give
+//! more, every core it has and every byte of physical memory it has, and both
+//! print that ceiling beside the reading:
+//!
+//! ```text
+//! CPU 240% of 1600%
+//! MEM 3.20 GiB of 128.0 GiB
+//! ```
+//!
+//! which makes the choice checkable rather than a matter of taste:
+//!
+//! > **the fill is the quotient of the two numbers in the bar's own label.**
+//!
+//! `tools/hud-check.py` reads both numbers off the wire and divides. A ceiling
+//! nobody printed cannot satisfy that, and neither can one invented to make
+//! the bar look busy. It is also what forces the label to stay unnormalised:
+//! the honest figure is the numerator, and the fill is that same fact taken
+//! against the denominator standing next to it.
+//!
+//! # Why `getrusage` and not `ps`
+//!
+//! `ru_utime + ru_stime` is a cumulative counter, so a rate over a window is
+//! the only reading it can give and the first sample can only report that it
+//! has nothing yet. `ps` answers with a lifetime average instead, which is a
+//! different question wearing the same units: a server that was busy for a
+//! minute an hour ago reads busy under `ps` forever.
+
+use std::{
+    mem::MaybeUninit,
+    time::{Duration, Instant},
+};
+
+use flecs_ecs::prelude::*;
+use hyperion_minecraft_proto::{
+    packets::play::player::{BossBarColor, BossBarOverlay},
+    text::NamedColor,
+};
+
+use crate::egress::boss_bar::{BossBar, Progress, ShownTo, Style, Text, Title};
+
+/// How long a CPU window is.
+///
+/// A rate needs a window to mean anything, and a window shorter than a tick on
+/// a 20 tps server measures where the scheduler happened to be rather than how
+/// busy the server is.
+const WINDOW: Duration = Duration::from_secs(1);
+
+/// How many steps a bar's fill is quantised to.
+///
+/// The bar is 182 pixels wide, so a step is under three pixels; what the
+/// quantisation buys is the other direction, which is that a reading drifting
+/// by a hundredth of a core does not cost every viewer a packet. See
+/// hyperion#1018, which measured the same effect on the match bar.
+const STEPS: f32 = 64.0;
+
+/// A bar's two halves: what it says and how full it is.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Readout {
+    /// The label, carrying the unnormalised reading and its ceiling.
+    pub title: Text,
+    /// `0.0..=1.0`.
+    pub fill: f32,
+}
+
+/// The rolling sample the two bars are drawn from.
+#[derive(Component, Debug, Default)]
+pub struct Load {
+    /// When the open window started, and the CPU counter it started at.
+    window: Option<(Instant, Duration)>,
+    /// Cores' worth of CPU over the last closed window.
+    ///
+    /// `None` until one has closed. One sample of a cumulative counter has no
+    /// rate in it, and answering with the lifetime average instead is exactly
+    /// the `ps` mistake this module exists to avoid.
+    pub cores_used: Option<f64>,
+    /// Resident set size in bytes, or `None` where the platform will not say.
+    pub resident: Option<u64>,
+}
+
+/// The two bar entities, so `/serverload` can find them.
+#[derive(Component, Debug, Clone, Copy)]
+pub struct LoadBars {
+    /// The CPU bar.
+    pub cpu: Entity,
+    /// The memory bar.
+    pub memory: Entity,
+}
+
+impl Load {
+    /// Fold one reading in, closing the window if it is due.
+    ///
+    /// Returns whether anything a bar draws has changed, so an idle server
+    /// rewrites nothing.
+    fn absorb(&mut self, now: Instant, cpu: Option<Duration>, resident: Option<u64>) -> bool {
+        let mut moved = self.resident != resident;
+        self.resident = resident;
+
+        let Some(cpu) = cpu else {
+            return moved;
+        };
+        match self.window {
+            None => self.window = Some((now, cpu)),
+            Some((started, before)) => {
+                let elapsed = now.duration_since(started);
+                if elapsed < WINDOW {
+                    return moved;
+                }
+                let used = cpu.saturating_sub(before).as_secs_f64() / elapsed.as_secs_f64();
+                moved = true;
+                self.cores_used = Some(used);
+                self.window = Some((now, cpu));
+            }
+        }
+        moved
+    }
+}
+
+/// The CPU bar for `cores_used` cores' worth against a machine of `cores`.
+///
+/// The label is the unnormalised figure and its ceiling; the fill is the one
+/// divided by the other. Both numbers are percentages so that the ceiling
+/// reads as what it is -- sixteen cores is 1600% -- rather than as a bare
+/// count the reader has to convert.
+#[must_use]
+pub fn cpu_readout(cores_used: Option<f64>, cores: f64) -> Readout {
+    let ceiling = percent(cores);
+    let Some(used) = cores_used else {
+        return Readout {
+            title: Text::text("CPU sampling").color(NamedColor::Gray),
+            fill: 0.0,
+        };
+    };
+    let used_percent = percent(used);
+    Readout {
+        title: Text::text(format!("CPU {used_percent}% of {ceiling}%")).color(NamedColor::Aqua),
+        fill: quantise(ratio(f64::from(used_percent), f64::from(ceiling))),
+    }
+}
+
+/// The memory bar for `resident` bytes against `total` bytes of physical
+/// memory.
+///
+/// Resident set and not virtual size, because resident is what the kernel
+/// counts when it decides who to kill.
+///
+/// Two decimals on the reading and one on the ceiling: the reading is the
+/// number being watched and needs the resolution, and the ceiling is a fixed
+/// property of the box that only has to be recognisable. Both are far finer
+/// than one step of the fill, which is what lets the gate divide one by the
+/// other and get the fill back.
+#[must_use]
+pub fn memory_readout(resident: Option<u64>, total: Option<u64>) -> Readout {
+    let (Some(resident), Some(total)) = (resident, total) else {
+        return Readout {
+            title: Text::text("MEM unavailable").color(NamedColor::Gray),
+            fill: 0.0,
+        };
+    };
+    let used = gibibytes(resident);
+    let ceiling = gibibytes(total);
+    Readout {
+        title: Text::text(format!("MEM {used:.2} GiB of {ceiling:.1} GiB"))
+            .color(NamedColor::Green),
+        fill: quantise(ratio(used, ceiling)),
+    }
+}
+
+/// Cores' worth as a whole percentage, which is the unit `top` reports in.
+///
+/// Saturating rather than wrapping at both ends: a machine with more than
+/// forty million cores is allowed to have a wrong bar, and a negative rate,
+/// which a clock that went backwards could produce, reads as idle.
+fn percent(cores: f64) -> u32 {
+    let scaled = (cores * 100.0).round();
+    if !scaled.is_finite() || scaled <= 0.0 {
+        return 0;
+    }
+    if scaled >= f64::from(u32::MAX) {
+        return u32::MAX;
+    }
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "bounded into 0..u32::MAX by the two tests above"
+    )]
+    let whole = scaled as u32;
+    whole
+}
+
+fn gibibytes(bytes: u64) -> f64 {
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "a byte count under 2^53 is exact"
+    )]
+    let bytes = bytes as f64;
+    bytes / 1_073_741_824.0
+}
+
+/// `part` out of `whole`, clamped, and zero rather than a division by zero.
+fn ratio(part: f64, whole: f64) -> f32 {
+    let value = part / whole;
+    if value.is_finite() {
+        #[expect(clippy::cast_possible_truncation, reason = "clamped to 0..=1")]
+        let value = value.clamp(0.0, 1.0) as f32;
+        value
+    } else {
+        0.0
+    }
+}
+
+/// `fraction` snapped down to a whole [`STEPS`] step.
+fn quantise(fraction: f32) -> f32 {
+    (fraction.clamp(0.0, 1.0) * STEPS).floor() / STEPS
+}
+
+/// The resident set size out of the text of `/proc/self/statm`.
+///
+/// A pure function over a string with a fixture beside it, because the gates
+/// run on darwin where `/proc` does not exist: this parser cannot be exercised
+/// on the machine that decides whether the change is good, and an untested
+/// `/proc` reader shipped to a Linux fleet is the risk in this file.
+///
+/// The layout is `proc(5)`'s: `size resident shared text lib data dt`, in
+/// pages. Field **one**, and the fixture is built so that every field holds a
+/// different number and only the right index gives the right answer.
+#[must_use]
+pub fn resident_from_statm(text: &str, page_size: u64) -> Option<u64> {
+    let pages: u64 = text.split_ascii_whitespace().nth(1)?.parse().ok()?;
+    pages.checked_mul(page_size)
+}
+
+/// How many cores' worth of CPU this machine can give.
+///
+/// `available_parallelism` and not the raw processor count, because it follows
+/// a cgroup CPU quota: in a container the honest ceiling is what the container
+/// is allowed, not what the host has.
+fn cores() -> f64 {
+    std::thread::available_parallelism().map_or(1.0, |count| {
+        #[expect(clippy::cast_precision_loss, reason = "no machine has 2^53 cores")]
+        let count = count.get() as f64;
+        count
+    })
+}
+
+/// This process's CPU time so far, user plus system.
+fn cpu_time() -> Option<Duration> {
+    let mut usage = MaybeUninit::<libc::rusage>::zeroed();
+    // SAFETY: `getrusage` writes one `struct rusage` through the pointer it is
+    // given and reads nothing through it; `RUSAGE_SELF` is one of its two
+    // defined `who` arguments.
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } != 0 {
+        return None;
+    }
+    // SAFETY: the call returned zero, which is defined as having written the
+    // whole struct.
+    let usage = unsafe { usage.assume_init() };
+    Some(elapsed(usage.ru_utime) + elapsed(usage.ru_stime))
+}
+
+fn elapsed(value: libc::timeval) -> Duration {
+    let seconds = u64::try_from(value.tv_sec).unwrap_or(0);
+    let micros = u32::try_from(value.tv_usec).unwrap_or(0);
+    Duration::new(seconds, micros.saturating_mul(1_000))
+}
+
+/// Physical memory on this machine, in bytes.
+fn total_memory() -> Option<u64> {
+    // SAFETY: `sysconf` takes an int and returns a long; it has no
+    // preconditions and touches no memory the caller owns.
+    let pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
+    // SAFETY: as above.
+    let size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    let pages = u64::try_from(pages).ok()?;
+    let size = u64::try_from(size).ok()?;
+    pages.checked_mul(size)
+}
+
+/// The system page size, for turning `/proc/self/statm`'s pages into bytes.
+#[cfg(target_os = "linux")]
+fn page_size() -> Option<u64> {
+    // SAFETY: see `total_memory`.
+    u64::try_from(unsafe { libc::sysconf(libc::_SC_PAGESIZE) }).ok()
+}
+
+/// This process's resident set size, in bytes.
+#[cfg(target_os = "linux")]
+fn resident_bytes() -> Option<u64> {
+    let text = std::fs::read_to_string("/proc/self/statm").ok()?;
+    resident_from_statm(&text, page_size()?)
+}
+
+/// This process's resident set size, in bytes.
+#[cfg(target_os = "macos")]
+fn resident_bytes() -> Option<u64> {
+    let mut info = MaybeUninit::<libc::proc_taskinfo>::zeroed();
+    let size = i32::try_from(size_of::<libc::proc_taskinfo>()).ok()?;
+    // SAFETY: `proc_pidinfo` writes at most `size` bytes of `struct
+    // proc_taskinfo` through the pointer, which points at exactly that much
+    // owned, zeroed storage.
+    let written = unsafe {
+        libc::proc_pidinfo(
+            libc::getpid(),
+            libc::PROC_PIDTASKINFO,
+            0,
+            info.as_mut_ptr().cast(),
+            size,
+        )
+    };
+    // A short write means the kernel's struct is not the one `libc` describes,
+    // and reading `pti_resident_size` out of it would be reading whichever
+    // field happens to land at that offset instead.
+    if written != size {
+        return None;
+    }
+    // SAFETY: the call wrote the whole struct, as just checked.
+    Some(unsafe { info.assume_init() }.pti_resident_size)
+}
+
+/// This process's resident set size, in bytes.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn resident_bytes() -> Option<u64> {
+    None
+}
+
+/// Show or hide the load bars for `viewer`, and say which it just did.
+///
+/// One audience, shared by both bars, so they cannot get out of step: this
+/// adds and removes `(ShownTo, viewer)` and everything else -- the `Add`
+/// packets, the `Remove` packets, the diffing in between -- falls out of
+/// `egress::boss_bar`.
+#[must_use]
+pub fn toggle(world: WorldRef<'_>, viewer: Entity) -> bool {
+    world.get::<&LoadBars>(|bars| {
+        let showing = world
+            .entity_from_id(bars.cpu)
+            .has((id::<ShownTo>(), viewer));
+        for bar in [bars.cpu, bars.memory] {
+            let bar = world.entity_from_id(bar);
+            if showing {
+                bar.remove((id::<ShownTo>(), viewer));
+            } else {
+                bar.add((id::<ShownTo>(), viewer));
+            }
+        }
+        !showing
+    })
+}
+
+#[derive(Component)]
+pub struct ServerLoadModule;
+
+impl Module for ServerLoadModule {
+    fn module(world: &World) {
+        world.component::<Load>().add_trait::<flecs::Singleton>();
+        world
+            .component::<LoadBars>()
+            .add_trait::<flecs::Singleton>();
+        world.set(Load::default());
+
+        // Two bars, made once and shown to nobody. A bar with an empty
+        // audience costs one query row a tick and sends nothing at all, which
+        // is what makes "opt in" a relationship rather than a lifecycle.
+        //
+        // One colour each and no thresholds. A colour change is an alarm, and
+        // an alarm at a fraction nobody can justify is noise on a readout that
+        // is already carrying the number. `Progress` and not a notched overlay
+        // for the same reason: notches would claim the quantity comes in
+        // twenty pieces, and it does not.
+        let cpu = world
+            .entity_named("hyperion::server_load::cpu")
+            .add(id::<BossBar>())
+            .set(Title(cpu_readout(None, cores()).title))
+            .set(Progress(0.0))
+            .set(Style {
+                colour: BossBarColor::Blue,
+                overlay: BossBarOverlay::Progress,
+            })
+            .id();
+        let memory = world
+            .entity_named("hyperion::server_load::memory")
+            .add(id::<BossBar>())
+            .set(Title(memory_readout(None, None).title))
+            .set(Progress(0.0))
+            .set(Style {
+                colour: BossBarColor::Green,
+                overlay: BossBarOverlay::Progress,
+            })
+            .id();
+        world.set(LoadBars { cpu, memory });
+
+        // PreStore, so a reading taken this tick is on the bar's components
+        // before `boss_bar_sync` runs in OnStore and reaches the wire the same
+        // tick rather than the next one.
+        world
+            .system_named::<&mut Load>("server_load_sample")
+            .kind(id::<flecs::pipeline::PreStore>())
+            .each_iter(|it, _, load| {
+                if !load.absorb(Instant::now(), cpu_time(), resident_bytes()) {
+                    return;
+                }
+                let world = it.world();
+                let cpu = cpu_readout(load.cores_used, cores());
+                let memory = memory_readout(load.resident, total_memory());
+                world.get::<&LoadBars>(|bars| {
+                    for (bar, readout) in [(bars.cpu, &cpu), (bars.memory, &memory)] {
+                        world
+                            .entity_from_id(bar)
+                            .set(Title(readout.title.clone()))
+                            .set(Progress(readout.fill));
+                    }
+                });
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The label is what `top` would say, and the fill is that against the
+    /// machine. Getting these two the same way round is the whole point of the
+    /// bar.
+    #[test]
+    fn the_cpu_label_is_unnormalised_and_the_fill_is_not() {
+        let readout = cpu_readout(Some(2.4), 16.0);
+        assert_eq!(readout.title.plain(), "CPU 240% of 1600%");
+        // 240/1600 = 0.15, which is 9.6 steps, so it draws at nine.
+        assert!((readout.fill - 9.0 / 64.0).abs() < 1e-6, "{}", readout.fill);
+        assert!((0.0..=1.0).contains(&readout.fill));
+    }
+
+    /// A process over a whole core still reports what it is using. The fill
+    /// has nowhere left to go and says so by being full; the label does not
+    /// lie to keep it company.
+    #[test]
+    fn a_bar_that_is_full_still_says_how_far_past_full_it_is() {
+        let readout = cpu_readout(Some(2.4), 1.0);
+        assert_eq!(readout.title.plain(), "CPU 240% of 100%");
+        assert!((readout.fill - 1.0).abs() < 1e-6, "{}", readout.fill);
+    }
+
+    /// One sample of a cumulative counter has no rate in it.
+    #[test]
+    fn the_first_sample_reports_nothing_rather_than_an_average() {
+        let mut load = Load::default();
+        let start = Instant::now();
+        assert!(!load.absorb(start, Some(Duration::from_secs(90)), None));
+        assert_eq!(load.cores_used, None);
+        assert_eq!(
+            cpu_readout(load.cores_used, 16.0).title.plain(),
+            "CPU sampling"
+        );
+
+        // A window shorter than `WINDOW` is still not a reading.
+        assert!(!load.absorb(
+            start + Duration::from_millis(500),
+            Some(Duration::from_secs(91)),
+            None
+        ));
+        assert_eq!(load.cores_used, None);
+
+        // Two seconds of CPU across two seconds of wall clock is one core.
+        assert!(load.absorb(
+            start + Duration::from_secs(2),
+            Some(Duration::from_secs(92)),
+            None
+        ));
+        assert_eq!(load.cores_used, Some(1.0));
+        assert_eq!(
+            cpu_readout(load.cores_used, 16.0).title.plain(),
+            "CPU 100% of 1600%"
+        );
+    }
+
+    /// The property the whole ceiling choice is defensible under: whatever the
+    /// numbers, the fill is the quotient of the two in the label.
+    #[test]
+    fn the_fill_is_the_quotient_of_the_two_numbers_in_the_label() {
+        for (used, cores) in [
+            (0.0_f64, 1.0_f64),
+            (0.005, 8.0),
+            (1.0, 8.0),
+            (7.9, 8.0),
+            (12.34, 16.0),
+        ] {
+            let readout = cpu_readout(Some(used), cores);
+            let label = readout.title.plain();
+            let (numerator, denominator) = label
+                .strip_prefix("CPU ")
+                .and_then(|rest| rest.split_once("% of "))
+                .expect(&label);
+            let numerator: f64 = numerator.parse().expect(&label);
+            let denominator: f64 = denominator.trim_end_matches('%').parse().expect(&label);
+            let quoted = numerator / denominator;
+            assert!(
+                (f64::from(readout.fill) - quoted).abs() <= 1.0 / 64.0,
+                "{label} draws at {} but its own numbers say {quoted}",
+                readout.fill
+            );
+        }
+    }
+
+    /// The reading is the second field, and every other field in the fixture
+    /// holds a different number so an off-by-one cannot pass.
+    #[test]
+    fn statm_reads_the_resident_field_and_not_a_neighbour() {
+        // `size resident shared text lib data dt`, in pages.
+        let statm = "70086 6789 4321 21 0 1234 0\n";
+        assert_eq!(resident_from_statm(statm, 4096), Some(6789 * 4096));
+        assert_eq!(resident_from_statm(statm, 16384), Some(6789 * 16384));
+    }
+
+    /// A `/proc` read that is not what this expects reports nothing rather
+    /// than a number, because a wrong memory bar is worse than an absent one.
+    #[test]
+    fn a_statm_line_that_is_not_one_reads_as_nothing() {
+        assert_eq!(resident_from_statm("", 4096), None);
+        assert_eq!(resident_from_statm("70086", 4096), None);
+        assert_eq!(resident_from_statm("70086 nonsense", 4096), None);
+        assert_eq!(resident_from_statm("70086 -1 4321", 4096), None);
+        // Pages times page size has to fit in the units it is reported in.
+        assert_eq!(resident_from_statm("1 18446744073709551615 2", 4096), None);
+    }
+
+    #[test]
+    fn the_memory_label_carries_its_own_ceiling() {
+        let readout = memory_readout(Some(3_435_973_836), Some(137_438_953_472));
+        assert_eq!(readout.title.plain(), "MEM 3.20 GiB of 128.0 GiB");
+        assert!((f64::from(readout.fill) - 0.025).abs() <= 1.0 / 64.0);
+        assert_eq!(
+            memory_readout(None, Some(1)).title.plain(),
+            "MEM unavailable"
+        );
+    }
+
+    /// The real samplers answer on the machine the tests run on. Neither is a
+    /// number this can predict, so the claim is only that the platform path
+    /// exists and is plausible.
+    #[test]
+    fn this_process_can_read_its_own_cpu_and_memory() {
+        assert!(cpu_time().is_some(), "getrusage said nothing");
+        let resident = resident_bytes().expect("this platform has an rss reader");
+        assert!(
+            resident > 1 << 20,
+            "{resident} bytes resident is not a process"
+        );
+        let total = total_memory().expect("this platform reports its memory");
+        assert!(total > resident, "{resident} resident of {total} total");
+    }
+}

--- a/docs/flecs-rust-api-notes.md
+++ b/docs/flecs-rust-api-notes.md
@@ -235,6 +235,59 @@ into a five-second one.
 
 ---
 
+## Papercut: pair *data* keyed on a runtime entity has no typed getter
+
+`egress::boss_bar` keeps what each viewer was last told as the data on
+`(Sent, viewer)`, where `viewer` is only known at runtime. Writing it is fine —
+`EntityView::set_first(value, second)` takes the second half as an
+`impl IntoEntity`. Reading one back is where the API stops:
+
+* `EntityViewGet::try_get::<T>` goes through `GetTuple`, which needs *both*
+  halves of a pair at compile time. `try_get::<&(Sent, Wildcard)>` returns the
+  first match and cannot say which target it came from.
+* `get_first_untyped::<First>(second)` returns `*const c_void` and leaves the
+  cast, and the question of when the pointer dies, to the caller.
+
+The way out is a query rather than an entity lookup: a `&mut (Sent, Wildcard)`
+term produces **one result per matching target**, and `TableIter::pair(index)`
+names which one.
+
+```rust
+let shown = world
+    .query::<(&Title, &mut (Sent, flecs::Wildcard))>()
+    .with(id::<BossBar>())
+    .build();
+
+shown.each_iter(|it, row, (title, sent)| {
+    let bar = it.entity(row);
+    let viewer = it.pair(1).second_id().id();
+    // ...
+});
+```
+
+Two things about that are worth writing down because neither is obvious and
+both are silent when wrong.
+
+**One result per target, not one per entity.** Nothing else in this repo
+iterates a wildcard pair for its *data*, and the failure mode if it went the
+other way is that the second viewer of a shared bar silently never updates. It
+is pinned as
+`egress::boss_bar::tests::a_wildcard_pair_term_visits_every_target_not_just_the_first`
+rather than assumed.
+
+**`it.pair(i)` returns a temporary.** `IdView::second_id` borrows from it, so
+`let viewer = it.pair(1).second_id();` is a borrow of something dropped at the
+end of the statement. Take the id and re-view it —
+`world.entity_from_id(it.pair(1).second_id().id())` — which is what the
+compiler's own suggestion amounts to.
+
+**Proposed upstream.** A `try_get_first::<First, R>(second, f)` on `EntityView`,
+mirroring `set_first`, would close this: the closure bound is already how every
+other typed read in the crate manages the borrow, and the pair id is already
+built by `get_first_untyped`.
+
+---
+
 ## Documentation hazard: `flecs_ecs/tests/docs/**` is never compiled
 
 `tests/docs/main.rs` declares only `pub mod common_test;`. Every other file in
@@ -331,5 +384,6 @@ and the diff to upstream stays legible.
 Ready to send upstream, in priority order: the `OUT_DIR` fix (bug 1, correctness
 and affects everyone), the `emit` assertion or default (bug 2, silent
 misbehaviour), the `self`-by-value constructors (bug 3, mechanical and
-source-compatible), the `each_target` lifetime (bug 4), the const-assert
-messages (papercut), and the dead `tests/docs` directory.
+source-compatible), the `each_target` lifetime (bug 4), `try_get_first` for
+runtime-keyed pair data (papercut), the const-assert messages (papercut), and
+the dead `tests/docs` directory.

--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -14,14 +14,16 @@
 //! noise an ability makes is part of what the ability *is* and belongs with the
 //! kit that declares it; all that is left here is the encoding.
 
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    sync::{Arc, Mutex},
+};
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 use hyperion::{
-    egress::player_join::roster,
+    egress::{boss_bar, player_join::roster},
     hyperion_minecraft_proto::{
-        Uuid,
         generated::packet_id::play::clientbound::PacketId,
         packets::play::{
             chunk::{LevelParticles, Particle},
@@ -30,9 +32,8 @@ use hyperion::{
                 SetTitleText, SetTitlesAnimation,
             },
             player::{
-                BossBarColor, BossBarOverlay, BossBarProperties, BossEvent, BossEventOperation,
-                DisplaySlot, NumberFormat, ObjectiveDisplay, ObjectiveRenderType, SetObjective,
-                SetScore,
+                BossBarColor, BossBarOverlay, DisplaySlot, NumberFormat, ObjectiveDisplay,
+                ObjectiveRenderType, SetObjective, SetScore,
             },
         },
     },
@@ -263,6 +264,7 @@ impl Module for SmashAdapterModule {
         world.import::<crate::SmashModule>();
 
         world.component::<OpQueue>().add_trait::<flecs::Singleton>();
+        world.component::<HudBar>();
 
         let ops = Arc::new(Mutex::new(Vec::new()));
         world.set(OpQueue(Arc::clone(&ops)));
@@ -314,14 +316,31 @@ impl Module for SmashAdapterModule {
                 let world = it.world();
                 let drained =
                     std::mem::take(&mut *queue.0.lock().expect("server op queue poisoned"));
+                // Every player's bar, resolved before any op is applied.
+                //
+                // `world.entity()` hands back its id at once but the
+                // `set(HudBar)` that records it is deferred to the merge, so
+                // two `SetBossBar` ops for one player in one drain would each
+                // see no bar and mint one. Resolving them up front, in one
+                // map, is what makes a second bar impossible rather than
+                // merely unlikely.
+                let mut bars = HashMap::new();
+                for op in &drained {
+                    if let Op::SetBossBar { player, .. } = op
+                        && let Entry::Vacant(slot) = bars.entry(*player)
+                        && let Some(bar) = hud_bar(world, *player)
+                    {
+                        slot.insert(bar);
+                    }
+                }
                 for op in drained {
-                    apply(world, compose, op);
+                    apply(world, compose, op, &bars);
                 }
             });
     }
 }
 
-fn apply(world: WorldRef<'_>, compose: &Compose, op: Op) {
+fn apply(world: WorldRef<'_>, compose: &Compose, op: Op, bars: &HashMap<Entity, Entity>) {
     match op {
         Op::AddVelocity { player, delta } => {
             let entity = world.entity_from_id(player);
@@ -475,10 +494,19 @@ fn apply(world: WorldRef<'_>, compose: &Compose, op: Op) {
             );
         }
         Op::SetBossBar { player, bar } => {
-            let Some(connection) = connection_of(world, player) else {
+            let Some(entity) = bars.get(&player) else {
                 return;
             };
-            boss_bar(compose, connection, bar_id(player), &bar);
+            world
+                .entity_from_id(*entity)
+                .set(boss_bar::Title(bar.title))
+                .set(boss_bar::Progress(bar.progress))
+                .set(boss_bar::Style {
+                    colour: colour(bar.colour),
+                    // No notches: the quantity under this bar is health and a
+                    // percentage, and neither of them comes in six pieces.
+                    overlay: BossBarOverlay::Progress,
+                });
         }
         Op::ShowTitle { player, title } => {
             let Some(connection) = connection_of(world, player) else {
@@ -499,45 +527,45 @@ fn connection_of(world: WorldRef<'_>, player: Entity) -> Option<ConnectionId> {
     entity.try_get::<&ConnectionId>(|id| *id)
 }
 
-/// The high half of every boss bar id this game invents.
+/// Which boss bar entity is this player's, making it if they have none.
 ///
-/// A bar is addressed by a UUID the *server* chooses and reuses across every
-/// update to it, so the id has to be stable for a player and distinct between
-/// them. The player's own entity id is both, so it is the low half and this is
-/// a namespace that keeps those ids away from any other bar a host might run.
-const BAR_NAMESPACE: u128 = 0x736d_6173_685f_6261_7200_0000_0000_0000;
-
-fn bar_id(player: Entity) -> Uuid {
-    Uuid(BAR_NAMESPACE | u128::from(player.0))
+/// The bar this game draws is per player -- it carries a percentage that is
+/// only true of the person reading it -- so its audience is one edge,
+/// `(ShownTo, player)`. Everything after that is `egress::boss_bar`'s: the
+/// `Add` on the first push, one operation per field that moves after it, and
+/// the `Remove` when the player leaves.
+///
+/// A child of the player, so it dies with them under flecs's own
+/// `(ChildOf, OnDeleteTarget, Delete)`. Without that the bar entity would
+/// outlive its only viewer with an empty audience forever, which on a server
+/// nobody restarts is a leak measured in players seen.
+///
+/// No fog, no darkened sky and no boss music, which is the default `Effects`:
+/// each of them changes how the arena looks or sounds, and this bar is a
+/// readout rather than an event.
+fn hud_bar(world: WorldRef<'_>, player: Entity) -> Option<Entity> {
+    let player = world.entity_from_id(player);
+    if !player.is_alive() {
+        return None;
+    }
+    if let Some(bar) = player.try_get::<&HudBar>(|bar| bar.0)
+        && world.entity_from_id(bar).is_alive()
+    {
+        return Some(bar);
+    }
+    let bar = world
+        .entity()
+        .child_of(player)
+        .add(id::<boss_bar::BossBar>())
+        .add((id::<boss_bar::ShownTo>(), player))
+        .id();
+    player.set(HudBar(bar));
+    Some(bar)
 }
 
-/// Push one player's boss bar.
-///
-/// `Add` every time rather than `Add` once and `UpdateProgress` after, which
-/// would need this file to remember which players already have a bar. It does
-/// not need to: the client's `BossHealthOverlay.add` is a `put` into a
-/// `LinkedHashMap` keyed on the id, so a second `Add` under the same id
-/// replaces the bar in place and keeps its slot on screen. What is lost is the
-/// client-side lerp between two progress values, and that is not wanted here:
-/// the number on this bar is a percentage that steps when somebody is hit, and
-/// sliding it smoothly would be an animation of something that did not happen
-/// smoothly.
-fn boss_bar(compose: &Compose, to: ConnectionId, id: Uuid, bar: &BossBar) {
-    let packet = BossEvent {
-        id,
-        operation: BossEventOperation::Add {
-            name: bar.title.clone(),
-            progress: bar.progress.clamp(0.0, 1.0),
-            color: colour(bar.colour),
-            overlay: BossBarOverlay::Progress,
-            // No fog, no darkened sky and no boss music. Every one of them is
-            // a change to how the arena looks or sounds, and this bar is a
-            // readout rather than an event.
-            properties: BossBarProperties::NONE,
-        },
-    };
-    let _unused = compose.unicast(Clientbound::new(PacketId::BossEvent.to_raw(), &packet), to);
-}
+/// The boss bar entity a player's HUD writes to.
+#[derive(Component, Debug, Copy, Clone)]
+struct HudBar(Entity);
 
 const fn colour(colour: BarColour) -> BossBarColor {
     match colour {

--- a/events/smash/src/module/hud.rs
+++ b/events/smash/src/module/hud.rs
@@ -469,6 +469,16 @@ pub fn winner(world: WorldRef<'_>) -> Option<String> {
 /// until something adds one. So the first tick compares against the truth
 /// rather than against a guess, and a player who joins gets exactly one push
 /// of each rather than none or two.
+///
+/// Since the boss bar became `hyperion::egress::boss_bar`, which diffs per
+/// viewer against what actually went on the wire, this half of `Shown` no
+/// longer decides whether a packet is sent. It is not therefore redundant, and
+/// the two are not the same rule written twice: this one decides whether a
+/// *text component is cloned and queued*, twenty times a second per player, on
+/// a value that is usually the same as last tick. The wire diff cannot help
+/// with that, because by the time it runs the allocation has happened. The
+/// experience bar has no wire diff at all and needs this one for both jobs,
+/// which is the other reason the two fields stay in one struct.
 #[derive(Component, Debug, Clone, PartialEq, Default)]
 struct Shown {
     experience: Experience,

--- a/tools/hud-check.py
+++ b/tools/hud-check.py
@@ -56,10 +56,26 @@ S2C_SET_EXPERIENCE = 0x67
 S2C_SET_SUBTITLE_TEXT = 0x70
 S2C_SET_TITLES_ANIMATION = 0x73
 
-# `BossEventOperation::type_id`.
+# `BossEventOperation::type_id`, in ordinal order.
 BOSS_ADD = 0
+BOSS_OPERATIONS = [
+    "add",
+    "remove",
+    "update_progress",
+    "update_name",
+    "update_style",
+    "update_properties",
+]
 # `BossBarColor`, as ordinals.
 BOSS_COLOURS = ["pink", "blue", "red", "green", "yellow", "purple", "white"]
+
+# `egress::server_load`. Both labels carry the reading and the ceiling it is
+# drawn against, which is what makes "the fill is the quotient of the two
+# numbers in the label" a thing this file can check rather than a claim.
+CPU_LABEL = re.compile(r"CPU (\d+)% of (\d+)%")
+MEMORY_LABEL = re.compile(r"MEM (\d+\.\d+) GiB of (\d+\.\d+) GiB")
+# `egress::server_load::STEPS`, which is also `hud.rs`'s `METER_STEPS`.
+LOAD_STEPS = 64.0
 
 # A kit's abilities take the hotbar slots in the order it declares them, so for
 # the Iron Golem slot 2 is Seismic Slam at seven seconds, slot 1 is Iron Hook at
@@ -91,7 +107,19 @@ class Screen(match.MatchClient):
         # Every experience bar, boss bar and title in the order they arrived, so
         # a check can ask about the last one or about the whole sequence.
         self.experience = []
+        # What each bar looks like right now, keyed on its id. The client's own
+        # `BossHealthOverlay` is exactly this map, so this is the client, and
+        # every check about what a player can *see* reads it rather than
+        # reading packets.
+        self.bar_state = {}
+        # One entry per resulting state, in order, so a check written against
+        # the old `Add`-every-time server still asks the same question.
         self.bars = []
+        # One entry per packet: `(id, operation, fields that actually moved)`.
+        # This is the other half, and the only place "an update sends only the
+        # update" is visible at all: the states above come out identical
+        # whether the server resent the whole bar or moved one field.
+        self.bar_ops = []
         self.titles = []
         self.subtitles = []
         self.animations = []
@@ -130,13 +158,7 @@ class Screen(match.MatchClient):
             self.experience.append({"progress": progress, "level": level, "total": total})
             self.log("<- experience bar %.4f full, level %d" % (progress, level))
         elif packet_id == S2C_BOSS_EVENT:
-            bar = decode_boss_event(payload)
-            if bar is not None:
-                self.bars.append(bar)
-                self.log(
-                    "<- boss bar %r %.3f full, %s"
-                    % (bar["title"], bar["progress"], bar["colour"])
-                )
+            self.absorb_boss_event(payload)
         elif packet_id == match.S2C_SET_TITLE_TEXT:
             text, _ = match.take_nbt_string(payload, 0)
             self.titles.append(text)
@@ -155,6 +177,45 @@ class Screen(match.MatchClient):
             fade_in, stay, fade_out = struct.unpack(">iii", payload[:12])
             self.animations.append((fade_in, stay, fade_out))
             self.screen.append(("times", (fade_in, stay, fade_out)))
+
+    def absorb_boss_event(self, payload):
+        """Apply one boss bar operation to this client's own picture of it."""
+        uuid, operation, fields = decode_boss_event(payload)
+        before = self.bar_state.get(uuid)
+        self.bar_ops.append(
+            (uuid, operation, moved_fields(before, fields), before is not None)
+        )
+        if operation == "remove":
+            self.bar_state.pop(uuid, None)
+            self.log("<- boss bar %s removed" % uuid[:8])
+            return
+        if operation == "add":
+            self.bar_state[uuid] = dict(fields, uuid=uuid)
+        elif uuid in self.bar_state:
+            self.bar_state[uuid].update(fields)
+        else:
+            # An update for a bar this client was never given. The server is
+            # not allowed to do that, and saying so here beats silently
+            # inventing a bar to hang the field on.
+            self.log("<- boss bar %s %s with no Add before it" % (uuid[:8], operation))
+            return
+        bar = dict(self.bar_state[uuid])
+        bar["colour"] = colour_name(bar["colour"])
+        self.bars.append(bar)
+        self.log(
+            "<- boss bar %s %r %.3f full, %s"
+            % (operation, bar["title"], bar["progress"], bar["colour"])
+        )
+
+    def ops_for(self, uuid):
+        """Every operation this client was sent for one bar, in order."""
+        return [name for bar, name, _, _ in self.bar_ops if bar == uuid]
+
+    def bars_titled(self, pattern):
+        """Every id this client holds whose current title matches."""
+        return [
+            uuid for uuid, bar in self.bar_state.items() if pattern.match(bar["title"])
+        ]
 
     def absorb_slot(self, payload):
         """Only enough of `ContainerSetSlot` to know the hotbar has arrived."""
@@ -185,29 +246,69 @@ class Screen(match.MatchClient):
 
 
 def decode_boss_event(payload):
-    """One `ClientboundBossEventPacket`, or `None` for an operation this does
-    not read.
+    """One `ClientboundBossEventPacket`: which bar, which operation, and the
+    fields that operation carries.
 
-    Only `Add` is decoded, because it is the only one the server sends: see the
-    note on `adapter::boss_bar` for why every update is a fresh `Add`.
+    Every operation, not only `Add`. `egress::boss_bar` sends one packet per
+    field that actually moved, so a decoder that read `Add` and returned `None`
+    for the rest -- which is what this was, when the server only ever sent
+    `Add` -- would not fail against the new server. It would report that no
+    boss bar ever arrived, which is a silent pass, and it is why the model
+    below exists rather than a list of `Add`s.
     """
+    uuid = payload[:16].hex()
     operation, offset = take_var_int(payload, 16)
-    if operation != BOSS_ADD:
-        return None
-    title, offset = match.take_nbt_string(payload, offset)
-    (progress,) = struct.unpack_from(">f", payload, offset)
-    offset += 4
-    colour, offset = take_var_int(payload, offset)
-    overlay, offset = take_var_int(payload, offset)
-    flags = payload[offset]
-    return {
-        "uuid": payload[:16].hex(),
-        "title": title,
-        "progress": progress,
-        "colour": BOSS_COLOURS[colour] if colour < len(BOSS_COLOURS) else colour,
-        "overlay": overlay,
-        "flags": flags,
-    }
+    name = BOSS_OPERATIONS[operation] if operation < len(BOSS_OPERATIONS) else operation
+    fields = {}
+    if operation == BOSS_ADD:
+        fields["title"], offset = match.take_nbt_string(payload, offset)
+        (fields["progress"],) = struct.unpack_from(">f", payload, offset)
+        offset += 4
+        colour, offset = take_var_int(payload, offset)
+        fields["colour"] = colour
+        fields["overlay"], offset = take_var_int(payload, offset)
+        fields["flags"] = payload[offset]
+    elif name == "update_progress":
+        (fields["progress"],) = struct.unpack_from(">f", payload, offset)
+    elif name == "update_name":
+        fields["title"], offset = match.take_nbt_string(payload, offset)
+    elif name == "update_style":
+        fields["colour"], offset = take_var_int(payload, offset)
+        fields["overlay"], offset = take_var_int(payload, offset)
+    elif name == "update_properties":
+        fields["flags"] = payload[offset]
+    return uuid, name, fields
+
+
+def colour_name(ordinal):
+    return BOSS_COLOURS[ordinal] if ordinal < len(BOSS_COLOURS) else ordinal
+
+
+# A bar has four fields, and the protocol has one operation for each. Colour
+# and overlay are one field and not two: `UpdateStyle` carries both and there
+# is no operation that carries either alone, so "only the changed field" can
+# only ever mean "only the changed *pair*" for those.
+BOSS_FIELDS = {
+    "title": ("title",),
+    "progress": ("progress",),
+    "style": ("colour", "overlay"),
+    "flags": ("flags",),
+}
+
+
+def moved_fields(before, fields):
+    """Which of a bar's four fields this packet actually changed.
+
+    `None` for a bar the client did not have, where every field it carries is
+    new by definition.
+    """
+    if before is None:
+        return set(BOSS_FIELDS)
+    moved = set()
+    for name, keys in BOSS_FIELDS.items():
+        if any(key in fields and fields[key] != before[key] for key in keys):
+            moved.add(name)
+    return moved
 
 
 class Run:
@@ -284,9 +385,22 @@ class Run:
         )
         lobby = [bar for bar in client.bars if "Waiting for players" in bar["title"]]
         if lobby:
+            # The denominator is `LobbyConfig::min_players`, read off the bar
+            # rather than written down here. It was written down here, as the
+            # literal `1/4`, and hyperion#1019 moved that constant to two and
+            # left this line asserting a number the server had stopped saying.
+            # A gate that restates a server constant is a second place to
+            # change it and the first one to be forgotten.
+            counted = re.search(r"(\d+)/(\d+)$", lobby[0]["title"])
+            needed = int(counted.group(2)) if counted else 0
             self.check(
-                lobby[0]["colour"] == "blue" and lobby[0]["title"].endswith("1/4"),
-                "and it counts how many more it needs: %s" % lobby[0],
+                lobby[0]["colour"] == "blue"
+                and counted is not None
+                and int(counted.group(1)) == 1
+                and needed >= 2
+                and math.isclose(lobby[0]["progress"], 1.0 / needed, abs_tol=STEP),
+                "and it counts how many more it needs, with the bar under it "
+                "drawing the same fraction: %s" % lobby[0],
             )
 
         client.command("kit %s" % KIT)
@@ -529,6 +643,304 @@ class Run:
                 % fresh["flags"],
             )
 
+    # --- the server's own load ------------------------------------------
+
+    def load_check(self):
+        """The two bars carrying the host process's CPU and memory.
+
+        Also the three lifecycle claims the boss bar API rests on, because
+        these are the only bars in the game with an audience of more than one
+        person: a second viewer joining an already-running bar gets the *same*
+        id the first one holds, and a viewer leaving the audience gets a
+        `Remove` for it. A per-player bar can demonstrate neither.
+        """
+        admin = self.clients[0]
+        second = self.clients[1]
+
+        # `/serverload` is Admin, and there is no other way for a test client
+        # to reach an Admin command: no config default, no env override, and
+        # `PermissionStorage` starts empty and is keyed on UUID. So this gate
+        # promotes its own clients, which works only because `/perms` is itself
+        # gated at Normal. That is a real privilege escalation, filed as
+        # ENG-10871, and closing it has to land a way to seed a group at
+        # startup or this check goes with it.
+        for client in (admin, second):
+            # `Group` is a clap `ValueEnum`, so its variants are lower case.
+            admin.command("perms set %s admin" % client.name)
+        self.pump(1.0)
+
+        admin.bar_ops.clear()
+        admin.command("serverload")
+        shown = self.until(
+            lambda: len(admin.bars_titled(CPU_LABEL)) == 1
+            and len(admin.bars_titled(MEMORY_LABEL)) == 1,
+            20.0,
+            "the load bars, with a reading on each",
+        )
+        if not self.check(
+            shown,
+            "/serverload puts the host's CPU and memory on two boss bars: %s"
+            % [bar["title"] for bar in admin.bar_state.values()],
+        ):
+            return
+        cpu = admin.bars_titled(CPU_LABEL)[0]
+        memory = admin.bars_titled(MEMORY_LABEL)[0]
+
+        # The reading is what `top` would say and the ceiling is the machine.
+        used, ceiling = (int(value) for value in CPU_LABEL.match(admin.bar_state[cpu]["title"]).groups())
+        self.check(
+            ceiling > 100,
+            "the CPU label is unnormalised, so its ceiling is every core and "
+            "not one: %s" % admin.bar_state[cpu]["title"],
+        )
+        self.check(
+            0.0 <= admin.bar_state[cpu]["progress"] <= 1.0,
+            "and the fill stays a fraction however far past a core the "
+            "reading goes: %.4f" % admin.bar_state[cpu]["progress"],
+        )
+        # The property the whole choice of ceiling is defensible under. A
+        # ceiling nobody printed cannot satisfy it and neither can an invented
+        # one, because both numbers are read off the bar's own label here.
+        self.check(
+            abs(admin.bar_state[cpu]["progress"] - used / ceiling) <= 1.0 / LOAD_STEPS,
+            "the CPU fill is the quotient of the two numbers in its own "
+            "label: %.4f against %d/%d" % (admin.bar_state[cpu]["progress"], used, ceiling),
+        )
+        resident, total = (
+            float(value) for value in MEMORY_LABEL.match(admin.bar_state[memory]["title"]).groups()
+        )
+        self.check(
+            0.0 < resident < total and 0.0 <= admin.bar_state[memory]["progress"] <= 1.0,
+            "the memory bar is this process's resident set against the "
+            "machine's: %s" % admin.bar_state[memory]["title"],
+        )
+        self.check(
+            abs(admin.bar_state[memory]["progress"] - resident / total) <= 1.0 / LOAD_STEPS,
+            "and its fill is the quotient of its own two numbers too: %.4f "
+            "against %.2f/%.1f" % (admin.bar_state[memory]["progress"], resident, total),
+        )
+
+        # An update sends only the update. The CPU label is rewritten every
+        # second while its fill, quantised against every core the machine has,
+        # usually does not move at all, so a label-only second is an
+        # `UpdateName` on its own and nothing else. The colour and the effects
+        # never move, and after the `Add` that carried them they are never on
+        # the wire again.
+        self.until(
+            lambda: admin.ops_for(cpu).count("update_name") >= 3, 20.0, "three CPU readings"
+        )
+        for name, uuid in (("CPU", cpu), ("memory", memory)):
+            operations = admin.ops_for(uuid)
+            self.check(
+                operations[:1] == ["add"],
+                "the %s bar arrives as one packet carrying the whole bar: %s"
+                % (name, operations[:3]),
+            )
+            self.check(
+                "update_style" not in operations
+                and "update_properties" not in operations,
+                "and its colour and effects, which never move, are never on "
+                "the wire again after it: %s" % operations,
+            )
+        self.check(
+            admin.ops_for(cpu).count("update_name") >= 2,
+            "a new CPU reading that moves only the label costs one packet "
+            "carrying only the label: %s" % admin.ops_for(cpu),
+        )
+        # And the memory bar, whose reading did not move far enough to change
+        # either the two decimals on its label or a sixty-fourth of the
+        # machine, says nothing at all. There is no assertion on how many
+        # packets that is, because it depends on how much memory the box has:
+        # what is checked is that whatever it sent obeyed the rule, which
+        # `diff_check` does over every packet of the whole run.
+        self.log(
+            "the memory bar sent %d packet(s) against the CPU bar's %d"
+            % (len(admin.ops_for(memory)), len(admin.ops_for(cpu)))
+        )
+
+        # A viewer who joins an audience that already exists is told about the
+        # bars under the ids everybody else already holds. This is the whole
+        # reason the sent state is `(Sent, viewer)` pair data: the second
+        # viewer has none, so the next tick sends them `Add`, and there is no
+        # join handler anywhere.
+        second.bar_ops.clear()
+        second.command("serverload")
+        joined = self.until(
+            lambda: cpu in second.bar_state and memory in second.bar_state,
+            20.0,
+            "the second viewer to be given the running bars",
+        )
+        self.check(
+            joined,
+            "a viewer joining a running bar's audience is sent it under the "
+            "same id the others hold: %s" % sorted(second.bar_state),
+        )
+        if joined:
+            self.check(
+                second.ops_for(cpu)[0] == "add" and second.ops_for(memory)[0] == "add",
+                "as an Add and not as an update to a bar they never had: %s"
+                % [second.ops_for(cpu)[:2], second.ops_for(memory)[:2]],
+            )
+
+        # And leaving that audience takes them away, which is the same
+        # `(Sent, viewer)` pair going away as a viewer disconnecting.
+        second.bar_ops.clear()
+        second.command("serverload")
+        gone = self.until(
+            lambda: cpu not in second.bar_state and memory not in second.bar_state,
+            20.0,
+            "the second viewer's bars to be taken away",
+        )
+        self.check(
+            gone,
+            "leaving a bar's audience removes it from that screen and nobody "
+            "else's: %s" % sorted(second.bar_state),
+        )
+        self.check(
+            sorted(second.ops_for(cpu)) == ["remove"]
+            and cpu in admin.bar_state
+            and memory in admin.bar_state,
+            "with a Remove, while the viewer who is still watching keeps "
+            "theirs: %s / %s" % (second.ops_for(cpu), sorted(admin.bar_state)),
+        )
+
+        # A viewer disconnecting while a bar is on their screen is the third
+        # way a bar stops being shown, and the one with nothing to observe on
+        # the wire: the packet that must *not* be written is one to a socket
+        # that has gone. What is observable is that the server carries on.
+        leaver = Screen(self.args.host, self.args.port, "HX", self.started)
+        leaver.handshake(self.args.host, self.args.port, 2)
+        leaver.login()
+        leaver.configuration()
+        leaver.enter_play()
+        self.clients.append(leaver)
+        self.until(lambda: leaver.joined, 60.0, "the disconnecting viewer to join")
+        admin.command("perms set %s admin" % leaver.name)
+        self.pump(1.0)
+        leaver.command("serverload")
+        self.until(lambda: cpu in leaver.bar_state, 20.0, "the leaver's own load bars")
+        leaver.sock.close()
+        leaver.alive = False
+        admin.bar_ops.clear()
+        survived = self.until(
+            lambda: admin.ops_for(cpu).count("update_name") >= 2,
+            20.0,
+            "the load bars to keep updating after a viewer vanished",
+        )
+        self.check(
+            survived,
+            "a viewer disconnecting with a bar on their screen leaves the "
+            "server drawing everybody else's: %d further packet(s)"
+            % len(admin.bar_ops),
+        )
+
+    # --- a player who arrives after the match started --------------------
+
+    def joiner_check(self):
+        """Somebody who was not there when the bar was made still gets one.
+
+        The bar this server draws for a match is per player, so a joiner's own
+        bar is new; what the claim is about is that nothing in the server had
+        to notice they arrived. They have no `(Sent, bar)` pair, so the next
+        tick sends them an `Add`, and the join case is the absence of state
+        rather than a code path.
+        """
+        late = Screen(self.args.host, self.args.port, "H9", self.started)
+        late.handshake(self.args.host, self.args.port, 2)
+        late.login()
+        late.configuration()
+        late.enter_play()
+        self.clients.append(late)
+        if not self.until(lambda: late.joined, 60.0, "the late client in play"):
+            self.check(False, "a client joined after the match started")
+            return
+        arrived = self.until(lambda: late.bar_state, 20.0, "the late client's own bar")
+        self.check(
+            arrived,
+            "a player who joins after a match started is given the bar for "
+            "it: %s" % [bar["title"] for bar in late.bar_state.values()],
+        )
+        if not arrived:
+            return
+        uuid = next(iter(late.bar_state))
+        self.check(
+            late.ops_for(uuid)[0] == "add",
+            "as an Add carrying the whole bar, not as an update to one they "
+            "never had: %s" % late.ops_for(uuid)[:3],
+        )
+        held = {bar for client in self.clients[:8] for bar in client.bar_state}
+        self.check(
+            uuid not in held,
+            "and under its own id, because this bar carries a number that is "
+            "only true of them: %s against %d others" % (uuid[:8], len(held)),
+        )    # --- the diffing, over every packet of the whole run ------------------
+
+    def diff_check(self):
+        """No packet ever carried a field that did not change.
+
+        This is the one claim that cannot be made from any single moment, and
+        it is the claim the whole API is for. Every boss bar packet every
+        client received in this run is checked against the state that client
+        was in when it arrived, so a diff that leaked one field on one
+        transition fails here even though every screen looked right.
+
+        Three rules, and they are the whole of `egress::boss_bar::operation`
+        and the observer that tears a bar down:
+
+        * A packet that changes nothing must not exist. An unchanged bar is
+          silence, and a narrow operation can only carry its own field, so
+          this one rule covers "an update sends only the update" outright: an
+          `UpdateName` whose title the client already had is a packet with
+          nothing in it.
+        * A repeat `Add` is only allowed where it is *cheaper* than the narrow
+          operations it replaces, which is two or more fields at once, and it
+          is what makes a multi-field change atomic on a protocol that has no
+          other way to be.
+        * Nothing arrives for a bar the client was never given. A `Sent` pair
+          recorded without the `Add` that goes with it, or one left behind
+          after a `Remove`, both surface here and nowhere else -- from the
+          server both look exactly like doing it right.
+        """
+        packets = 0
+        empty = []
+        wasteful = []
+        orphans = []
+        for client in self.clients:
+            for uuid, operation, moved, known in client.bar_ops:
+                packets += 1
+                if not known:
+                    if operation != "add":
+                        orphans.append((client.name, uuid[:8], operation))
+                    continue
+                if operation == "remove":
+                    continue
+                if operation == "add":
+                    if len(moved) < 2:
+                        wasteful.append((client.name, uuid[:8], sorted(moved)))
+                elif not moved:
+                    empty.append((client.name, uuid[:8], operation))
+
+        self.check(
+            packets > 200,
+            "%d boss bar packet(s) went out this run, which is enough of them "
+            "for the rules below to mean something" % packets,
+        )
+        self.check(
+            not empty,
+            "no boss bar packet said anything the client already knew: "
+            "%d of %d %s" % (len(empty), packets, empty[:3]),
+        )
+        self.check(
+            not wasteful,
+            "and a whole bar was only ever resent where two or more fields "
+            "moved at once: %d of %d %s" % (len(wasteful), packets, wasteful[:3]),
+        )
+        self.check(
+            not orphans,
+            "and nothing arrived for a bar the client had never been given: "
+            "%d of %d %s" % (len(orphans), packets, orphans[:3]),
+        )
+
     def run(self):
         self.connect(1)
         if not self.until(lambda: self.clients[0].joined, 90.0, "the first client in play"):
@@ -536,6 +948,9 @@ class Run:
             return self.report()
         self.experience_check()
         self.match_check()
+        self.joiner_check()
+        self.load_check()
+        self.diff_check()
         return self.report()
 
     def report(self):
@@ -557,8 +972,11 @@ def main():
         "--clients",
         type=int,
         default=8,
-        help="`LobbyConfig::full_players`, which is what makes the countdown ten "
-        "seconds rather than sixty",
+        help="at or above `LobbyConfig::full_players`, which is what makes the "
+        "countdown its ten second one rather than its sixty second one. Eight "
+        "and not the four that now fills a lobby, because `diff_check` wants "
+        "more than one client's worth of traffic to count and the two joiner "
+        "checks want a match already under way to walk into",
     )
     args = parser.parse_args()
     return Run(args).run()


### PR DESCRIPTION
`BossEvent` reached the wire for the first time in #1018, as one bar, hand
rolled in a game event's adapter: one UUID per player, `Add` for every change,
and a diff in the game half to stop it resending. That was correct and it was
measured, and it did not survive the next ask, which was two more bars carrying
something that is not a game concept at all.

## A bar is an entity and its audience is a set of edges

```rust
let bar = world
    .entity()
    .add(BossBar::id())
    .set(Title(Text::text("CPU 240% of 1600%").color(NamedColor::Aqua)))
    .set(Progress(0.15))
    .add((ShownTo, operator));
```

and later `bar.set(Progress(0.31))`, which sends one `UpdateProgress` to each
viewer and nothing else. `smash`'s `Server::set_boss_bar` is now four `set`s on
one of these, and the packet it used to build is gone.

The load-bearing choice is not the components; it is where the per-viewer sent
state lives. `Sent` is the data on the `(Sent, viewer)` pair, holding exactly
what that client was last told, and it is what makes the two cases that are
usually bugs stop being code:

* **Joining.** A player who was not there has no `(Sent, bar)` pair, so the
  next tick sends them `Add`. There is no join handler in this change.
* **Leaving.** A bar is destroyed, a player disconnects, or an audience
  shrinks. All three end with the pair going away -- flecs does the first two
  itself under `(OnDeleteTarget, Remove)` -- and one `OnRemove` observer on
  `(Sent, Wildcard)` sends the `Remove`. Teardown cannot leak, because the fact
  that says "this client has this bar" and the thing that gets cleaned up are
  the same fact.

There is no explicit join or leave path anywhere in `boss_bar.rs`. That was the
test of whether the shape was right.

## The change the wire gate found

A change of state usually moves several fields at once, each operation is its
own packet, and between the first and the last the client is holding a bar that
is half one state and half the next. There is no ordering that fixes it: put
the title last and a countdown ticking over draws the next second's fill under
this second's number; put it first and a lobby bar becoming a countdown is a
countdown in the lobby's blue.

`smash-hud-e2e` caught the second of those as a real failure -- one of #1018's
own checks, `and it is yellow, not the lobby's blue`, against a bar that was
briefly exactly that. So one field moving is that field's narrow operation, and
two or more is a single fresh `Add`. `Add` is *also* the smaller packet: every
operation repeats the sixteen byte id, so two updates already cost more than
the one that carries all four fields, and `BossHealthOverlay.add` is a `put`
into a map keyed on the id, so it replaces the bar in place.

Packet count is unchanged from #1018's 1,135 -- both send one packet per change
-- and each packet is now at most the size of the `Add` it replaced.

## The two bars that carry the host

`/serverload`, Admin, opt in. Fifteen people in a lobby staring at server
telemetry is a strange default and three stacked bars is most of the strip.

**CPU is `getrusage(RUSAGE_SELF)`, not `ps`.** `ru_utime + ru_stime` is a
cumulative counter, so a rate over a window is the only reading it can give and
the first sample reports that it has nothing yet. `ps` answers the lifetime
average instead, which is a different question wearing the same units: a server
busy for a minute an hour ago reads busy under `ps` forever.

**Memory is RSS**, which is what the kernel counts when it decides who to kill.
`/proc/self/statm` field one on Linux, `proc_pidinfo`/`PROC_PIDTASKINFO` on
darwin. The Linux path cannot run on the box the gates run on, so the parser is
a pure function over a string with a fixture whose seven fields all hold
different numbers -- an off-by-one cannot pass it.

### The bar that has no natural full

Neither quantity is a fraction. A process can use more than one core's worth of
CPU, and it can allocate until the machine refuses. So both are drawn against
the point where the machine stops being able to give more -- every core it has,
every byte of physical memory -- and both print that ceiling beside the
reading:

```
CPU 240% of 1600%
MEM 3.20 GiB of 128.0 GiB
```

which turns the choice into something checkable rather than a matter of taste:

> **the fill is the quotient of the two numbers in the bar's own label.**

`hud-check.py` reads both numbers off the wire and divides. A ceiling nobody
printed cannot satisfy that, and neither can one invented to make the bar look
busy. It is also what keeps the label unnormalised: the honest figure is the
numerator, and the fill is that same fact taken against the denominator
standing next to it. 200% is two cores, which is what `top` says and what the
question meant.

Cores come from `available_parallelism`, not the raw processor count, because
in a container the honest ceiling is what the container is allowed.

## The gate

`nix run .#smash-hud-e2e`, 48 checks, up from 25.

`decode_boss_event` read only `Add` and returned `None` for everything else,
because `Add` was all the server sent. Left alone against this server it would
not have failed -- it would have reported that no boss bar ever arrived, which
is a silent pass. It now decodes all six operations into a model of the
client's own `BossHealthOverlay`, so #1018's twenty-five checks ask the same
questions of the same states, and the operations are kept separately as the
only place the diffing is visible at all.

One check that was already there was also red before this branch touched
anything. #1019 moved `LobbyConfig::min_players` from four to two, and the hub
bar's `1/4` was written into `hud-check.py` as a literal, so the gate has been
failing on `main` against a server saying `1/2`. #1019 rewrote six
`tests/lobby.rs` tests for exactly this reason and the one in `tools/` was
missed, because nothing in CI runs the wire gates. It now reads the denominator
off the bar and additionally checks that the fill under the label is
`1/needed`, which is a stronger claim than the literal it replaces and cannot
go stale again. Filed as ENG-10878.

The new checks, beyond the two bars' own numbers:

* An update sends only the update, over **every** boss bar packet of the whole
  run rather than at one moment. Three rules -- no packet says anything the
  client already knew, a whole bar is only resent where two or more fields
  moved, nothing arrives for a bar the client was never given -- checked
  against 849 packets in the run below.
* A mid-match joiner gets the bar for the match it walked into, as an `Add`
  carrying the whole thing.
* A second viewer joining a *running* bar's audience gets it under the same id
  the first one holds. The load bars are the only ones in the game with an
  audience of more than one person, so they are the only place this is
  observable.
* Leaving that audience sends a `Remove` to that viewer and nothing to anybody
  else.
* A viewer disconnecting with a bar on their screen leaves the server drawing
  everybody else's.

## Broken, and watched to fail

Every new guard was inverted and run. Selected output.

### The parser reads `/proc/self/statm`'s first field instead of its second

```
statm_reads_the_resident_field_and_not_a_neighbour
  left: Some(287072256)  right: Some(27807744)
a_statm_line_that_is_not_one_reads_as_nothing
  left: Some(287072256)  right: None
```

The fixture's seven fields all hold different numbers, so the off-by-one is a
wrong answer rather than a coincidence, and the second test caught it too.

### The CPU label is normalised, which is the whole point of the ask

```
the_cpu_label_is_unnormalised_and_the_fill_is_not
  left: "CPU 15% of 100%"  right: "CPU 240% of 1600%"
```

and on the wire, with the same edit:

```
FAIL the CPU label is unnormalised, so its ceiling is every core and not one: CPU 0% of 100%
```

### The first CPU sample answers with the lifetime average, the way `ps` does

```
the_first_sample_reports_nothing_rather_than_an_average
  left: Some(90.0)  right: None
```

### `Sent` is cleaned up with `Delete` rather than `Remove`

```
a_viewer_leaving_removes_only_their_own_record
  one viewer leaving destroyed the bar
```

Which is the whole teardown design failing in the direction that would be
hardest to notice in play: one person quits and the bar goes off everybody's
screen.

### Every change resends the whole bar

```
FAIL and a whole bar was only ever resent where two or more fields moved at once:
  827 of 872 [('H1', '6879705f', ['title']), ('H1', '6879705f', ['title']), ...]
FAIL a new CPU reading that moves only the label costs one packet carrying only
  the label: ['add', 'add', 'add', 'add', 'add']
```

### A client is recorded as having a bar it was never sent

```
FAIL and nothing arrived for a bar the client had never been given:
  39 of 981 [('H1', '6879705f', 'update_name'), ...]
FAIL the hub puts a boss bar up saying what it is waiting for: []
```

The second line is what this failure looks like from the outside, and it is why
the first one exists: a bar that never arrives is indistinguishable from a
server that never drew one, until something is watching for updates to a bar
nobody has.

### The id is per viewer rather than per bar, and the teardown observer is gone

```
FAIL a viewer joining a running bar's audience is sent it under the same id the
  others hold: ['...0584', '...5816a', '...5816d', '...58784']
FAIL with a Remove, while the viewer who is still watching keeps theirs:
  [] / ['...057e', '...5787e', '...57e6a', '...57e6d']
```

Four ids where there should be two, because every viewer minted its own, and no
`Remove` at all where a viewer had just left the audience.

## Verified

Local only, per ENG-10817.

* `nix run .#test` -- 704 passed, 1 skipped
* `nix run .#smash-hud-e2e` -- 48 checks, 0 failed
* `nix run .#fmt` -- clean
* `nix run .#lint` -- **one failure, and it is not this branch's**:

```
error: unused import: `flecs_ecs::prelude`
   --> events/smash/tests/abilities.rs:595:9
```

Reproduced against a detached worktree at `origin/main` with its own
`CARGO_TARGET_DIR`, running the same command `flake.nix:182` runs, with no part
of this branch present:

```
$ CARGO_TARGET_DIR=/tmp/mainlint-target cargo clippy --all-targets --all-features -- -D warnings
error: unused import: `flecs_ecs::prelude`
   --> events/smash/tests/abilities.rs:595:9
rc=101
```

Filed as ENG-10890 rather than fixed here, because it belongs to #1023 and not
to this change. Worth knowing while chasing it: plain `cargo clippy -p smash
--tests` over the same tree exits 0, because `unused_imports` is only a failure
under the `-- -D warnings` the flake adds -- which is how it got past #1023's
own check, and how it briefly looked like mine.

## Deliberately not built

* **No synthetic load past 100% on the wire.** The gate proves the fill stays a
  fraction, that the ceiling is every core, and that the fill is the quotient
  of the label's own two numbers; it does not observe a reading above one
  core's worth, because forcing the server process over a core from a test
  client would mean a burn command in production code. The unnormalised case is
  a unit test with the numbers injected: 2.4 cores of 16 reads `CPU 240% of
  1600%`, and 2.4 cores of 1 reads `CPU 240% of 100%` with a full bar.
* **The `/proc/self/statm` fixture is written to `proc(5)`, not captured off a
  running host.** The gates run on darwin. What the fixture does prove is the
  field index, which is the failure that would ship, because every field holds
  a different number.
* **The sidebar is still hand rolled in smash's adapter.** It has the same
  argument as the boss bar and it should follow, but porting it is a second
  change and this one already moves a gate.
* **`ShownToEveryone` has no caller.** It is in the API because "everyone" is a
  rule rather than a list -- a player who connects a minute from now is in it --
  and it is covered by the drive system's own path, but nothing in the tree
  shows a bar to everybody yet.

## Also filed

**ENG-10878**: `smash-hud-e2e` was red on `main` before this branch, as above.
Fixed here. The follow-up worth having is a job that runs the eight gates in
`e2eOffsets`, because a change that breaks only one of them is invisible today
until somebody runs it by hand.

**ENG-10871**: `/perms set <player> Admin` is gated at `Normal`, so any player
who can connect can make themselves Admin. The derive gates a whole clap enum
at once, so `Get` and `Set` cannot differ. This gate depends on the hole -- it
promotes its own clients, because there is no other way for a test client to
reach an Admin command -- so closing it needs a way to seed a group at startup
landed alongside. `hud-check.py` names the ticket at the line that depends on
it.

---

Written by Claude (Opus 5) with human direction.
