### PR TITLE
fix(smash): the gate declares the lobby it needs, and checks it got it

### DIFF
--- a/events/smash/src/module/lobby.rs
+++ b/events/smash/src/module/lobby.rs
@@ -83,19 +83,73 @@ impl Default for LobbyConfig {
     }
 }
 
+/// Read a player count from the environment, or keep `fallback`.
+///
+/// A value that is set but unreadable stops the server. It is a typo in a
+/// number the whole match schedule turns on, and a lobby quietly running
+/// thresholds nobody asked for is worse than one that does not boot.
+fn threshold_from_env(name: &str, fallback: u32) -> u32 {
+    std::env::var(name).map_or(fallback, |raw| {
+        raw.parse().unwrap_or_else(|error| {
+            panic!("{name} is not a player count: {raw:?} ({error})");
+        })
+    })
+}
+
 impl LobbyConfig {
+    /// The lobby this server is configured to run.
+    ///
+    /// `SMASH_MIN_PLAYERS` and `SMASH_FULL_PLAYERS` set the two thresholds, in
+    /// the same `SMASH_`-prefixed namespace the binary already reads its
+    /// address and its certificates from.
+    ///
+    /// This is the seam the type's own comment describes. The counts are the
+    /// part of a lobby deployments actually differ on -- a duels box, a full
+    /// house, a soak run -- and each wants its own without a rebuild and
+    /// without touching the state machine. The durations are not exposed,
+    /// because nobody has yet wanted them to differ.
+    #[must_use]
+    pub fn from_env() -> Self {
+        let defaults = Self::default();
+        let config = Self {
+            min_players: threshold_from_env("SMASH_MIN_PLAYERS", defaults.min_players),
+            full_players: threshold_from_env("SMASH_FULL_PLAYERS", defaults.full_players),
+            ..defaults
+        };
+        assert!(
+            config.min_players >= 1,
+            "SMASH_MIN_PLAYERS is 0, so an empty lobby would start a match"
+        );
+        assert!(
+            config.full_players >= config.min_players,
+            "SMASH_FULL_PLAYERS is {} and SMASH_MIN_PLAYERS is {}, so the lobby would be full \
+             before it was allowed to start",
+            config.full_players,
+            config.min_players,
+        );
+        config
+    }
+
     /// How long the countdown should be for this many players, or `None` if
     /// there are not enough to run one.
+    ///
+    /// The minimum is checked first and alone. It used to be the last of three
+    /// branches, which let the three-quarters rule answer for a lobby that had
+    /// not reached its minimum at all: at `min_players: 4, full_players: 4`
+    /// three players satisfy `3 * 4 >= 4 * 3` and started a countdown under a
+    /// minimum of four. The field is named `min_players`, so it is a minimum;
+    /// the bands below only choose how long.
     #[must_use]
     pub const fn countdown_for(&self, players: u32) -> Option<f32> {
+        if players < self.min_players {
+            return None;
+        }
         if players >= self.full_players {
             Some(self.countdown_at_full)
         } else if players * 4 >= self.full_players * 3 {
             Some(self.countdown_at_three_quarters)
-        } else if players >= self.min_players {
-            Some(self.countdown_at_min)
         } else {
-            None
+            Some(self.countdown_at_min)
         }
     }
 }
@@ -296,7 +350,7 @@ impl Module for LobbyModule {
             .add_trait::<flecs::Singleton>();
         world.component::<PhaseChanged>();
         world.set(Lobby::default());
-        world.set(LobbyConfig::default());
+        world.set(LobbyConfig::from_env());
 
         world.system_named::<()>("smash::lobby_tick").run(|mut it| {
             while it.next() {

--- a/events/smash/tests/lobby.rs
+++ b/events/smash/tests/lobby.rs
@@ -78,6 +78,75 @@ fn the_countdown_length_depends_on_how_full_the_lobby_is() {
     );
 }
 
+/// The bug: the three-quarters band answered for lobbies that had not reached
+/// their minimum, so `min_players` was not actually a minimum.
+///
+/// It needs a config whose bands touch. At 2/4 and at 4/8 the arithmetic hides
+/// it -- `full_players * 3 / 4` is above `min_players` in both -- which is why
+/// this went in unnoticed and why the case is spelled out rather than left to
+/// the live defaults.
+#[test]
+fn a_lobby_never_starts_below_its_own_minimum() {
+    for full_players in 1..=12 {
+        for min_players in 1..=full_players {
+            let config = LobbyConfig {
+                min_players,
+                full_players,
+                ..LobbyConfig::default()
+            };
+            for players in 0..min_players {
+                assert_eq!(
+                    config.countdown_for(players),
+                    None,
+                    "a lobby of min {min_players} / full {full_players} started a countdown with \
+                     {players} players, under its own stated minimum"
+                );
+            }
+            assert!(
+                config.countdown_for(min_players).is_some(),
+                "a lobby of min {min_players} / full {full_players} would not start at its own \
+                 stated minimum"
+            );
+        }
+    }
+}
+
+/// The reordering above is inert for both configurations anyone runs.
+///
+/// Production is 2/4 and `smash-e2e` declares 4/8. Neither has a player count
+/// whose band changed, and this is the check that says so rather than a claim
+/// in a commit message.
+#[test]
+fn the_live_configurations_are_unaffected_by_the_minimum_check() {
+    // What the old three-branch order returned, before the minimum was hoisted.
+    fn previously(config: &LobbyConfig, players: u32) -> Option<f32> {
+        if players >= config.full_players {
+            Some(config.countdown_at_full)
+        } else if players * 4 >= config.full_players * 3 {
+            Some(config.countdown_at_three_quarters)
+        } else if players >= config.min_players {
+            Some(config.countdown_at_min)
+        } else {
+            None
+        }
+    }
+
+    for (min_players, full_players) in [(2, 4), (4, 8)] {
+        let config = LobbyConfig {
+            min_players,
+            full_players,
+            ..LobbyConfig::default()
+        };
+        for players in 0..=full_players * 3 {
+            assert_eq!(
+                config.countdown_for(players),
+                previously(&config, players),
+                "min {min_players} / full {full_players} changed answer at {players} players"
+            );
+        }
+    }
+}
+
 #[test]
 fn reaching_the_minimum_starts_the_long_countdown() {
     let config = config();

--- a/flake.nix
+++ b/flake.nix
@@ -380,6 +380,42 @@
             smash-hud-e2e = 8000;
           };
 
+          # The lobby `smash-e2e` runs against, which is deliberately not the
+          # one the product ships.
+          #
+          # The gate's ability sweep changes kits, and a committed match
+          # refuses to, so the sweep needs a roster the lobby will not start
+          # on. That roster also needs at least two players in it, because
+          # `hurts_target` and `heals_caster` are claims about a second body.
+          # Production runs 2/4 so two people can start a game, and under 2/4
+          # no roster is both things at once. So the gate states the lobby it
+          # needs rather than inferring one, and `smash-match.py` checks it got
+          # it: the run fails if the lobby leaves the hub mid-sweep. Before
+          # this, the harness had `min_players - 1` written into it and the
+          # numbers moved out from under it (#1019).
+          #
+          # Both thresholds and not only the minimum: `full_players` is what
+          # decides the three-quarters band, which is the one that actually
+          # fired. At 2/4 three players satisfy `3 * 4 >= 4 * 3` and the sweep
+          # died 0.6 seconds in. These are the pre-#1019 numbers, under which
+          # three players start nothing even by the old band order, so this
+          # gate does not depend on the `countdown_for` fix that shipped
+          # alongside it.
+          smashGateLobby = {
+            sweepClients = 3;
+            env = {
+              SMASH_MIN_PLAYERS = 4;
+              SMASH_FULL_PLAYERS = 8;
+            };
+          };
+
+          # `env` as shell, for the gates that are scripts rather than checks.
+          exportsFor =
+            env:
+            lib.concatStringsSep "\n" (
+              lib.mapAttrsToList (name: value: "export ${name}=${toString value}") env
+            );
+
           # Two gates on one offset, as a build failure rather than as a race.
           #
           # An eval-time check and not a runtime one: the failure it catches is a
@@ -637,7 +673,8 @@
               deps = [ pkgs.git ];
               text = ''
                 export HYPERION_EVENT=smash
-                export HYPERION_E2E_CLIENT=tools/smash-match.py
+                export HYPERION_E2E_CLIENT="tools/smash-match.py --sweep-clients ${toString smashGateLobby.sweepClients}"
+                ${exportsFor smashGateLobby.env}
                 export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.smash-e2e)}}"
                 export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.smash-e2e)}}"
                 exec "${lib.getExe runners.e2e}" "$@"
@@ -882,6 +919,11 @@
               gameServer = gameBinaries.smash;
               proxy = gameBinaries.hyperion-proxy;
               client = "smash-match.py";
+              clientArgs = [
+                "--sweep-clients"
+                (toString smashGateLobby.sweepClients)
+              ];
+              serverEnv = smashGateLobby.env;
               # A match is four clients playing for up to five minutes, so the
               # cap is the client's own budget plus room to boot and report.
               timeout = 480;

--- a/nix/e2e.nix
+++ b/nix/e2e.nix
@@ -297,6 +297,10 @@ let
       proxy,
       client,
       clientArgs ? [ ],
+      # Environment for the game server process. A gate whose question needs a
+      # server configured differently from the one the product ships says so
+      # here, rather than the client inferring it.
+      serverEnv ? { },
       needsGenMap ? false,
       timeout ? 300,
     }:
@@ -327,6 +331,9 @@ let
         mkdir -p "$XDG_CACHE_HOME"
         ${lib.optionalString needsGenMap seedGenMap}
 
+        ${lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (name: value: "export ${name}=${toString value}") serverEnv
+        )}
         export HYPERION_E2E_GAME_SERVER="${lib.getExe gameServer}"
         export HYPERION_E2E_PROXY="${lib.getExe proxy}"
         export HYPERION_E2E_CLIENT="${clients}/tools/${client} ${lib.escapeShellArgs clientArgs}"

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-"""Drive four scripted clients through one whole Super Smash Mobs match.
+"""Drive a roster of scripted clients through one whole Super Smash Mobs match.
 
 `client-26.2.py` answers "is the server joinable". This answers the next
 question, which is the one a single client structurally cannot: does a *match*
-happen. `min_players` is four, so nothing past the hub is reachable until four
-clients are in the world at once, and four separate processes cannot hit each
-other because neither knows the other's entity id. Both problems disappear if
-one process owns every socket, so this drives all of them from a single loop
-and prints one interleaved transcript.
+happen. Nothing past the hub is reachable until the lobby has reached its
+minimum, which is more clients than one process usually is, and separate
+processes cannot hit each other because neither knows the other's entity id.
+Both problems disappear if one process owns every socket, so this drives all of
+them from a single loop and prints one interleaved transcript.
 
 Protocol 776 throughout. The framing, the handshake, the login and the
 configuration state are `client-26.2.py`'s, imported rather than copied, so
@@ -22,10 +22,16 @@ each one and holds it to the effects that entry declares. Nothing here lists a
 kit or an ability, so a kit added tomorrow is a kit this gate tests tomorrow,
 and one whose ability does nothing fails here rather than passing quietly.
 
-The sweep runs in the hub with one client short of `min_players`, which is what
-keeps the lobby in `Waiting` for as long as it takes: there is no countdown to
-race, no kill plane under the lobby, and kits can still be changed. The last
-client joins when the sweep is done and the match runs after it.
+The sweep runs in the hub, on a roster small enough that the lobby will not
+start under it: a committed match has a kill plane, locks abilities and refuses
+to change a kit, and the sweep needs all three of those not to be true. How
+small that is depends on the server's thresholds, so `--sweep-clients` says it
+outright and nothing here computes it. This file does not know the lobby's
+numbers and must not guess: a guess that is wrong reads as fifteen kits passing
+when the last three never ran. It is checked against the running server
+instead -- if the lobby leaves the hub while the sweep is in it, the run fails
+there, naming the roster. The rest of the clients join once the sweep is done,
+and the match runs after them.
 
 What this proves and what it does not
 -------------------------------------
@@ -635,7 +641,7 @@ class MatchClient(base.Client):
 
 
 class Match:
-    """The run: four clients, one transcript, and what it proved."""
+    """The run: a roster of clients, one transcript, and what it proved."""
 
     def __init__(self, args):
         self.args = args
@@ -690,6 +696,9 @@ class Match:
         self.died_awaiting_respawn = set()
         self.falls = 0
         self.phase = "hub"
+        # Set by `hub_only` when the lobby starts under a sweep that needed it
+        # not to. Fatal, because everything after it measures the wrong game.
+        self.hub_lost = False
         self.last_step = 0.0
 
     def log(self, line):
@@ -732,6 +741,42 @@ class Match:
 
     def wait(self, seconds):
         self.wait_until(lambda: False, seconds)
+
+    def hub_only(self, during):
+        """Whether the lobby is still in the hub, where the sweep can work.
+
+        The sweep changes kits, and a committed match refuses to: every `/kit`
+        after the countdown commits is answered with a red line and ignored.
+        So a sweep roster the lobby will start on does not fail the run, it
+        silently stops proving anything. That is how this last broke -- three
+        clients against thresholds that had moved under them produced twelve
+        real ability results, three that were only `You cannot change kit once
+        the game has started.`, and then a loop with no exit, because the match
+        it was waiting to run had already run without it.
+
+        Checking the phase costs nothing and turns all of that into one line.
+        `self.phase` is driven by the server's own broadcasts, so this asks the
+        server what state it is in rather than deciding from a player count.
+        It therefore stays correct whatever the thresholds are, and it is not a
+        second copy of them.
+        """
+        if self.phase == "hub":
+            return True
+        self.hub_lost = True
+        # Logged here rather than left to the caller. The caller's job is to
+        # stop, and the first version of this only recorded the line in
+        # `sweep_failures`, which `sweep` prints at the end of a sweep it no
+        # longer reaches -- so the run failed with the reason nowhere in the
+        # transcript. A guard that stops the right run for a reason nobody can
+        # read is most of a guard.
+        self.log(
+            "SWEEP ABANDONED the lobby left the hub %s. %d clients is enough "
+            "for this server to start a countdown, so kits can no longer be "
+            "changed and nothing further would be proved. Either "
+            "--sweep-clients is too many for this lobby, or the server needs a "
+            "higher SMASH_MIN_PLAYERS/SMASH_FULL_PLAYERS." % (during, len(self.clients))
+        )
+        return False
 
     # --- reading -------------------------------------------------------
 
@@ -989,6 +1034,12 @@ class Match:
 
     def sweep(self):
         """Fire every ability the registry names and check what it promised."""
+        # Before the manifest rather than after, because the sweep is ten
+        # minutes and a lobby that has already started makes every result in it
+        # meaningless. The roster joined a moment ago, so a countdown it was
+        # enough to trigger has had time to be announced.
+        if not self.hub_only("before the sweep began"):
+            return
         if not self.fetch_manifest():
             return
 
@@ -996,7 +1047,11 @@ class Match:
         for entry in self.manifest:
             by_kit.setdefault(entry["kit"], []).append(entry)
 
-        for kit, abilities in by_kit.items():
+        for done, (kit, abilities) in enumerate(by_kit.items()):
+            # Again per kit: the roster is constant, but a player who is not
+            # this harness can join the same server and push it over.
+            if not self.hub_only("with %d of %d kits swept" % (done, len(by_kit))):
+                return
             self.log("== %s ==" % kit)
             if not self.select_kit(kit):
                 self.sweep_failures.append("%s: the kit never equipped" % kit)
@@ -1481,16 +1536,24 @@ class Match:
     # --- the script ----------------------------------------------------
 
     def run(self):
-        # One short of the lobby's minimum, so the sweep runs in a hub that
-        # cannot start a countdown under it, has no kill plane and still allows
-        # a kit to be changed. The last client joins once the sweep is done.
-        self.connect(max(1, self.args.clients - 1))
+        # The sweep's roster, which the gate declares and `hub_only` checks
+        # against the server. Nothing is subtracted from anything here: the
+        # number that matters is the largest roster this lobby will not start
+        # on, and that is the server's to know, not this file's. The rest of
+        # the clients join once the sweep is done.
+        self.connect(self.args.sweep_clients)
         if not self.wait_until(lambda: all(c.joined for c in self.clients), 60.0):
             self.log("clients never reached the world")
             return self.report()
 
         if self.args.abilities:
             self.sweep()
+            # Straight to the report. Running the match now would be running it
+            # in a countdown the sweep already lost to, and the transcript
+            # would show a mostly-passing match under a failed run -- which is
+            # exactly the reading that let this bug survive its first sighting.
+            if self.hub_lost:
+                return self.report()
 
         self.connect(self.args.clients - len(self.clients))
         kits = [kit.strip() for kit in self.args.kits.split(",")]
@@ -1941,6 +2004,17 @@ def main():
     parser.add_argument("--port", type=int, default=25565)
     parser.add_argument("--clients", type=int, default=4)
     parser.add_argument(
+        "--sweep-clients",
+        type=int,
+        default=3,
+        help="how many clients are in the world for the ability sweep. Must be "
+        "a roster this server's lobby will not start a countdown on: the sweep "
+        "changes kits and a committed match refuses to. The run fails naming "
+        "this flag if the lobby starts anyway, so it is checked and not "
+        "trusted. Minimum 2, because an ability that hurts or heals a target "
+        "needs a target",
+    )
+    parser.add_argument(
         "--kits",
         default="Iron Golem,Skeleton,Enderman,Slime",
         help="comma-separated, one per client; the first one attacks",
@@ -1966,6 +2040,21 @@ def main():
         help="the Y a client claims to be at when the script wants it to die",
     )
     args = parser.parse_args()
+
+    # Two floors, both structural. The upper one is not about the lobby: the
+    # lobby's limit is the server's to state and `hub_only` is what checks it.
+    if args.sweep_clients < 2:
+        raise SystemExit(
+            "--sweep-clients is %d: the sweep proves `hurts_target` and calls "
+            "`wound_attacker` for `heals_caster`, and both are claims about a "
+            "body that is not the caster's" % args.sweep_clients
+        )
+    if args.sweep_clients > args.clients:
+        raise SystemExit(
+            "--sweep-clients is %d but --clients is %d, so the match after the "
+            "sweep would have fewer players than the sweep did"
+            % (args.sweep_clients, args.clients)
+        )
 
     chosen = [kit.strip() for kit in args.kits.split(",")]
     if args.clients > len(chosen):


### PR DESCRIPTION
## Effect

`nix run .#smash-e2e` passes again, all 15 kits. It has been red since #1019.

## What broke

#1019 moved `LobbyConfig::default()` from 4/8 to 2/4, which the operator asked for. `tools/smash-match.py` had those numbers written into it a second time -- as `max(1, self.args.clients - 1)`, as "`min_players` is four" in its docstring, and as "one short of the lobby's minimum" at the call site -- so the sweep's three clients went from below the threshold to above it. The countdown started, the match committed, and every later kit change was refused with `You cannot change kit once the game has started.`

Reproduced on e4bbcc2 before changing anything:

```
     0.60s       PROVED lobby started a match: server announced the countdown with 3 players connected
     0.68s       PROVED four in play: 3 clients hold a Login packet: P1=67110240, P2=1377, P3=1378
    30.79s [P3 ] <- chat: §cYou cannot change kit once the game has started.
    45.78s [P3 ] <- chat: §cYou cannot change kit once the game has started.
    60.83s [P1 ] <- chat: §cYou cannot change kit once the game has started.
```

## It was not the minimum that fired, and that decides the fix

The countdown started 0.6 seconds in, not at `min_players`. `countdown_for` checked the three-quarters band before the minimum, so at 2/4 three players satisfy `3 * 4 >= 4 * 3` and take the 30-second band.

So `min_players - 1` was never a sound expression of "a roster that cannot start a countdown". The real condition depends on `full_players` too. At 4/8 the subtraction worked by luck.

## Why not read the threshold off the wire

#1018 puts `Waiting for players {n}/{min_players}` on a boss bar, and a harness that reads its own limit off that packet cannot disagree with the server. I rejected it as the fix, because it cannot be one. The sweep needs two clients to prove `hurts_target` and to call `wound_attacker` for `heals_caster`; at `min_players: 2` the number it would read off the wire is one, and a one-client sweep goes green while proving less. Observation cannot manufacture headroom, only control can. The bar also advertises only `min_players`, which per the section above is not the number that decides this.

## So the gate declares the lobby, and the harness checks it got it

- `LobbyConfig::from_env()` reads `SMASH_MIN_PLAYERS` and `SMASH_FULL_PLAYERS`, in the `SMASH_`-prefixed namespace `hyperion_event_runner::run` already reads the address and certificates from. Not added to the shared `Args`, which bedwars would then carry and never read.
- `nix/e2e.nix`'s `mkCheck` gained `serverEnv`. `smashGateLobby` in `flake.nix` declares 4/8 and a sweep roster of 3 in one place and feeds both the app and the check.
- `smash-match.py` takes `--sweep-clients` and subtracts nothing. The docstring no longer says four.

4/8 and not just a higher minimum, because `full_players` is what gates the three-quarters band. These are the pre-#1019 numbers, under which three players start nothing even by the old band order, so the gate does not depend on the `countdown_for` change below.

## The guard is the repro

`hub_only` fails the run if the lobby leaves the hub while the sweep needs it, checked before the sweep and again before each kit. It reads the phase off the server's own broadcasts rather than recomputing a threshold, so it stays right whatever the numbers become and is not a second copy of them.

Broken deliberately, by pointing `smashGateLobby.env` at production's 2/4:

```
     0.72s       SWEEP ABANDONED the lobby left the hub before the sweep began. 3 clients is enough for this server to start a countdown, so kits can no longer be changed and nothing further would be proved. Either --sweep-clients is too many for this lobby, or the server needs a higher SMASH_MIN_PLAYERS/SMASH_FULL_PLAYERS.
     0.72s       RESULT: 10 of 12 steps did not happen
rc=1
```

571 seconds and a hang become 0.72 seconds and a cause. Restored to 4/8 afterwards.

Breaking it is also what found a real bug in it. The first version stopped the run but only recorded its reason in `sweep_failures`, which `sweep` prints at the end of a sweep it no longer reached -- so the run failed with the reason nowhere in the transcript, and then went on to run a mostly-passing match underneath the failure. It now logs directly and returns straight to the report.

## countdown_for checks the minimum first

Fixed here rather than filed, because it is a reordering in a file this PR already touches and its failure mode is silent. `min_players` was a partial lie: at `min_players: 4, full_players: 4`, three players started a countdown under a stated minimum of four.

Provably inert for both configurations anyone runs. `the_live_configurations_are_unaffected_by_the_minimum_check` keeps the old three-branch order in the test and asserts the new one agrees with it at every count from 0 to `full_players * 3`, for 2/4 and 4/8. `a_lobby_never_starts_below_its_own_minimum` is the case that would have caught it, over every config from 1/1 to 12/12.

## Checks

`cargo nextest run -p smash`: 257 passed. `cargo clippy -p smash --all-targets`: clean. `cargo fmt --check`: clean.

`nix run .#smash-e2e`, all 15 kits and all 12 claims:

```
 254.43s       === what the match proved ===
 254.43s         proved      the server published its ability registry
 254.43s                     51 abilities across 15 kits (Blaze, Chicken, Cow, Creeper, Enderman, Guardian, Iron Golem, Skeleton, Sky Squid, Slime, Snowman, Spider, Wither Skeleton, Wolf, Zombie), every one of them declaring what a client would see
 254.43s         proved      every declared ability did what it declared
 254.43s                     51 abilities fired by a real client, each one checked against the effects its own registry entry names
 254.43s         proved      every declared ability was heard
 254.43s                     51 abilities fired by a real client, each one answered by a ClientboundSoundPacket carrying the vanilla sound event its own registry entry names
 254.43s         proved      cooldowns refused a second use
 254.43s                     47 abilities answered a second right-click inside their cooldown with 'That ability is recharging.' on the action bar
 254.43s         proved      four in play
 254.43s         proved      lobby started a match
 254.43s                     server announced the countdown with 4 players connected
 254.43s         proved      kits equipped
 254.43s         proved      arena is a committed map
 254.43s         proved      knockback from an ability
 254.43s         proved      a hit was heard where it landed
 254.43s         proved      life lost and respawned
 254.43s         proved      match ended, back in the hub
 254.43s       RESULT: a whole match ran at protocol 776
rc=0
```

The sweep is 73 seconds for all 51 abilities, not the 571 seconds the broken run took: that figure was time spent on refused kit changes, not real work. The check's 480s timeout has room.

## Not done, and one thing found

I did not run the `smash-e2e` **check** derivation, only the app. CI covers it and the timing above says it fits.

ENG-10889: `tools/smash-selector.py` has this same defect twice, `FULL_PLAYERS = 8` with a comment citing `LobbyConfig::default` and "Three, which is one short of `min_players`" above its own `connect(3)`. `smash-selector-e2e` is likely broken by #1019 in exactly the way this gate was. Not run and not fixed here. `hotbar-check.py:22` and `smash-map-check.py:1141` have stale prose about the same numbers but still behave.
