### PR TITLE
fix(tools): scripted clients read protocol.json, not each other's source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,9 @@
               root = ./.;
               tools = ./tools;
               protoSource = ./crates/hyperion-minecraft-proto/src;
+              # The scripted clients resolve registry ids to names through
+              # this, the same file build.rs reads.
+              protocolJson = ./crates/hyperion-minecraft-proto/protocol.json;
               kitSkins = ./events/smash/skins;
               genmap = ./crates/hyperion-genmap/src/lib.rs;
             };
@@ -985,6 +988,7 @@
             # produces, or the copy cargo reads is a fiction.
             minecraft-proto-generated = minecraft.generatedUpToDate;
             minecraft-proto-coverage = minecraft.coverageRatchet;
+            tool-paths = minecraft.toolPaths;
             minecraft-registry-data = minecraft.registryDataUpToDate;
             minecraft-tag-data = minecraft.tagDataUpToDate;
             minecraft-tags-load = minecraft.tagsLoadForClient;

--- a/nix/check-tool-paths.py
+++ b/nix/check-tool-paths.py
@@ -1,0 +1,89 @@
+"""Fail when a script names a repository path that does not exist.
+
+A Python tool reaching into `crates/.../src/generated/registry.rs` is a
+dependency the compiler cannot see and `cargo` cannot break. When that file
+became a directory, two scripted clients kept building, kept passing review and
+failed only inside four end-to-end gates, twenty minutes into CI, with a
+`FileNotFoundError` that named a path nobody had grepped for because it was in
+a string in a language nothing type-checks against the tree.
+
+This is the cheap half of the fix. The real half is that those two now read
+`protocol.json`, which is a data interface rather than somebody else's source
+file. But the class outlives the instance: any script may name any path, and
+this makes a stale one fail in seconds rather than in a gate.
+
+Only paths anchored at a top-level directory of this repository are checked, so
+`"target/debug"` and `"a/b.rs"` in prose are not mistaken for claims.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# A string literal is treated as a claim about the tree when it starts with one
+# of these. Anchoring on real directories is what keeps a doc string mentioning
+# `some/path` out of the results.
+ANCHORS = ("crates/", "events/", "nix/", "tools/", "docs/", "assets/")
+
+# `crates/hyperion/src/lib.rs`, but not `crates/{}/src` or `crates/%s/x`.
+CANDIDATE = re.compile(
+    r"""["']((?:%s)[A-Za-z0-9_./-]+)["']""" % "|".join(re.escape(a) for a in ANCHORS)
+)
+
+# Where a path is deliberately not a file: a glob, or a name built at runtime.
+PLACEHOLDER = re.compile(r"[{}%*?]|\$\{")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--root", required=True, type=Path)
+    args = ap.parse_args()
+
+    listing = subprocess.run(
+        ["git", "ls-files", "-z", "*.py", "*.sh", "*.nix"],
+        cwd=args.root, check=True, capture_output=True, text=True,
+    ).stdout
+
+    broken: list[tuple[str, int, str]] = []
+    checked = 0
+    for name in listing.split("\0"):
+        if not name:
+            continue
+        try:
+            text = (args.root / name).read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for number, line in enumerate(text.splitlines(), 1):
+            for claim in CANDIDATE.findall(line):
+                if PLACEHOLDER.search(claim):
+                    continue
+                checked += 1
+                if not (args.root / claim).exists():
+                    broken.append((name, number, claim))
+
+    print(
+        "{} repository paths named in scripts, {} of them missing".format(
+            checked, len(broken)
+        ),
+        file=sys.stderr,
+    )
+    for name, number, claim in broken:
+        print("MISSING {}:{}  {}".format(name, number, claim), file=sys.stderr)
+    if broken:
+        print(
+            "\nA script names a path this tree does not have. Nothing else catches "
+            "this: a path in a\nstring is invisible to cargo and to every Rust "
+            "grep, so it fails inside whichever gate runs\nthat script. Either fix "
+            "the path, or -- better -- stop reaching into another component's\n"
+            "source and read its committed data instead.",
+            file=sys.stderr,
+        )
+    return 1 if broken else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nix/e2e.nix
+++ b/nix/e2e.nix
@@ -100,15 +100,21 @@ let
   '';
 
   # The scripted clients read four things off disk: each other, the registry
-  # contents they check the server's tags against, the generated item registry
-  # they name items from, and the committed kit skins a profile has to match.
-  # All four are under one root because the clients reach for them by
-  # repository-relative path.
+  # contents they check the server's tags against, `protocol.json` -- which is
+  # how they turn a registry id on the wire into a name -- and the committed
+  # kit skins a profile has to match. All four are under one root because the
+  # clients reach for them by repository-relative path.
+  #
+  # `protocol.json` and not the generated Rust: two clients used to scrape the
+  # tables out of `src/generated/registry.rs` with a regex, and both broke the
+  # day that file became a directory. A path into somebody else's source is not
+  # an interface.
   clients = lib.fileset.toSource {
     root = sources.root;
     fileset = lib.fileset.unions [
       (lib.fileset.fileFilter (file: file.hasExt "py") sources.tools)
       sources.protoSource
+      sources.protocolJson
       sources.kitSkins
     ];
   };

--- a/nix/minecraft-data.nix
+++ b/nix/minecraft-data.nix
@@ -322,6 +322,9 @@ let
   coverageChecker = pkgs.writers.writePython3Bin "check-minecraft-proto-coverage" pythonWriterOptions
     (builtins.readFile ./check-proto-coverage.py);
 
+  toolPathChecker = pkgs.writers.writePython3Bin "check-tool-paths" pythonWriterOptions
+    (builtins.readFile ./check-tool-paths.py);
+
   # The NBT blobs live next to the Rust that `include_bytes!`es them, so this
   # output is a whole directory rather than a single file.
   generatedRegistryData = pkgs.runCommand "hyperion-minecraft-registry-data-${pin.id}"
@@ -694,6 +697,48 @@ let
       touch $out
     '';
 
+  # A script naming a repository path that does not exist.
+  #
+  # Two scripted clients read `src/generated/registry.rs` with a regex. When
+  # that file became a directory, both kept building -- a path in a Python
+  # string is invisible to cargo and to every Rust grep -- and failed twenty
+  # minutes into CI inside four end-to-end gates, on a `FileNotFoundError`.
+  # A third named `src/entity_type.rs` and would have failed the same way one
+  # merge later.
+  #
+  # The real fix was to stop reaching into another component's source: all
+  # three read `protocol.json` now, which is data with a shape rather than a
+  # file with a location. This is the cheap half, and it is what makes the
+  # class fail in seconds instead of in a gate.
+  toolPaths = pkgs.runCommand "check-tool-paths"
+    {
+      nativeBuildInputs = [ toolPathChecker pkgs.git ];
+    }
+    ''
+      cp -r ${toolPathSource} source
+      chmod -R u+w source
+      cd source
+      git init -q .
+      git add -A
+      check-tool-paths --root .
+      touch $out
+    '';
+
+  # The checker reads scripts and stats paths, so it needs the tree's shape as
+  # well as the scripts themselves. `fileFilter` on the whole root would drag
+  # in every Rust file's contents; this takes names cheaply by taking the
+  # directories the anchors name.
+  toolPathSource = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../tools
+      ../nix
+      ../crates
+      ../events
+      ../docs
+    ];
+  };
+
   # protocol.json is the input build.rs reads, so a stale copy is a stale
   # packet struct in every build that does not go through nix. Guarding it is
   # what lets the structs live in OUT_DIR instead of in the tree.
@@ -738,6 +783,8 @@ in
     syncBlockStatesScript
     coverageChecker
     coverageRatchet
+    toolPathChecker
+    toolPaths
     generatedUpToDate
     registryDataUpToDate
     tagDataUpToDate

--- a/tools/client-26.2.py
+++ b/tools/client-26.2.py
@@ -15,6 +15,7 @@ declares.
 from __future__ import annotations
 
 import argparse
+import json
 import pathlib
 import re
 import socket
@@ -25,6 +26,35 @@ import zlib
 
 PROTOCOL = 776
 VERSION = "26.2"
+
+# The extracted protocol description, which is the same file `build.rs` reads
+# and the same one every generated table comes out of.
+PROTOCOL_JSON = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "crates/hyperion-minecraft-proto/protocol.json"
+)
+
+
+def registry_entries(registry: str) -> list[str]:
+    """A vanilla registry's entry names, in network-id order.
+
+    Read from `protocol.json` rather than scraped out of the generated Rust.
+    Two tools used to do the latter, each with its own regex and its own
+    defensive slice to skip the registry's own name -- which sits in the same
+    table and looks exactly like an entry, so getting it wrong shifted every id
+    by one and turned `brigadier:string` into `brigadier:long`. Both broke the
+    day the generated table became a directory, because a path is not an
+    interface. This is: the ids here are the indices, with nothing to skip.
+    """
+    doc = json.loads(PROTOCOL_JSON.read_text())
+    found = doc["registries"].get(registry)
+    if found is None:
+        raise SystemExit(
+            "%s has no %s; it has %d registries, starting %s"
+            % (PROTOCOL_JSON, registry, len(doc["registries"]), sorted(doc["registries"])[:3])
+        )
+    return found["entries"]
+
 
 # Serverbound ids, from crates/hyperion-minecraft-proto/src/generated/packet_id.rs.
 C2S_INTENTION = 0x00

--- a/tools/completions-check.py
+++ b/tools/completions-check.py
@@ -42,7 +42,6 @@ import time
 
 TOOLS = pathlib.Path(__file__).resolve().parent
 ROOT = TOOLS.parent
-REGISTRY_SOURCE = ROOT / "crates/hyperion-minecraft-proto/src/generated/registry.rs"
 
 
 def _load_client():
@@ -109,25 +108,16 @@ POSSIBLE_VALUES = re.compile(r"\[possible values: ([^\]]*)\]")
 def argument_type_names():
     """`minecraft:command_argument_type`, in network id order.
 
-    Read out of the generated registry table rather than listed here, because
-    the ids are positions in that table and a protocol bump moves them. A
-    parser named wrongly would let a wrong-parser bug pass.
+    Read out of `protocol.json` rather than listed here, because the ids are
+    positions in that registry and a protocol bump moves them. A parser named
+    wrongly would let a wrong-parser bug pass.
     """
-    text = REGISTRY_SOURCE.read_text()
-    start = text.find("pub static COMMAND_ARGUMENT_TYPE: Registry = Registry {")
-    if start < 0:
-        raise SystemExit("no COMMAND_ARGUMENT_TYPE in %s" % REGISTRY_SOURCE)
-    # From `entries`, not from the declaration: the registry's own name sits
-    # above it and looks exactly like an entry, which shifts every id by one
-    # and turns `brigadier:string` into `brigadier:long`. That reads a
-    # properties byte that is not there and desynchronises the whole tree.
-    start = text.index("entries: &[", start)
-    end = text.index("};", start)
-    names = re.findall(r'"([a-z0-9_.]+:[a-z0-9_./]+)"', text[start:end])
+    names = base.registry_entries("minecraft:command_argument_type")
     if "brigadier:string" not in names:
         raise SystemExit(
-            "COMMAND_ARGUMENT_TYPE in %s has %d entries and no brigadier:string, "
-            "so this read the table wrong" % (REGISTRY_SOURCE, len(names))
+            "minecraft:command_argument_type in %s has %d entries and no "
+            "brigadier:string, so this read the table wrong"
+            % (base.PROTOCOL_JSON, len(names))
         )
     return names
 

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -53,7 +53,6 @@ import importlib.util
 import json
 import math
 import pathlib
-import re
 import struct
 import sys
 import time
@@ -421,21 +420,16 @@ LINGER_WINDOW = 1.5
 # window it is trying to measure and turn a working shield into a failure.
 SHIELD_PROBE_WINDOW = 0.4
 
-ITEM_REGISTRY = ROOT / "crates/hyperion-minecraft-proto/src/generated/registry.rs"
-
 
 def load_item_names():
-    """`minecraft:item` registry ids to names, read from the generated table.
+    """`minecraft:item` registry ids to names, in network-id order.
 
     An item on the wire is a bare registry id, so a transcript without this
     says "the hotbar holds item 903" where the interesting claim is that it
-    holds an iron axe. The table is generated from the same jar the server's
-    ids come from, which is why it is read rather than restated here.
+    holds an iron axe. Read from `protocol.json`, which is the same file the
+    server's own ids are generated from.
     """
-    source = ITEM_REGISTRY.read_text()
-    start = source.index('pub static ITEM: Registry = Registry {')
-    end = source.index('};', start)
-    return re.findall(r'"(minecraft:[a-z0-9_/]+)"', source[start:end])[1:]
+    return base.registry_entries("minecraft:item")
 
 
 def stamp(started):

--- a/tools/smash-selector.py
+++ b/tools/smash-selector.py
@@ -59,7 +59,6 @@ import importlib.util
 import json
 import math
 import pathlib
-import re
 import struct
 import sys
 import time
@@ -86,7 +85,6 @@ mc_string = base.mc_string
 take_nbt_string = match.take_nbt_string
 BlockNames = world.BlockNames
 ROOT = TOOLS.parent
-ENTITY_TYPES = ROOT / "crates/hyperion-minecraft-proto/src/entity_type.rs"
 decode_chunk = world.decode_chunk
 decode_section_blocks_update = world.decode_section_blocks_update
 
@@ -177,18 +175,19 @@ FACE_UP = 1
 
 
 def entity_names():
-    """Registry id to entity name, from the generated table.
+    """Registry id to entity name, in network-id order.
 
     The same trick `smash-map-check.py` uses for blocks, and for the same
     reason: the numbering is Mojang's and restating it here would be a copy
-    that is wrong the next time the jar moves. Reading the table the server
-    encodes from is what makes "that is a creeper" a check rather than a hope.
+    that is wrong the next time the jar moves. Reading what the server encodes
+    from is what makes "that is a creeper" a check rather than a hope.
+
+    From `protocol.json` rather than by regex over the generated Rust. The
+    regex version matched `Self::new("...", n)`, which stopped existing the day
+    entity types became a plain enum, and would have failed here rather than
+    where the change was.
     """
-    pattern = re.compile(r'Self::new\("([^"]+)", (\d+)\)')
-    found = {int(number): name for name, number in pattern.findall(ENTITY_TYPES.read_text())}
-    if not found:
-        raise SystemExit("no entity types found in %s" % ENTITY_TYPES)
-    return found
+    return dict(enumerate(base.registry_entries("minecraft:entity_type")))
 
 
 def stamp(started):


### PR DESCRIPTION
fix(tools): scripted clients read protocol.json, not each other's source

## What broke, and how it got through

#1021 turned `crates/hyperion-minecraft-proto/src/generated/registry.rs` into a
directory. Three Python clients under `tools/` were reading that file as text
and pulling registry names out of it with a regex. They kept "building", passed
every Rust gate, and failed twenty minutes into CI inside four end-to-end
checks:

```
FileNotFoundError: [Errno 2] No such file or directory:
'/nix/store/bavm52as33izbs3kl5zihvszxgskz7lw-source/crates/hyperion-minecraft-proto/src/generated/registry.rs'

enforced checks that failed: completions-e2e smash-e2e smash-hotbar-e2e smash-hud-e2e
```

A path in a Python string is invisible to cargo and to every Rust grep. I
searched for `generated::registry` before landing #1021 and found the Rust
callers; I did not search for `generated/registry.rs`, and nothing made me.

`smash-selector-e2e` is the same bug one merge later: `tools/smash-selector.py`
read `src/entity_type.rs`, which #1024 deleted, with a regex matching
`Self::new("...", n)` — a spelling that stopped existing when entity types
became a plain enum. CI had not reached it yet. Running the whole gate locally
found it:

```
enforced checks that failed: completions-e2e smash-e2e smash-hotbar-e2e smash-hud-e2e smash-selector-e2e
```

## The fix is that they stop reading Rust

Pointing three regexes at three new paths would have restored green and left
the same trap armed. All three now call one reader:

```python
def registry_entries(registry: str) -> list[str]:
    """A vanilla registry's entry names, in network-id order."""
```

in `tools/client-26.2.py`, reading `crates/hyperion-minecraft-proto/protocol.json`
— the same file `build.rs` reads and the same file every generated table comes
out of. `protocol.json` joins the e2e client fileset in `nix/e2e.nix`.

Two bugs went with the scrapers. `completions-check.py` carried a comment
explaining that it had to index from `entries: &[` rather than from the
declaration, because the registry's own name sits in the same table and looks
exactly like an entry — getting it wrong shifted every id by one and turned
`brigadier:string` into `brigadier:long`. `smash-match.py` compensated for the
same thing with a bare `[1:]`. Neither is needed: `entries` in the JSON is the
entries, and the index is the id.

## The gate, because the class outlives the instance

`nix flake check .#tool-paths` fails when any tracked `.py`, `.sh` or `.nix`
file names a repository path that does not exist. Only strings anchored at a
real top-level directory count, and anything containing a format placeholder or
a glob is skipped, so prose is not mistaken for a claim.

It earned itself immediately. Its first run, before I had looked at
`smash-selector.py`, found the bug #1024 had just introduced:

```
4 repository paths named in scripts, 1 of them missing
MISSING tools/smash-selector.py:89  crates/hyperion-minecraft-proto/src/entity_type.rs
```

Broken deliberately as well, by putting the dead path back into
`completions-check.py`:

```
4 repository paths named in scripts, 1 of them missing
MISSING tools/completions-check.py:44  crates/hyperion-minecraft-proto/src/generated/registry.rs

A script names a path this tree does not have. Nothing else catches this: a path in a
string is invisible to cargo and to every Rust grep, so it fails inside whichever gate runs
that script. Either fix the path, or -- better -- stop reaching into another component's
source and read its committed data instead.
```

Restored, and it reports `3 repository paths named in scripts, 0 of them missing`.

This is the cheap half of the fix and it is worth saying which half. It cannot
tell that a regex has stopped matching a file that still exists — only that the
file is gone. What stops the other half is the three clients no longer parsing
Rust at all.

## Gates

| gate | result |
| --- | --- |
| `nix build .#checks.aarch64-darwin.completions-e2e` | rc=0, `RESULT: every completion claim held` |
| `nix build .#checks.aarch64-darwin.tool-paths` | rc=0, 3/3 |
| `nix eval .#checks.aarch64-darwin.flake-gate.drvPath` | rc=0 |
| `cargo fmt --all --check` | rc=0 |
| `flake8` on all five changed scripts | rc=0 for everything this change touched |

`completions-e2e` is the one that was failing and it is the one I ran to
completion. The other four e2e checks share the same reader through
`smash-match.py`'s `load_item_names` and `smash-selector.py`'s `entity_names`,
both of which are exercised by the unit-level check above, but I did not wait
on all five locally -- each compiles the whole server. CI runs them.

Two lint findings in `tools/smash-selector.py` (E301, E302) are pre-existing;
I checked by stashing and re-running. Not fixed here.

---

AI-authored (Claude) under human direction.
