### PR TITLE
fix(smash): drop an unused import the charge tests never needed

### DIFF
--- a/events/smash/tests/abilities.rs
+++ b/events/smash/tests/abilities.rs
@@ -592,7 +592,6 @@ fn an_ultimate_is_granted_for_a_window_and_then_taken_back() {
 mod charge {
     use std::sync::atomic::{AtomicU32, Ordering};
 
-    use flecs_ecs::prelude::*;
     use glam::Vec3;
     use smash::module::{
         ability::{self, Cast, Observable},


### PR DESCRIPTION
`nix run .#lint` on #1023 failed with `unused import: flecs_ecs::prelude` in the charge module added to `tests/abilities.rs`. The module reaches for nothing in the prelude: it drives the ability through `ability::use_slot` and reads the result out of an atomic.

Worth recording why it reached main: `cargo clippy -p smash --all-targets` was green locally, twice, including after the rebase. The repo lint is not that command, and the difference is what caught this. Running `nix run .#lint` before pushing is the habit; a local clippy is not a substitute for it.

`nix run --accept-flake-config .#lint` is green on this branch, and `cargo test -p smash --test abilities` still passes.