### PR TITLE
fix(bedwars): a bow that shoots at the speed a real one does

### DIFF
--- a/crates/hyperion-inventory/src/lib.rs
+++ b/crates/hyperion-inventory/src/lib.rs
@@ -274,14 +274,22 @@ impl Inventory {
         Ok(())
     }
 
+    /// The stack in the player's hand.
+    ///
+    /// Named `get_cursor` until it caught someone out: in Minecraft the cursor
+    /// is the stack you are dragging on the mouse inside an open container,
+    /// which is a different thing that this type does not model at all. This
+    /// has only ever returned `self.get(self.hand_slot)`, the held hotbar item.
     #[must_use]
-    pub fn get_cursor(&self) -> &ItemSlot {
+    pub fn held(&self) -> &ItemSlot {
         self.get(self.hand_slot)
             .expect("hand_slot is a valid index")
     }
 
+    /// Which slot the player's hand rests on, numbered over the whole
+    /// inventory rather than over the nine visible keys.
     #[must_use]
-    pub const fn get_cursor_index(&self) -> u16 {
+    pub const fn held_slot(&self) -> u16 {
         self.hand_slot
     }
 

--- a/crates/hyperion-item/src/lib.rs
+++ b/crates/hyperion-item/src/lib.rs
@@ -31,7 +31,7 @@ impl Module for ItemModule {
                     let world = query.world;
                     let inventory = &mut *query.inventory;
 
-                    let stack = &inventory.get_cursor().stack;
+                    let stack = &inventory.held().stack;
 
                     if stack.is_empty() {
                         return Ok(());

--- a/crates/hyperion/src/simulation/handlers.rs
+++ b/crates/hyperion/src/simulation/handlers.rs
@@ -499,7 +499,7 @@ fn player_action(body: &[u8], query: &mut PacketSwitchQuery<'_>) -> anyhow::Resu
         player_action::Action::ReleaseUseItem => {
             let event = event::ReleaseUseItem {
                 from: query.id,
-                item: query.inventory.get_cursor().stack.item,
+                item: query.inventory.held().stack.item,
             };
 
             query.id.entity_view(query.world).set(HandStates::new(0));
@@ -599,10 +599,10 @@ fn use_item(body: &[u8], query: &mut PacketSwitchQuery<'_>) -> anyhow::Result<()
     let packet: c2s::UseItem = decode_body(body)?;
     let hand = hand(packet.hand);
 
-    let cursor = &query.inventory.get_cursor().stack;
+    let held = &query.inventory.held().stack;
 
-    if !cursor.is_empty() {
-        if cursor.item == ItemKind::WrittenBook {
+    if !held.is_empty() {
+        if held.item == ItemKind::WrittenBook {
             send(
                 query.compose,
                 query.io_ref,
@@ -685,7 +685,7 @@ fn use_item_on(body: &[u8], query: &mut PacketSwitchQuery<'_>) -> anyhow::Result
     }
 
     // Attempt to place a block
-    let held = &query.inventory.get_cursor().stack;
+    let held = &query.inventory.held().stack;
 
     if held.is_empty() {
         return Ok(());

--- a/crates/hyperion/src/simulation/inventory.rs
+++ b/crates/hyperion/src/simulation/inventory.rs
@@ -186,7 +186,7 @@ impl Module for InventoryModule {
                 // and armour. The wearer is excluded because their own copy is
                 // already right; the slot packets below are what correct it.
                 let mut equipment: Vec<(EquipmentSlot, Slot<'_>)> = Vec::new();
-                let hand_slot = inventory.get_cursor_index();
+                let hand_slot = inventory.held_slot();
                 for (idx, slot) in inventory.slots_mut().iter_mut().enumerate() {
                     if !slot.changed {
                         continue;

--- a/events/bedwars/src/module/attack.rs
+++ b/events/bedwars/src/module/attack.rs
@@ -493,7 +493,7 @@ const fn calculate_toughness(item: &ItemStack) -> f32 {
 
 // TODO: split this up into separate functions
 fn calculate_stats(inventory: &PlayerInventory, critical_hit: bool) -> CombatStats {
-    let hand = inventory.get_cursor();
+    let hand = inventory.held();
     let multiplier = if critical_hit { 1.5 } else { 1.0 };
     let damage = calculate_damage(&hand.stack) * multiplier;
     let armor = calculate_armor(&inventory.get_helmet().stack)

--- a/events/bedwars/src/module/bow.rs
+++ b/events/bedwars/src/module/bow.rs
@@ -11,13 +11,50 @@ use hyperion::{
     simulation::{
         Owner, Pitch, Player, Position, Spawn, Uuid, Velocity, Yaw,
         entity_kind::EntityKind,
-        event, get_direction_from_rotation,
+        event::{self, ClientStatusCommand, ClientStatusEvent},
+        get_direction_from_rotation,
+        handlers::PacketSwitchQuery,
         metadata::living_entity::{ArrowsInEntity, HandStates},
+        packet::HandlerRegistry,
     },
     storage::{EventQueue, Events},
 };
 use hyperion_inventory::PlayerInventory;
 use tracing::debug;
+
+// The three numbers below and the curve in `BowCharging::get_charge` are all
+// transcribed from one place:
+//
+//   net.minecraft.world.item.BowItem#getPowerForTime(int)
+//   net.minecraft.world.item.BowItem#releaseUsing(ItemStack, Level, LivingEntity, int)
+//
+// Written down here rather than generated, because unlike a registry or a
+// packet layout this is a method *body* and nothing in the toolchain reads
+// those yet. That makes the citation the only thing standing between this and
+// a silent drift on the next version bump, so it names the class and the exact
+// signature: the point is that a reader can open the decompiled source and
+// check the transcription rather than trust it.
+
+/// Ticks in a second, for turning an elapsed `Duration` into vanilla's unit.
+const TICKS_PER_SECOND: f32 = 20.0;
+
+/// Ticks of holding that count as a full draw.
+///
+/// `getPowerForTime` divides the charge by 20 and caps the result at 1.0, so a
+/// bow reaches full power one second after it is nocked. The same number as
+/// [`TICKS_PER_SECOND`] and a different quantity: one is how fast the clock
+/// runs, the other is how long the bow takes, and vanilla is free to change
+/// either without the other.
+const FULL_DRAW_TICKS: f32 = 20.0;
+
+/// Blocks per tick a fully drawn bow gives its arrow.
+///
+/// `releaseUsing` passes `f * 3.0` to `AbstractArrow#shootFromRotation`, where
+/// `f` is the fraction [`BowCharging::get_charge`] returns. This is the 3.0,
+/// and it is the same number
+/// `crates/hyperion/tests/differential/scenarios/arrow-level-shot.json` records
+/// a vanilla shot at.
+const MAX_ARROW_SPEED: f32 = 3.0;
 
 #[derive(Component)]
 pub struct BowModule;
@@ -57,8 +94,8 @@ pub struct BowCharging {
 }
 
 // Same reason as LastFireTime: it is a (flecs::With, _) target. Unlike
-// LastFireTime the epoch is the wrong default here -- `get_charge` clamps
-// elapsed time to 1.2s, so a player who never drew the bow would release a
+// LastFireTime the epoch is the wrong default here -- `get_charge` saturates a
+// second after the bow is nocked, so a player who never drew it would release a
 // full-power shot. "Started charging now" is the minimum charge.
 impl Default for BowCharging {
     fn default() -> Self {
@@ -74,15 +111,30 @@ impl BowCharging {
         }
     }
 
+    /// How far the bow is drawn, as a fraction of a full draw.
+    ///
+    /// This is `getPowerForTime` and nothing else: the draw is counted in
+    /// ticks, the curve is quadratic, and it saturates at 20 of them. So a full
+    /// draw is one second, not the 1.2 this clamped to before, and because the
+    /// result is a fraction the caller's `* 3.0` lands on exactly vanilla's
+    /// maximum arrow speed.
+    ///
+    /// What it used to return was *seconds*, clamped to 1.2, which that same
+    /// multiply turned into 3.6 blocks a tick -- a fifth faster than a real bow
+    /// can shoot -- under a comment claiming 3.0 was the maximum.
     #[must_use]
+    #[expect(
+        clippy::suboptimal_flops,
+        reason = "mul_add is a fused multiply-add: one rounding where Java does \
+                  two. getPowerForTime evaluates `(f * f + f * 2.0F) / 3.0F` as \
+                  separate float operations, and this file exists to give the \
+                  same answer it does, so the two roundings are the behaviour \
+                  rather than an oversight"
+    )]
     pub fn get_charge(&self) -> f32 {
         let elapsed = self.start_time.elapsed().unwrap_or(Duration::ZERO);
-        let secs = elapsed.as_secs_f32();
-        // Minecraft bow charge mechanics:
-        // - Takes 1.2 second to fully charge
-        // - Minimum charge is 0.000001
-        // - Maximum charge is 1.0
-        secs.clamp(0.01, 1.2)
+        let f = elapsed.as_secs_f32() * TICKS_PER_SECOND / FULL_DRAW_TICKS;
+        ((f * f + f * 2.0) / 3.0).min(1.0)
     }
 }
 
@@ -110,8 +162,7 @@ impl Module for BowModule {
                     .entity
                     .entity_view(world)
                     .get::<&PlayerInventory>(|inventory| {
-                        let cursor = inventory.get_cursor();
-                        if cursor.stack.item != ItemKind::Bow {
+                        if inventory.held().stack.item != ItemKind::Bow {
                             return;
                         }
 
@@ -187,8 +238,7 @@ impl Module for BowModule {
 
                         // Calculate the direction vector from the player's rotation
                         let direction = get_direction_from_rotation(**yaw, **pitch);
-                        // Calculate the velocity of the arrow based on the charge (3.0 is max velocity)
-                        let velocity = direction * (charge * 3.0);
+                        let velocity = direction * (charge * MAX_ARROW_SPEED);
 
                         let spawn_pos =
                             Vec3::new(position.x, position.y + 1.62, position.z) + direction * 0.5;
@@ -228,7 +278,24 @@ impl Module for BowModule {
                         (velocity.0.length() * 2.0, owner.entity)
                     });
 
-                if damage == 0.0 && owner == event.client {
+                // Two separate refusals, and they were one `&&` before, which
+                // meant an arrow was only ever ignored when it was both
+                // stationary *and* the victim's own -- so a player's own moving
+                // arrow damaged them, and any arrow at rest still counted as a
+                // hit against everybody else.
+                //
+                // An arrow that has stopped has already been pinned into a
+                // block by `arrow_block_hit`, and a stuck arrow is scenery.
+                if damage == 0.0 {
+                    continue;
+                }
+
+                // Vanilla gives an arrow a few ticks of immunity to its own
+                // shooter, because it spawns 0.5 blocks in front of the eyes and
+                // would otherwise clip the hitbox it came out of on tick one.
+                // Nothing here integrates that grace period, so the owner is
+                // simply never a valid target.
+                if owner == event.client {
                     continue;
                 }
 
@@ -274,6 +341,38 @@ impl Module for BowModule {
                         **position = event.collision.point;
                     });
             }
+        });
+
+        // Arrows stuck in a player are cosmetic, and until now they were
+        // permanent: `arrow_entity_hit` only ever incremented this, so a player
+        // who took six arrows over a match wore all six for the rest of it and
+        // through every respawn after. Vanilla bleeds them off over time and
+        // clears them outright on respawn; this does the clearing, which is the
+        // half that stops the count growing without bound.
+        //
+        // A `HandlerRegistry` handler and not a system on
+        // `EventQueue<ClientStatusEvent>`, because `EventQueue::drain` is
+        // destructive and single-consumer: a second drain of that queue would
+        // race `attack.rs` for the same events and one of the two would
+        // silently stop seeing respawns. The registry fans every handler out
+        // over the same value instead.
+        world.get::<&mut HandlerRegistry>(|registry| {
+            registry.add_handler(Box::new(
+                |status: &ClientStatusEvent, query: &mut PacketSwitchQuery<'_>| {
+                    if status.status == ClientStatusCommand::RequestStats {
+                        return Ok(());
+                    }
+
+                    status
+                        .client
+                        .entity_view(query.world)
+                        .get::<&mut ArrowsInEntity>(|arrows| {
+                            arrows.0 = 0;
+                        });
+
+                    Ok(())
+                },
+            ));
         });
     }
 }

--- a/events/smash/src/input.rs
+++ b/events/smash/src/input.rs
@@ -230,7 +230,7 @@ impl Module for InputModule {
 
 /// Which of the nine hotbar slots the player is holding.
 fn held_slot(player: EntityView<'_>) -> Option<u8> {
-    hotbar_slot(player.try_get::<&PlayerInventory>(PlayerInventory::get_cursor_index)?)
+    hotbar_slot(player.try_get::<&PlayerInventory>(PlayerInventory::held_slot)?)
 }
 
 /// The hotbar slot an inventory cursor index names, if it names one at all.

--- a/events/smash/src/mirror.rs
+++ b/events/smash/src/mirror.rs
@@ -64,7 +64,7 @@ impl Module for MirrorModule {
                     // rather than resetting to zero: the alternative reads as
                     // "you are holding slot 0" and would put slot 0's cooldown
                     // on the experience bar of somebody holding nothing.
-                    if let Some(slot) = hotbar_slot(inventory.get_cursor_index()) {
+                    if let Some(slot) = hotbar_slot(inventory.held_slot()) {
                         selected.0 = slot;
                     }
                 },

--- a/flake.nix
+++ b/flake.nix
@@ -381,6 +381,7 @@
             completions-e2e = 6000;
             smash-hotbar-e2e = 7000;
             smash-hud-e2e = 8000;
+            bedwars-bow-e2e = 9000;
           };
 
           # The lobby `smash-e2e` runs against, which is deliberately not the
@@ -821,6 +822,34 @@
                 export HYPERION_E2E_CLIENT=tools/hud-check.py
                 export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.smash-hud-e2e)}}"
                 export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.smash-hud-e2e)}}"
+                exec "${lib.getExe runners.e2e}" "$@"
+              '';
+            };
+
+            # The bow, on bedwars, read off the wire by the client that fired it.
+            #
+            # The only gate here that is not a smash gate, because the bow is
+            # not a smash feature: Super Smash Mobs hands a Skeleton a bow as
+            # the *icon* for a charged ability, and `smash-e2e` already proves
+            # that path. This is the vanilla weapon -- nock, spend an arrow,
+            # launch it at a speed the draw decides -- which only bedwars has,
+            # and bedwars is what `nix run .#dev` and `packages.default` build.
+            #
+            # It asserts the launch velocity out of `ClientboundAddEntity`
+            # rather than watching where the arrow lands, because since 26.2
+            # that packet carries the velocity and a number is a far sharper
+            # claim than a trajectory. The bug it was written for shipped a
+            # fully drawn bow at 3.6 blocks a tick instead of 3.0 and no gate
+            # noticed, because no gate looked.
+            bedwars-bow-e2e = {
+              deps = [
+                pkgs.git
+                pkgs.python3
+              ];
+              text = ''
+                export HYPERION_E2E_CLIENT=tools/bow-check.py
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.bedwars-bow-e2e)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.bedwars-bow-e2e)}}"
                 exec "${lib.getExe runners.e2e}" "$@"
               '';
             };

--- a/tools/bow-check.py
+++ b/tools/bow-check.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""What a bow does, read off the wire by the client that fired it.
+
+The bow had a working charge, a working cooldown and a working arrow, and no
+gate that would notice if any of them stopped. Everything below is a claim a
+client can check for itself, because everything below arrives as a packet.
+
+  * `/bow` puts a real `minecraft:bow` and real `minecraft:arrow`s on the bar,
+    which is what proves the item the command grants and the `ItemKind::Bow`
+    the module compares against are the same thing
+  * releasing a drawn bow spawns an entity of type `minecraft:arrow` and the
+    shooter is told about it, in a `ClientboundAddEntity`
+  * that packet carries the launch velocity, so the charge curve is readable
+    directly rather than inferred from where the arrow lands
+  * a full draw launches at exactly 3.0 blocks a tick
+  * a longer draw launches faster than a shorter one
+  * an arrow that hits a block stops
+  * a second release inside the 150 ms cooldown launches nothing
+  * firing spends one arrow
+
+What it does not pin, deliberately: the absolute speed of a *partial* draw.
+An earlier version checked one against vanilla's curve and it was dropped,
+because at a quarter draw the quadratic and the linear bug it was meant to
+catch are 0.2 blocks a tick apart while the script's own scheduling moves the
+answer by more than that. It passed with the bug present, which is the
+definition of a check that is not one. The saturated draw is the discriminating
+assertion and it is exact: `min(f, 1)` means any hold past a second is 1.0,
+so the expected speed is 3.0 with no dependence on timing at all.
+
+Two of the three bugs this shipped alongside are not covered here either. A
+self-hit needs an arrow that comes back to its shooter, and `ArrowsInEntity`
+is entity metadata that only another client can see, so both want a second
+connection this gate does not open.
+
+The velocity assertion is the one this file was written for. `get_charge`
+returned *seconds* clamped to 1.2 and the caller multiplied by 3.0, so a fully
+drawn bow fired at 3.6 blocks a tick -- a fifth faster than vanilla can -- under
+a comment claiming 3.0 was the maximum. Nothing caught it because nothing looked
+at the number. A full draw is the right thing to assert on because vanilla's
+curve saturates: `min(f, 1)` means any hold past one second gives exactly 1.0,
+so the expected speed is 3.0 with no dependence on how precisely this script
+sleeps.
+
+Exits non-zero on the first thing that is not true, after printing what it saw.
+"""
+
+import argparse
+import importlib.util
+import pathlib
+import struct
+import sys
+import time
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+
+
+def _load(name, filename):
+    """Import a sibling tool whose file name is not a Python identifier."""
+    spec = importlib.util.spec_from_file_location(name, TOOLS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+match = _load("smash_match", "smash-match.py")
+base = match.base
+
+take_var_int = base.take_var_int
+var_int = base.var_int
+
+S2C_ADD_ENTITY = 0x01
+
+# `PlayerInventory::HOTBAR_START_SLOT`: `ClientboundContainerSetSlot` numbers
+# the whole inventory, and the nine keys a player can see begin here.
+HOTBAR_START_SLOT = match.HOTBAR_START_SLOT
+
+# `BowItem.releaseUsing` passes `f * 3.0` to `shootFromRotation`. Kept here as
+# the number the *test* expects, deliberately not imported from anywhere, so
+# that changing the constant in Rust cannot also change what proves it.
+MAX_ARROW_SPEED = 3.0
+
+# `LastFireTime::can_fire`, in seconds.
+FIRE_COOLDOWN = 0.150
+
+
+def entity_type_id(name):
+    """The network id of `name` in `minecraft:entity_type`.
+
+    `base.registry_entries` reads `protocol.json`, where the ids are the
+    indices. This file used to scrape the generated Rust instead, which cost it
+    a wrong answer on its very first run: the regex also matched the registry's
+    own `name` field, so every id came out one too high and the gate looked for
+    an arrow of type 7 while the server sent type 6.
+    """
+    entries = base.registry_entries("minecraft:entity_type")
+    if name not in entries:
+        raise SystemExit(
+            "%s is not in minecraft:entity_type, which has %d entries, so this "
+            "gate cannot tell an arrow from any other entity."
+            % (name, len(entries))
+        )
+    return entries.index(name)
+
+
+class Archer(match.MatchClient):
+    """A scripted player that remembers every entity it was told about."""
+
+    def __init__(self, host, port, name, started):
+        super().__init__(host, port, name, started)
+        # Every AddEntity this client received, as dicts.
+        self.spawned = []
+        self.slots = {}
+
+    def absorb(self, packet_id, payload):
+        if packet_id == match.S2C_LOGIN:
+            self.entity_id = struct.unpack(">i", payload[:4])[0]
+            self.joined = True
+            self.log("** in the world ** entity_id=%d" % self.entity_id)
+        elif packet_id == match.S2C_PLAYER_POSITION:
+            teleport_id, offset = take_var_int(payload)
+            x, y, z = struct.unpack(">ddd", payload[offset : offset + 24])
+            self.position = (x, y, z)
+            self.send(match.C2S_ACCEPT_TELEPORTATION, var_int(teleport_id))
+            self.log("<- teleported to (%.1f, %.1f, %.1f)" % (x, y, z))
+        elif packet_id == match.S2C_KEEP_ALIVE:
+            self.send(match.C2S_KEEP_ALIVE, payload[:8])
+        elif packet_id == S2C_ADD_ENTITY:
+            self.absorb_add_entity(payload)
+        elif packet_id == match.S2C_CONTAINER_SET_SLOT:
+            self.absorb_slot(payload)
+        elif packet_id == match.S2C_SYSTEM_CHAT:
+            text, _ = match.take_nbt_string(payload, 0)
+            self.log("<- chat: %s" % text)
+        elif packet_id == match.S2C_DISCONNECT:
+            text, _ = match.take_nbt_string(payload, 0)
+            self.log("<- DISCONNECTED: %s" % text)
+            self.alive = False
+
+    def absorb_add_entity(self, payload):
+        """`ClientboundAddEntityPacket#STREAM_CODEC`, field for field.
+
+        Since 26.2 this packet carries the entity's velocity itself, through
+        the same packed codec `set_entity_motion` uses, which is the whole
+        reason a launch speed is checkable from a client at all.
+        """
+        entity_id, offset = take_var_int(payload)
+        offset += 16  # uuid
+        type_id, offset = take_var_int(payload, offset)
+        x, y, z = struct.unpack(">ddd", payload[offset : offset + 24])
+        offset += 24
+        motion, offset = match.take_lp_vec3(payload, offset)
+        speed = (motion[0] ** 2 + motion[1] ** 2 + motion[2] ** 2) ** 0.5
+        entry = {
+            "id": entity_id,
+            "type": type_id,
+            "position": (x, y, z),
+            "motion": motion,
+            "speed": speed,
+        }
+        self.spawned.append(entry)
+        self.log(
+            "<- AddEntity id=%d type=%d at (%.2f, %.2f, %.2f) motion=(%.3f, "
+            "%.3f, %.3f) |v|=%.3f"
+            % ((entity_id, type_id, x, y, z) + motion + (speed,))
+        )
+
+    def absorb_slot(self, payload):
+        _container, offset = take_var_int(payload)
+        _state, offset = take_var_int(payload, offset)
+        (slot,) = struct.unpack(">h", payload[offset : offset + 2])
+        offset += 2
+        count, offset = take_var_int(payload, offset)
+        if count <= 0:
+            self.slots.pop(slot, None)
+            return
+        item_id, offset = take_var_int(payload, offset)
+        name = ITEMS[item_id] if item_id < len(ITEMS) else "<%d>" % item_id
+        self.slots[slot] = (name, count)
+        self.log("<- slot %d now holds %d x %s" % (slot, count, name))
+
+    def hotbar_slot_of(self, item):
+        """The visible key holding `item`, or None."""
+        for slot, (name, _count) in sorted(self.slots.items()):
+            key = slot - HOTBAR_START_SLOT
+            if name == item and 0 <= key < 9:
+                return key
+        return None
+
+    def count_of(self, item):
+        return sum(count for name, count in self.slots.values() if name == item)
+
+
+ITEMS = match.load_item_names()
+
+
+def pump(client, seconds):
+    """Read the socket for a while, keeping the connection alive."""
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if not client.alive:
+            return
+        for packet_id, payload in client.drain():
+            client.absorb(packet_id, payload)
+        if client.joined:
+            client.repeat_position()
+        time.sleep(0.01)
+
+
+def wait_until(client, predicate, seconds, what):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        pump(client, 0.05)
+        if predicate():
+            return True
+    print("TIMEOUT waiting for %s" % what, file=sys.stderr)
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=25565)
+    parser.add_argument("--name", default="Archer")
+    args = parser.parse_args()
+
+    started = time.time()
+    failures = []
+
+    def check(ok, message):
+        print("%s %s" % ("PASS" if ok else "FAIL", message), flush=True)
+        if not ok:
+            failures.append(message)
+
+    arrow_type = entity_type_id("minecraft:arrow")
+    print("minecraft:arrow is entity type %d" % arrow_type, flush=True)
+
+    client = Archer(args.host, args.port, args.name, started)
+    client.handshake(args.host, args.port, 2)
+    client.login()
+    client.configuration()
+    client.enter_play()
+
+    if not wait_until(client, lambda: client.joined, 30.0, "the world"):
+        return 1
+    pump(client, 1.0)
+
+    # --- the bow itself ------------------------------------------------
+
+    client.command("bow")
+    wait_until(
+        client,
+        lambda: client.hotbar_slot_of("minecraft:bow") is not None,
+        10.0,
+        "a bow on the bar",
+    )
+    bow_slot = client.hotbar_slot_of("minecraft:bow")
+    arrows = client.count_of("minecraft:arrow")
+    check(
+        bow_slot is not None,
+        "/bow puts a minecraft:bow on a visible key (key %s)" % bow_slot,
+    )
+    check(
+        arrows > 0,
+        "/bow puts minecraft:arrow in the inventory (%d of them)" % arrows,
+    )
+    if bow_slot is None:
+        print("RESULT: failure (no bow to draw)", flush=True)
+        return 1
+
+    def arrows_seen():
+        """Every distinct arrow entity, as (launch, latest).
+
+        One arrow shows up in more than one `AddEntity`: the launch, and then
+        another when `arrow_block_hit` pins it into whatever it ran into. They
+        share an entity id, so the id is what counts an arrow and the order
+        gives the before and after.
+        """
+        out = {}
+        for entry in client.spawned:
+            if entry["type"] != arrow_type:
+                continue
+            if entry["id"] in out:
+                out[entry["id"]][1] = entry
+            else:
+                out[entry["id"]] = [entry, entry]
+        return list(out.values())
+
+    def draw(seconds, note):
+        """Nock, hold for `seconds`, release. Returns the arrows that flew."""
+        client.spawned.clear()
+        client.use_slot(bow_slot, "(nock)")
+        pump(client, seconds)
+        client.release_slot(bow_slot, note)
+        pump(client, 1.0)
+        return arrows_seen()
+
+    # --- a full draw ---------------------------------------------------
+
+    before = client.count_of("minecraft:arrow")
+    full = draw(1.5, "(full draw)")
+    check(
+        len(full) == 1,
+        "a full draw spawns exactly one minecraft:arrow the client is told "
+        "about (got %d)" % len(full),
+    )
+    if not full:
+        print("RESULT: failure (nothing was fired)", flush=True)
+        return 1
+
+    launch, latest = full[0]
+    speed = launch["speed"]
+    check(
+        abs(speed - MAX_ARROW_SPEED) < 0.05,
+        "a full draw launches at vanilla's %.1f blocks a tick, not the 3.6 the "
+        "old seconds-as-charge produced (got %.3f)" % (MAX_ARROW_SPEED, speed),
+    )
+
+    # `arrow_block_hit` zeroes the velocity and pins the arrow at the collision
+    # point, and the client is told again. Free to assert here because the
+    # world bedwars loads has something to hit in every direction.
+    check(
+        latest is not launch and latest["speed"] == 0.0,
+        "an arrow that hits a block stops: it was re-sent at (%.2f, %.2f, "
+        "%.2f) with |v|=%.3f"
+        % (latest["position"] + (latest["speed"],)),
+    )
+
+    pump(client, 0.5)
+    after = client.count_of("minecraft:arrow")
+    check(
+        after == before - 1,
+        "firing spends exactly one arrow (%d -> %d)" % (before, after),
+    )
+
+    # --- a shorter draw ------------------------------------------------
+
+    pump(client, 0.5)
+    short = draw(0.25, "(quarter draw)")
+    check(
+        len(short) == 1,
+        "a short draw still fires (got %d arrows)" % len(short),
+    )
+    if short:
+        short_speed = short[0][0]["speed"]
+        check(
+            short_speed < speed,
+            "a shorter draw launches slower than a full one (%.3f < %.3f)"
+            % (short_speed, speed),
+        )
+
+    # --- the cooldown --------------------------------------------------
+
+    pump(client, 0.5)
+    client.spawned.clear()
+    client.use_slot(bow_slot, "(nock, first of two)")
+    pump(client, 1.2)
+    client.release_slot(bow_slot, "(first release)")
+    # Deliberately inside `LastFireTime::can_fire`'s 150 ms window.
+    time.sleep(FIRE_COOLDOWN / 3.0)
+    client.release_slot(bow_slot, "(second release, inside the cooldown)")
+    pump(client, 1.0)
+    burst = arrows_seen()
+    check(
+        len(burst) == 1,
+        "two releases %d ms apart fire once, not twice (got %d arrows)"
+        % (int(FIRE_COOLDOWN / 3.0 * 1000), len(burst)),
+    )
+
+    print(
+        "RESULT: %s (%d checks failed)"
+        % ("ok" if not failures else "failure", len(failures)),
+        flush=True,
+    )
+    for failure in failures:
+        print("  failed: %s" % failure, file=sys.stderr)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A fully drawn bow in bedwars fired at **3.6 blocks a tick**. Vanilla's maximum is 3.0, and the comment next to the multiply said 3.0, but `get_charge` returned *seconds* clamped to 1.2 and the caller multiplied that by 3.0. The arrow flew, it hit things, and it was a fifth too fast for as long as the module has existed, because nothing ever looked at the number.

This fixes that and two other bugs in the same file, and adds the gate that would have caught all of it.

## Where the bow actually was

The brief I started from was that the bow "does nothing" because `BowModule` is never imported into smash. That turned out to be wrong, and the measurement is worth recording because it changed the whole shape of the work.

`nix run .#smash-e2e`, unmodified `e4bbcc2`, real clients:

```
0.89s  PROVED kits equipped: P1 0:minecraft:bow, 1:minecraft:iron_axe, 2:minecraft:arrow
1.83s  [P1] -> right-click hotbar slot 0 (Barrage)
4.27s  [P1] -> release hotbar slot 0 (Barrage, fully charged)
4.27s  [P2] <- sound minecraft:entity.arrow.shoot at (6.0, 65.0, -11.0)
4.33s  [P1] <- knockback on P2: (-1.758, 1.788, 2.906) |v| = 3.839 blocks/tick
4.34s  [P2] <- health 16.64/20 ... 13.28/20 ... 9.92/20
```

The bow in Super Smash Mobs is the **icon for a charged ability**, not a weapon. `events/smash/src/input.rs` routes `ItemInteract` and `ReleaseUseItem` to `ability::use_slot` / `ability::release_slot`, and smash runs its own projectile integrator with its own `Position` type. `ItemKind::Bow` is never on that path.

**Importing `BowModule` into smash would have broken the game.** `EventQueue::drain()` is destructive and single-consumer; `BowModule`'s release handler is `PreUpdate` and smash's is the default `OnUpdate`, so the bow would have eaten `ReleaseUseItem` first and every charged ability in the game would have silently stopped firing. So the module stays in bedwars, which is the only game that wants a bow you nock and spend arrows from — and which is `packages.default` and what `nix run .#dev` builds, so all three bugs were live in the default deployment.

## The three fixes

**The charge curve.** `get_charge` is now `BowItem.getPowerForTime` and nothing else: ticks over 20, quadratic, saturating at one second. It returns a fraction, so the caller's `* 3.0` lands on vanilla's actual maximum. `FULL_DRAW_TICKS` and `MAX_ARROW_SPEED` have names now.

**A self-hit that wasn't.** `if damage == 0.0 && owner == event.client` refused a hit only when the arrow was both stationary *and* the victim's own, so your own moving arrow damaged you, and a stuck arrow still counted against everyone else. Two independent refusals wearing one `&&`; now two `if`s.

**`ArrowsInEntity` grew without bound.** Incremented in `bow.rs` and decremented nowhere in the tree — a player wore every arrow they had ever taken, through every respawn. Now cleared on respawn from a `HandlerRegistry` handler rather than a second drain of `EventQueue<ClientStatusEvent>`, since that queue is single-consumer and `attack.rs` already owns it.

**Plus a rename.** `PlayerInventory::get_cursor` is `held`, `get_cursor_index` is `held_slot`. In Minecraft the cursor is the stack on the mouse inside an open container; this has only ever returned `self.get(self.hand_slot)`. The old name already sent one reader down the wrong path this week.

## The gate

`nix run .#bedwars-bow-e2e` drives a real client and reads the launch velocity out of `ClientboundAddEntity` — since 26.2 that packet carries the velocity, so the charge curve is a number on the wire rather than something inferred from a trajectory.

```
PASS /bow puts a minecraft:bow on a visible key (key 0)
PASS /bow puts minecraft:arrow in the inventory (64 of them)
PASS a full draw spawns exactly one minecraft:arrow the client is told about (got 1)
PASS a full draw launches at vanilla's 3.0 blocks a tick, not the 3.6 the old seconds-as-charge produced (got 3.000)
PASS an arrow that hits a block stops: it was re-sent at (12.50, 4.00, 40.00) with |v|=0.000
PASS firing spends exactly one arrow (64 -> 63)
PASS a short draw still fires (got 1 arrows)
PASS a shorter draw launches slower than a full one (0.697 < 3.000)
PASS two releases 49 ms apart fire once, not twice (got 1 arrows)
RESULT: ok (0 checks failed)
```

## Every guard broken, and what it said

**The charge curve** — reverted `get_charge` to the original seconds-clamp:

```
<- AddEntity id=1018 type=6 motion=(0.000, 0.000, 3.600) |v|=3.600
FAIL a full draw launches at vanilla's 3.0 blocks a tick, not the 3.6 the old
     seconds-as-charge produced (got 3.600)
RESULT: failure (1 checks failed)    rc=1
```

**The cooldown, the block stop and the arrow spend**, broken together so their messages could not be confused:

```
FAIL an arrow that hits a block stops: it was re-sent at (15.50, 4.00, 8.00) with |v|=3.000
FAIL firing spends exactly one arrow (64 -> 64)
FAIL two releases 49 ms apart fire once, not twice (got 2 arrows)
RESULT: failure (3 checks failed)    rc=1
```

The double-fire is visible in the transcript as two distinct entity ids where there should be one:

```
8.01s <- AddEntity id=1020 type=6 motion=(0.000, 0.000, 3.000)
8.07s <- AddEntity id=1021 type=6 motion=(0.000, 0.000, 3.000)
```

**The gate also caught its own bug on its first run.** The entity-type id was scraped out of the generated Rust with a regex that also matched the registry's own `name` field, so every id came out one too high and it looked for an arrow of type 7 while the server sent type 6. It now uses `base.registry_entries`, which #1028 added for exactly this reason and whose docstring describes the same off-by-one.

## What this does not cover, and why

The **self-hit** and **`ArrowsInEntity`** fixes are not covered by the gate. A self-hit needs an arrow that comes back to its shooter; `ArrowsInEntity` is entity metadata only another client can see. Both want a second connection this gate does not open. They were found by reading and are argued in the commit message, not proven on the wire.

An earlier version also checked a **partial** draw against vanilla's curve. I deleted it: it *passed* during the fire drill with the bug present. At a quarter draw the quadratic and the linear bug are 0.2 blocks a tick apart while the script's own scheduling moves the answer by more than that. The saturated full draw is the discriminating assertion, and it is exact — `min(f, 1)` means any hold past a second is 1.0, so 3.0 is expected with no timing dependence at all.

## One note on the differential scenario

`crates/hyperion/tests/differential/scenarios/arrow-level-shot.json` fires at `"power": 3.0` and passes, before and after this change. It does **not** constrain the launch: `differential.rs:202` reads the starting velocity out of the recorded vanilla trace, and `power` is an input to the Java recorder only. So the scenario validates the flight integrator, not the bow. Worth knowing, because a reader seeing `"power": 3.0` next to a launch that produced 3.6 would reasonably assume one bounded the other.

## Checks

- `nix run .#bedwars-bow-e2e` — green, 9 assertions, `rc=0`
- `nix run .#lint` — `rc=0`
- `cargo test --workspace` — 112 test targets, all ok, `rc=0`, including `differential::scenarios_match_vanilla`
- `nix run .#e2e` (the bedwars gate this shares a runner with) — green, `rc=0`
