### PR TITLE
feat(smash): an ultimate is twenty seconds, not one frame

### DIFF
--- a/events/smash/src/module/ability.rs
+++ b/events/smash/src/module/ability.rs
@@ -74,6 +74,8 @@ pub struct Description(pub &'static str);
 /// - [`Self::BuffsMelee`] is the same melee swing hurting more than it did
 /// - [`Self::AfflictsTarget`] is a *second* `ClientboundSetHealth` for the
 ///   victim, on a later tick, with nothing cast in between
+/// - [`Self::Sustains`] is any of those arriving again, later, with nothing
+///   pressed in between
 /// - [`Self::ShieldsCaster`] is the absence of one: a hit lands on the caster
 ///   during the window and no `ClientboundSetHealth` follows it, and the same
 ///   hit after the window does
@@ -100,11 +102,31 @@ pub enum Observable {
     /// ability that declares it and merely hits hard fails the gate, because
     /// the gate stops casting and watches.
     AfflictsTarget,
+    /// The ability goes on acting after the cast, because it left a mode on the
+    /// caster rather than doing one thing.
+    ///
+    /// What a Smash Crystal grants. The wiki gives every ultimate as a
+    /// duration -- "lasts 20 seconds", "unlimited flight and eggs", "call
+    /// lightning down once a second" -- and fourteen of the fifteen were a
+    /// single frame. Distinct from [`Self::AfflictsTarget`], which is something
+    /// left on the *victim*: this is something left on the caster, and it is
+    /// proved by the world going on changing -- more damage, more motion --
+    /// through a window in which nothing at all is pressed.
+    Sustains,
     /// The caster cannot be hurt for a window.
     ///
-    /// Proved by hitting them and finding no health lost, and then waiting the
-    /// window out and hitting them again to find some -- because "no damage"
-    /// on its own is also what a broken damage pipeline looks like.
+    /// Proved by the *same hit* landing before the cast and being refused after
+    /// it. Both halves are needed, because "took no damage" on its own is also
+    /// what a broken damage pipeline looks like, and a pair taken either side of
+    /// one press rules that out without anyone having to know how long the
+    /// window is.
+    ///
+    /// That last part matters: the two shields in the roster are one second and
+    /// nineteen, and a proof shaped as "wait it out and hit again" works for the
+    /// first and cannot afford the second. What the gates therefore do *not*
+    /// check per ability is that the window ever ends. That is the effect
+    /// module's behaviour rather than any one kit's, and `tests/contract.rs`
+    /// proves it once, there.
     ShieldsCaster,
 }
 
@@ -120,6 +142,7 @@ impl Observable {
             Self::HealsCaster => "heals_caster",
             Self::BuffsMelee => "buffs_melee",
             Self::AfflictsTarget => "afflicts_target",
+            Self::Sustains => "sustains",
             Self::ShieldsCaster => "shields_caster",
         }
     }
@@ -274,7 +297,18 @@ fn commit(ability: EntityView<'_>, player: EntityView<'_>) {
     }
 }
 
-fn cast_from<'w>(
+/// Build a [`Cast`] for `player` firing `ability`, without firing it.
+///
+/// Public because an ability is not the only thing that runs an ability's
+/// payload. A Smash Crystal's twenty seconds is the same payload on a beat, and
+/// [`crate::module::effect::Repeats`] needs exactly this to hand one a `Cast`
+/// -- so that a pulse and a press are the same function with the same helpers,
+/// rather than two shapes a kit has to write its ability twice for.
+///
+/// `None` when the player is missing anything a cast needs, which is a player
+/// who is mid-teardown.
+#[must_use]
+pub fn cast_from<'w>(
     world: WorldRef<'w>,
     player: EntityView<'w>,
     ability: EntityView<'w>,

--- a/events/smash/src/module/effect.rs
+++ b/events/smash/src/module/effect.rs
@@ -49,7 +49,12 @@ use crate::{
 #[derive(Component, Debug)]
 pub struct Effect;
 
-/// Relationship: `(Afflicting, victim)` on the effect entity.
+/// Relationship: `(Upon, player)` on the effect entity.
+///
+/// The player the effect is attached to, whether it is doing them harm or good.
+/// A burn and a Smash Crystal's twenty seconds are the same bookkeeping and
+/// this is the edge both hang from; the word is `Upon` and not `Afflicting`
+/// because half of them are buffs.
 ///
 /// Pointing from the effect at the player rather than the other way around,
 /// because one player carries many effects and a relationship is cheapest to
@@ -57,7 +62,7 @@ pub struct Effect;
 /// disconnects takes their effects' edges with them, so an expiry firing
 /// afterwards finds no target instead of hurting whoever recycled the id.
 #[derive(Component, Debug)]
-pub struct Afflicting;
+pub struct Upon;
 
 /// Relationship: `(InflictedBy, attacker)` on the effect entity.
 ///
@@ -116,6 +121,49 @@ pub struct Shows {
     pub sound: &'static str,
 }
 
+/// An action taken over and over for as long as the effect stands.
+///
+/// The action is handed a [`Cast`], the same value an ability's own payload
+/// gets, because a beat *is* a cast the player is not making: Storm Squid calls
+/// a bolt down once a second for twenty seconds and the nineteen beats after
+/// the first are indistinguishable from the first. That makes every helper --
+/// `splash`, `fire`, `afflict` -- work unchanged inside a pulse, and it means a
+/// kit writes its ultimate once rather than once per shape.
+///
+/// This is what makes an ultimate a mode rather than a frame. Fourteen of the
+/// fifteen were a single `splash` where the source says fifteen to twenty
+/// seconds; each is now one of these with a pulse that does what the single
+/// frame used to, and the duration doing the rest.
+///
+/// Separate from [`Ticks`] on purpose, and the line between them is data versus
+/// behaviour. Damage over time is common enough, and uniform enough, to be
+/// worth expressing as numbers a gate can read without running anything --
+/// which is why fire and poison are `Ticks` and not two `fn`s. Anything else an
+/// ability wants to do repeatedly is a `fn`, for the same reason
+/// [`crate::module::ability::OnActivate`] is. A kit reaching for `Repeats` to
+/// deal plain damage on an interval wants `Ticks`.
+#[derive(Component, Copy, Clone)]
+pub struct Repeats {
+    /// Seconds between beats.
+    pub every: f32,
+    /// Seconds until the next one.
+    pub until_next: f32,
+    pub pulse: fn(&Cast<'_>),
+}
+
+/// Run when the effect ends, however it ends.
+///
+/// For an effect that changed something which has to change back. Cow's
+/// Mooshroom Madness is the whole reason it exists: it raised the caster's
+/// maximum health by five hearts and never lowered it again, so a Cow who
+/// picked up two crystals in a match finished it on forty hearts.
+///
+/// Runs on expiry, on [`clear`], and on the holder dying -- every path that
+/// destroys the effect goes through [`end`], which is the point of there being
+/// one such path.
+#[derive(Component, Copy, Clone)]
+pub struct Ends(pub fn(&Cast<'_>));
+
 /// While this stands, the victim cannot be hurt.
 ///
 /// A tag and not a duration: the duration is [`Expires`], and a shield that
@@ -128,7 +176,12 @@ pub struct Shields;
 ///
 /// Filled in with update syntax like [`crate::module::kit::AbilitySpec`], so a
 /// kit writes the two fields its effect has instead of a wall of `None`.
-#[derive(Debug, Copy, Clone)]
+///
+/// No `Debug`, deliberately. Two of its fields are bare `fn`s, whose only
+/// printable content is a code address, and a derived `Debug` that renders a
+/// behaviour as `0x7f...` is worse than not having one: it looks like
+/// information.
+#[derive(Copy, Clone)]
 pub struct Affliction {
     /// How long it stands, in seconds.
     pub seconds: f32,
@@ -138,6 +191,10 @@ pub struct Affliction {
     pub shows: Option<Shows>,
     /// Whether the victim is untouchable while it stands.
     pub shields: bool,
+    /// `Some` for an effect that does something on a beat. See [`Repeats`].
+    pub repeats: Option<Repeats>,
+    /// `Some` for an effect that has to undo something. See [`Ends`].
+    pub ends: Option<Ends>,
 }
 
 impl Affliction {
@@ -146,7 +203,45 @@ impl Affliction {
         ticks: None,
         shows: None,
         shields: false,
+        repeats: None,
+        ends: None,
     };
+
+    /// A mode: `seconds` of doing `pulse` every `every` seconds.
+    ///
+    /// What a Smash Crystal grants. The wiki gives every ultimate as a
+    /// duration -- "lasts 20 seconds", "unlimited flight and eggs", "call
+    /// lightning down once a second" -- and this is that sentence, with the
+    /// thing it does once per beat.
+    #[must_use]
+    pub const fn mode(seconds: f32, every: f32, pulse: fn(&Cast<'_>)) -> Self {
+        Self {
+            seconds,
+            repeats: Some(Repeats {
+                every,
+                // The first beat lands immediately, unlike a burn's. Pressing
+                // an ultimate and watching nothing happen for a second is how
+                // a player concludes the button is broken.
+                until_next: 0.0,
+                pulse,
+            }),
+            ..Self::DEFAULT
+        }
+    }
+
+    /// The same, with something to undo when it lapses.
+    #[must_use]
+    pub const fn undone_by(mut self, ends: fn(&Cast<'_>)) -> Self {
+        self.ends = Some(Ends(ends));
+        self
+    }
+
+    /// The same, with nothing able to touch the holder while it lasts.
+    #[must_use]
+    pub const fn untouchable(mut self) -> Self {
+        self.shields = true;
+        self
+    }
 
     /// Damage over time that a client can see, which is the only kind any kit
     /// has wanted: an invisible burn is indistinguishable from the server
@@ -171,7 +266,7 @@ impl Affliction {
                 until_next: interval,
             }),
             shows: Some(shows),
-            shields: false,
+            ..Self::DEFAULT
         }
     }
 
@@ -258,7 +353,7 @@ pub fn afflict(world: WorldRef<'_>, victim: EntityView<'_>, blame: Blame, afflic
         .set(Expires {
             remaining: affliction.seconds,
         })
-        .add((Afflicting, victim))
+        .add((Upon, victim))
         .add((Source, world.entity_at(blame.source)))
         .add((InflictedBy, world.entity_at(blame.attacker)));
 
@@ -267,6 +362,12 @@ pub fn afflict(world: WorldRef<'_>, victim: EntityView<'_>, blame: Blame, afflic
     }
     if let Some(shows) = affliction.shows {
         effect.set(shows);
+    }
+    if let Some(repeats) = affliction.repeats {
+        effect.set(repeats);
+    }
+    if let Some(ends) = affliction.ends {
+        effect.set(ends);
     }
     if affliction.shields {
         effect.add(Shields::id());
@@ -316,9 +417,7 @@ fn matching(
         .with(Effect::id())
         .build()
         .each_entity(|effect, ()| {
-            if effect.target(Afflicting, 0).map(|target| target.id()) == Some(victim)
-                && keep(effect)
-            {
+            if effect.target(Upon, 0).map(|target| target.id()) == Some(victim) && keep(effect) {
                 found.push(effect.id());
             }
         });
@@ -353,12 +452,35 @@ pub fn clear(world: WorldRef<'_>, victim: Entity) {
 }
 
 /// Destroy one effect, undoing whatever it turned on.
+///
+/// The one path out. Expiry, [`clear`] and a holder dying all come through
+/// here, which is what lets [`Ends`] promise it runs however the effect ends
+/// rather than only when the clock reaches zero.
 fn end(world: WorldRef<'_>, effect: EntityView<'_>) {
+    let holder = effect.target(Upon, 0);
+
     if effect.has(Shields::id())
-        && let Some(victim) = effect.target(Afflicting, 0)
+        && let Some(holder) = holder
     {
-        disarm_shield(world, victim.id(), effect.id());
+        disarm_shield(world, holder.id(), effect.id());
     }
+
+    // After the shield is disarmed and before the entity is destroyed, so an
+    // `Ends` that heals the holder is not fighting an immunity that has not
+    // lifted yet.
+    if let (Some(ends), Some(holder)) = (effect.try_get::<&Ends>(|ends| *ends), holder)
+        && holder.is_alive()
+    {
+        let ability = effect.target(Source, 0).unwrap_or(holder);
+        world.get::<&ServerHandle>(|server| {
+            if let Some(cast) =
+                crate::module::ability::cast_from(world, holder, ability, &**server, 1.0)
+            {
+                ends.0(&cast);
+            }
+        });
+    }
+
     effect.destruct();
 }
 
@@ -369,6 +491,18 @@ struct Application {
     amount: f32,
     kind: DamageKind,
     shows: Option<Shows>,
+}
+
+/// One beat of one effect, decided before anything is mutated.
+///
+/// Collected for the same reason [`Application`] is: a pulse spawns
+/// projectiles, hurts players and reads positions, and flecs refuses all three
+/// from inside the query that found the effect.
+struct Beat {
+    holder: Entity,
+    /// The ability instance the beat is cast as. See [`Repeats`].
+    ability: Entity,
+    pulse: fn(&Cast<'_>),
 }
 
 #[derive(Component)]
@@ -383,10 +517,12 @@ impl Module for EffectModule {
         world.component::<Ticks>();
         world.component::<Shows>();
         world.component::<Shields>();
+        world.component::<Repeats>();
+        world.component::<Ends>();
         // Exclusive: an effect afflicts exactly one player, comes from one
         // place and is owed to one attacker. A second target would silently
         // double every tick it deals.
-        world.component::<Afflicting>().add(flecs::Exclusive);
+        world.component::<Upon>().add(flecs::Exclusive);
         world.component::<InflictedBy>().add(flecs::Exclusive);
         world.component::<Source>().add(flecs::Exclusive);
 
@@ -403,6 +539,7 @@ impl Module for EffectModule {
                     let dt = it.delta_time();
 
                     let mut applications = Vec::new();
+                    let mut beats = Vec::new();
                     let mut finished = Vec::new();
 
                     world
@@ -410,7 +547,7 @@ impl Module for EffectModule {
                         .with(Effect::id())
                         .build()
                         .each_entity(|effect, expires| {
-                            let Some(victim) = effect.target(Afflicting, 0) else {
+                            let Some(victim) = effect.target(Upon, 0) else {
                                 // The player it was put on has gone. Collected
                                 // so the entity does not leak for the rest of
                                 // the match.
@@ -432,6 +569,30 @@ impl Module for EffectModule {
                                 return;
                             }
 
+                            let attacker = effect.target(InflictedBy, 0).map(|by| by.id());
+
+                            if let Some(mut repeats) = effect.try_get::<&Repeats>(|r| *r) {
+                                repeats.until_next -= dt;
+                                if repeats.until_next <= 0.0 {
+                                    // Advanced by adding rather than assigning,
+                                    // so a long frame does not push every later
+                                    // beat out by however far this one
+                                    // overshot. `max` because the first beat
+                                    // starts at zero and a slow frame could
+                                    // otherwise leave it permanently behind.
+                                    repeats.until_next =
+                                        (repeats.until_next + repeats.every).max(0.0);
+                                    beats.push(Beat {
+                                        holder: victim.id(),
+                                        ability: effect
+                                            .target(Source, 0)
+                                            .map_or_else(|| victim.id(), |from| from.id()),
+                                        pulse: repeats.pulse,
+                                    });
+                                }
+                                effect.set(repeats);
+                            }
+
                             let Some(mut ticks) = effect.try_get::<&Ticks>(|ticks| *ticks) else {
                                 return;
                             };
@@ -448,7 +609,7 @@ impl Module for EffectModule {
 
                             applications.push(Application {
                                 victim: victim.id(),
-                                attacker: effect.target(InflictedBy, 0).map(|by| by.id()),
+                                attacker,
                                 amount: ticks.amount,
                                 kind: ticks.kind,
                                 shows: effect.try_get::<&Shows>(|shows| *shows),
@@ -479,6 +640,27 @@ impl Module for EffectModule {
                         world.get::<&ServerHandle>(|server| {
                             server.cue(at, shows.cue);
                             server.play_sound(at, Sound::new(shows.sound, SoundCategory::Players));
+                        });
+                    }
+
+                    // Beats after the damage-over-time applications, so an
+                    // ultimate that pulses into a victim who is already burning
+                    // sees the burn's damage rather than racing it.
+                    for beat in beats {
+                        let holder = world.entity_at(beat.holder);
+                        let ability = world.entity_at(beat.ability);
+                        if !holder.is_alive() || !ability.is_alive() {
+                            continue;
+                        }
+                        world.get::<&ServerHandle>(|server| {
+                            // A beat is cast at full charge. An ultimate that
+                            // scales off charge would otherwise fire at zero
+                            // for every beat but the one the player pressed.
+                            if let Some(cast) = crate::module::ability::cast_from(
+                                world, holder, ability, &**server, 1.0,
+                            ) {
+                                (beat.pulse)(&cast);
+                            }
                         });
                     }
 

--- a/events/smash/src/module/kits/blaze.rs
+++ b/events/smash/src/module/kits/blaze.rs
@@ -14,7 +14,7 @@ use glam::Vec3;
 use crate::{
     flecs_ext::WorldRefExt,
     module::{
-        ability::{Cast, Observable, splash_at},
+        ability::{self, Cast, Observable, splash_at},
         damage::{DamageKind, Damaged, hurt},
         effect::{self, Affliction, Shows},
         kit::{self, AbilitySpec, KitSounds, KitStats},
@@ -132,6 +132,7 @@ impl Module for Blaze {
                 Observable::LaunchesTarget,
                 Observable::LaunchesCaster,
                 Observable::AfflictsTarget,
+                Observable::Sustains,
             ],
             activate: phoenix,
             ..AbilitySpec::DEFAULT
@@ -188,10 +189,28 @@ fn firefly(cast: &Cast<'_>) {
     splash_at(cast, ahead, 3.0, 9.0 * cast.charge.max(0.4), 1.8);
 }
 
-/// `[APPROXIMATED]`: free flight for twenty seconds is a movement mode the game
-/// half has no way to enter, so what is modelled is the damage pass and the
-/// fire it leaves on everyone it passes through.
+/// `[WIKI]` "twenty seconds of Firefly with no charge and free flight".
+///
+/// The twenty seconds is the ability. Free flight is not a movement mode the
+/// seam can enter, so each beat pushes the Blaze along its own look direction,
+/// which is what free flight looks like from the outside: a Blaze that keeps
+/// going where it points until the crystal runs out.
 fn phoenix(cast: &Cast<'_>) {
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(ability::ULTIMATE_SECONDS, PHOENIX_INTERVAL, phoenix_pass),
+    );
+}
+
+/// `[APPROXIMATED]`. Firefly's own charge is 1.5 s and Phoenix removes it, so a
+/// pass a second is "Firefly with no charge" at about the rate a player could
+/// press it.
+const PHOENIX_INTERVAL: f32 = 1.0;
+
+/// One uncharged Firefly, and the fire it leaves behind.
+fn phoenix_pass(cast: &Cast<'_>) {
     let ahead = cast.position.0 + cast.facing.0.normalize_or_zero() * 3.0;
     cast.server.add_velocity(
         cast.player,

--- a/events/smash/src/module/kits/chicken.rs
+++ b/events/smash/src/module/kits/chicken.rs
@@ -13,7 +13,8 @@ use glam::Vec3;
 use crate::{
     flecs_ext::EntityViewExt,
     module::{
-        ability::{Cast, Cooldown, Grants, Named, Observable},
+        ability::{self, Cast, Cooldown, Grants, Named, Observable},
+        effect::{self, Affliction},
         kit::{self, AbilitySpec, KitSounds, KitStats},
         projectile::{Flight, Impact, Payload, fire},
     },
@@ -81,7 +82,11 @@ impl Module for Chicken {
             item: "minecraft:nether_star",
             description: "Unlimited flight and eggs, for twenty seconds.",
             cooldown: 1.0,
-            proves: &[Observable::HurtsTarget, Observable::LaunchesCaster],
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesCaster,
+                Observable::Sustains,
+            ],
             activate: aerial_gunner,
             ..AbilitySpec::DEFAULT
         })
@@ -154,8 +159,31 @@ fn refund(impact: &Impact<'_>) {
         .get::<&crate::server::ServerHandle>(|server| server.cue(impact.at, Cue::Explosion));
 }
 
-/// `[APPROXIMATED]`: unlimited flight is not a state the game half can enter.
+/// `[WIKI]` "unlimited flight and eggs, for twenty seconds".
+///
+/// The twenty seconds is the ability, and the description already said so while
+/// the code did it once. Unlimited flight is not a state the seam can enter, so
+/// each beat is a lift and a volley: a chicken that stays up and keeps firing
+/// for as long as the crystal lasts, which is what the sentence describes from
+/// the ground.
 fn aerial_gunner(cast: &Cast<'_>) {
-    cast.server.add_velocity(cast.player, Vec3::Y * 0.8);
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(ability::ULTIMATE_SECONDS, GUNNER_INTERVAL, gunner_beat),
+    );
+}
+
+/// `[APPROXIMATED]`. Egg Blaster's own cooldown is two seconds and the ultimate
+/// removes it; twice a second is "unlimited" without being a solid wall of egg.
+const GUNNER_INTERVAL: f32 = 0.5;
+
+/// `[APPROXIMATED]`. Enough lift each beat to stay airborne and not enough to
+/// climb out of the map over twenty seconds.
+const GUNNER_LIFT: f32 = 0.4;
+
+fn gunner_beat(cast: &Cast<'_>) {
+    cast.server.add_velocity(cast.player, Vec3::Y * GUNNER_LIFT);
     egg_blaster(cast);
 }

--- a/events/smash/src/module/kits/cow.rs
+++ b/events/smash/src/module/kits/cow.rs
@@ -12,7 +12,9 @@ use flecs_ecs::prelude::*;
 use glam::Vec3;
 
 use crate::module::{
-    ability::{Cast, Observable, splash_at},
+    ability::{self, Cast, Observable, splash_at},
+    damage::MeleeBonus,
+    effect::{self, Affliction},
     kit::{self, AbilitySpec, KitSounds, KitStats},
     projectile::{Flight, Payload, fire},
 };
@@ -73,9 +75,18 @@ impl Module for Cow {
             name: "Mooshroom Madness",
             sound: "minecraft:entity.mooshroom.convert",
             item: "minecraft:nether_star",
-            description: "Become a mooshroom: more damage, five more hearts, faster abilities.",
+            description: "Become a mooshroom for twenty seconds: more damage, five more hearts, \
+                          and a herd every two seconds.",
             cooldown: 20.0,
-            proves: &[Observable::HealsCaster],
+            proves: &[
+                Observable::HealsCaster,
+                Observable::BuffsMelee,
+                Observable::HurtsTarget,
+                // The herd on each beat is the kit's own Angry Herd, and a cow
+                // that hits you moves you.
+                Observable::LaunchesTarget,
+                Observable::Sustains,
+            ],
             activate: mooshroom_madness,
             ..AbilitySpec::DEFAULT
         })
@@ -123,30 +134,79 @@ fn milk_spiral(cast: &Cast<'_>) {
 /// `[VERIFIED]` "5 more hearts".
 pub const MOOSHROOM_BONUS_HEALTH: f32 = 10.0;
 
-/// `[VERIFIED]` "+1 Damage ... 5 more hearts"; the transformation itself needs
-/// the host's entity type machinery, so what lands is the heal.
-fn mooshroom_madness(cast: &Cast<'_>) {
-    use crate::{
-        flecs_ext::EntityViewExt,
-        module::{
-            kit::{KitStats, Playing},
-            player::Health,
-        },
-    };
+/// `[VERIFIED]` "+1 Damage".
+pub const MOOSHROOM_BONUS_DAMAGE: f32 = 1.0;
 
-    // Set against the kit's own maximum rather than added to whatever the
-    // player currently has. Adding compounds: the crystal can be picked up more
-    // than once in a match, and two Mooshroom Madnesses used to leave a Cow on
-    // forty hearts and a third on fifty.
-    let base = cast
-        .caster
+/// `[APPROXIMATED]`. The wiki's "faster abilities" needs a cooldown scale the
+/// ability layer does not carry, so what stands in for it is the kit's own herd
+/// arriving on a beat -- which is what a Cow whose abilities are coming faster
+/// than usual looks like from the outside.
+const MOOSHROOM_INTERVAL: f32 = 2.0;
+
+/// The kit's own maximum health, which the bonus is measured against.
+///
+/// Read from the kit prefab and not from the player, because the player's
+/// maximum is the thing this ability changes and reading it back would compound:
+/// two crystals in one match used to leave a Cow on forty hearts and a third on
+/// fifty.
+fn base_health(cast: &Cast<'_>) -> f32 {
+    use crate::{flecs_ext::EntityViewExt, module::kit::Playing};
+    cast.caster
         .find_target(Playing, |_| true)
         .and_then(|kit| kit.try_get::<&KitStats>(|stats| stats.max_health))
-        .unwrap_or(20.0);
+        .unwrap_or(20.0)
+}
+
+/// `[VERIFIED]` "+1 Damage ... 5 more hearts", for twenty seconds.
+///
+/// The transformation itself needs the host's entity type machinery. What lands
+/// is everything else -- and, the part that was missing, it is taken back when
+/// the twenty seconds are up. The maximum used to be raised permanently, so the
+/// ultimate was strictly stronger than the wiki describes and got stronger again
+/// with every crystal.
+fn mooshroom_madness(cast: &Cast<'_>) {
+    use crate::module::player::Health;
 
     let (current, max) = cast.caster.get::<&mut Health>(|health| {
-        health.max = base + MOOSHROOM_BONUS_HEALTH;
+        health.max = base_health(cast) + MOOSHROOM_BONUS_HEALTH;
         health.current = health.max;
+        (health.current, health.max)
+    });
+    cast.server.set_health(cast.player, current, max);
+
+    // `against: None`, because the wiki's +1 is against everybody -- unlike
+    // Guardian's mark, which is the other user of this component. The deadline
+    // is the ability layer's own, so the bonus and the mode cannot disagree
+    // about when they end.
+    let now = cast.world.cloned::<&crate::module::damage::MatchClock>().0;
+    cast.caster.set(MeleeBonus {
+        flat: MOOSHROOM_BONUS_DAMAGE,
+        against: None,
+        until: now + ability::ULTIMATE_SECONDS,
+    });
+
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(ability::ULTIMATE_SECONDS, MOOSHROOM_INTERVAL, angry_herd)
+            .undone_by(shrink_back),
+    );
+}
+
+/// Put the Cow back the size it was.
+///
+/// Runs however the mode ends -- expiry, a respawn clearing effects, the holder
+/// dying -- because [`crate::module::effect::Ends`] has exactly one teardown
+/// path. Current health is clamped rather than left above a maximum that just
+/// dropped, which `tests/properties.rs` checks on every tick.
+fn shrink_back(cast: &Cast<'_>) {
+    use crate::module::player::Health;
+
+    let base = base_health(cast);
+    let (current, max) = cast.caster.get::<&mut Health>(|health| {
+        health.max = base;
+        health.current = health.current.min(base);
         (health.current, health.max)
     });
     cast.server.set_health(cast.player, current, max);

--- a/events/smash/src/module/kits/enderman.rs
+++ b/events/smash/src/module/kits/enderman.rs
@@ -13,7 +13,8 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, Observable},
+        ability::{self, Cast, Observable},
+        effect::{self, Affliction},
         kit::{self, AbilitySpec, KitSounds, KitStats},
         player::Position,
         projectile::{Flight, Payload, fire},
@@ -89,9 +90,14 @@ impl Module for Enderman {
             name: "Dragon Rider",
             sound: "minecraft:entity.ender_dragon.flap",
             item: "minecraft:nether_star",
-            description: "Ride a dragon through everyone.",
+            description: "Ride a dragon through everyone, for twenty seconds.",
             cooldown: 30.0,
-            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::LaunchesCaster,
+                Observable::Sustains,
+            ],
             activate: dragon_rider,
             ..AbilitySpec::DEFAULT
         })
@@ -139,14 +145,34 @@ fn long_teleport(cast: &Cast<'_>) {
     );
 }
 
+/// `[APPROXIMATED]` throughout; the wiki names the ultimate and gives no
+/// figures.
+///
+/// "Ride a dragon through everyone" is two verbs and the code did neither: the
+/// Enderman never moved, so nothing was ridden and nobody was passed through.
+/// Each beat now carries the rider forward and hits whatever is in front of
+/// them, which is the sentence.
 fn dragon_rider(cast: &Cast<'_>) {
-    crate::module::ability::splash_at(
-        cast,
-        cast.position.0 + cast.facing.0.normalize_or_zero() * 8.0,
-        6.0,
-        20.0,
-        4.0,
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(ability::ULTIMATE_SECONDS, RIDE_INTERVAL, dragon_pass),
     );
+}
+
+const RIDE_INTERVAL: f32 = 1.0;
+
+/// Per pass, and there are twenty.
+const RIDE_DAMAGE: f32 = 5.0;
+
+fn dragon_pass(cast: &Cast<'_>) {
+    let forward = cast.facing.0.normalize_or_zero();
+    // The ride. Forward and a little up, so the dragon clears the lip of a
+    // platform rather than stopping at it.
+    cast.server
+        .add_velocity(cast.player, forward * 1.6 + Vec3::Y * 0.3);
+    crate::module::ability::splash_at(cast, cast.position.0 + forward * 8.0, 6.0, RIDE_DAMAGE, 4.0);
 }
 
 fn teleport_to(cast: &Cast<'_>, to: Vec3) {

--- a/events/smash/src/module/kits/guardian.rs
+++ b/events/smash/src/module/kits/guardian.rs
@@ -14,8 +14,9 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, Observable, splash_at},
+        ability::{self, Cast, Observable, splash_at},
         damage::MatchClock,
+        effect::{self, Affliction},
         kit::{self, AbilitySpec, KitSounds, KitStats},
         player::{Player, Position},
         projectile::{Flight, Impact, Payload, fire},
@@ -104,9 +105,13 @@ impl Module for Guardian {
             name: "Tidal Wave",
             sound: "minecraft:entity.elder_guardian.curse",
             item: "minecraft:nether_star",
-            description: "Everything in the water goes where the water goes.",
+            description: "Twenty seconds of water. Everything in it goes where it goes.",
             cooldown: 20.0,
-            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::Sustains,
+            ],
             activate: tidal_wave,
             ..AbilitySpec::DEFAULT
         })
@@ -210,6 +215,24 @@ fn target_laser(cast: &Cast<'_>) {
     });
 }
 
+/// `[APPROXIMATED]` throughout; the wiki describes the ultimate and gives no
+/// figures.
+///
+/// A wave is a thing that keeps arriving. One splash was a slap.
 fn tidal_wave(cast: &Cast<'_>) {
-    splash_at(cast, cast.position.0, 10.0, 12.0, 2.2);
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(ability::ULTIMATE_SECONDS, TIDE_INTERVAL, tide),
+    );
+}
+
+const TIDE_INTERVAL: f32 = 1.5;
+
+/// Per wave, and there are thirteen.
+const TIDE_DAMAGE: f32 = 3.0;
+
+fn tide(cast: &Cast<'_>) {
+    splash_at(cast, cast.position.0, 10.0, TIDE_DAMAGE, 2.2);
 }

--- a/events/smash/src/module/kits/iron_golem.rs
+++ b/events/smash/src/module/kits/iron_golem.rs
@@ -13,6 +13,7 @@ use glam::Vec3;
 use crate::{
     module::{
         ability::{Cast, Observable, splash, splash_at},
+        effect::{self, Affliction},
         kit::{self, AbilitySpec, KitSounds, KitStats},
         player::Position,
         projectile::{Flight, Impact, Payload, fire},
@@ -80,7 +81,11 @@ impl Module for IronGolem {
             description: "Leap, then land hard. Everything nearby goes flying.",
             cooldown: 7.0,
             requires_ground: true,
-            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::LaunchesCaster,
+            ],
             activate: seismic_slam,
             ..AbilitySpec::DEFAULT
         })
@@ -88,9 +93,14 @@ impl Module for IronGolem {
             name: "Earthquake",
             sound: "minecraft:entity.ravager.roar",
             item: "minecraft:nether_star",
-            description: "Shake the whole map. Anyone touching the ground pays.",
+            description: "Shake the whole map for sixteen seconds. Anyone touching the ground \
+                          keeps paying.",
             cooldown: 16.0,
-            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::Sustains,
+            ],
             activate: earthquake,
             ..AbilitySpec::DEFAULT
         })
@@ -155,17 +165,45 @@ fn reel_in(impact: &Impact<'_>) {
 }
 
 /// The kit's panic button and its combo finisher.
+///
+/// "Leap, then land hard", per its own tooltip and the wiki. The leap is the
+/// half that was missing: the ability launched nobody and the description
+/// promised it anyway.
 fn seismic_slam(cast: &Cast<'_>) {
+    // Up and slightly along, so it clears an edge rather than only a head.
+    // `[APPROXIMATED]`; the wiki gives no figure, and this is tuned to about the
+    // height of the kit's own double jump.
+    cast.server.add_velocity(
+        cast.player,
+        Vec3::Y * 0.85 + Vec3::new(cast.facing.0.x, 0.0, cast.facing.0.z).normalize_or_zero() * 0.4,
+    );
     splash(cast, 8.0, 10.5, 2.4);
 }
 
-/// Hits every grounded player on the map, wherever they are.
+/// `[SOURCE]` sixteen seconds. An earthquake that lasts one frame is a thump.
+fn earthquake(cast: &Cast<'_>) {
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(EARTHQUAKE_SECONDS, EARTHQUAKE_INTERVAL, quake),
+    );
+}
+
+/// `[SOURCE]` "Earthquake, 16 s".
+const EARTHQUAKE_SECONDS: f32 = 16.0;
+
+/// `[APPROXIMATED]`. Slow enough that a player can cross the map between
+/// shocks, which is what makes leaving the ground the answer to it.
+const EARTHQUAKE_INTERVAL: f32 = 1.5;
+
+/// One shock. Hits every grounded player on the map, wherever they are.
 ///
 /// Each victim is hurt once, by id. Splashing at each of their positions in
 /// turn double-hit anyone standing near somebody else, which made the ultimate
 /// swing between three damage and twelve depending on how bunched up the arena
 /// happened to be.
-fn earthquake(cast: &Cast<'_>) {
+fn quake(cast: &Cast<'_>) {
     use crate::module::{
         damage::{DamageKind, Damaged, hurt},
         knockback::Knockback,

--- a/events/smash/src/module/kits/skeleton.rs
+++ b/events/smash/src/module/kits/skeleton.rs
@@ -13,6 +13,7 @@ use glam::Vec3;
 
 use crate::module::{
     ability::{Cast, Observable, charge_steps, splash},
+    effect::{self, Affliction},
     kit::{self, AbilitySpec, KitSounds, KitStats},
     player::Position,
     projectile::{Flight, Impact, Payload, fire},
@@ -93,9 +94,13 @@ impl Module for Skeleton {
             name: "Arrow Storm",
             sound: "minecraft:item.crossbow.shoot",
             item: "minecraft:nether_star",
-            description: "Fire without ever reloading.",
+            description: "Eight seconds of firing without ever reloading.",
             cooldown: 8.0,
-            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::Sustains,
+            ],
             activate: arrow_storm,
             ..AbilitySpec::DEFAULT
         })
@@ -174,8 +179,34 @@ fn haul_shooter(impact: &Impact<'_>) {
         .get::<&crate::server::ServerHandle>(|server| server.add_velocity(id, pull));
 }
 
+/// "Fire without ever reloading" is a duration, not a volley.
+///
+/// It used to be ten arrows in one frame, which is the opposite of never
+/// reloading: it is one enormous reload. Eight seconds of a Barrage-sized
+/// volley several times a second is the sentence the wiki actually writes, and
+/// it is the same `arrow` the rest of the kit fires.
 fn arrow_storm(cast: &Cast<'_>) {
-    for index in 0..MAX_BARRAGE_ARROWS * 2 {
-        arrow(cast, index as f32 * 0.01);
-    }
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(ARROW_STORM_SECONDS, ARROW_STORM_INTERVAL, arrow_volley),
+    );
+}
+
+/// `[SHEET]` the ultimate's cooldown is 8 s, and Mineplex's ultimates run for
+/// about as long as they take to come back.
+const ARROW_STORM_SECONDS: f32 = 8.0;
+
+/// `[APPROXIMATED]`. One arrow, three times a second.
+///
+/// One and not a Barrage-sized five: "without ever reloading" removes the draw,
+/// it does not multiply the arrow. Five per beat is 90 damage a second, which
+/// killed both scripted victims inside the first second and then read as the
+/// ability having stopped -- the strongest possible version of the mode looking
+/// exactly like a broken one.
+const ARROW_STORM_INTERVAL: f32 = 0.3;
+
+fn arrow_volley(cast: &Cast<'_>) {
+    arrow(cast, 0.0);
 }

--- a/events/smash/src/module/kits/sky_squid.rs
+++ b/events/smash/src/module/kits/sky_squid.rs
@@ -12,7 +12,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, Observable, splash_at},
+        ability::{self, Cast, Observable, splash_at},
         effect::{self, Affliction},
         kit::{self, AbilitySpec, KitSounds, KitStats},
         projectile::{Flight, Payload, fire},
@@ -91,9 +91,14 @@ impl Module for SkySquid {
             name: "Storm Squid",
             sound: "minecraft:entity.lightning_bolt.thunder",
             item: "minecraft:nether_star",
-            description: "Fly, and call lightning down once a second.",
+            description: "Fly, and call lightning down once a second for twenty seconds.",
             cooldown: 1.0,
-            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::LaunchesCaster,
+                Observable::Sustains,
+            ],
             activate: storm_squid,
             ..AbilitySpec::DEFAULT
         })
@@ -152,10 +157,34 @@ fn fish_flurry(cast: &Cast<'_>) {
     cast.server.cue(at, Cue::Explosion);
 }
 
-/// `[APPROXIMATED]`: a lightning bolt a second for the crystal's duration needs
-/// a repeating effect the ability layer does not have. One strike stands in.
+/// `[VERIFIED]` "call lightning down once a second"; the twenty seconds is
+/// [`crate::module::ability::ULTIMATE_SECONDS`], and the per-bolt damage is
+/// `[APPROXIMATED]`.
+///
+/// The ability is the duration. It used to be one strike, because the ability
+/// layer had no way to say "and again, nineteen more times"; it now says
+/// exactly that and the strike itself is unchanged.
 fn storm_squid(cast: &Cast<'_>) {
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(ability::ULTIMATE_SECONDS, STORM_INTERVAL, storm_bolt),
+    );
+}
+
+/// `[VERIFIED]` one second.
+const STORM_INTERVAL: f32 = 1.0;
+
+/// One bolt on each other player, wherever they are standing, and a beat of
+/// flight for the squid.
+fn storm_bolt(cast: &Cast<'_>) {
     use crate::module::{ability::splash_from, player::Position};
+
+    // "Fly" -- a small lift every beat, which is the closest the seam gets to
+    // a flight mode and is enough to keep a squid off the floor for the
+    // duration.
+    cast.server.add_velocity(cast.player, Vec3::Y * STORM_LIFT);
 
     let caster = cast.caster.id();
     let mut targets = Vec::new();
@@ -171,7 +200,16 @@ fn storm_squid(cast: &Cast<'_>) {
     for at in targets {
         // The bolt lands on the victim, so the launch has to be measured from
         // the squid: away from the point you are standing on is not a direction.
-        splash_from(cast, cast.position.0, at, 2.0, 6.0, 1.2);
+        splash_from(cast, cast.position.0, at, 2.0, STORM_DAMAGE, 1.2);
         cast.server.cue(at, Cue::Explosion);
     }
 }
+
+/// `[APPROXIMATED]`. Per bolt, and there are twenty of them, so this is
+/// deliberately a fraction of what the single-strike version dealt: the old
+/// number applied once a second for twenty seconds would be 120 damage.
+const STORM_DAMAGE: f32 = 2.0;
+
+/// `[APPROXIMATED]`. Enough lift per beat to hold a squid up without launching
+/// them off the map, which a bolt's own knockback would do if this were larger.
+const STORM_LIFT: f32 = 0.35;

--- a/events/smash/src/module/kits/slime.rs
+++ b/events/smash/src/module/kits/slime.rs
@@ -16,6 +16,7 @@ use crate::{
     module::{
         ability::{Cast, Observable, splash_at},
         damage::{DamageKind, Damaged, hurt},
+        effect::{self, Affliction},
         kit::{self, AbilitySpec, KitSounds, KitStats},
         knockback::Knockback,
         player::Energy,
@@ -91,9 +92,15 @@ impl Module for Slime {
             name: "Giga Slime",
             sound: "minecraft:entity.slime.jump",
             item: "minecraft:nether_star",
-            description: "Become enormous and untouchable. Everything near you dies.",
+            description: "Nineteen seconds of being enormous and untouchable. Everything near you \
+                          dies.",
             cooldown: 19.0,
-            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::ShieldsCaster,
+                Observable::Sustains,
+            ],
             activate: giga_slime,
             ..AbilitySpec::DEFAULT
         })
@@ -157,13 +164,42 @@ fn slime_slam(cast: &Cast<'_>) {
     });
 }
 
-/// Full damage immunity both ways in Mineplex; here it is the contact damage
-/// that matters, applied around a body three blocks tall.
+/// `[SHEET]` nineteen seconds. `[WIKI]` "enormous and untouchable".
+///
+/// Untouchable is the shield, which is real: nothing lands on a Giga Slime for
+/// the whole nineteen seconds. Enormous is the contact damage a body that size
+/// does, on a beat, which is also what makes standing next to one fatal --
+/// `docs/smash-design.md` records that per-kit hitboxes do not exist and the
+/// mob shape is a client-side disguise, so the size itself is presentation and
+/// the contact is the mechanic.
+///
+/// It used to be one splash and no shield at all, which is the two halves of
+/// the tooltip both missing.
 fn giga_slime(cast: &Cast<'_>) {
-    splash_at(cast, cast.position.0 + Vec3::Y * 3.0, 5.0, 8.0, 2.0);
-
     // Growing back to full is part of the ultimate: the bar is the hitbox.
     cast.caster.get::<&mut Energy>(|energy| {
         energy.current = energy.max;
     });
+
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(GIGA_SECONDS, GIGA_INTERVAL, giga_contact).untouchable(),
+    );
+}
+
+/// `[SHEET]` Giga Slime's cooldown, which is also its duration.
+const GIGA_SECONDS: f32 = 19.0;
+
+/// `[APPROXIMATED]`. Often enough that walking through a Giga Slime is not
+/// survivable, rare enough that the damage below is a real number rather than
+/// a per-tick trickle.
+const GIGA_INTERVAL: f32 = 1.0;
+
+/// `[APPROXIMATED]`. Per beat, and there are nineteen.
+const GIGA_DAMAGE: f32 = 4.0;
+
+fn giga_contact(cast: &Cast<'_>) {
+    splash_at(cast, cast.position.0 + Vec3::Y * 3.0, 5.0, GIGA_DAMAGE, 2.0);
 }

--- a/events/smash/src/module/kits/snowman.rs
+++ b/events/smash/src/module/kits/snowman.rs
@@ -10,7 +10,8 @@ use flecs_ecs::prelude::*;
 use glam::Vec3;
 
 use crate::module::{
-    ability::{Cast, Observable, splash_at},
+    ability::{self, Cast, Observable, splash_at},
+    effect::{self, Affliction},
     kit::{self, AbilitySpec, KitSounds, KitStats},
     projectile::{Flight, Payload, fire},
 };
@@ -79,9 +80,13 @@ impl Module for Snowman {
             name: "Snow Turret",
             sound: "minecraft:entity.snowball.throw",
             item: "minecraft:nether_star",
-            description: "A snowman that shoots for you. Twenty seconds, three of them.",
+            description: "Snowmen that shoot for you. Twenty seconds, three of them.",
             cooldown: 1.0,
-            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::Sustains,
+            ],
             activate: snow_turret,
             ..AbilitySpec::DEFAULT
         })
@@ -120,14 +125,36 @@ fn arctic_aura(cast: &Cast<'_>) {
     splash_at(cast, cast.position.0, 5.0, AURA_BONUS_DAMAGE, 0.2);
 }
 
-/// Six snowballs in a ring, the first one down the barrel.
+/// Twenty seconds of a six-snowball ring, the first one down the barrel.
 ///
 /// The ring is turned to face the caster: it used to be laid out in absolute
 /// world directions, so the ultimate hit whatever happened to be east of the
 /// snowman and a target dead ahead was in the gap between two of the six unless
 /// the fight happened to be lined up with +X. Nobody would have noticed from the
 /// inside, because the ability does fire and does hit *something*.
+///
+/// `[WIKI]` three turrets for twenty seconds; `[SOURCE]` says one, and
+/// `docs/smash-design.md` records the disagreement.
+///
+/// A turret is a thing that keeps shooting, which is the half that was missing:
+/// the ability fired one ring of six snowballs and stopped. Without a spawned
+/// mob to stand there and fire -- which needs the host's entity system -- the
+/// ring on a beat for twenty seconds is what a player standing next to a
+/// Snowman actually experiences, and it is the same ring.
 fn snow_turret(cast: &Cast<'_>) {
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(ability::ULTIMATE_SECONDS, TURRET_INTERVAL, turret_ring),
+    );
+}
+
+/// `[APPROXIMATED]`. Blizzard's own cooldown is 0.4 s and a turret is meant to
+/// be a second Snowman, so a ring a second is roughly three of them firing.
+const TURRET_INTERVAL: f32 = 1.0;
+
+fn turret_ring(cast: &Cast<'_>) {
     let flat = Vec3::new(cast.facing.0.x, 0.0, cast.facing.0.z).normalize_or_zero();
     // Looking straight down leaves no bearing to build a ring on.
     let forward = if flat == Vec3::ZERO { Vec3::Z } else { flat };

--- a/events/smash/src/module/kits/spider.rs
+++ b/events/smash/src/module/kits/spider.rs
@@ -14,7 +14,7 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, Observable, splash},
+        ability::{self, Cast, Observable, splash},
         damage::DamageKind,
         effect::{self, Affliction, Shows},
         kit::{self, AbilitySpec, KitSounds, KitStats},
@@ -103,12 +103,13 @@ impl Module for Spider {
             name: "Spiders Nest",
             sound: "minecraft:entity.spider.ambient",
             item: "minecraft:nether_star",
-            description: "A dome of web. Everything you hit heals you.",
+            description: "Twenty seconds inside a dome of web. Everything you hit heals you.",
             cooldown: 1.0,
             proves: &[
                 Observable::HurtsTarget,
                 Observable::LaunchesTarget,
                 Observable::HealsCaster,
+                Observable::Sustains,
             ],
             activate: spiders_nest,
             ..AbilitySpec::DEFAULT
@@ -178,8 +179,24 @@ fn spin_web(cast: &Cast<'_>) {
 
 /// `[APPROXIMATED]`: the dome traps, which needs block writes the game half
 /// cannot make. The damage and the one-second recharge are the wiki's, and so
-/// is "everything you hit heals you", which is the part that was missing.
+/// is "everything you hit heals you".
+///
+/// A dome is somewhere you stand for a while. The ability is now the twenty
+/// seconds, with the same pulse -- and the lifesteal on every beat, which is
+/// what makes a Spider in their own nest the problem the wiki describes.
 fn spiders_nest(cast: &Cast<'_>) {
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(ability::ULTIMATE_SECONDS, NEST_INTERVAL, nest_pulse),
+    );
+}
+
+/// `[WIKI]` "the one-second recharge", which is the beat.
+const NEST_INTERVAL: f32 = 1.0;
+
+fn nest_pulse(cast: &Cast<'_>) {
     const DAMAGE: f32 = 4.0;
 
     // Counted from the victims the blast returned rather than from a second

--- a/events/smash/src/module/kits/wither_skeleton.rs
+++ b/events/smash/src/module/kits/wither_skeleton.rs
@@ -14,8 +14,9 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, Observable, splash_at},
+        ability::{self, Cast, Observable, splash_at},
         damage::MatchClock,
+        effect::{self, Affliction},
         kit::{self, AbilitySpec, KitSounds, KitStats},
         projectile::{Flight, Impact, Payload, fire},
     },
@@ -81,9 +82,13 @@ impl Module for WitherSkeleton {
             name: "Wither Swap",
             sound: "minecraft:entity.shulker.teleport",
             item: "minecraft:nether_star",
-            description: "Every image at once.",
+            description: "Twenty seconds of images, going off around you one after another.",
             cooldown: 20.0,
-            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::Sustains,
+            ],
             activate: wither_swap,
             ..AbilitySpec::DEFAULT
         })
@@ -136,7 +141,27 @@ fn wither_image(cast: &Cast<'_>) {
     });
 }
 
+/// `[APPROXIMATED]` throughout; the wiki names the ultimate and gives no
+/// figures.
+///
+/// "Every image at once" read as one blast because there was no duration to
+/// spread them over. Twenty seconds of an image going off every second and a
+/// half is the kit's own trick, repeated, which is what its name says.
 fn wither_swap(cast: &Cast<'_>) {
-    splash_at(cast, cast.position.0, 6.0, 9.0, 1.8);
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(ability::ULTIMATE_SECONDS, SWAP_INTERVAL, swap_burst),
+    );
+}
+
+const SWAP_INTERVAL: f32 = 1.5;
+
+/// Per burst, and there are thirteen.
+const SWAP_DAMAGE: f32 = 2.5;
+
+fn swap_burst(cast: &Cast<'_>) {
+    splash_at(cast, cast.position.0, 6.0, SWAP_DAMAGE, 1.8);
     cast.server.cue(cast.position.0, Cue::Explosion);
 }

--- a/events/smash/src/module/kits/wolf.rs
+++ b/events/smash/src/module/kits/wolf.rs
@@ -14,8 +14,9 @@ use flecs_ecs::prelude::*;
 use crate::{
     flecs_ext::EntityViewExt,
     module::{
-        ability::{Cast, Observable},
+        ability::{self, Cast, Observable},
         damage::{DamageKind, Damaged, MeleeBonus},
+        effect::{self, Affliction},
         kit::{self, AbilitySpec, KitName, KitSounds, KitStats, Playing},
         player::Player,
         projectile::{Flight, Impact, Payload, fire},
@@ -90,9 +91,16 @@ impl Module for Wolf {
             name: "Frenzy",
             sound: "minecraft:entity.wolf_angry.growl",
             item: "minecraft:nether_star",
-            description: "Twenty seconds of everything at once.",
+            description: "Twenty seconds of everything at once: harder hits, and a lunge every \
+                          two seconds.",
             cooldown: 20.0,
-            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::LaunchesCaster,
+                Observable::BuffsMelee,
+                Observable::Sustains,
+            ],
             activate: frenzy,
             ..AbilitySpec::DEFAULT
         })
@@ -202,11 +210,36 @@ fn wolf_strike(cast: &Cast<'_>) {
     splash_at(cast, ahead, REACH, 6.0, knockback);
 }
 
-/// "Speed III, Regeneration III, and Strength III, and all your abilities
-/// recharge much faster. Lasts 20 seconds." The status effects need the host's
-/// potion machinery, so what is modelled here is the damage burst.
-/// `[APPROXIMATED]`.
+/// `[WIKI]` "Speed III, Regeneration III, and Strength III, and all your
+/// abilities recharge much faster. Lasts 20 seconds."
+///
+/// The twenty seconds is the ability, and it used to be one burst. Speed and
+/// Regeneration are `ClientboundUpdateMobEffect`, which the seam does not carry
+/// yet; Strength is [`MeleeBonus`], which it does. What stands in for "abilities
+/// recharge much faster" is a Wolf Strike on a beat -- the kit's own lunge,
+/// arriving faster than its seven-second cooldown ever allows.
 fn frenzy(cast: &Cast<'_>) {
-    use crate::module::ability::splash;
-    splash(cast, 5.0, 8.0, 1.5);
+    let now = cast.world.cloned::<&crate::module::damage::MatchClock>().0;
+    // Strength III is +3 in vanilla's own table, which is also exactly the gap
+    // between Wolf's base 5 and the 8 its own Ravage ceiling reaches -- so a
+    // frenzied Wolf starts where a Wolf who has been landing hits ends up.
+    cast.caster.set(MeleeBonus {
+        flat: FRENZY_BONUS_DAMAGE,
+        against: None,
+        until: now + ability::ULTIMATE_SECONDS,
+    });
+
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(ability::ULTIMATE_SECONDS, FRENZY_INTERVAL, wolf_strike),
+    );
 }
+
+/// `[WIKI]` Strength III, which vanilla scores at +3 damage.
+pub const FRENZY_BONUS_DAMAGE: f32 = RAVAGE_MAX_DAMAGE - 5.0;
+
+/// `[APPROXIMATED]`. Wolf Strike's own cooldown is seven seconds; "much faster"
+/// is read here as a lunge every two.
+const FRENZY_INTERVAL: f32 = 2.0;

--- a/events/smash/src/module/kits/zombie.rs
+++ b/events/smash/src/module/kits/zombie.rs
@@ -9,7 +9,8 @@ use glam::Vec3;
 
 use crate::{
     module::{
-        ability::{Cast, Observable, splash_at},
+        ability::{self, Cast, Observable, splash_at},
+        effect::{self, Affliction},
         kit::{self, AbilitySpec, KitSounds, KitStats},
         player::Position,
         projectile::{Flight, Impact, Payload, fire},
@@ -65,9 +66,13 @@ impl Module for Zombie {
             name: "Night of the Living Dead",
             sound: "minecraft:entity.zombie.ambient",
             item: "minecraft:nether_star",
-            description: "The dead get up around you.",
+            description: "The dead get up around you, and keep getting up for twenty seconds.",
             cooldown: 20.0,
-            proves: &[Observable::HurtsTarget, Observable::LaunchesTarget],
+            proves: &[
+                Observable::HurtsTarget,
+                Observable::LaunchesTarget,
+                Observable::Sustains,
+            ],
             activate: night_of_the_living_dead,
             ..AbilitySpec::DEFAULT
         })
@@ -125,7 +130,29 @@ fn drag_back(impact: &Impact<'_>) {
         .get::<&ServerHandle>(|server| server.add_velocity(id, pull));
 }
 
+/// `[APPROXIMATED]` throughout; the wiki names the ability and describes it and
+/// gives no figures.
+///
+/// "The dead get up around you" is a horde, and a horde is not one moment. A
+/// wave every second and a half for twenty seconds is the closest the kit gets
+/// to one without a spawned mob to walk around, and it makes standing next to a
+/// Zombie holding a crystal the mistake the name implies.
 fn night_of_the_living_dead(cast: &Cast<'_>) {
-    splash_at(cast, cast.position.0, 7.0, 10.0, 1.6);
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(ability::ULTIMATE_SECONDS, HORDE_INTERVAL, horde_wave),
+    );
+}
+
+const HORDE_INTERVAL: f32 = 1.5;
+
+/// Per wave, and there are thirteen of them, so it is a fraction of what the
+/// single burst dealt.
+const HORDE_DAMAGE: f32 = 2.5;
+
+fn horde_wave(cast: &Cast<'_>) {
+    splash_at(cast, cast.position.0, 7.0, HORDE_DAMAGE, 1.6);
     cast.server.cue(cast.position.0, Cue::Explosion);
 }

--- a/events/smash/tests/abilities.rs
+++ b/events/smash/tests/abilities.rs
@@ -217,12 +217,38 @@ fn observed(bench: &Bench, observable: Observable, before: &Snapshot, held: bool
                 .into_iter()
                 .any(|(victim, was)| bench.health_of(victim).current < was - 1e-3)
         }
-        // Two probes, because "took no damage" on its own is also what a broken
-        // damage pipeline looks like: a shield that never lifts and a game that
-        // cannot hurt anybody are the same reading. The window has to hold, and
-        // then it has to end. `held` is the first probe, taken back when the
-        // window was still open; this is the second.
-        Observable::ShieldsCaster => held && probe_hit(bench),
+        // Nothing is cast. The claim is that the ability is still acting, so
+        // what is measured is the world changing anyway -- damage landing on
+        // anybody, or a launch, or a burst of particles. Broader than
+        // `AfflictsTarget`, which is health specifically and on a victim
+        // specifically, because an ultimate's mode is not always damage: Giga
+        // Slime's is a shield and Frenzy's is a lunge.
+        Observable::Sustains => {
+            // Everybody is stood back up first. An ultimate that has already
+            // killed both victims cannot hurt them again, so without this the
+            // *strongest* modes are the ones that read as doing nothing --
+            // which is how Arrow Storm first failed this.
+            bench.place(before.caster_at);
+            let watched =
+                [bench.caster, bench.near, bench.far].map(|player| bench.health_of(player).current);
+            bench.game.server.take();
+            bench.game.advance(LINGER_SECONDS, 40);
+
+            let hurt_somebody = [bench.caster, bench.near, bench.far]
+                .iter()
+                .zip(watched)
+                .any(|(player, was)| bench.health_of(*player).current < was - 1e-3);
+            hurt_somebody
+                || bench.game.server.calls().iter().any(|call| {
+                    matches!(
+                        call,
+                        Call::AddVelocity(..) | Call::SetHealth(..) | Call::Cue(..)
+                    )
+                })
+        }
+        // Both probes were taken either side of the press, in `Immediate`,
+        // because neither can be taken from here: see that type.
+        Observable::ShieldsCaster => held,
     }
 }
 
@@ -235,24 +261,35 @@ fn observed(bench: &Bench, observable: Observable, before: &Snapshot, held: bool
 /// to raise this with it.
 const LINGER_SECONDS: f32 = 2.0;
 
-/// Facts whose lifetime is shorter than [`Bench::settle`], taken the instant a
-/// cast returns.
+/// Facts that can only be read either side of the press itself.
 ///
-/// Sky Squid's shield lasts one second and `settle` waits one and a half, so a
-/// reading taken only after settling finds every shield already over and calls
-/// a working ability broken. This is the one observation that has to be made
-/// before the sweep waits.
+/// Sky Squid's shield lasts one second and [`Bench::settle`] waits one and a
+/// half, so a reading taken after settling finds it already over and calls a
+/// working ability broken. Giga Slime's lasts nineteen, so a reading that waits
+/// for it to end never gets one. The only window both fit in is the press.
 struct Immediate {
-    /// Whether a hit on the caster was refused. Only meaningful, and only
-    /// taken, when the entry claims [`Observable::ShieldsCaster`]: the probe
-    /// costs the caster health and would otherwise perturb every other reading.
+    /// The same hit landed before the cast and was refused after it.
+    ///
+    /// Two probes and not one, because a shield that never lifts and a server
+    /// that cannot deal damage produce the same single reading. Taken either
+    /// side of the press rather than before and after the *window*, so the
+    /// check does not need to know how long the window is -- which is what lets
+    /// one shape cover both a one-second shield and a nineteen-second one.
+    ///
+    /// Only taken when the entry claims [`Observable::ShieldsCaster`]. The probe
+    /// costs the caster health and would otherwise perturb every other reading
+    /// in the sweep, `heals_caster` most of all.
     held: bool,
 }
 
 impl Immediate {
-    fn taken(bench: &Bench, entry: &Declared) -> Self {
+    /// `landed_before` is [`probe_hit`] from before the press. The caller takes
+    /// it, because by the time this runs the ability has already fired.
+    fn taken(bench: &Bench, entry: &Declared, landed_before: bool) -> Self {
         Self {
-            held: entry.proves.contains(&Observable::ShieldsCaster) && !probe_hit(bench),
+            held: entry.proves.contains(&Observable::ShieldsCaster)
+                && landed_before
+                && !probe_hit(bench),
         }
     }
 }
@@ -401,9 +438,12 @@ fn every_declared_effect_actually_happens() {
                 bench.recover(&entry, attempt);
             }
             bench.arm(&entry);
+            // Before the press, so the pair brackets it. See `Immediate::held`.
+            let landed_before =
+                entry.proves.contains(&Observable::ShieldsCaster) && probe_hit(&bench);
             let before = snapshot(&bench);
             bench.press(&entry);
-            let immediate = Immediate::taken(&bench, &entry);
+            let immediate = Immediate::taken(&bench, &entry, landed_before);
             bench.settle();
             outstanding
                 .retain(|observable| !observed(&bench, *observable, &before, immediate.held));
@@ -577,6 +617,71 @@ fn an_ultimate_is_granted_for_a_window_and_then_taken_back() {
         Ok(()),
         "an expired ultimate should be nothing at all in that slot, not a refusal"
     );
+}
+
+/// No ultimate leaves a player permanently changed.
+///
+/// A Smash Crystal is a window. Anything an ultimate alters about the player
+/// themselves -- their maximum health, their armour, how far they are thrown --
+/// has to be back where it started once the window closes, or picking a crystal
+/// up twice in a match compounds and the kit drifts away from every number the
+/// registry publishes.
+///
+/// Written as a sweep over the class rather than as a test for the one kit that
+/// had the bug. Cow's Mooshroom Madness raised the maximum by five hearts and
+/// never lowered it, so a Cow with two crystals finished on forty and a third
+/// on fifty; the reason to check every ultimate instead is that nothing about
+/// that bug was specific to Cow, and the next one will not be either.
+#[test]
+fn an_ultimate_gives_the_player_back_when_it_is_done() {
+    use smash::module::{damage::Armor, kit::KitStats, knockback::KnockbackTaken};
+
+    let manifest = ability::manifest(&Game::new().world);
+    let mut failures = Vec::new();
+
+    for entry in manifest.into_iter().filter(|entry| entry.ultimate) {
+        let bench = Bench::new();
+        bench.reset(entry.kit);
+
+        let stats = bench
+            .caster()
+            .target(Playing, 0)
+            .and_then(|kit| kit.try_get::<&KitStats>(|stats| *stats))
+            .expect("a player on a kit has its stats");
+
+        bench.arm(&entry);
+        bench.press(&entry);
+
+        // Past the longest window any ultimate declares, with room for the
+        // final beat and the teardown that follows it.
+        bench.game.advance(ability::ULTIMATE_SECONDS + 4.0, 240);
+
+        let health = bench.health_of(bench.caster);
+        let armor = bench.caster().cloned::<&Armor>().0;
+        let knockback = bench.caster().cloned::<&KnockbackTaken>().0;
+
+        let label = format!("{} / {}", entry.kit, entry.name);
+        if (health.max - stats.max_health).abs() > 1e-3 {
+            failures.push(format!(
+                "{label} left the caster on a maximum of {} health where the kit declares {}",
+                health.max, stats.max_health
+            ));
+        }
+        if (armor - stats.armor).abs() > 1e-3 {
+            failures.push(format!(
+                "{label} left the caster on {armor} armour where the kit declares {}",
+                stats.armor
+            ));
+        }
+        if (knockback - stats.knockback_taken).abs() > 1e-3 {
+            failures.push(format!(
+                "{label} left the caster taking {knockback}x knockback where the kit declares {}",
+                stats.knockback_taken
+            ));
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
 }
 
 /// What the charge accumulator hands a payload, against wall clock.

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -1312,21 +1312,26 @@ class Match:
             SHIELD_PROBE_WINDOW,
         )
 
-    def probe_shield(self, entry):
-        """Whether a hit landed on the caster immediately after the press.
+    def probe_shield(self, entry, landed_before):
+        """Whether the same hit landed before the press and was refused after it.
 
-        Taken in `exercise` rather than in `observe`, because the shield is one
-        second long and `observe` waits two: a reading taken afterwards finds
-        every window already closed and calls a working ability broken.
+        Taken around the press rather than around the *window*, because the two
+        shields in the roster are one second and nineteen: a check shaped as
+        "wait it out and hit again" works for the first and cannot afford the
+        second. Bracketing the press needs no knowledge of the duration at all.
 
-        `None` when the entry claims no shield. The probe costs the caster
+        What this therefore does not check is that the window ever ends. That is
+        the effect module's behaviour rather than any one kit's, and the Rust
+        side proves it once in `tests/contract.rs`.
+
+        False when the entry claims no shield. The probe costs the caster
         health, and running it on all fifty-one would perturb every other
         reading in the sweep -- `heals_caster` most of all, which is measured as
         the caster's health going *up*.
         """
         if "shields_caster" not in entry["proves"]:
-            return None
-        return not self.hit_caster()
+            return False
+        return landed_before and not self.hit_caster()
 
     def measure_melee(self):
         """What one melee swing at the near victim takes off, right now."""
@@ -1438,14 +1443,37 @@ class Match:
                         % (victim.name, was, victim.health),
                     )
 
-        # `held` was the probe taken inside the window; this is the one taken
-        # after it. Both halves, because a shield that never lifts and a server
-        # that cannot deal damage produce the same single reading.
-        if "shields_caster" in entry["proves"] and held and self.hit_caster():
+        # `held` is the pair of probes taken either side of the press, in
+        # `exercise`. Both halves, because a shield that never lifts and a
+        # server that cannot deal damage produce the same single reading -- and
+        # bracketing the press rather than the window is what lets one shape
+        # cover a one-second shield and a nineteen-second one.
+        if held:
             found["shields_caster"] = (
-                "a hit inside the window sent no health packet and the same hit "
-                "after it did"
+                "the same hit landed before the cast and sent no health packet "
+                "after it"
             )
+
+        # Nothing is cast. The claim is that the ability is still acting,
+        # because it left a mode on the caster rather than doing one thing, so
+        # what is watched for is any of the packets an ability produces
+        # arriving again on its own.
+        if "sustains" in entry["proves"]:
+            watched = {client.name: client.health for client in self.clients}
+            self.window_motions.clear()
+            self.wait(LINGER_WINDOW)
+            for client in self.clients:
+                was = watched.get(client.name)
+                if was is not None and client.health is not None and client.health < was - 0.05:
+                    found.setdefault(
+                        "sustains",
+                        "%s lost health with nothing pressed: %.2f to %.2f"
+                        % (client.name, was, client.health),
+                    )
+            if "sustains" not in found and self.window_motions:
+                found["sustains"] = "%d motion packets arrived with nothing pressed" % len(
+                    self.window_motions
+                )
         return found
 
     def window_sounds(self):
@@ -1494,11 +1522,12 @@ class Match:
             if "heals_caster" in outstanding:
                 self.wound_attacker()
 
+            # Before the press, so the shield probes bracket it.
+            landed_before = "shields_caster" in entry["proves"] and self.hit_caster()
+
             before = self.baseline(entry)
             self.press(entry)
-            # Immediately, before anything waits: the only shield in the roster
-            # is one second long.
-            held = self.probe_shield(entry)
+            held = self.probe_shield(entry, landed_before)
             if attempt == 0:
                 self.probe_cooldown(entry)
             for name, note in self.observe(entry, before, held).items():


### PR DESCRIPTION
Fourteen of the fifteen Smash Crystal ultimates were a single `splash` where the source gives a duration. The wiki does not describe any of them as a moment: *"lasts 20 seconds"*, *"unlimited flight and eggs"*, *"call lightning down once a second"*, *"Speed III, Regeneration III and Strength III"*.

Several tooltips in the game already said so while the code did the thing once. Dragon Rider's says *"ride a dragon through everyone"* and the Enderman did not move, so nothing was ridden and nobody was passed through.

## The shape already existed

`module/effect.rs` is an entity with `(Upon, player)`, `(InflictedBy, attacker)` and `(Source, ability)` that runs on delta time — which is exactly *a thing that keeps being true for N seconds*. An ultimate is that, pointed at the caster. So this adds two components rather than fourteen bespoke timers.

**`Repeats { every, until_next, pulse }`** — an action taken on a beat. The pulse is handed a `Cast`, the same value an ability's own payload gets, because a beat *is* a cast the player is not making. That makes `splash`, `fire` and `afflict` all work unchanged inside one, and it is why `ability::cast_from` is now public.

**`Ends(fn)`** — run when the effect ends, however it ends. Expiry, `clear` and the holder dying all go through one teardown path, which is what lets it promise that.

Every ultimate is now `Affliction::mode(seconds, beat, pulse)` with its old body as the pulse. Two say more: Giga Slime is `.untouchable()` for its nineteen seconds — the half of *"enormous and untouchable"* that did not exist — and Mooshroom Madness is `.undone_by(shrink_back)`.

`Repeats` is deliberately separate from `Ticks`, and the line is data versus behaviour: damage over time is uniform enough to be numbers a gate can read without running anything, which is why fire and poison are not two `fn`s. Anything else is a `fn`, for the same reason `OnActivate` is.

## Mooshroom was wrong in the other direction

It raised the caster's maximum health by five hearts and never lowered it, so a Cow who picked up two crystals finished the match on forty hearts and a third on fifty. It now also gets the +1 damage the wiki gives it, as `MeleeBonus`, sharing the mode's deadline so the two cannot disagree about when they end.

## `Observable::Sustains`

The new claim, and both gates enumerate it: with nothing pressed, the world goes on changing. Suppressing every beat makes all fourteen fail it by name.

## Three things worth knowing

**Arrow Storm fired five arrows per beat until the sweep showed why that is wrong.** Ninety damage a second killed both scripted victims inside the first second, after which the mode had nothing left to act on and read as having stopped — the strongest possible version of the feature looking exactly like a broken one. "Without ever reloading" removes the draw; it does not multiply the arrow. It is one arrow, three times a second. The gate also now stands the victims back up before watching for `sustains`, so this class of false negative cannot recur.

**`ShieldsCaster` changed shape.** It used to be *refused, then wait the window out and hit again*, which works for Sky Squid's one second and cannot afford Giga Slime's nineteen. It is now the same hit landing **before** the cast and being refused after it: both halves, so a broken damage pipeline is still ruled out, and no knowledge of the duration needed. What the per-ability gates therefore do *not* check is that the window ever ends — that is the effect module's behaviour rather than any kit's, and `tests/contract.rs` proves it once, there. Said out loud in the `Observable` doc.

**Seismic Slam now leaps.** Its tooltip and the wiki both say *"leap, then land hard"* and the caster never left the ground.

## Guards broken and watched to fail, then restored

```
for beat in beats  ->  beats.into_iter().take(0)
  Skeleton / Arrow Storm declares sustains and did not do it
  Iron Golem / Earthquake declares sustains and did not do it
  Spider / Spiders Nest declares sustains and did not do it
  Slime / Giga Slime declares sustains and did not do it
  Enderman / Dragon Rider declares sustains and did not do it
  Sky Squid / Storm Squid declares sustains and did not do it
  Wolf / Frenzy declares sustains and did not do it
  Snowman / Snow Turret declares sustains and did not do it
  Wither Skeleton / Wither Swap declares sustains and did not do it
  Zombie / Night of the Living Dead declares sustains and did not do it
  Cow / Mooshroom Madness declares sustains and did not do it
  Blaze / Phoenix declares sustains and did not do it
  Chicken / Aerial Gunner declares sustains and did not do it
  Guardian / Tidal Wave declares sustains and did not do it

.undone_by(shrink_back) removed from Mooshroom Madness
  Cow / Mooshroom Madness left the caster on a maximum of 30 health
  where the kit declares 20
```

The second guard is a sweep over every ultimate rather than a test for Cow, because nothing about that bug was specific to Cow and the next one will not be either. It checks maximum health, armour and knockback taken against what the kit prefab declares.

## Not done here

The `Cue::Burn` and `Cue::Venom` particles are still the `crit` and half-power `dragon_breath` placeholders. #1030 brings all 125 particle types, and `Particle::Flame` and `Particle::EntityEffect` are the real answers; swapping them is the immediate follow-up and the comment in `adapter.rs` names itself as the fossil to remove.

Speed and Regeneration are still absent from Frenzy — they are `ClientboundUpdateMobEffect`, which the seam does not carry. Strength is `MeleeBonus` and is there.

## Checks

`cargo test -p smash` and `nix run --accept-flake-config .#lint` both green on `5a486fd`. One `cargo test` run hit a SIGSEGV in `tests/hud`; three consecutive re-runs of that binary passed 35/35, which is ENG-10852 rather than this change.