### PR TITLE
fix(smash): the selector gate stops guessing the lobby too

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -413,8 +413,8 @@
               ]) uuids;
             };
 
-          # The lobby `smash-e2e` runs against, which is deliberately not the
-          # one the product ships.
+          # The lobby `smash-e2e` and `smash-selector-e2e` run against, which
+          # is deliberately not the one the product ships.
           #
           # The gate's ability sweep changes kits, and a committed match
           # refuses to, so the sweep needs a roster the lobby will not start
@@ -434,6 +434,11 @@
           # three players start nothing even by the old band order, so this
           # gate does not depend on the `countdown_for` fix that shipped
           # alongside it.
+          #
+          # `smash-selector-e2e` needs the same thing for the same reason: its
+          # hub checks run on three clients, which #1019 also put above the
+          # threshold, and its last check fills the lobby on purpose and so
+          # needs to know what full is.
           smashGateLobby = {
             sweepClients = 3;
             env = {
@@ -441,6 +446,10 @@
               SMASH_FULL_PLAYERS = 8;
             };
           };
+
+          # The roster that fills the gate's lobby, read off the threshold
+          # rather than written twice.
+          smashGateFullClients = toString smashGateLobby.env.SMASH_FULL_PLAYERS;
 
           # `env` as shell, for the gates that are scripts rather than checks.
           exportsFor =
@@ -729,7 +738,8 @@
               deps = [ pkgs.git ];
               text = ''
                 export HYPERION_EVENT=smash
-                export HYPERION_E2E_CLIENT=tools/smash-selector.py
+                export HYPERION_E2E_CLIENT="tools/smash-selector.py --full-clients ${smashGateFullClients}"
+                ${exportsFor smashGateLobby.env}
                 export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.smash-selector-e2e)}}"
                 export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.smash-selector-e2e)}}"
                 exec "${lib.getExe runners.e2e}" "$@"
@@ -1014,6 +1024,11 @@
               gameServer = gameBinaries.smash;
               proxy = gameBinaries.hyperion-proxy;
               client = "smash-selector.py";
+              clientArgs = [
+                "--full-clients"
+                smashGateFullClients
+              ];
+              serverEnv = smashGateLobby.env;
               timeout = 420;
             };
 

--- a/tools/hotbar-check.py
+++ b/tools/hotbar-check.py
@@ -19,9 +19,12 @@ the server does send, per kit, and holds them against the server's own registry:
   * they run from 0 upwards with no holes
   * switching kit leaves nothing of the last one behind
 
-One client and no match. The lobby needs four players to start a countdown, so
-a single connection stands in the hub indefinitely and can change kit as often
-as it likes, which is the cheapest place to ask this question.
+One client and no match. One player is below any minimum this server is
+configured to run, so a single connection stands in the hub indefinitely and
+can change kit as often as it likes, which is the cheapest place to ask this
+question. Said that way on purpose: this used to claim the lobby needs four,
+which was `LobbyConfig::default` restated here and stopped being true when
+#1019 made it two.
 
 Exits non-zero on the first thing that is not true, after printing what it saw.
 """

--- a/tools/hud-check.py
+++ b/tools/hud-check.py
@@ -18,8 +18,8 @@ Two halves, because they need different numbers of players.
      claim the whole feature rests on and the one that a bar wired to the wrong
      slot would still pass half of.
 
-  2. Eight clients, which is `full_players`, so the lobby runs its shortest
-     countdown rather than its sixty second one. That gets the phase machine
+  2. Enough clients to fill the lobby, so it runs its shortest countdown
+     rather than its sixty second one. That gets the phase machine
      through Countdown, Preparing and into Playing inside twenty seconds, and
      the titles, subtitles and the percentage bar with it.
 

--- a/tools/smash-map-check.py
+++ b/tools/smash-map-check.py
@@ -1138,8 +1138,10 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=25565)
-    # Eight, because `LobbyConfig::countdown_for` gives a full lobby a ten
-    # second countdown and a merely sufficient one sixty.
+    # Enough to fill the lobby, so `countdown_for` runs its shortest countdown
+    # rather than its longest. Eight covers every `full_players` this server
+    # has shipped; the comment used to say eight *was* `full_players`, which
+    # was `LobbyConfig::default` restated here and went stale at #1019.
     parser.add_argument("--clients", type=int, default=8)
     parser.add_argument("--timeout", type=float, default=240.0)
     args = parser.parse_args()

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -459,6 +459,30 @@ def load_item_names():
     return base.registry_entries("minecraft:item")
 
 
+def hub_lost(during, clients):
+    """Why a gate that needed an unstarted lobby cannot go on, in one line.
+
+    The hub is the only place a gate can change a kit, click a podium or read
+    an untouched ring and be sure nothing is racing it. Several harnesses need
+    to know they still have it, for the same reason and with the same two
+    remedies, so the sentence is written once here rather than worded four
+    ways. `hotbar-check.py`, `hud-check.py`, `identity-check.py` and
+    `smash-selector.py` all load this module already.
+
+    What this deliberately does not do is tell a gate how many clients are
+    safe. That answer is `min_players` and `full_players` together, it belongs
+    to the server, and a helper that returned it would be exactly the copy of
+    `LobbyConfig::default` that this whole change exists to delete.
+    """
+    return (
+        "the lobby left the hub %s. %d clients is enough for this server to "
+        "start a countdown, so the hub is gone and nothing after this would be "
+        "proved. Either the gate's roster is too many for this lobby, or the "
+        "server needs a higher SMASH_MIN_PLAYERS/SMASH_FULL_PLAYERS."
+        % (during, clients)
+    )
+
+
 def stamp(started):
     return "%7.2fs" % (time.time() - started)
 
@@ -791,13 +815,7 @@ class Match:
         # longer reaches -- so the run failed with the reason nowhere in the
         # transcript. A guard that stops the right run for a reason nobody can
         # read is most of a guard.
-        self.log(
-            "SWEEP ABANDONED the lobby left the hub %s. %d clients is enough "
-            "for this server to start a countdown, so kits can no longer be "
-            "changed and nothing further would be proved. Either "
-            "--sweep-clients is too many for this lobby, or the server needs a "
-            "higher SMASH_MIN_PLAYERS/SMASH_FULL_PLAYERS." % (during, len(self.clients))
-        )
+        self.log("SWEEP ABANDONED %s" % hub_lost(during, len(self.clients)))
         return False
 
     # --- reading -------------------------------------------------------

--- a/tools/smash-selector.py
+++ b/tools/smash-selector.py
@@ -149,10 +149,10 @@ PODIUM_END_PREFIX = "smash-podiums-end "
 FREE_BLOCK = "minecraft:lime_wool"
 TAKEN_BLOCK = "minecraft:red_wool"
 
-# events/smash/src/module/lobby.rs: `LobbyConfig::default`. Eight is
-# `full_players`, which is the shortest countdown the lobby will run and so the
-# cheapest way to reach a committed match.
-FULL_PLAYERS = 8
+# The roster that fills the lobby is `--full-clients` and not a constant here.
+# It was `FULL_PLAYERS = 8`, under a comment naming `LobbyConfig::default` as
+# where it came from, which is what made it a copy: #1019 moved that default to
+# 4 and this number stayed at 8, still claiming to be it.
 
 # How many lines a complete run reports. More than the nine claims, because two
 # of the checks answer several: the roster sweep proves the sound, its audience
@@ -563,6 +563,24 @@ class Run:
         self.failures.append(why)
         self.log("FAILED %s" % why)
 
+    def hub_only(self, during):
+        """Whether the lobby is still unstarted, which the hub checks need.
+
+        The wording is `smash-match.py`'s, which hit this first and owns the
+        sentence. Three clients used to sit below `min_players` and now sit
+        above it, so these checks run with a countdown underneath them rather
+        than in a hub that will wait, and a claim made while the match commits
+        is a claim about the wrong game.
+
+        Reading the phase off the server's own broadcasts rather than
+        recomputing a threshold is what keeps this right whatever the numbers
+        become, and is what keeps it from being one more copy of them.
+        """
+        if self.phase == "waiting":
+            return True
+        self.fail(match.hub_lost(during, len(self.live())))
+        return False
+
     def connect(self, count):
         for _ in range(count):
             name = "S%d" % (len(self.clients) + 1)
@@ -809,16 +827,26 @@ class Run:
     # --- the script -----------------------------------------------------
 
     def run(self):
-        # Three, which is one short of `min_players`, so the lobby stays in
-        # `Waiting` for as long as these checks take. A fourth client here
-        # would start a countdown underneath them and every later assertion
-        # would be racing it.
+        # Three because the checks below need three named roles -- a holder, a
+        # watcher, and somebody to take a freed mob -- and not because of any
+        # threshold. It used to say "one short of `min_players`", which was a
+        # second copy of `LobbyConfig::default` and stopped being true when
+        # #1019 moved it: three is now one *over* the minimum, and a countdown
+        # starts under these checks rather than after them.
+        #
+        # The lobby has to stay unstarted for all of them even so, which is the
+        # server's business and is checked with `hub_only` rather than computed
+        # here. `selection_survives_the_countdown` at the end wants the exact
+        # opposite and fills the lobby deliberately.
         one, two, three = self.connect(3)
         if not self.wait_until(
             lambda: all(client.joined for client in self.clients),
             60.0,
             "three clients to reach the world",
         ):
+            return self.report()
+
+        if not self.hub_only("before the hub checks began"):
             return self.report()
 
         self.the_ring_exists(one)
@@ -828,6 +856,11 @@ class Run:
         # the skin half is answered by a client that is not the one selecting.
         self.every_mob_answers_in_its_own_voice(one, two)
         self.a_skin_change_costs_nobody_their_world(one, two)
+        # Again before anything is claimed. The reads above cost real seconds,
+        # and a countdown that started during them makes every claim below a
+        # claim about a lobby that is no longer taking them.
+        if not self.hub_only("after reading the ring, before claiming a mob"):
+            return self.report()
         taken = self.a_click_picks_the_mob(one)
         if taken is None:
             return self.report()
@@ -1311,7 +1344,7 @@ class Run:
         not spend a minute of wall clock proving something a ten-second one
         proves.
         """
-        joining = FULL_PLAYERS - len(self.live())
+        joining = self.args.full_clients - len(self.live())
         if joining > 0:
             self.connect(joining)
         if not self.wait_until(
@@ -1479,6 +1512,17 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=25565)
+    parser.add_argument(
+        "--full-clients",
+        type=int,
+        default=8,
+        help="how many clients fill the lobby for the last check, which wants "
+        "a committed match and the shortest countdown the server will run. "
+        "Must be at or above the server's `full_players`. Declared by the gate "
+        "rather than read from a default here, because it is the server's "
+        "number: it was `FULL_PLAYERS = 8` copied out of `LobbyConfig::default` "
+        "until #1019 moved that default to 4 and the copy stayed at 8",
+    )
     args = parser.parse_args()
     return Run(args).run()
 


### PR DESCRIPTION
## Effect

`nix run .#smash-selector-e2e` gets the treatment `smash-e2e` got in #1027. It had the identical defect, twice, and #1019 broke it the same way. Filed as ENG-10889 while fixing #1027; fixing rather than leaving it filed.

## The two copies

**`FULL_PLAYERS = 8`**, under a comment naming `LobbyConfig::default` as its source, which is exactly what made it a copy. #1019 moved that default to 4 and the number here stayed at 8, still claiming to be it. It is now `--full-clients`, which the gate derives from its own `SMASH_FULL_PLAYERS` so the two cannot disagree.

**"Three, which is one short of `min_players`"** above its own `connect(3)`. Three is now one *over* the minimum, so a countdown ran underneath the hub checks instead of after them -- the comment's own stated failure mode, arrived at by the comment going stale.

Three stays. The checks need three named roles (a holder, a watcher, and somebody to take a freed mob), which is a fact about this gate and not arithmetic on a threshold. What changed is that it is no longer described as arithmetic on a threshold, because it never was.

## The guard, not the number

`hub_only` fails the run if the lobby leaves `Waiting` while the hub checks still need it: once after the clients join, and again before the first claim, since the reads in between cost real seconds. It reads the phase off the server's own broadcasts, so it stays right whatever the thresholds become.

`smash-selector-e2e` also now gets `serverEnv = smashGateLobby.env`, so it runs against the same declared 4/8 lobby as `smash-e2e` rather than inheriting the product's.

## One shared helper, and the thing it refuses to do

The message both harnesses print is now `hub_lost` in `smash-match.py`, which `smash-selector.py`, `hotbar-check.py`, `hud-check.py` and `identity-check.py` all already load. One failure, one wording.

**It shares the consequence, not the number, and it could not share the number.** There is no single safe roster to share: the ability sweep wants 3, the selector wants 3 for entirely unrelated reasons, and filling a lobby wants 8. The thing that was duplicated is `LobbyConfig::default`, and the right number of copies of that in Python is zero rather than one. A helper returning "the largest roster that will not start" would be the fourth copy wearing a hat, so `hub_lost` says in its own docstring that it will not answer that.

## No mechanical gate, and what a reviewer now has to catch

I considered a lint over `tools/*.py` -- forbid an integer literal on a line mentioning `min_players`/`full_players`, or a module constant named `*_PLAYERS`. I did not add one. It would have caught `FULL_PLAYERS = 8` and would not have caught `connect(3)` under a false comment, which is the other half of this same bug. A regex over the spelling that happened to occur last time is the failure mode that lets the fourth instance through while reading as protection.

The real protection is the runtime guard, which does not care how the number was arrived at. It is opt-in, so three things still need a human:

1. **A new hub-dependent harness that never calls `hub_only`.** Nothing forces adoption.
2. **A roster flag without the matching `SMASH_*` export.** `--full-clients` and `--sweep-clients` only mean anything because their gate also sets the threshold; the flag and the env have to move together. Only `smash-e2e` and `smash-selector-e2e` are wired this way.
3. **`hud-check.py` and `smash-map-check.py` still pass 8 as "enough to fill" against a server they do not configure.** They pass today only because 8 is above a `full_players` of 4. If it ever goes above 8 they will quietly stop testing the full band instead of failing. I did not close this: those gates belong to other agents, and closing it means giving them `serverEnv` too. Named here rather than left implicit.

## Stale prose, three files

`hotbar-check.py` claimed the lobby needs four players. It needs two, and that gate uses one client, so only the reason was wrong. `smash-map-check.py` called 8 "`full_players`" rather than "at or above it". `hud-check.py` had the same in its docstring; its `--clients` help was already corrected on main by another agent and I took theirs over mine in the rebase.

## Checks

`nix run .#smash-selector-e2e`, all 15 claims:

```
PASS  the hub has a podium per mob, with that mob standing on it
PASS  every mob wears its kit's name, always visible       15 of 15
PASS  a click plays the mob's own declared sound           15 of 15 kits answered
PASS  and only the player who clicked hears it             S2 heard none of 15 selections
PASS  all fifteen mobs answer in different voices          15 distinct sounds over 15 kits
PASS  the other player sees the new skin on the wire
PASS  and it did not cost the wearer its world
PASS  a right-click on a podium picks that mob
PASS  a taken mob is red without anybody reading anything
PASS  a mob somebody else has is refused, by name
PASS  the refusal is about that mob and not about clicking
PASS  a holder who disconnects frees their mob at once
PASS  a full lobby holds one mob each                      S2=Iron Golem; S3=Skeleton; ... S9=Wolf
PASS  a selection made in the hub survives the countdown   8 clients started the match on the mob they clicked for
PASS  a click after the match commits is refused
RESULT: the kit selector works, on the wire
rc=0
```

Guard broken deliberately, by pointing `smashGateLobby.env` at production's 2/4:

```
   0.72s      FAILED the lobby left the hub before the hub checks began. 3 clients is enough for this server to start a countdown, so the hub is gone and nothing after this would be proved. Either the gate's roster is too many for this lobby, or the server needs a higher SMASH_MIN_PLAYERS/SMASH_FULL_PLAYERS.
RESULT: 1 checks failed
rc=1
```

That run is also the confirmation ENG-10889 was missing: at 2/4 three clients start a countdown 0.72 seconds in, so `smash-selector-e2e` really was broken by #1019 and not merely suspicious. Restored to 4/8 afterwards.

## `smash-e2e` may be red on main, but I could not confirm it here, and this PR does not touch it

Reported honestly rather than overstated: `nix run .#smash-e2e` failed on a Sky Squid `shields_caster` probe in every run of mine that reached it (5a486fd twice, 54de2ba once), filed as ENG-10906. But I cannot confirm a real bug from this machine, and the ticket now says so.

The box has sat at load average ~20 all night (22 users, seven agents). The shield probe hits the caster immediately after the press expecting the immunity tag already applied, which makes it the tightest-timing probe in the sweep and the first to flake under load. When I stacked a `cargo` compile on top, the sweep took 377s instead of 121s and *five* unrelated timing probes failed (both shields, Storm Squid's launches, `buffs_melee` on two kits) -- a load signature, not five bugs.

The load-immune instrument disagrees with the wire: `events/smash/tests/abilities.rs::every_declared_effect_actually_happens` passes on 54de2ba, and it is not a blind test -- I made `arm_shield` a no-op and watched it fail in 1.2s with verbatim the same sentence. So the shield works in-process, and the leading explanation for the wire failure is the probe racing the shield's application, not a broken shield. #1032 already retired the old "hit 50ms after the press" probe for exactly this reason. The wire verdict needs CI's `Flake` job or an idle host; ENG-10906 is rescoped to that rather than closed or asserted.

None of this is in scope for this PR, which touches only the harness wiring and prose. Its own gate, `smash-selector-e2e`, is green.

Python: `python3 -m py_compile` on all five changed harnesses, and `ruff check` clean on `smash-selector.py` before and after.
