### PR TITLE
fix(clap): reading a permission and granting one are not one permission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
 name = "hyperion-clap-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 3.0.3",
 ]

--- a/crates/hyperion-clap-macros/Cargo.toml
+++ b/crates/hyperion-clap-macros/Cargo.toml
@@ -1,4 +1,5 @@
 [dependencies]
+proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
 

--- a/crates/hyperion-clap-macros/src/lib.rs
+++ b/crates/hyperion-clap-macros/src/lib.rs
@@ -1,59 +1,343 @@
+//! `#[derive(CommandPermission)]`: which group a command, and each of its
+//! subcommands, is for.
+//!
+//! # A group per subcommand, not per command
+//!
+//! This derive used to emit one group for the whole type. On a `clap` enum,
+//! where each variant is a subcommand, that made the weakest variant the gate
+//! for all of them, and `/perms` was declared `Normal` because `/perms get` is:
+//! every player who could connect could run `/perms set <themselves> Admin`
+//! (ENG-10871).
+//!
+//! So a group is declared on the type, on a variant, or on both:
+//!
+//! ```ignore
+//! #[derive(Parser, CommandPermission)]
+//! #[command(name = "perms")]
+//! pub enum PermissionCommand {
+//!     #[command_permission(group = "Admin")]
+//!     Set(SetCommand),
+//!     #[command_permission(group = "Normal")]
+//!     Get(GetCommand),
+//! }
+//! ```
+//!
+//! A type-level group is the default for variants that do not declare their
+//! own, which is how a command whose subcommands are all equally dangerous
+//! stays one line.
+//!
+//! # Declaring some but not all of them is a compile error
+//!
+//! What is refused is the shape that produced the bug: no type-level group and
+//! only some variants carrying one. There the undeclared variants would have to
+//! fall back to something, and every available fallback is a guess about
+//! whether the author meant "same as the others" or forgot. The error names the
+//! variants that are missing.
+//!
+//! # Where the generated code is used
+//!
+//! `hyperion_clap::MinecraftCommand::register` asks three separate questions,
+//! and getting the wrong one is how this bug was reachable in the first place:
+//!
+//! * `has_required_permission` -- may this player use the command at all,
+//!   which is true when they may use *any* of its subcommands. It decides
+//!   whether the command's own node is in the tree, and `CommandRegistry`
+//!   lists it.
+//! * `subcommand_has_required_permission` -- may this player see this
+//!   subcommand's literal in their command tree.
+//! * `variant_has_required_permission` -- may this player run *this* parsed
+//!   invocation. This is the one that gates execution, and the only one that
+//!   is a security boundary.
+
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{DeriveInput, Error, Ident, Lit, parse_macro_input};
+use syn::{
+    Attribute, Data, DeriveInput, Error, Fields, Ident, Lit, LitStr, Variant, parse_macro_input,
+    spanned::Spanned,
+};
 
-#[proc_macro_derive(CommandPermission, attributes(command_permission))]
-pub fn derive_command_permission(input: TokenStream) -> TokenStream {
-    // Parse the input as a DeriveInput (struct or enum)
-    let input = parse_macro_input!(input as DeriveInput);
-    let name = input.ident.clone(); // Clone the Ident to prevent moving
-
-    // Extract the group from the `#[command_permission(group = "Admin")]` attribute
+/// The group named by a `#[command_permission(group = "...")]` on `attrs`.
+fn declared_group(attrs: &[Attribute]) -> syn::Result<Option<Ident>> {
     let mut group = None;
-    for attr in &input.attrs {
-        if attr.path().is_ident("command_permission")
-            && let Err(err) = attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("group")
-                    && let Ok(Lit::Str(lit)) = meta.value()?.parse::<Lit>()
-                {
-                    group = Some(lit);
+
+    for attr in attrs {
+        if !attr.path().is_ident("command_permission") {
+            continue;
+        }
+
+        let mut found: Option<LitStr> = None;
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("group") {
+                if let Lit::Str(lit) = meta.value()?.parse::<Lit>()? {
+                    found = Some(lit);
+                    return Ok(());
                 }
-                Ok(())
-            })
+                return Err(meta.error("group takes a string, such as group = \"Admin\""));
+            }
+            Err(meta.error("the only key is `group`"))
+        })?;
+
+        let Some(found) = found else {
+            return Err(Error::new_spanned(
+                attr,
+                "`#[command_permission]` needs a group: `#[command_permission(group = \
+                 \"Admin\")]`",
+            ));
+        };
+
+        group = Some(Ident::new(&found.value(), found.span()));
+    }
+
+    Ok(group)
+}
+
+/// Refuse a `#[command_permission]` written somewhere it would be ignored.
+///
+/// A derive helper attribute on a field parses and then does nothing, so
+/// without this a group declared one level too deep is a command that silently
+/// keeps the group above it.
+fn reject_group_on_fields(fields: &Fields) -> syn::Result<()> {
+    for field in fields {
+        if field
+            .attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("command_permission"))
         {
-            return Error::new_spanned(attr, format!("Failed to parse attribute: {err}"))
-                .to_compile_error()
-                .into();
+            return Err(Error::new(
+                field.span(),
+                "a group belongs on the command or on one of its subcommands, not on an \
+                 argument; a `#[command_permission]` here would be ignored",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// What `clap` calls this variant on the command line.
+///
+/// `clap_derive` kebab-cases the variant's name unless `#[command(name = ...)]`
+/// says otherwise, and this has to arrive at the same answer or the group would
+/// be filed under a subcommand that does not exist. It is not trusted to:
+/// `MinecraftCommand::register` checks every name `clap` reports against
+/// `declared_subcommands` and refuses to start the server if one is missing,
+/// so a disagreement is a startup failure naming both spellings rather than a
+/// subcommand quietly falling back to the command's own group.
+fn clap_name(variant: &Variant) -> String {
+    for attr in &variant.attrs {
+        if !attr.path().is_ident("command") && !attr.path().is_ident("clap") {
+            continue;
+        }
+
+        let mut named = None;
+        // Every other `command` key is clap's business, so an unrecognised one
+        // is skipped rather than rejected.
+        drop(attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("name")
+                && let Ok(value) = meta.value()
+                && let Ok(Lit::Str(lit)) = value.parse::<Lit>()
+            {
+                named = Some(lit.value());
+            }
+            Ok(())
+        }));
+
+        if let Some(named) = named {
+            return named;
         }
     }
 
-    let group_ident = match group {
-        Some(g) => Ident::new(&g.value(), g.span()),
-        None => {
-            return Error::new_spanned(
-                input,
-                "Missing required `#[command_permission(group = \"<GroupName>\")]` attribute.",
-            )
-            .to_compile_error()
-            .into();
+    kebab_case(&variant.ident.to_string())
+}
+
+/// `heck`'s kebab-casing, for the identifiers a clap subcommand can be.
+fn kebab_case(ident: &str) -> String {
+    let chars: Vec<char> = ident.chars().collect();
+    let mut out = String::with_capacity(chars.len() + 2);
+
+    for (index, &current) in chars.iter().enumerate() {
+        if current == '_' {
+            out.push('-');
+            continue;
         }
-    };
 
-    // Generate the trait implementation
-    let expanded = quote! {
-        impl CommandPermission for #name {
-            fn has_required_permission(user_group: ::hyperion_permission::Group) -> bool {
-                const REQUIRED_GROUP: ::hyperion_permission::Group = ::hyperion_permission::Group::#group_ident;
-
-                if REQUIRED_GROUP == ::hyperion_permission::Group::Banned {
-                    // When checking for the group "Banned" we don't want to check for higher groups.
-                    return REQUIRED_GROUP == user_group;
-                } else {
-                    return user_group as u32 >= REQUIRED_GROUP as u32
-                }
+        if current.is_uppercase() && index != 0 {
+            let previous = chars[index - 1];
+            let next_is_lower = chars.get(index + 1).is_some_and(|c| c.is_lowercase());
+            if previous.is_lowercase() || previous.is_numeric() || (previous.is_uppercase() && next_is_lower) {
+                out.push('-');
             }
         }
+
+        out.extend(current.to_lowercase());
+    }
+
+    out
+}
+
+/// `user_group.allows(Group::#group)`, which is the whole permission rule.
+fn allows(group: &Ident) -> proc_macro2::TokenStream {
+    quote! {
+        ::hyperion_permission::Group::allows(user_group, ::hyperion_permission::Group::#group)
+    }
+}
+
+#[proc_macro_derive(CommandPermission, attributes(command_permission))]
+pub fn derive_command_permission(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    match expand(&input) {
+        Ok(tokens) => tokens.into(),
+        Err(error) => error.to_compile_error().into(),
+    }
+}
+
+fn expand(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let name = &input.ident;
+    let default_group = declared_group(&input.attrs)?;
+
+    let (any, variant, subcommand, declared) = match &input.data {
+        Data::Enum(data) => {
+            for variant in &data.variants {
+                reject_group_on_fields(&variant.fields)?;
+            }
+            enum_arms(name, default_group.as_ref(), data)?
+        }
+        Data::Struct(data) => {
+            reject_group_on_fields(&data.fields)?;
+            let Some(group) = default_group else {
+                return Err(Error::new_spanned(
+                    input,
+                    "missing `#[command_permission(group = \"<GroupName>\")]`, which says who \
+                     this command is for",
+                ));
+            };
+            let check = allows(&group);
+            (
+                check,
+                quote! { <Self as CommandPermission>::has_required_permission(user_group) },
+                quote! { <Self as CommandPermission>::has_required_permission(user_group) },
+                Vec::new(),
+            )
+        }
+        Data::Union(_) => {
+            return Err(Error::new_spanned(
+                input,
+                "a command is a struct or an enum, not a union",
+            ));
+        }
     };
 
-    TokenStream::from(expanded)
+    Ok(quote! {
+        impl CommandPermission for #name {
+            fn has_required_permission(user_group: ::hyperion_permission::Group) -> bool {
+                #any
+            }
+
+            fn variant_has_required_permission(
+                &self,
+                user_group: ::hyperion_permission::Group,
+            ) -> bool {
+                #variant
+            }
+
+            fn subcommand_has_required_permission(
+                subcommand: ::core::option::Option<&str>,
+                user_group: ::hyperion_permission::Group,
+            ) -> bool {
+                #subcommand
+            }
+
+            fn declared_subcommands() -> &'static [&'static str] {
+                &[#(#declared),*]
+            }
+        }
+    })
+}
+
+type Arms = (
+    proc_macro2::TokenStream,
+    proc_macro2::TokenStream,
+    proc_macro2::TokenStream,
+    Vec<String>,
+);
+
+fn enum_arms(
+    name: &Ident,
+    default_group: Option<&Ident>,
+    data: &syn::DataEnum,
+) -> syn::Result<Arms> {
+    if data.variants.is_empty() {
+        return Err(Error::new_spanned(
+            name,
+            "a command with no subcommands has nothing to gate",
+        ));
+    }
+
+    let mut groups = Vec::new();
+    let mut undeclared = Vec::new();
+
+    for variant in &data.variants {
+        match declared_group(&variant.attrs)?.or_else(|| default_group.cloned()) {
+            Some(group) => groups.push((variant, group)),
+            None => undeclared.push(variant.ident.to_string()),
+        }
+    }
+
+    if !undeclared.is_empty() {
+        // The shape that produced ENG-10871, refused rather than guessed at.
+        return Err(Error::new_spanned(
+            name,
+            format!(
+                "these subcommands declare no group and the command declares no default for \
+                 them: {undeclared:?}. Either give the command a \
+                 `#[command_permission(group = ...)]` covering every subcommand, or give each \
+                 subcommand its own. Declaring only some is refused because the fallback would \
+                 be a guess, and the guess that used to be made here let any player run \
+                 `/perms set` (ENG-10871)."
+            ),
+        ));
+    }
+
+    let any_checks: Vec<_> = groups.iter().map(|(_, group)| allows(group)).collect();
+
+    let variant_arms: Vec<_> = groups
+        .iter()
+        .map(|(variant, group)| {
+            let ident = &variant.ident;
+            let check = allows(group);
+            quote! { Self::#ident { .. } => #check }
+        })
+        .collect();
+
+    let mut declared = Vec::new();
+    let mut subcommand_arms = Vec::new();
+    for (variant, group) in &groups {
+        let literal = clap_name(variant);
+        let check = allows(group);
+        subcommand_arms.push(quote! { ::core::option::Option::Some(#literal) => #check });
+        declared.push(literal);
+    }
+
+    Ok((
+        // May this player use the command at all: true when any one of its
+        // subcommands is open to them.
+        quote! { #(#any_checks)||* },
+        quote! { match self { #(#variant_arms),* } },
+        quote! {
+            match subcommand {
+                // The command's own node, which is in the tree when any
+                // subcommand under it is.
+                ::core::option::Option::None => {
+                    <Self as CommandPermission>::has_required_permission(user_group)
+                }
+                #(#subcommand_arms,)*
+                // Unreachable: `register` refuses to start a server whose clap
+                // subcommands are not all declared here. Fails closed anyway,
+                // because the alternative is the weakest-variant-wins default
+                // this derive exists to remove.
+                ::core::option::Option::Some(_) => false,
+            }
+        },
+        declared,
+    ))
 }

--- a/crates/hyperion-clap/src/lib.rs
+++ b/crates/hyperion-clap/src/lib.rs
@@ -42,8 +42,27 @@
 //! ```ignore
 //! PermissionCommand::register(registry, world).completes("player", Player::id());
 //! ```
+//!
+//! # A permission is per subcommand, and it is checked twice
+//!
+//! Both mechanisms above are gated, and they are gated separately because they
+//! fail differently. The command tree leaves out any node the player may not
+//! use, so a `Normal` player is never offered `/perms set` -- getting that
+//! wrong costs a misleading autocomplete. [`MinecraftCommand::register`]'s
+//! execute path checks the *parsed* invocation before running it -- getting
+//! that wrong is a privilege escalation, and it was one: the derive could only
+//! carry one group for a whole `clap` enum, so `/perms` was `Normal` because
+//! `/perms get` is, and every player could run `/perms set` (ENG-10871).
+//!
+//! Which group each subcommand needs is declared on it. See
+//! [`hyperion_clap_macros`] for the shapes the derive accepts and the ones it
+//! refuses. Nobody starts out holding a group that a command hands out, so the
+//! first administrator is named in configuration rather than appointed:
+//! [`hyperion_permission::seed`].
 
 pub mod completion;
+
+use std::sync::Arc;
 
 use clap::{Arg as ClapArg, Parser, ValueEnum, ValueHint, error::ErrorKind};
 use flecs_ecs::{
@@ -61,7 +80,9 @@ use hyperion::{
     net::{Compose, ConnectionId, DataBundle, agnostic, protocol::Clientbound},
     simulation::{
         IgnMap, Player,
-        command::{FixedSuggestions, Suggests, get_root_command_entity, suggestions},
+        command::{
+            FixedSuggestions, HasPermission, Suggests, get_root_command_entity, suggestions,
+        },
         handlers::PacketSwitchQuery,
     },
     storage::CommandCompletionRequest,
@@ -81,17 +102,31 @@ fn is_greedy(arg: &ClapArg) -> bool {
         .is_some_and(|range| range.max_values() > 1)
 }
 
+/// The gate for one node of `C`'s tree: the command's own node when
+/// `subcommand` is `None`, and that subcommand's otherwise.
+fn gate_for<C: MinecraftCommand>(subcommand: Option<String>) -> HasPermission {
+    Arc::new(move |world: &World, caller: Entity| {
+        caller.entity_view(world).get::<&Group>(|group| {
+            C::subcommand_has_required_permission(subcommand.as_deref(), *group)
+        })
+    })
+}
+
 /// Build the graph nodes under `parent` for one clap command, and return the
 /// shape the completion walk reads.
 ///
 /// Positionals chain one after another because that is the order they are
 /// typed in; subcommands hang off the end of that chain as literals, which for
 /// every command here means directly off the command's own node.
-fn build(
+///
+/// `under` is the subcommand this subtree hangs beneath, which is what decides
+/// the gate on every node in it. A subcommand's own children are gated as it
+/// is: nothing below `/perms set` can be for a wider audience than `set`.
+fn build<C: MinecraftCommand>(
     world: &World,
     parent: Entity,
     cmd: &clap::Command,
-    has_permission: fn(&World, Entity) -> bool,
+    under: Option<&str>,
 ) -> Vec<Step<Entity>> {
     let mut on = parent;
     let mut created = Vec::new();
@@ -136,11 +171,12 @@ fn build(
     let mut steps: Vec<Step<Entity>> = cmd
         .get_subcommands()
         .map(|sub| {
+            let key = under.unwrap_or_else(|| sub.get_name());
             let literal = world
                 .entity()
                 .set(hyperion::simulation::command::Command::literal(
                     sub.get_name().to_owned(),
-                    has_permission,
+                    gate_for::<C>(Some(key.to_owned())),
                 ))
                 .child_of(on);
             Step {
@@ -148,7 +184,7 @@ fn build(
                 id: sub.get_name().to_owned(),
                 node: literal.id(),
                 greedy: false,
-                next: build(world, literal.id(), sub, has_permission),
+                next: build::<C>(world, literal.id(), sub, Some(key)),
             }
         })
         .collect();
@@ -230,16 +266,42 @@ impl Registered<'_> {
     }
 }
 
-pub trait MinecraftCommand: Parser + CommandPermission {
+pub trait MinecraftCommand: Parser + CommandPermission + 'static {
     fn execute(self, system: EntityView<'_>, caller: Entity);
 
     fn pre_register(_world: &World) {}
 
+    /// # Panics
+    /// When the command declares a group for some subcommand `clap` does not
+    /// have, or has a subcommand it declares no group for. Both mean a
+    /// subcommand whose gate is not the one anybody wrote down, and the server
+    /// refusing to start is cheaper than finding that out from a player.
     fn register<'w>(registry: &mut CommandRegistry, world: &'w World) -> Registered<'w> {
         Self::pre_register(world);
 
         let cmd = Self::command();
         let name = cmd.get_name().to_owned();
+
+        // The derive files each subcommand's group under the name it works out
+        // that `clap` will use, by kebab-casing the variant. This is where that
+        // is checked against the name `clap` actually reports, because the
+        // failure it prevents is silent: a group filed under a name no
+        // subcommand has leaves that subcommand falling back, and falling back
+        // to the weakest group is exactly ENG-10871.
+        let declared = Self::declared_subcommands();
+        if !declared.is_empty() {
+            let actual: Vec<&str> = cmd.get_subcommands().map(clap::Command::get_name).collect();
+            let undeclared: Vec<&&str> = actual
+                .iter()
+                .filter(|name| !declared.contains(name))
+                .collect();
+            assert!(
+                undeclared.is_empty(),
+                "/{name} has subcommand(s) {undeclared:?} that carry no permission group. The \
+                 derive declared groups for {declared:?} and clap named {actual:?}; the two have \
+                 to agree or those subcommands are gated by nothing anybody wrote."
+            );
+        }
 
         let has_permissions = |world: &World, caller: Entity| {
             caller
@@ -247,15 +309,17 @@ pub trait MinecraftCommand: Parser + CommandPermission {
                 .get::<&Group>(|group| Self::has_required_permission(*group))
         };
 
-        let node_to_register =
-            hyperion::simulation::command::Command::literal(name.clone(), has_permissions);
+        let node_to_register = hyperion::simulation::command::Command::literal(
+            name.clone(),
+            gate_for::<Self>(None),
+        );
 
         let root = world
             .entity()
             .set(node_to_register)
             .child_of(get_root_command_entity());
 
-        let shape = build(world, root.id(), &cmd, has_permissions);
+        let shape = build::<Self>(world, root.id(), &cmd, None);
 
         let mut values = Vec::new();
         value_steps(&shape, &mut values);
@@ -266,10 +330,13 @@ pub trait MinecraftCommand: Parser + CommandPermission {
 
             match Self::try_parse_from(input) {
                 Ok(elem) => {
+                    // The parsed invocation, not the command. `/perms get` and
+                    // `/perms set` are one command and two permissions, and
+                    // asking the command was ENG-10871.
                     if world.get::<&Compose>(|compose| {
                         caller.entity_view(world).get::<(&ConnectionId, &Group)>(
                             |(stream, group)| {
-                                if Self::has_required_permission(*group) {
+                                if elem.variant_has_required_permission(*group) {
                                     true
                                 } else {
                                     let chat = agnostic::chat(
@@ -398,8 +465,41 @@ impl MinecraftArg for ClapArg {
     }
 }
 
+/// Who a command, and each of its subcommands, is for.
+///
+/// Derived; see [`hyperion_clap_macros`] for how a group is declared. The three
+/// questions are separate because they have three different answers, and
+/// answering the third with the first is the bug this shape exists to prevent:
+/// `/perms` as a command is for everybody, and `/perms set` is not.
 pub trait CommandPermission {
+    /// Whether `user_group` may use this command at all, which is true when it
+    /// may use at least one of the command's subcommands.
+    ///
+    /// This is a visibility question, not a security one. It decides whether
+    /// the command's own node reaches a player's tree and whether
+    /// [`hyperion_command::CommandRegistry::get_permitted`] lists it.
     fn has_required_permission(user_group: hyperion_permission::Group) -> bool;
+
+    /// Whether `user_group` may run *this* parsed invocation.
+    ///
+    /// The security boundary. Every other method on this trait can be wrong
+    /// and cost a player a misleading autocomplete; this one being wrong is a
+    /// privilege escalation.
+    fn variant_has_required_permission(&self, user_group: hyperion_permission::Group) -> bool;
+
+    /// Whether `user_group` may see `subcommand`'s literal in their command
+    /// tree. `None` asks about the command's own node.
+    fn subcommand_has_required_permission(
+        subcommand: Option<&str>,
+        user_group: hyperion_permission::Group,
+    ) -> bool;
+
+    /// The subcommand names this command declares a group for, empty when one
+    /// group covers the whole command.
+    ///
+    /// [`MinecraftCommand::register`] checks this against the names `clap`
+    /// reports and refuses to start the server when they disagree.
+    fn declared_subcommands() -> &'static [&'static str];
 }
 
 #[derive(Clone, Debug, ValueEnum, PartialEq, Eq)]
@@ -424,11 +524,26 @@ pub struct GetCommand {
     player: String,
 }
 
+/// `/perms`: read a player's group, or write one.
+///
+/// The two halves are declared separately and deliberately. Reading a group is
+/// a `Normal` thing to do -- it is how a player finds out what they may run --
+/// and writing one is the act that hands out every other `Admin` command on the
+/// server, permanently, because `PermissionStorage` is keyed on the profile id
+/// and survives a restart.
+///
+/// There is no type-level `#[command_permission]` here on purpose. With one,
+/// adding a third subcommand would silently inherit it; without one, the derive
+/// refuses to compile until the new subcommand says who it is for.
+///
+/// The way to appoint the first administrator is not this command, which would
+/// be circular. It is [`hyperion_permission::seed`].
 #[derive(Parser, CommandPermission, Debug)]
 #[command(name = "perms")]
-#[command_permission(group = "Normal")]
 pub enum PermissionCommand {
+    #[command_permission(group = "Admin")]
     Set(SetCommand),
+    #[command_permission(group = "Normal")]
     Get(GetCommand),
 }
 
@@ -541,5 +656,99 @@ impl Module for ClapCommandModule {
             PermissionCommand::register(registry, world).completes("player", Player::id());
             ServerLoadCommand::register(registry, world);
         });
+    }
+}
+
+#[cfg(test)]
+mod permission_gates {
+    use clap::{CommandFactory, Parser};
+    use hyperion_permission::Group;
+
+    use super::{CommandPermission, PermissionCommand, ServerLoadCommand};
+
+    fn parse(line: &str) -> PermissionCommand {
+        PermissionCommand::try_parse_from(line.split_whitespace()).unwrap()
+    }
+
+    /// ENG-10871. Before the derive could carry a group per variant this
+    /// assertion read `assert!(...)` and passed, because `Set` and `Get` were
+    /// one gate and `Get` set it.
+    #[test]
+    fn a_normal_player_cannot_write_a_group() {
+        let set = parse("perms set Andrew admin");
+        assert!(!set.variant_has_required_permission(Group::Normal));
+        assert!(!set.variant_has_required_permission(Group::Moderator));
+        assert!(set.variant_has_required_permission(Group::Admin));
+    }
+
+    /// And the half that was always meant to be open stays open, which is the
+    /// reason this could not be fixed by moving the whole command to `Admin`.
+    #[test]
+    fn a_normal_player_can_still_read_one() {
+        assert!(parse("perms get Andrew").variant_has_required_permission(Group::Normal));
+    }
+
+    /// A banned player is not a weak player: they are refused both halves.
+    #[test]
+    fn a_banned_player_gets_neither() {
+        assert!(!parse("perms get Andrew").variant_has_required_permission(Group::Banned));
+        assert!(!parse("perms set Andrew admin").variant_has_required_permission(Group::Banned));
+    }
+
+    /// `/perms` itself stays visible to everybody, because `get` is: the
+    /// command-level question is "may you use any of this", and answering it
+    /// with the strongest variant would hide a command players may run.
+    #[test]
+    fn the_command_is_visible_to_whoever_may_use_any_of_it() {
+        assert!(PermissionCommand::has_required_permission(Group::Normal));
+        assert!(!PermissionCommand::has_required_permission(Group::Banned));
+    }
+
+    /// The tree a `Normal` player is sent has `/perms get` in it and not
+    /// `/perms set`. A unit test on the execute path would pass while the
+    /// client was still being offered the command.
+    #[test]
+    fn the_tree_offers_only_the_half_the_player_may_use() {
+        assert!(PermissionCommand::subcommand_has_required_permission(
+            Some("get"),
+            Group::Normal
+        ));
+        assert!(!PermissionCommand::subcommand_has_required_permission(
+            Some("set"),
+            Group::Normal
+        ));
+        assert!(PermissionCommand::subcommand_has_required_permission(
+            Some("set"),
+            Group::Admin
+        ));
+    }
+
+    /// The same check `register` makes at startup, made here too so it fails in
+    /// `nix run .#test` rather than on a server nobody has booted yet. The
+    /// derive kebab-cases variant names to guess what `clap` will call them,
+    /// and this is what says the guess was right.
+    #[test]
+    fn every_subcommand_clap_has_carries_a_declared_group() {
+        let command = PermissionCommand::command();
+        let actual: Vec<&str> = command.get_subcommands().map(clap::Command::get_name).collect();
+        let declared = PermissionCommand::declared_subcommands();
+
+        assert!(!actual.is_empty(), "perms has subcommands");
+        for name in &actual {
+            assert!(
+                declared.contains(name),
+                "clap calls a subcommand {name:?} and the derive declared {declared:?}"
+            );
+        }
+    }
+
+    /// A command with one group covering it declares no subcommands, so the
+    /// startup check does not apply to it and its execution gate is its own.
+    #[test]
+    fn a_single_group_command_is_unchanged() {
+        assert!(ServerLoadCommand::declared_subcommands().is_empty());
+        assert!(ServerLoadCommand.variant_has_required_permission(Group::Admin));
+        assert!(!ServerLoadCommand.variant_has_required_permission(Group::Moderator));
+        assert!(!ServerLoadCommand.variant_has_required_permission(Group::Normal));
     }
 }

--- a/crates/hyperion-permission/src/lib.rs
+++ b/crates/hyperion-permission/src/lib.rs
@@ -14,7 +14,10 @@ use num_derive::{FromPrimitive, ToPrimitive};
 #[derive(Component)]
 pub struct PermissionModule;
 
+pub mod seed;
 mod storage;
+
+pub use seed::SeededGroups;
 
 #[derive(
     Default,
@@ -37,7 +40,27 @@ pub enum Group {
     Admin,
 }
 
-// todo:
+impl Group {
+    /// Whether a player in this group may use something declared for
+    /// `required`.
+    ///
+    /// The groups are ordinal and a higher one subsumes a lower one, with one
+    /// exception: `Banned` is not the weakest group that everybody outranks,
+    /// it is a specific group, and a thing declared for it is for banned
+    /// players and nobody else.
+    ///
+    /// It lives here rather than in the code `CommandPermission` generates
+    /// because a comparison written into a macro's output is a comparison
+    /// nobody can put a test on.
+    #[must_use]
+    pub const fn allows(self, required: Self) -> bool {
+        if matches!(required, Self::Banned) {
+            matches!(self, Self::Banned)
+        } else {
+            self as u32 >= required as u32
+        }
+    }
+}
 
 impl Module for PermissionModule {
     fn module(world: &World) {
@@ -45,28 +68,62 @@ impl Module for PermissionModule {
         world
             .component::<storage::PermissionStorage>()
             .add_trait::<flecs::Singleton>();
+        world
+            .component::<SeededGroups>()
+            .add_trait::<flecs::Singleton>();
+
+        // Read once, at startup, and loudly. A server whose operator list is a
+        // typo has nobody in charge, and the only moment that is cheap to
+        // notice is before it is listening. See `seed`.
+        let seeded = SeededGroups::from_env()
+            .unwrap_or_else(|error| panic!("{:#}", error.context("reading the operator list")));
+        tracing::info!(
+            "{} account(s) hold a group from {}",
+            seeded.len(),
+            seed::ENV_VAR
+        );
+        world.set(seeded);
 
         world.get::<&LocalDb>(|db| {
             let storage = storage::PermissionStorage::new(db).unwrap();
             world.set(storage);
         });
 
-        observer!(world, flecs::OnSet, &Uuid, &storage::PermissionStorage)
-            .with(id::<Player>())
-            .each_entity(|entity, (uuid, permissions)| {
-                let group = permissions.get(**uuid);
-                entity.set(group);
-            });
+        observer!(
+            world,
+            flecs::OnSet,
+            &Uuid,
+            &storage::PermissionStorage,
+            &SeededGroups
+        )
+        .with(id::<Player>())
+        .each_entity(|entity, (uuid, permissions, seeded)| {
+            // Configuration outranks the database, so an operator joins in the
+            // group they are configured to hold whatever `/perms set` last did
+            // to them.
+            let group = seeded
+                .get(**uuid)
+                .unwrap_or_else(|| permissions.get(**uuid));
+            entity.set(group);
+        });
 
         observer!(
             world,
             flecs::OnRemove,
             &Uuid,
             &Group,
-            &storage::PermissionStorage
+            &storage::PermissionStorage,
+            &SeededGroups
         )
         .with(id::<Player>())
-        .each(|(uuid, group, permissions)| {
+        .each(|(uuid, group, permissions, seeded)| {
+            // And is authoritative in the other direction too: a group that
+            // came from configuration is never written to the database, so
+            // deleting the line takes the group away rather than leaving it
+            // behind in a file nobody remembers writing.
+            if seeded.contains(**uuid) {
+                return;
+            }
             permissions.set(**uuid, *group).unwrap();
         });
 

--- a/crates/hyperion-permission/src/seed.rs
+++ b/crates/hyperion-permission/src/seed.rs
@@ -1,0 +1,192 @@
+//! Groups an operator assigns in the server's configuration.
+//!
+//! # The problem this solves
+//!
+//! [`PermissionStorage`] starts empty and is only ever written by `/perms set`,
+//! which is itself an `Admin` command. A server booted against a fresh database
+//! therefore has no administrator and no way to appoint one: the only door to
+//! the group is behind the group. Before [`SeededGroups`] the way through that
+//! was that `/perms set` was mistakenly gated at `Normal`, so anybody could
+//! appoint themselves (ENG-10871).
+//!
+//! So an operator names the accounts that hold a group, in configuration,
+//! before the server starts. This is the ordinary way to run the server with
+//! administrators, not a test affordance: `docker run -e HYPERION_PERMISSIONS=...`
+//! and a `.env` file both reach it, and it is the only path to `Admin` on a
+//! database that has never had one.
+//!
+//! # Configuration
+//!
+//! `HYPERION_PERMISSIONS` is a comma separated list of `<uuid>=<group>`:
+//!
+//! ```text
+//! HYPERION_PERMISSIONS=069a79f4-44e9-4726-a5be-fca90e38aaf5=Admin,853c80ef-3c37-49fd-aa49-938b674adae6=Moderator
+//! ```
+//!
+//! The group names are the variants of [`Group`], matched without regard to
+//! case. A malformed entry stops the server at startup rather than being
+//! skipped, because the failure mode of a silently ignored line is a server
+//! that boots with nobody in charge and no indication why.
+//!
+//! Configuration wins over the database in both directions. A player named here
+//! joins in the group named here whatever `/perms set` did to them last week,
+//! and their group is not written back when they leave, so deleting a line here
+//! is enough to take the group away. A player not named here is unaffected and
+//! keeps whatever the database holds.
+//!
+//! # What a seeded group is worth
+//!
+//! Exactly as much as the server's idea of who a player is. This server is
+//! offline-mode: `hyperion::net::protocol` mints a random profile id for a
+//! client that presents a zero one, and takes the client's word for a non-zero
+//! one. Nothing verifies it against Mojang. So on an offline-mode server a
+//! profile id is a claim, and any client can make any claim. That is a property
+//! of offline mode rather than of this file, and it is the reason to key on the
+//! profile id rather than on the username anyway: when the server does
+//! authenticate, the id is the thing Mojang signed.
+//!
+//! [`PermissionStorage`]: crate::storage::PermissionStorage
+
+use std::{collections::HashMap, env, str::FromStr};
+
+use anyhow::{Context, bail};
+use clap::ValueEnum;
+use flecs_ecs::macros::Component;
+
+use crate::Group;
+
+/// The environment variable read at startup.
+pub const ENV_VAR: &str = "HYPERION_PERMISSIONS";
+
+/// The groups configuration assigns, by profile id.
+///
+/// A singleton, set by [`crate::PermissionModule`] from [`ENV_VAR`]. An
+/// embedder that gets its configuration from somewhere else can overwrite it
+/// after importing the module.
+#[derive(Component, Default, Debug, Clone, PartialEq, Eq)]
+pub struct SeededGroups(HashMap<uuid::Uuid, Group>);
+
+impl SeededGroups {
+    /// The group configuration assigns to `uuid`, if it assigns one.
+    #[must_use]
+    pub fn get(&self, uuid: uuid::Uuid) -> Option<Group> {
+        self.0.get(&uuid).copied()
+    }
+
+    /// Whether configuration says anything about `uuid`.
+    #[must_use]
+    pub fn contains(&self, uuid: uuid::Uuid) -> bool {
+        self.0.contains_key(&uuid)
+    }
+
+    /// How many accounts configuration names.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether configuration names nobody, which is the default.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Read [`ENV_VAR`], or nobody when it is unset or empty.
+    ///
+    /// # Errors
+    /// When the variable is set to something that is not a list of
+    /// `<uuid>=<group>`, naming the entry that could not be read.
+    pub fn from_env() -> anyhow::Result<Self> {
+        match env::var(ENV_VAR) {
+            Ok(value) => value.parse(),
+            Err(env::VarError::NotPresent) => Ok(Self::default()),
+            Err(error) => {
+                Err(error).with_context(|| format!("reading {ENV_VAR} from the environment"))
+            }
+        }
+    }
+}
+
+impl FromStr for SeededGroups {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> anyhow::Result<Self> {
+        let mut seeded = HashMap::new();
+
+        for entry in value.split(',').map(str::trim).filter(|e| !e.is_empty()) {
+            let Some((uuid, group)) = entry.split_once('=') else {
+                bail!(
+                    "{ENV_VAR} entry {entry:?} is not <uuid>=<group>; it is a comma separated \
+                     list such as 069a79f4-44e9-4726-a5be-fca90e38aaf5=Admin"
+                );
+            };
+
+            let uuid = uuid::Uuid::parse_str(uuid.trim())
+                .with_context(|| format!("{ENV_VAR} entry {entry:?} does not start with a uuid"))?;
+
+            let group = group.trim();
+            let group = Group::from_str(group, true).map_err(|_| {
+                // Listed from the enum rather than written out, so a group
+                // added or renamed cannot leave this message describing the
+                // groups of a year ago.
+                let known: Vec<String> = Group::value_variants()
+                    .iter()
+                    .filter_map(ValueEnum::to_possible_value)
+                    .map(|value| value.get_name().to_owned())
+                    .collect();
+                anyhow::anyhow!("{ENV_VAR} entry {entry:?} names no group; the groups are {known:?}")
+            })?;
+
+            if let Some(previous) = seeded.insert(uuid, group) {
+                bail!("{ENV_VAR} names {uuid} twice, as {previous:?} and as {group:?}");
+            }
+        }
+
+        Ok(Self(seeded))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Group, SeededGroups};
+
+    #[test]
+    fn an_unset_variable_names_nobody() {
+        assert!("".parse::<SeededGroups>().unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_list_is_read_whitespace_and_all() {
+        let seeded: SeededGroups = " 069a79f4-44e9-4726-a5be-fca90e38aaf5 = Admin , \
+                                    853c80ef-3c37-49fd-aa49-938b674adae6=moderator"
+            .parse()
+            .unwrap();
+
+        assert_eq!(seeded.len(), 2);
+        assert_eq!(
+            seeded.get("069a79f4-44e9-4726-a5be-fca90e38aaf5".parse().unwrap()),
+            Some(Group::Admin)
+        );
+        assert_eq!(
+            seeded.get("853c80ef-3c37-49fd-aa49-938b674adae6".parse().unwrap()),
+            Some(Group::Moderator)
+        );
+    }
+
+    /// The failure this file exists to make loud. A skipped line is a server
+    /// that boots with nobody in charge and no way to tell why.
+    #[test]
+    fn a_typo_is_an_error_rather_than_a_skipped_line() {
+        for broken in [
+            "069a79f4-44e9-4726-a5be-fca90e38aaf5",
+            "069a79f4-44e9-4726-a5be-fca90e38aaf5=Owner",
+            "andrew=Admin",
+            "069a79f4-44e9-4726-a5be-fca90e38aaf5=Admin,069a79f4-44e9-4726-a5be-fca90e38aaf5=Normal",
+        ] {
+            assert!(
+                broken.parse::<SeededGroups>().is_err(),
+                "{broken:?} was accepted"
+            );
+        }
+    }
+}

--- a/crates/hyperion/src/egress/player_join/mod.rs
+++ b/crates/hyperion/src/egress/player_join/mod.rs
@@ -60,7 +60,7 @@ impl Module for PlayerJoinModule {
             .add_trait::<flecs::Singleton>();
         world.set(RayonWorldStages { stages });
 
-        let root_command = world.entity().set(Command::ROOT);
+        let root_command = world.entity().set(Command::root());
 
         #[expect(
             clippy::unwrap_used,

--- a/crates/hyperion/src/simulation/command.rs
+++ b/crates/hyperion/src/simulation/command.rs
@@ -63,10 +63,26 @@ pub enum NodeData {
 }
 
 /// One node of the command tree, held on the entity that owns it.
+///
+/// The gate is per node rather than per command because a command's
+/// subcommands are not all for the same people: `/perms get` is for everybody
+/// and `/perms set` is for administrators, and a tree that offered both to
+/// everybody is how ENG-10871 read from a client. It is a closure rather than a
+/// function pointer for the same reason -- the gate `hyperion-clap` builds
+/// captures which subcommand the node is.
 #[derive(Component)]
 pub struct Command {
     data: NodeData,
-    has_permission: fn(world: &World, caller: Entity) -> bool,
+    has_permission: HasPermission,
+}
+
+/// Whether one player may see and use one node of the tree.
+pub type HasPermission = std::sync::Arc<dyn Fn(&World, Entity) -> bool + Send + Sync>;
+
+/// A gate that lets everybody through, for a node that is not a command.
+#[must_use]
+pub fn open() -> HasPermission {
+    std::sync::Arc::new(|_: &World, _: Entity| true)
 }
 
 pub(crate) static ROOT_COMMAND: once_cell::sync::OnceCell<Entity> =
@@ -153,22 +169,25 @@ pub fn suggestions(world: &World, node: Entity) -> Vec<String> {
 }
 
 impl Command {
-    pub const ROOT: Self = Self {
-        data: NodeData::Root,
-        has_permission: |_: _, _: _| true,
-    };
+    /// The tree's root, which matches nothing and is never gated.
+    #[must_use]
+    pub fn root() -> Self {
+        Self {
+            data: NodeData::Root,
+            has_permission: open(),
+        }
+    }
 
     #[must_use]
-    pub fn literal(
-        name: impl Into<String>,
-        has_permission: fn(world: &World, caller: Entity) -> bool,
-    ) -> Self {
+    pub fn literal(name: impl Into<String>, has_permission: HasPermission) -> Self {
         Self {
             data: NodeData::Literal { name: name.into() },
             has_permission,
         }
     }
 
+    /// An argument node, which carries no gate of its own: what may be typed
+    /// after a literal is decided by the literal.
     #[must_use]
     pub fn argument(name: impl Into<String>, parser: Parser) -> Self {
         Self {
@@ -176,7 +195,7 @@ impl Command {
                 name: name.into(),
                 parser,
             },
-            has_permission: |_: _, _: _| true,
+            has_permission: open(),
         }
     }
 }
@@ -583,7 +602,7 @@ mod tests {
                 data: NodeData::Literal {
                     name: "test".to_owned(),
                 },
-                has_permission: |_: _, _: _| true,
+                has_permission: open(),
             })
             .child_of(root);
 
@@ -610,7 +629,7 @@ mod tests {
                 data: NodeData::Literal {
                     name: "parent".to_owned(),
                 },
-                has_permission: |_: _, _: _| true,
+                has_permission: open(),
             })
             .child_of(root);
 
@@ -620,7 +639,7 @@ mod tests {
                 data: NodeData::Literal {
                     name: "child".to_owned(),
                 },
-                has_permission: |_: _, _: _| true,
+                has_permission: open(),
             })
             .child_of(parent);
 
@@ -652,7 +671,7 @@ mod tests {
                     data: NodeData::Literal {
                         name: format!("command_{i}"),
                     },
-                    has_permission: |_: _, _: _| true,
+                    has_permission: open(),
                 })
                 .child_of(parent);
             parent = child;

--- a/flake.nix
+++ b/flake.nix
@@ -384,6 +384,35 @@
             bedwars-bow-e2e = 9000;
           };
 
+          # The accounts `smash-hud-e2e` runs its `Admin` commands as.
+          #
+          # `/serverload` is `Admin` and nothing lets a client give itself a
+          # group, so the three clients that need it are named to the server as
+          # configuration before it starts, exactly as an operator would name
+          # their own administrators (`hyperion_permission::seed`). The gate
+          # used to promote itself with `/perms set`, which worked only while
+          # that command was gated at `Normal`: ENG-10871.
+          #
+          # The ids and the configuration naming them come off one list,
+          # because a client logging in under an id nobody configured is not an
+          # administrator and nothing says so: the failure surfaces much later
+          # as `/serverload` doing nothing.
+          hudAdmins =
+            let
+              uuids = [
+                "0be9a1d4-5c00-4e6a-9d21-6a5a1e0000a1"
+                "0be9a1d4-5c00-4e6a-9d21-6a5a1e0000a2"
+                "0be9a1d4-5c00-4e6a-9d21-6a5a1e0000a3"
+              ];
+            in
+            {
+              env.HYPERION_PERMISSIONS = lib.concatMapStringsSep "," (uuid: "${uuid}=Admin") uuids;
+              clientArgs = lib.concatMap (uuid: [
+                "--admin-uuid"
+                uuid
+              ]) uuids;
+            };
+
           # The lobby `smash-e2e` runs against, which is deliberately not the
           # one the product ships.
           #
@@ -417,7 +446,9 @@
           exportsFor =
             env:
             lib.concatStringsSep "\n" (
-              lib.mapAttrsToList (name: value: "export ${name}=${toString value}") env
+              lib.mapAttrsToList (
+                name: value: "export ${name}=${lib.escapeShellArg (toString value)}"
+              ) env
             );
 
           # Two gates on one offset, as a build failure rather than as a race.
@@ -819,7 +850,8 @@
               ];
               text = ''
                 export HYPERION_EVENT=smash
-                export HYPERION_E2E_CLIENT=tools/hud-check.py
+                export HYPERION_E2E_CLIENT="tools/hud-check.py ${lib.escapeShellArgs hudAdmins.clientArgs}"
+                ${exportsFor hudAdmins.env}
                 export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.smash-hud-e2e)}}"
                 export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.smash-hud-e2e)}}"
                 exec "${lib.getExe runners.e2e}" "$@"
@@ -1020,6 +1052,8 @@
               gameServer = gameBinaries.smash;
               proxy = gameBinaries.hyperion-proxy;
               client = "hud-check.py";
+              clientArgs = hudAdmins.clientArgs;
+              serverEnv = hudAdmins.env;
               timeout = 420;
             };
 

--- a/nix/e2e.nix
+++ b/nix/e2e.nix
@@ -338,7 +338,9 @@ let
         ${lib.optionalString needsGenMap seedGenMap}
 
         ${lib.concatStringsSep "\n" (
-          lib.mapAttrsToList (name: value: "export ${name}=${toString value}") serverEnv
+          lib.mapAttrsToList (
+            name: value: "export ${name}=${lib.escapeShellArg (toString value)}"
+          ) serverEnv
         )}
         export HYPERION_E2E_GAME_SERVER="${lib.getExe gameServer}"
         export HYPERION_E2E_PROXY="${lib.getExe proxy}"

--- a/tools/client-26.2.py
+++ b/tools/client-26.2.py
@@ -410,7 +410,7 @@ def printable(payload, limit=180):
 
 
 class Client:
-    def __init__(self, host, port, name, log):
+    def __init__(self, host, port, name, log, uuid=None):
         self.sock = socket.create_connection((host, port))
         self.sock.settimeout(20)
         self.name = name
@@ -418,6 +418,11 @@ class Client:
         self.log = log
         self.entity_id = None
         self.joined = False
+        # The profile id to log in under, or None to let the server mint one.
+        # A launcher presents the id it holds for the account and this server
+        # takes it, so a client that needs a *stable* identity across runs --
+        # one named in `HYPERION_PERMISSIONS`, say -- names its own.
+        self.claimed_uuid = uuid
         # The profile id the server minted, as hex. Offline mode makes this the
         # only thing distinguishing two players who typed the same name, so a
         # test about duplicate names has to be able to read it.
@@ -488,8 +493,15 @@ class Client:
         return text
 
     def login(self):
-        self.log("-> Hello name=%s" % self.name)
-        self.send(C2S_HELLO, mc_string(self.name) + b"\x00" * 16)
+        # A zero id asks the server to mint one; anything else is the id this
+        # client claims, which an offline-mode server accepts as written.
+        claimed = (
+            bytes.fromhex(self.claimed_uuid.replace("-", ""))
+            if self.claimed_uuid
+            else b"\x00" * 16
+        )
+        self.log("-> Hello name=%s uuid=%s" % (self.name, self.claimed_uuid or "server's"))
+        self.send(C2S_HELLO, mc_string(self.name) + claimed)
 
         while True:
             packet_id, payload = self.recv()

--- a/tools/hud-check.py
+++ b/tools/hud-check.py
@@ -37,6 +37,14 @@ import time
 
 TOOLS = pathlib.Path(__file__).resolve().parent
 
+# `§` followed by one character is a legacy colour code, which the server writes
+# into chat and a client renders rather than reads.
+COLOUR = re.compile("§.")
+
+
+def uncoloured(text):
+    return COLOUR.sub("", text)
+
 
 def _load(name, filename):
     """Import a sibling tool whose file name is not a Python identifier."""
@@ -102,8 +110,8 @@ COUNTDOWN_DIGITS = ["3", "2", "1"]
 class Screen(match.MatchClient):
     """A scripted player that remembers what was drawn on it."""
 
-    def __init__(self, host, port, name, started):
-        super().__init__(host, port, name, started)
+    def __init__(self, host, port, name, started, uuid=None):
+        super().__init__(host, port, name, started, uuid=uuid)
         # Every experience bar, boss bar and title in the order they arrived, so
         # a check can ask about the last one or about the whole sequence.
         self.experience = []
@@ -123,6 +131,9 @@ class Screen(match.MatchClient):
         self.titles = []
         self.subtitles = []
         self.animations = []
+        # Every system chat line, in order. `/perms get` answers in chat and
+        # nowhere else, so this is how the seeded group is read back.
+        self.chat = []
         # The three title packets in arrival order, which is the only place the
         # ordering they have to arrive in is observable at all.
         self.screen = []
@@ -143,6 +154,7 @@ class Screen(match.MatchClient):
         elif packet_id == match.S2C_SYSTEM_CHAT:
             text, _ = match.take_nbt_string(payload, 0)
             self.log("<- chat: %s" % text)
+            self.chat.append(text)
             if text.startswith("Kit set to "):
                 self.kit = text[len("Kit set to ") :].rstrip(".")
         elif packet_id == match.S2C_CONTAINER_SET_SLOT:
@@ -319,6 +331,11 @@ class Run:
         self.started = time.time()
         self.clients = []
         self.failures = []
+        # The profile ids the server was told hold `Admin`, before it started,
+        # through `HYPERION_PERMISSIONS`. See `hyperion_permission::seed`, and
+        # `flake.nix`'s `hudAdmins`, which is the one list both the server's
+        # configuration and this argument are built from.
+        self.admins = list(args.admin_uuid or [])
 
     def log(self, line):
         print("%s %-5s %s" % (match.stamp(self.started), "", line), flush=True)
@@ -332,10 +349,31 @@ class Run:
             self.failures.append(message)
         return ok
 
+    def admin_uuid(self, index):
+        """The profile id of the `index`-th account configured as `Admin`.
+
+        A client cannot promote itself. `/perms set` is an `Admin` command, and
+        it is reachable only by an account an operator named before the server
+        started; this gate used to reach it by promoting itself through a hole
+        in `/perms` (ENG-10871), which is closed.
+        """
+        if index >= len(self.admins):
+            raise SystemExit(
+                "this gate needs %d configured admin(s) and was given %d. Pass "
+                "--admin-uuid once per account named as Admin in "
+                "HYPERION_PERMISSIONS." % (index + 1, len(self.admins))
+            )
+        return self.admins[index]
+
     def connect(self, count):
         for _ in range(count):
             name = "H%d" % (len(self.clients) + 1)
-            client = Screen(self.args.host, self.args.port, name, self.started)
+            # The two clients the load bars need an `Admin` command from are
+            # the first two, so they log in under the two configured ids and
+            # the rest let the server mint one as any player would.
+            index = len(self.clients)
+            uuid = self.admin_uuid(index) if index < 2 else None
+            client = Screen(self.args.host, self.args.port, name, self.started, uuid=uuid)
             client.handshake(self.args.host, self.args.port, 2)
             client.login()
             client.configuration()
@@ -657,17 +695,49 @@ class Run:
         admin = self.clients[0]
         second = self.clients[1]
 
-        # `/serverload` is Admin, and there is no other way for a test client
-        # to reach an Admin command: no config default, no env override, and
-        # `PermissionStorage` starts empty and is keyed on UUID. So this gate
-        # promotes its own clients, which works only because `/perms` is itself
-        # gated at Normal. That is a real privilege escalation, filed as
-        # ENG-10871, and closing it has to land a way to seed a group at
-        # startup or this check goes with it.
+        # `/serverload` is Admin, and these two clients hold it because an
+        # operator said so before the server started: they logged in under
+        # profile ids named in `HYPERION_PERMISSIONS`, which is the ordinary
+        # way to run this server with administrators
+        # (`hyperion_permission::seed`).
+        #
+        # This gate used to promote itself with `/perms set`, which worked only
+        # because that command was gated at `Normal` -- a privilege escalation
+        # any player could use, ENG-10871. Reading the group back with the
+        # `Normal` half of the same command is what proves the seeding, rather
+        # than the bar appearing proving it by side effect.
         for client in (admin, second):
-            # `Group` is a clap `ValueEnum`, so its variants are lower case.
-            admin.command("perms set %s admin" % client.name)
+            client.chat.clear()
+            client.command("perms get %s" % client.name)
         self.pump(1.0)
+        seeded = [
+            client.name
+            for client in (admin, second)
+            if any("group is Admin" in uncoloured(line) for line in client.chat)
+        ]
+        if not self.check(
+            len(seeded) == 2,
+            "an account named in the server's configuration joins holding the "
+            "group it was given, with nothing asked for: %s" % seeded,
+        ):
+            return
+
+        # And the hole itself, from a client that has none of this: a `Normal`
+        # player asking for `Admin` is refused, and the group does not move.
+        plain = self.clients[2]
+        plain.chat.clear()
+        plain.command("perms set %s admin" % plain.name)
+        self.pump(1.0)
+        refused = any("do not have permission" in uncoloured(line) for line in plain.chat)
+        plain.chat.clear()
+        plain.command("perms get %s" % plain.name)
+        self.pump(1.0)
+        self.check(
+            refused
+            and any("group is Normal" in uncoloured(line) for line in plain.chat),
+            "and a player who was not named cannot name themselves: %s"
+            % [uncoloured(line) for line in plain.chat],
+        )
 
         admin.bar_ops.clear()
         admin.command("serverload")
@@ -808,15 +878,15 @@ class Run:
         # way a bar stops being shown, and the one with nothing to observe on
         # the wire: the packet that must *not* be written is one to a socket
         # that has gone. What is observable is that the server carries on.
-        leaver = Screen(self.args.host, self.args.port, "HX", self.started)
+        leaver = Screen(
+            self.args.host, self.args.port, "HX", self.started, uuid=self.admin_uuid(2)
+        )
         leaver.handshake(self.args.host, self.args.port, 2)
         leaver.login()
         leaver.configuration()
         leaver.enter_play()
         self.clients.append(leaver)
         self.until(lambda: leaver.joined, 60.0, "the disconnecting viewer to join")
-        admin.command("perms set %s admin" % leaver.name)
-        self.pump(1.0)
         leaver.command("serverload")
         self.until(lambda: cpu in leaver.bar_state, 20.0, "the leaver's own load bars")
         leaver.sock.close()
@@ -968,6 +1038,16 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=25565)
+    parser.add_argument(
+        "--admin-uuid",
+        action="append",
+        metavar="UUID",
+        help="a profile id the server was told holds Admin, through "
+        "HYPERION_PERMISSIONS. This gate needs three of them, because "
+        "/serverload is an Admin command and nothing lets a client give "
+        "itself the group (ENG-10871). flake.nix builds both this argument "
+        "and the server's configuration from one list",
+    )
     parser.add_argument(
         "--clients",
         type=int,

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -454,8 +454,8 @@ class MatchClient(base.Client):
     cannot afford to block on any one of them.
     """
 
-    def __init__(self, host, port, name, started):
-        super().__init__(host, port, name, lambda line: None)
+    def __init__(self, host, port, name, started, uuid=None):
+        super().__init__(host, port, name, lambda line: None, uuid=uuid)
         self.started = started
         self.log = self._log
         self.host = host


### PR DESCRIPTION
Closes ENG-10871.

## A player could make themselves an administrator

`/perms set <player> Admin` was gated at `Normal`. Any client that could connect
could promote itself and then run every `Admin` and `Moderator` command on the
server, permanently: `PermissionStorage` is keyed on the profile id, so the new
group survived a reconnect and a restart.

The cause was the derive rather than the declaration, which is why this is not a
one-word change. `#[derive(CommandPermission)]` emitted a single
`has_required_permission` for a whole `clap` enum, so `Set` and `Get` could not
carry different groups, and `/perms` was declared `Normal` because `/perms get`
is. The weakest variant won, and that was the rule for every subcommand enum
anybody might write.

I confirmed that by running it rather than reading it, before changing anything:

```
test mechanism_proof::a_normal_player_passes_the_gate_on_perms ... ok
```

which asserted `PermissionCommand::has_required_permission(Group::Normal)`. The
execute path called exactly that static function, once, with no discrimination
on the parsed variant.

## What changed

**A group is declared per subcommand**, and the one question the derive used to
answer is now three, because they have three different answers:

| method | question | what it costs to get wrong |
|---|---|---|
| `has_required_permission` | may you use this command at all | a command missing from your list |
| `subcommand_has_required_permission` | may you see this subcommand in your tree | a misleading autocomplete |
| `variant_has_required_permission` | may you run *this* parsed invocation | a privilege escalation |

Only the third is a security boundary and it is the one the execute path asks.
The command tree asks the second, so a `Normal` player is not offered
`/perms set` at all. That needed a node's gate to become a closure rather than a
function pointer, because a per-subcommand gate has to capture which subcommand
the node is.

**Declaring some variants and not others is a compile error.** Every available
fallback is a guess about whether the author meant "same as the others" or
forgot, and the guess that used to be made here is this bug.

**Where the derive predicts what `clap` will call a subcommand**, by
kebab-casing the variant, `register` checks the prediction against the name
`clap` reports and refuses to start the server if they disagree. That is the
one hand-written thing in here that duplicates knowledge living somewhere else
(`heck`, via `clap_derive`), and the guard exists because I did not want the
duplication to be silent.

**Seeding a group at startup** is the other half and it had to land in the same
change. Nobody starts out holding the group that hands out groups, so on a fresh
database the only door to `Admin` was behind `Admin` -- which is why the hole
was load-bearing.

```
HYPERION_PERMISSIONS=069a79f4-44e9-4726-a5be-fca90e38aaf5=Admin,853c80ef-3c37-49fd-aa49-938b674adae6=Moderator
```

Read once at startup, and loudly: a malformed entry stops the server rather than
being skipped, because a silently skipped line is a server that boots with
nobody in charge and no indication why. Configuration outranks the database in
both directions, so deleting a line takes the group away rather than leaving it
behind in a file nobody remembers writing.

It is keyed on the profile id because `PermissionStorage` already is and because
that is what Mojang signs. The doc comment says plainly what a seeded group is
worth: this server is offline-mode and `pre_play.rs` takes whatever `profile_id`
a client claims, so a seeded group is exactly as strong as the server's identity
source. That is a property of offline mode, not of the seeding, and it should
not be read as a security boundary it cannot be.

## `smash-hud-e2e` is off the hole and on the legitimate path

The gate's own comment said what it was doing:

> `/serverload` is Admin, and there is no other way for a test client to reach
> an Admin command [...] So this gate promotes its own clients, which works only
> because `/perms` is itself gated at Normal.

Its three `Admin` clients now log in under profile ids named in
`HYPERION_PERMISSIONS`. `flake.nix`'s `hudAdmins` is one list read twice, into
the server's configuration and into the clients' arguments, because a client
logging in under an id nobody configured is not an administrator and nothing
says so.

## Wire assertions

A unit test on the permission check would pass today for a hole reachable from a
real client, so the claims are made on the wire, by a scripted 26.2 client
reading chat. Two new checks in `tools/hud-check.py`:

```
31.00s PASS an account named in the server's configuration joins holding the group it was given, with nothing asked for: ['H1', 'H2']
33.09s PASS and a player who was not named cannot name themselves: ["H3's group is Normal"]
```

`nix run .#smash-hud-e2e` on this branch:

```
43.06s       RESULT: ok (0 check(s) failed)
```

**50 of 50**, which is the 48 that were there before plus these two.

## Every guard broken, and what it said

### The compile error on partial declaration

Removed `#[command_permission(group = "Normal")]` from `Get`:

```
error: these subcommands declare no group and the command declares no default for them: ["Get"].
Either give the command a `#[command_permission(group = ...)]` covering every subcommand, or give
each subcommand its own. Declaring only some is refused because the fallback would be a guess, and
the guess that used to be made here let any player run `/perms set` (ENG-10871).
   --> crates/hyperion-clap/src/lib.rs:526:10
```

### The startup check on subcommand names

Made the derive's kebab-casing disagree with `clap`'s, by appending `-oops`:

```
thread 'main' panicked at crates/hyperion-clap/src/lib.rs:281:13:
/perms has subcommand(s) ["set", "get"] that carry no permission group. The derive declared groups
for ["set-oops", "get-oops"] and clap named ["set", "get"]; the two have to agree or those
subcommands are gated by nothing anybody wrote.
```

The gate reported `the game server exited before opening 127.0.0.1:43565`, which
is the intended severity: the server does not start.

### The operator list refusing a typo

Truncated one uuid in `hudAdmins`:

```
thread 'main' panicked at crates/hyperion-permission/src/lib.rs:79:37:
reading the operator list: HYPERION_PERMISSIONS entry "0be9a1d4-5c00-4e6a-9d21-6a5a1e=Admin" does
not start with a uuid: invalid group length in group 4: expected 12, found 6
```

### The wire assertion that a player cannot promote themselves

Put `Set` back to `Normal`, which is the state this PR fixes, and re-ran the
gate. This is ENG-10871 reproduced end to end, seen by a client:

```
33.15s FAIL and a player who was not named cannot name themselves: ["H3's group is Admin"]
40.38s       RESULT: failure (1 check(s) failed)
```

### The wire assertion that seeding works

Set `HYPERION_PERMISSIONS` to name nobody:

```
30.99s FAIL an account named in the server's configuration joins holding the group it was given, with nothing asked for: []
30.99s       RESULT: failure (1 check(s) failed)
```

## The rest of the surface, audited

Every command in the repo goes through `hyperion-clap`; `CommandHandler` is
constructed in exactly one place, so this is the whole surface. Sixteen
commands, and `perms` is the only multi-variant enum, which bounds the derive
defect to it alone.

Fine as declared: `kits`, `abilities`, `podiums` (read-only, `Normal`); `kit`
(`Normal`, picking a kit is the game); `serverload`, `xp`, `vanish`, `raycast`
(`Admin`); `fly`, `speed` (`Moderator`); `testgui` (`Normal`).

Flagged rather than changed, because they are game-design calls:

* **ENG-10907** -- bedwars `bow`, `chest` and `shoot` at `Normal`. Free items,
  and an unbounded `f32` arrow velocity.
* **ENG-10908** -- smash `crystal` at `Normal`, which grants the caller an
  ultimate. Deliberate today, per its doc comment, and nothing will notice when
  the arena lands and makes it not.

## Not done

* Tab completion is not gated. `completion::locate` works off the parsed shape
  and does not consult permissions, so a `Normal` player can still tab-complete
  `/perms set` even though the literal is absent from their tree and the
  execution is refused. Cosmetic, and I left it rather than widen the change.
* `exportsFor` in `flake.nix` and the exporter inside `mkCheck` are two copies
  of the same function. I quoted both with `escapeShellArg`, since this is the
  first value that is not a bare integer, but did not merge them.
* **ENG-10911** -- `smash-hud-e2e` dropped a client's connection on one of five
  runs tonight, unrelated to anything here, and it cost a re-run to establish
  that. Filed with the evidence.

## Checks

`nix run .#lint`, `cargo test --workspace --lib` and `nix run .#smash-hud-e2e`
all green on the rebased tree. The flake lint caught one thing `cargo build` did
not, exactly as warned: an unnecessary `Result` in the macro crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
