### PR TITLE
feat(smash): fifty-one abilities stop sharing three pictures

### DIFF
--- a/crates/hyperion-clap-macros/src/lib.rs
+++ b/crates/hyperion-clap-macros/src/lib.rs
@@ -80,8 +80,7 @@ fn declared_group(attrs: &[Attribute]) -> syn::Result<Option<Ident>> {
         let Some(found) = found else {
             return Err(Error::new_spanned(
                 attr,
-                "`#[command_permission]` needs a group: `#[command_permission(group = \
-                 \"Admin\")]`",
+                "`#[command_permission]` needs a group: `#[command_permission(group = \"Admin\")]`",
             ));
         };
 
@@ -105,8 +104,8 @@ fn reject_group_on_fields(fields: &Fields) -> syn::Result<()> {
         {
             return Err(Error::new(
                 field.span(),
-                "a group belongs on the command or on one of its subcommands, not on an \
-                 argument; a `#[command_permission]` here would be ignored",
+                "a group belongs on the command or on one of its subcommands, not on an argument; \
+                 a `#[command_permission]` here would be ignored",
             ));
         }
     }
@@ -163,7 +162,10 @@ fn kebab_case(ident: &str) -> String {
         if current.is_uppercase() && index != 0 {
             let previous = chars[index - 1];
             let next_is_lower = chars.get(index + 1).is_some_and(|c| c.is_lowercase());
-            if previous.is_lowercase() || previous.is_numeric() || (previous.is_uppercase() && next_is_lower) {
+            if previous.is_lowercase()
+                || previous.is_numeric()
+                || (previous.is_uppercase() && next_is_lower)
+            {
                 out.push('-');
             }
         }
@@ -288,12 +290,11 @@ fn enum_arms(
         return Err(Error::new_spanned(
             name,
             format!(
-                "these subcommands declare no group and the command declares no default for \
-                 them: {undeclared:?}. Either give the command a \
-                 `#[command_permission(group = ...)]` covering every subcommand, or give each \
-                 subcommand its own. Declaring only some is refused because the fallback would \
-                 be a guess, and the guess that used to be made here let any player run \
-                 `/perms set` (ENG-10871)."
+                "these subcommands declare no group and the command declares no default for them: \
+                 {undeclared:?}. Either give the command a `#[command_permission(group = ...)]` \
+                 covering every subcommand, or give each subcommand its own. Declaring only some \
+                 is refused because the fallback would be a guess, and the guess that used to be \
+                 made here let any player run `/perms set` (ENG-10871)."
             ),
         ));
     }

--- a/crates/hyperion-clap/src/lib.rs
+++ b/crates/hyperion-clap/src/lib.rs
@@ -309,10 +309,8 @@ pub trait MinecraftCommand: Parser + CommandPermission + 'static {
                 .get::<&Group>(|group| Self::has_required_permission(*group))
         };
 
-        let node_to_register = hyperion::simulation::command::Command::literal(
-            name.clone(),
-            gate_for::<Self>(None),
-        );
+        let node_to_register =
+            hyperion::simulation::command::Command::literal(name.clone(), gate_for::<Self>(None));
 
         let root = world
             .entity()
@@ -730,7 +728,10 @@ mod permission_gates {
     #[test]
     fn every_subcommand_clap_has_carries_a_declared_group() {
         let command = PermissionCommand::command();
-        let actual: Vec<&str> = command.get_subcommands().map(clap::Command::get_name).collect();
+        let actual: Vec<&str> = command
+            .get_subcommands()
+            .map(clap::Command::get_name)
+            .collect();
         let declared = PermissionCommand::declared_subcommands();
 
         assert!(!actual.is_empty(), "perms has subcommands");

--- a/crates/hyperion-permission/src/seed.rs
+++ b/crates/hyperion-permission/src/seed.rs
@@ -134,7 +134,9 @@ impl FromStr for SeededGroups {
                     .filter_map(ValueEnum::to_possible_value)
                     .map(|value| value.get_name().to_owned())
                     .collect();
-                anyhow::anyhow!("{ENV_VAR} entry {entry:?} names no group; the groups are {known:?}")
+                anyhow::anyhow!(
+                    "{ENV_VAR} entry {entry:?} names no group; the groups are {known:?}"
+                )
             })?;
 
             if let Some(previous) = seeded.insert(uuid, group) {
@@ -181,7 +183,8 @@ mod tests {
             "069a79f4-44e9-4726-a5be-fca90e38aaf5",
             "069a79f4-44e9-4726-a5be-fca90e38aaf5=Owner",
             "andrew=Admin",
-            "069a79f4-44e9-4726-a5be-fca90e38aaf5=Admin,069a79f4-44e9-4726-a5be-fca90e38aaf5=Normal",
+            "069a79f4-44e9-4726-a5be-fca90e38aaf5=Admin,\
+             069a79f4-44e9-4726-a5be-fca90e38aaf5=Normal",
         ] {
             assert!(
                 broken.parse::<SeededGroups>().is_err(),

--- a/events/bedwars/src/module/bow.rs
+++ b/events/bedwars/src/module/bow.rs
@@ -125,11 +125,10 @@ impl BowCharging {
     #[must_use]
     #[expect(
         clippy::suboptimal_flops,
-        reason = "mul_add is a fused multiply-add: one rounding where Java does \
-                  two. getPowerForTime evaluates `(f * f + f * 2.0F) / 3.0F` as \
-                  separate float operations, and this file exists to give the \
-                  same answer it does, so the two roundings are the behaviour \
-                  rather than an oversight"
+        reason = "mul_add is a fused multiply-add: one rounding where Java does two. \
+                  getPowerForTime evaluates `(f * f + f * 2.0F) / 3.0F` as separate float \
+                  operations, and this file exists to give the same answer it does, so the two \
+                  roundings are the behaviour rather than an oversight"
     )]
     pub fn get_charge(&self) -> f32 {
         let elapsed = self.start_time.elapsed().unwrap_or(Duration::ZERO);

--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -7,12 +7,13 @@
 //! aborts at runtime. Draining once per tick in `PostUpdate` costs knockback one
 //! tick of latency and buys immunity from that whole class of bug.
 //!
-//! [`Cue`] and [`HotbarItem`] are the game's own closed vocabulary. Choosing
-//! which Minecraft particle and item each one becomes is a hosting decision, so
-//! the mapping lives here and nowhere under `src/module/`. [`Sound`] is the
-//! exception and arrives already naming a vanilla sound event, because which
-//! noise an ability makes is part of what the ability *is* and belongs with the
-//! kit that declares it; all that is left here is the encoding.
+//! [`HotbarItem`] is the game's own closed vocabulary, and choosing which
+//! Minecraft item each one becomes is a hosting decision, so that mapping
+//! lives here and nowhere under `src/module/`. [`Sound`] and [`Particles`] are
+//! the exceptions and arrive already naming a vanilla sound event and a
+//! vanilla particle, because what an ability sounds and looks like is part of
+//! what the ability *is* and belongs with the kit that declares it; all that
+//! is left here is handing them to the engine.
 
 use std::{
     collections::{HashMap, hash_map::Entry},
@@ -26,7 +27,6 @@ use hyperion::{
     hyperion_minecraft_proto::{
         generated::packet_id::play::clientbound::PacketId,
         packets::play::{
-            chunk::{LevelParticles, Particle},
             clientbound::{
                 SetActionBarText, SetDisplayObjective, SetExperience, SetHealth, SetSubtitleText,
                 SetTitleText, SetTitlesAnimation,
@@ -36,7 +36,6 @@ use hyperion::{
                 ObjectiveRenderType, SetObjective, SetScore,
             },
         },
-        particle::Argb,
     },
     net::{Compose, ConnectionId, agnostic, protocol, protocol::Clientbound},
     simulation::{
@@ -54,8 +53,8 @@ use valence_nbt::{Compound, List, Value};
 use crate::{
     module::kit::{self, Playing},
     server::{
-        BarColour, BossBar, Channel, Cue, Experience, HotbarItem, PlayerId, Server, SidebarLine,
-        Sound, SoundCategory, Text, Title,
+        BarColour, BossBar, Channel, Experience, HotbarItem, Particles, PlayerId, Server,
+        SidebarLine, Sound, SoundCategory, Text, Title,
     },
 };
 
@@ -99,10 +98,7 @@ enum Op {
         player: Entity,
         spectating: bool,
     },
-    Play {
-        at: Vec3,
-        cue: Cue,
-    },
+    Particles(Particles),
     PlaySound {
         at: Vec3,
         sound: Sound,
@@ -214,8 +210,8 @@ impl Server for HyperionServer {
         });
     }
 
-    fn cue(&self, at: Vec3, cue: Cue) {
-        self.push(Op::Play { at, cue });
+    fn particles(&self, effect: Particles) {
+        self.push(Op::Particles(effect));
     }
 
     fn play_sound(&self, at: Vec3, sound: Sound) {
@@ -445,7 +441,7 @@ fn apply(world: WorldRef<'_>, compose: &Compose, op: Op, bars: &HashMap<Entity, 
                 world.get::<&DefaultGamemode>(|default| entity.add_enum(default.0));
             }
         }
-        Op::Play { at, cue } => play_cue(compose, at, cue),
+        Op::Particles(effect) => effect.emit(world),
         Op::PlaySound { at, sound } => {
             let Some(packet) = encode(at, sound) else {
                 return;
@@ -773,59 +769,6 @@ fn sidebar(compose: &Compose, to: ConnectionId, title: &Text, lines: &[SidebarLi
             number_format: line.score.drawn().is_none().then_some(NumberFormat::Blank),
         };
         let _unused = compose.unicast(Clientbound::new(PacketId::SetScore.to_raw(), &packet), to);
-    }
-}
-
-/// The game's three cues, as Minecraft particles.
-///
-/// Sound used to be decided here as well, from a six-variant enum, which is why
-/// every ability in the game shared four noises between them. Audio now arrives
-/// already named: the game picks the vanilla sound event, because which sound
-/// an ability makes is a design decision belonging to the kit that declares it,
-/// and only the encoding is a hosting one. What is still a hosting decision,
-/// and so still here, is which particle each cue draws.
-///
-/// `[INFERRED]` throughout: Mineplex's own choices are not in the leaked source,
-/// which loaded them from the same spreadsheet as everything else.
-/// Half-width of the box a cue's particles are scattered through, in blocks.
-const CUE_SPREAD: f32 = 0.4;
-
-fn play_cue(compose: &Compose, at: Vec3, cue: Cue) {
-    let particle = match cue {
-        Cue::Explosion => Particle::Explosion,
-        Cue::Teleport => Particle::Portal,
-        Cue::Death => Particle::Cloud,
-        Cue::Burn => Particle::Flame,
-        // Vanilla's own poison colour, which is what `entity_effect` is drawn
-        // in when a `minecraft:poison` instance renders: `MobEffects.POISON`
-        // carries `0x4E9331`. Taken from the effect rather than picked, so the
-        // haze around a poisoned player is the green a player already reads as
-        // poison rather than an arbitrary green.
-        Cue::Venom => Particle::EntityEffect {
-            color: Argb::opaque(0x4E, 0x93, 0x31),
-        },
-    };
-    let packet = LevelParticles {
-        // A cue marks something that just happened to a player, so it is worth
-        // seeing from further out than the client's normal particle radius.
-        override_limiter: true,
-        // The client's particle setting is the player's own choice.
-        always_show: false,
-        x: f64::from(at.x),
-        y: f64::from(at.y),
-        z: f64::from(at.z),
-        x_dist: CUE_SPREAD,
-        y_dist: CUE_SPREAD,
-        z_dist: CUE_SPREAD,
-        max_speed: 0.5,
-        count: 40,
-        particle,
-    };
-    if let Err(error) = compose
-        .broadcast(Clientbound::new(PacketId::LevelParticles.to_raw(), &packet))
-        .send()
-    {
-        tracing::warn!("dropping a smash particle: {error}");
     }
 }
 

--- a/events/smash/src/module.rs
+++ b/events/smash/src/module.rs
@@ -13,3 +13,4 @@ pub mod projectile;
 pub mod scoreboard;
 pub mod selector;
 pub mod sound;
+pub mod visuals;

--- a/events/smash/src/module/ability.rs
+++ b/events/smash/src/module/ability.rs
@@ -19,8 +19,9 @@ use crate::{
     module::{
         player::{Energy, Facing, Health, OnGround, Player, Position},
         sound::{self, PlaysOnCast},
+        visuals,
     },
-    server::{Cue, PlayerId, Server, ServerHandle},
+    server::{PlayerId, Server, ServerHandle},
 };
 
 /// Tag on ability prefabs and ability instances.
@@ -711,6 +712,6 @@ pub fn charge_steps(charge: f32, max: u32) -> u32 {
 )]
 pub fn splash(cast: &Cast<'_>, radius: f32, damage: f32, multiplier: f32) -> Vec<Entity> {
     let victims = splash_at(cast, cast.position.0, radius, damage, multiplier);
-    cast.server.cue(cast.position.0, Cue::Explosion);
+    cast.server.particles(visuals::blast(cast.position.0));
     victims
 }

--- a/events/smash/src/module/effect.rs
+++ b/events/smash/src/module/effect.rs
@@ -42,7 +42,7 @@ use crate::{
         player::{Health, Position},
         projectile::Impact,
     },
-    server::{Cue, ServerHandle, Sound, SoundCategory},
+    server::{Particles, ServerHandle, Sound, SoundCategory},
 };
 
 /// Tag on effect entities.
@@ -113,9 +113,16 @@ pub struct Ticks {
 /// a poison are the same mechanic and this is the only thing that separates
 /// them for a player. Carried as one value so an effect cannot be given a noise
 /// and no picture.
-#[derive(Component, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Component, Debug, Copy, Clone)]
 pub struct Shows {
-    pub cue: Cue,
+    /// The effect drawn on the victim, given where they are standing.
+    ///
+    /// A function rather than a particle, so an affliction picks its own
+    /// shape and density and not just its colour. A bare `fn` and not a
+    /// closure for the same reason [`crate::module::projectile::Payload`]'s
+    /// `on_hit` is one: this is built in a `const` and has nowhere to put a
+    /// capture.
+    pub effect: fn(Vec3) -> Particles,
     /// A vanilla sound event id, held against the generated registry by
     /// `tests/sound.rs` like every other sound in the game.
     pub sound: &'static str,
@@ -648,7 +655,7 @@ impl Module for EffectModule {
                             continue;
                         };
                         world.get::<&ServerHandle>(|server| {
-                            server.cue(at, shows.cue);
+                            server.particles((shows.effect)(at));
                             server.play_sound(at, Sound::new(shows.sound, SoundCategory::Players));
                         });
                     }

--- a/events/smash/src/module/kits/blaze.rs
+++ b/events/smash/src/module/kits/blaze.rs
@@ -20,8 +20,8 @@ use crate::{
         kit::{self, AbilitySpec, KitSounds, KitStats},
         knockback::Knockback,
         player::{Health, Player, Position},
+        visuals,
     },
-    server::Cue,
 };
 
 /// `[VERIFIED]`: "it can be cancelled by taking 4 or more damage" while
@@ -42,7 +42,7 @@ pub const BURN_INTERVAL: f32 = 1.0;
 /// What a burning player looks and sounds like, once, so Inferno and Phoenix
 /// cannot drift into looking like two different things.
 const BURNING: Shows = Shows {
-    cue: Cue::Burn,
+    effect: visuals::burn,
     sound: "minecraft:entity.player.hurt_on_fire",
 };
 

--- a/events/smash/src/module/kits/chicken.rs
+++ b/events/smash/src/module/kits/chicken.rs
@@ -17,8 +17,8 @@ use crate::{
         effect::{self, Affliction},
         kit::{self, AbilitySpec, KitSounds, KitStats},
         projectile::{Flight, Impact, Payload, fire},
+        visuals,
     },
-    server::Cue,
 };
 
 /// `[VERIFIED]`: "Chicken is the only mob who can double jump eight times."
@@ -156,7 +156,7 @@ fn refund(impact: &Impact<'_>) {
     }
     impact
         .world
-        .get::<&crate::server::ServerHandle>(|server| server.cue(impact.at, Cue::Explosion));
+        .get::<&crate::server::ServerHandle>(|server| server.particles(visuals::blast(impact.at)));
 }
 
 /// `[WIKI]` "unlimited flight and eggs, for twenty seconds".

--- a/events/smash/src/module/kits/creeper.rs
+++ b/events/smash/src/module/kits/creeper.rs
@@ -9,15 +9,13 @@
 
 use flecs_ecs::prelude::*;
 
-use crate::{
-    module::{
-        ability::{Cast, Observable, splash},
-        damage::DamageKind,
-        kit::{self, AbilitySpec, KitSounds, KitStats},
-        player::Player,
-        projectile::{Flight, Impact, Payload, fire},
-    },
-    server::Cue,
+use crate::module::{
+    ability::{Cast, Observable, splash},
+    damage::DamageKind,
+    kit::{self, AbilitySpec, KitSounds, KitStats},
+    player::Player,
+    projectile::{Flight, Impact, Payload, fire},
+    visuals,
 };
 
 /// Speed II while charged, per the wiki's Lightning Shield description.
@@ -141,7 +139,7 @@ fn sulphur_bomb(cast: &Cast<'_>) {
 fn detonate(impact: &Impact<'_>) {
     impact
         .world
-        .get::<&crate::server::ServerHandle>(|server| server.cue(impact.at, Cue::Explosion));
+        .get::<&crate::server::ServerHandle>(|server| server.particles(visuals::blast(impact.at)));
 }
 
 /// 18 damage at full charge. `[VERIFIED]` from the wiki; the taper down to a

--- a/events/smash/src/module/kits/enderman.rs
+++ b/events/smash/src/module/kits/enderman.rs
@@ -11,15 +11,13 @@
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 
-use crate::{
-    module::{
-        ability::{self, Cast, Observable},
-        effect::{self, Affliction},
-        kit::{self, AbilitySpec, KitSounds, KitStats},
-        player::Position,
-        projectile::{Flight, Payload, fire},
-    },
-    server::Cue,
+use crate::module::{
+    ability::{self, Cast, Observable},
+    effect::{self, Affliction},
+    kit::{self, AbilitySpec, KitSounds, KitStats},
+    player::Position,
+    projectile::{Flight, Payload, fire},
+    visuals,
 };
 
 /// `Distance = 16`.
@@ -178,5 +176,5 @@ fn dragon_pass(cast: &Cast<'_>) {
 fn teleport_to(cast: &Cast<'_>, to: Vec3) {
     cast.caster.set(Position(to));
     cast.server.teleport(cast.player, to);
-    cast.server.cue(to, Cue::Teleport);
+    cast.server.particles(visuals::teleport(to));
 }

--- a/events/smash/src/module/kits/guardian.rs
+++ b/events/smash/src/module/kits/guardian.rs
@@ -20,8 +20,9 @@ use crate::{
         kit::{self, AbilitySpec, KitSounds, KitStats},
         player::{Player, Position},
         projectile::{Flight, Impact, Payload, fire},
+        visuals,
     },
-    server::{Cue, PlayerId, ServerHandle},
+    server::{PlayerId, ServerHandle},
 };
 
 /// `[VERIFIED]`: "increased damage (5 -> 7)", "8 seconds at maximum",
@@ -178,7 +179,7 @@ fn reel(impact: &Impact<'_>) {
 fn water_splash(cast: &Cast<'_>) {
     cast.server.add_velocity(cast.player, Vec3::Y * 0.9);
     splash_at(cast, cast.position.0, 5.0, 11.0, 1.4);
-    cast.server.cue(cast.position.0, Cue::Explosion);
+    cast.server.particles(visuals::blast(cast.position.0));
 }
 
 fn target_laser(cast: &Cast<'_>) {

--- a/events/smash/src/module/kits/iron_golem.rs
+++ b/events/smash/src/module/kits/iron_golem.rs
@@ -10,15 +10,13 @@
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 
-use crate::{
-    module::{
-        ability::{Cast, Observable, splash, splash_at},
-        effect::{self, Affliction},
-        kit::{self, AbilitySpec, KitSounds, KitStats},
-        player::Position,
-        projectile::{Flight, Impact, Payload, fire},
-    },
-    server::Cue,
+use crate::module::{
+    ability::{Cast, Observable, splash, splash_at},
+    effect::{self, Affliction},
+    kit::{self, AbilitySpec, KitSounds, KitStats},
+    player::Position,
+    projectile::{Flight, Impact, Payload, fire},
+    visuals,
 };
 
 /// `PerkSlow(0)`, reapplied every four seconds. The armour is meant to be paid
@@ -123,7 +121,7 @@ fn fissure(cast: &Cast<'_>) {
         let at = cast.position.0 + step * column as f32;
         splash_at(cast, at, HIT_RADIUS, 4.0 + column as f32, 1.0);
     }
-    cast.server.cue(cast.position.0, Cue::Explosion);
+    cast.server.particles(visuals::blast(cast.position.0));
 }
 
 /// A slow, heavy projectile that reels its victim in.
@@ -235,5 +233,5 @@ fn quake(cast: &Cast<'_>) {
             kind: DamageKind::Ability,
         });
     }
-    cast.server.cue(cast.position.0, Cue::Explosion);
+    cast.server.particles(visuals::blast(cast.position.0));
 }

--- a/events/smash/src/module/kits/sky_squid.rs
+++ b/events/smash/src/module/kits/sky_squid.rs
@@ -10,14 +10,12 @@
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 
-use crate::{
-    module::{
-        ability::{self, Cast, Observable, splash_at},
-        effect::{self, Affliction},
-        kit::{self, AbilitySpec, KitSounds, KitStats},
-        projectile::{Flight, Payload, fire},
-    },
-    server::Cue,
+use crate::module::{
+    ability::{self, Cast, Observable, splash_at},
+    effect::{self, Affliction},
+    kit::{self, AbilitySpec, KitSounds, KitStats},
+    projectile::{Flight, Payload, fire},
+    visuals,
 };
 
 /// `[VERIFIED]` "Each pellet deals 1.725 damage, so a total damage of 12.075 if
@@ -154,7 +152,7 @@ fn ink_shotgun(cast: &Cast<'_>) {
 fn fish_flurry(cast: &Cast<'_>) {
     let at = cast.position.0 + cast.facing.0.normalize_or_zero() * 4.0;
     splash_at(cast, at, 2.5, 2.0, 0.7);
-    cast.server.cue(at, Cue::Explosion);
+    cast.server.particles(visuals::blast(at));
 }
 
 /// `[VERIFIED]` "call lightning down once a second"; the twenty seconds is
@@ -201,7 +199,7 @@ fn storm_bolt(cast: &Cast<'_>) {
         // The bolt lands on the victim, so the launch has to be measured from
         // the squid: away from the point you are standing on is not a direction.
         splash_from(cast, cast.position.0, at, 2.0, STORM_DAMAGE, 1.2);
-        cast.server.cue(at, Cue::Explosion);
+        cast.server.particles(visuals::blast(at));
     }
 }
 

--- a/events/smash/src/module/kits/slime.rs
+++ b/events/smash/src/module/kits/slime.rs
@@ -12,16 +12,14 @@
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 
-use crate::{
-    module::{
-        ability::{Cast, Observable, splash_at},
-        damage::{DamageKind, Damaged, hurt},
-        effect::{self, Affliction},
-        kit::{self, AbilitySpec, KitSounds, KitStats},
-        knockback::Knockback,
-        player::Energy,
-    },
-    server::Cue,
+use crate::module::{
+    ability::{Cast, Observable, splash_at},
+    damage::{DamageKind, Damaged, hurt},
+    effect::{self, Affliction},
+    kit::{self, AbilitySpec, KitSounds, KitStats},
+    knockback::Knockback,
+    player::Energy,
+    visuals,
 };
 
 /// `Energy Per Tick = 0.004` on a 49 ms tick.
@@ -144,7 +142,7 @@ fn slime_rocket(cast: &Cast<'_>) {
         rocket_damage(size),
         cast.charge.mul_add(1.4, 1.0),
     );
-    cast.server.cue(ahead, Cue::Explosion);
+    cast.server.particles(visuals::blast(ahead));
 }
 
 /// Deals 7 at a 2.0 multiplier, and hands a quarter of both back to the caster

--- a/events/smash/src/module/kits/spider.rs
+++ b/events/smash/src/module/kits/spider.rs
@@ -12,16 +12,14 @@
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 
-use crate::{
-    module::{
-        ability::{self, Cast, Observable, splash},
-        damage::DamageKind,
-        effect::{self, Affliction, Shows},
-        kit::{self, AbilitySpec, KitSounds, KitStats},
-        player::Health,
-        projectile::{Flight, Impact, Payload, fire},
-    },
-    server::Cue,
+use crate::module::{
+    ability::{self, Cast, Observable, splash},
+    damage::DamageKind,
+    effect::{self, Affliction, Shows},
+    kit::{self, AbilitySpec, KitSounds, KitStats},
+    player::Health,
+    projectile::{Flight, Impact, Payload, fire},
+    visuals,
 };
 
 /// What a needle leaves behind.
@@ -35,7 +33,7 @@ pub const POISON_PER_TICK: f32 = 1.0;
 pub const POISON_INTERVAL: f32 = 1.25;
 
 const POISONED: Shows = Shows {
-    cue: Cue::Venom,
+    effect: visuals::venom,
     sound: "minecraft:entity.player.hurt_sweet_berry_bush",
 };
 

--- a/events/smash/src/module/kits/wither_skeleton.rs
+++ b/events/smash/src/module/kits/wither_skeleton.rs
@@ -12,15 +12,13 @@
 use flecs_ecs::prelude::*;
 use glam::Vec3;
 
-use crate::{
-    module::{
-        ability::{self, Cast, Observable, splash_at},
-        damage::MatchClock,
-        effect::{self, Affliction},
-        kit::{self, AbilitySpec, KitSounds, KitStats},
-        projectile::{Flight, Impact, Payload, fire},
-    },
-    server::Cue,
+use crate::module::{
+    ability::{self, Cast, Observable, splash_at},
+    damage::MatchClock,
+    effect::{self, Affliction},
+    kit::{self, AbilitySpec, KitSounds, KitStats},
+    projectile::{Flight, Impact, Payload, fire},
+    visuals,
 };
 
 /// How long a dropped image stands before it fades.
@@ -115,7 +113,7 @@ fn guided_wither_skull(cast: &Cast<'_>) {
 fn burst(impact: &Impact<'_>) {
     impact
         .world
-        .get::<&crate::server::ServerHandle>(|server| server.cue(impact.at, Cue::Explosion));
+        .get::<&crate::server::ServerHandle>(|server| server.particles(visuals::blast(impact.at)));
 }
 
 /// First use drops the image; a second use while it stands swaps you to it.
@@ -131,7 +129,7 @@ fn wither_image(cast: &Cast<'_>) {
     {
         cast.caster.remove(Image::id());
         cast.server.teleport(cast.player, image.at);
-        cast.server.cue(image.at, Cue::Teleport);
+        cast.server.particles(visuals::teleport(image.at));
         return;
     }
 
@@ -163,5 +161,5 @@ const SWAP_DAMAGE: f32 = 2.5;
 
 fn swap_burst(cast: &Cast<'_>) {
     splash_at(cast, cast.position.0, 6.0, SWAP_DAMAGE, 1.8);
-    cast.server.cue(cast.position.0, Cue::Explosion);
+    cast.server.particles(visuals::blast(cast.position.0));
 }

--- a/events/smash/src/module/kits/zombie.rs
+++ b/events/smash/src/module/kits/zombie.rs
@@ -14,8 +14,9 @@ use crate::{
         kit::{self, AbilitySpec, KitSounds, KitStats},
         player::Position,
         projectile::{Flight, Impact, Payload, fire},
+        visuals,
     },
-    server::{Cue, PlayerId, ServerHandle},
+    server::{PlayerId, ServerHandle},
 };
 
 #[derive(Component)]
@@ -154,5 +155,5 @@ const HORDE_DAMAGE: f32 = 2.5;
 
 fn horde_wave(cast: &Cast<'_>) {
     splash_at(cast, cast.position.0, 7.0, HORDE_DAMAGE, 1.6);
-    cast.server.cue(cast.position.0, Cue::Explosion);
+    cast.server.particles(visuals::blast(cast.position.0));
 }

--- a/events/smash/src/module/lives.rs
+++ b/events/smash/src/module/lives.rs
@@ -15,8 +15,9 @@ use crate::{
         hud, kit,
         player::{self, Health, JumpsLeft, Player, Position},
         sound::{self, PlaysOnDeath},
+        visuals,
     },
-    server::{Channel, Cue, NamedColor, PlayerId, ServerHandle, Sound, SoundCategory, Text},
+    server::{Channel, NamedColor, PlayerId, ServerHandle, Sound, SoundCategory, Text},
 };
 
 /// Mineplex's `MAX_LIVES`.
@@ -356,7 +357,7 @@ impl Module for LivesModule {
                 sound::play_kit_voice(world, victim, PlaysOnDeath, at);
 
                 world.get::<&ServerHandle>(|server| {
-                    server.cue(at, Cue::Death);
+                    server.particles(visuals::death(at));
                     match killer_name.as_deref() {
                         Some(killer_name) => server.broadcast(
                             Channel::Chat,

--- a/events/smash/src/module/visuals.rs
+++ b/events/smash/src/module/visuals.rs
@@ -1,0 +1,114 @@
+//! What the recurring moments of the game look like.
+//!
+//! An ability going off, a teleport landing, a player dying, a burn ticking, a
+//! poison ticking. Each is one moment that happens in a dozen places and should
+//! look the same in all of them, so each is written once, here.
+//!
+//! This is not the old `Cue` enum under another name. A `Cue` was a closed set
+//! and the *only* thing an ability could ask for, which is why Bone Explosion,
+//! Water Splash and Fish Flurry were all `Cue::Explosion` and all drew the same
+//! grey puff. These are plain functions returning a [`Particles`], so a kit
+//! that wants bones rather than a blast composes its own and does not have to
+//! widen anything:
+//!
+//! ```ignore
+//! cast.server.particles(
+//!     Particles::sphere(Particle::Item { item_stack: bone }, at, 2.0)
+//!         .points(30)
+//!         .speed(0.1),
+//! );
+//! ```
+//!
+//! `[INFERRED]` throughout. Mineplex's own particle choices are not in the
+//! leaked source, which loaded them from the same spreadsheet as everything
+//! else, so these are read off what vanilla draws for the same events.
+
+use glam::Vec3;
+
+use crate::server::{Argb, Particle, Particles};
+
+/// Half-width of the box a point effect scatters its particles through.
+///
+/// Small enough to read as one thing happening in one place rather than as
+/// weather.
+const SPREAD: f32 = 0.4;
+
+/// How fast a scattered particle drifts. Nearly still: these mark a place, and
+/// a puff that flies apart stops marking it.
+const DRIFT: f32 = 0.02;
+
+/// Roughly chest height on a standing player, where a status effect reads best.
+const CHEST: f32 = 0.9;
+
+/// An ability going off here.
+///
+/// The default for anything with no look of its own yet, which is most of
+/// them, and the one to stop reaching for as soon as a kit has something to
+/// say.
+pub const fn blast(at: Vec3) -> Particles {
+    Particles::burst(Particle::Explosion, at)
+        .count(40)
+        .offset(Vec3::splat(SPREAD))
+        .speed(0.5)
+        // Something that just happened to a player is worth seeing from
+        // further out than the client's usual particle radius.
+        .long_distance(true)
+}
+
+/// Somebody arriving somewhere they were not.
+///
+/// A sphere rather than a puff, because a teleport has a shape: the eye reads
+/// a shell as an arrival and a scatter as damage.
+pub fn teleport(at: Vec3) -> Particles {
+    Particles::sphere(Particle::Portal, at + Vec3::Y, 1.0)
+        .points(40)
+        .count(2)
+        .speed(0.05)
+        .long_distance(true)
+}
+
+/// A player dying here.
+pub fn death(at: Vec3) -> Particles {
+    Particles::burst(Particle::Cloud, at + Vec3::Y)
+        .count(40)
+        .offset(Vec3::new(SPREAD, 0.8, SPREAD))
+        .speed(0.1)
+        .long_distance(true)
+}
+
+/// One tick of something burning a player.
+///
+/// `minecraft:flame`, which is what vanilla draws on a burning entity. This was
+/// pinned to `crit` for as long as the protocol layer could spell only five
+/// particles.
+pub fn burn(at: Vec3) -> Particles {
+    Particles::burst(Particle::Flame, at + Vec3::Y * CHEST)
+        .count(12)
+        .offset(Vec3::new(0.3, 0.5, 0.3))
+        .speed(DRIFT)
+}
+
+/// One tick of something poisoning a player.
+///
+/// `minecraft:entity_effect` in vanilla's own poison green, which is what a
+/// potion effect draws. Distinct from [`burn`] by its picture and by nothing
+/// else, which is the whole point: both take a point of health a second off
+/// somebody standing still, and a player who cannot tell them apart cannot tell
+/// a Blaze from a Spider.
+pub fn venom(at: Vec3) -> Particles {
+    Particles::burst(
+        Particle::EntityEffect {
+            // Vanilla's own poison colour, which is what `entity_effect`
+            // is drawn in when a `minecraft:poison` instance renders:
+            // `MobEffects.POISON` carries `0x4E9331`. Taken from the effect
+            // rather than picked, so the haze around a poisoned player is the
+            // green a player already reads as poison rather than an arbitrary
+            // green.
+            color: Argb::opaque(0x4E, 0x93, 0x31),
+        },
+        at + Vec3::Y * CHEST,
+    )
+    .count(12)
+    .offset(Vec3::new(0.3, 0.5, 0.3))
+    .speed(DRIFT)
+}

--- a/events/smash/src/server.rs
+++ b/events/smash/src/server.rs
@@ -11,8 +11,10 @@ use std::sync::Arc;
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
-pub use hyperion_minecraft_proto::text::{
-    Component, Decoration, NamedColor, Rgb24, Run, Style, TextColor,
+pub use hyperion::effects::{Effect, Shape};
+pub use hyperion_minecraft_proto::{
+    particle::{Argb, Particle, ParticleKind},
+    text::{Component, Decoration, NamedColor, Rgb24, Run, Style, TextColor},
 };
 
 pub mod mock;
@@ -100,31 +102,23 @@ pub struct HotbarItem {
     pub lore: Vec<String>,
 }
 
-/// A one-shot burst of particles. Purely cosmetic, so the game never branches
-/// on whether it succeeded.
+/// A particle effect the host draws. Purely cosmetic, so the game never
+/// branches on whether it succeeded.
 ///
-/// Sound used to travel on this enum too, which is why every ability that
-/// wanted to be heard reached for [`Self::Explosion`] and the game had four
-/// noises for fifty-one abilities. Audio is now [`Sound`], which carries the
-/// vanilla sound event itself rather than a name something else has to map, so
-/// what is left here is only the particle: a short list of shapes, each of
-/// which really is one distinct thing a client can be shown.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Cue {
-    Explosion,
-    Teleport,
-    Death,
-    /// One tick of something burning a player.
-    Burn,
-    /// One tick of something poisoning them.
-    ///
-    /// A separate cue from [`Self::Burn`] and not a shared "damage over time"
-    /// one, because the two are told apart by their picture and by nothing
-    /// else: both take a point of health a second off somebody who is standing
-    /// still, and a player who cannot see which is which cannot tell a Blaze
-    /// from a Spider.
-    Venom,
-}
+/// This replaced a `Cue` enum, which by the end had five variants standing in
+/// for every visual in the game: an explosion, a teleport, a death, a burn and
+/// a poison. Bone Explosion, Water Splash and Fish Flurry all drew
+/// `Cue::Explosion`, so bones, water and fish were the same picture. The enum
+/// was never really the problem: the protocol layer under it could spell five
+/// particles, so five was all an ability could ask for. Now that [`Particle`]
+/// is the whole registry, an ability names the one it wants and composes the
+/// shape itself.
+///
+/// A re-export rather than a type of its own, for the same reason [`Text`] is
+/// one: a second copy of a builder is a second thing to keep in step with the
+/// first. It is pure data -- a particle, a point and a shape -- and lives in
+/// the engine because the emitter that draws it across several ticks does.
+pub type Particles = Effect<'static>;
 
 /// Which of the listener's volume sliders governs a sound.
 ///
@@ -358,7 +352,8 @@ pub trait Server: Send + Sync + 'static {
     /// Toggle spectator mode: invisible, non-colliding, flying, no attacks.
     fn set_spectating(&self, player: PlayerId, spectating: bool);
 
-    fn cue(&self, at: Vec3, cue: Cue);
+    /// Draw a particle effect. Everyone close enough to its origin sees it.
+    fn particles(&self, effect: Particles);
 
     /// Play a sound at a point in the world. Everyone close enough hears it,
     /// attenuated by how far they are standing from `at`.

--- a/events/smash/src/server/mock.rs
+++ b/events/smash/src/server/mock.rs
@@ -10,8 +10,8 @@ use std::sync::Mutex;
 use glam::Vec3;
 
 use super::{
-    BossBar, Channel, Cue, Experience, HotbarItem, PlayerId, Server, SidebarLine, Sound, Text,
-    Title,
+    BossBar, Channel, Experience, HotbarItem, Particles, PlayerId, Server, SidebarLine, Sound,
+    Text, Title,
 };
 
 /// One thing the game asked the server to do.
@@ -25,7 +25,7 @@ pub enum Call {
     Broadcast(Channel, Text),
     Sidebar(PlayerId, Text, Vec<SidebarLine>),
     Spectating(PlayerId, bool),
-    Cue(Vec3, Cue),
+    Particles(Particles),
     /// A positioned sound, heard by everyone in range.
     Sound(Vec3, Sound),
     /// A sound only one player hears.
@@ -93,6 +93,17 @@ impl MockServer {
 
     /// Every positioned sound so far, with where it played.
     #[must_use]
+    /// Every particle effect asked for, in order.
+    pub fn particles(&self) -> Vec<Particles> {
+        self.calls()
+            .iter()
+            .filter_map(|call| match call {
+                Call::Particles(effect) => Some(effect.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
     pub fn sounds(&self) -> Vec<(Vec3, Sound)> {
         self.calls()
             .iter()
@@ -208,8 +219,8 @@ impl Server for MockServer {
         self.push(Call::Spectating(player, spectating));
     }
 
-    fn cue(&self, at: Vec3, cue: Cue) {
-        self.push(Call::Cue(at, cue));
+    fn particles(&self, effect: Particles) {
+        self.push(Call::Particles(effect));
     }
 
     fn play_sound(&self, at: Vec3, sound: Sound) {

--- a/events/smash/tests/abilities.rs
+++ b/events/smash/tests/abilities.rs
@@ -242,7 +242,7 @@ fn observed(bench: &Bench, observable: Observable, before: &Snapshot, held: bool
                 || bench.game.server.calls().iter().any(|call| {
                     matches!(
                         call,
-                        Call::AddVelocity(..) | Call::SetHealth(..) | Call::Cue(..)
+                        Call::AddVelocity(..) | Call::SetHealth(..) | Call::Particles(..)
                     )
                 })
         }

--- a/events/smash/tests/contract.rs
+++ b/events/smash/tests/contract.rs
@@ -242,7 +242,7 @@ fn contracts() -> Vec<Contract> {
                         0.1,
                         DamageKind::Environment,
                         effect::Shows {
-                            cue: smash::server::Cue::Burn,
+                            effect: smash::module::visuals::burn,
                             sound: "minecraft:entity.player.hurt_on_fire",
                         },
                     ),

--- a/events/smash/tests/visuals.rs
+++ b/events/smash/tests/visuals.rs
@@ -1,0 +1,134 @@
+//! Every ability draws something, and no two things that hurt you look alike.
+//!
+//! An invisible ability is the same bug as a silent one: the damage lands, the
+//! knockback packet goes out, and the only symptom is that the player cannot
+//! see what hit them. `Cue` made that bug structural rather than accidental --
+//! five variants stood in for every visual in the game, so a kit could not draw
+//! anything Mineplex had not already needed. These are the assertions that keep
+//! the replacement honest now that a kit can draw all 125.
+//!
+//! Checked on the `MockServer` call log, which is the same seam
+//! `tests/sound.rs` reads, and for the same reason: a scripted client cannot
+//! assert that a human found the effect legible, but it can assert that the
+//! packet carrying it was asked for at all.
+
+mod harness;
+
+use glam::Vec3;
+use harness::Game;
+use smash::{
+    module::{damage::DamageKind, effect, visuals},
+    server::{Particle, Particles},
+};
+
+/// The particle every point of an effect draws.
+fn drawn(effect: &Particles) -> Particle<'_> {
+    effect
+        .packets()
+        .next()
+        .expect("an effect with no points draws nothing")
+        .particle
+}
+
+/// Burn and poison are told apart by their picture and by nothing else.
+///
+/// Both take a point of health a second off somebody standing still. When both
+/// were `Cue`s the game had no way to draw them differently, and a player could
+/// not tell a Blaze from a Spider. This is the assertion that says the two are
+/// still distinct after any future tidy-up of `visuals`.
+#[test]
+fn a_burn_and_a_poison_do_not_look_the_same() {
+    let at = Vec3::new(0.0, 64.0, 0.0);
+    assert_ne!(drawn(&visuals::burn(at)), drawn(&visuals::venom(at)));
+}
+
+/// The two that were placeholders are now the particles vanilla actually uses.
+///
+/// `burn` was pinned to `crit` and `venom` to half-power `dragon_breath` for as
+/// long as the protocol layer could spell five particles. Naming the real ones
+/// here is what stops a future edit quietly reverting to the nearest thing.
+#[test]
+fn a_burn_is_flame_and_a_poison_is_an_effect_tint() {
+    let at = Vec3::new(0.0, 64.0, 0.0);
+    assert_eq!(drawn(&visuals::burn(at)), Particle::Flame);
+    assert!(
+        matches!(drawn(&visuals::venom(at)), Particle::EntityEffect { .. }),
+        "a poison is a tinted potion effect, not a shape"
+    );
+}
+
+/// Every visual puts its particles where it was asked to, near enough that a
+/// player reads it as happening to them.
+///
+/// An effect drawn at the feet of somebody two blocks away marks the wrong
+/// player. The bound is a player's own height: 1.8 blocks tall, and these draw
+/// from the feet up to a shell over the head, so everything should land inside
+/// roughly one player-sized box around the point it was given.
+#[test]
+fn every_visual_is_drawn_where_it_was_asked_for() {
+    let at = Vec3::new(12.5, 64.0, -3.5);
+    for (name, effect) in [
+        ("blast", visuals::blast(at)),
+        ("teleport", visuals::teleport(at)),
+        ("death", visuals::death(at)),
+        ("burn", visuals::burn(at)),
+        ("venom", visuals::venom(at)),
+    ] {
+        let packets: Vec<_> = effect.packets().collect();
+        assert!(!packets.is_empty(), "{name} draws nothing");
+        for packet in &packets {
+            // The packet carries doubles; the game's own positions are f32,
+            // so narrowing back is exactly the round trip a caller made.
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "the position went in as an f32 and the packet only widened it"
+            )]
+            let drawn_at = Vec3::new(packet.x as f32, packet.y as f32, packet.z as f32);
+            assert!(
+                drawn_at.distance(at) <= 2.5,
+                "{name} drew a particle {:.2} blocks from {at:?}, at {drawn_at:?}",
+                drawn_at.distance(at)
+            );
+            assert!(packet.count > 0, "{name} sends a packet that draws nothing");
+        }
+    }
+}
+
+/// An affliction that ticks draws the picture its `Shows` names.
+///
+/// This is the assertion that was missing when `Cue` came out. Deleting the
+/// enum moved the picture from a field the compiler checked to a function
+/// pointer it also checks, but nothing anywhere said the picture still
+/// *arrived* -- an affliction whose particle call was dropped would tick, hurt,
+/// make its noise, and be invisible, and every test in the suite would pass.
+#[test]
+fn an_affliction_draws_the_picture_it_names() {
+    let mut game = Game::new();
+    let player = game.player("burned", Vec3::new(0.0, 64.0, 0.0));
+
+    effect::afflict(
+        (&game.world).into(),
+        game.world.entity_from_id(player),
+        effect::Blame {
+            source: player,
+            attacker: player,
+        },
+        effect::Affliction::over_time(1.0, 2.0, 0.1, DamageKind::Environment, effect::Shows {
+            effect: visuals::burn,
+            sound: "minecraft:entity.player.hurt_on_fire",
+        }),
+    );
+    game.server.take();
+    game.advance(0.4, 4);
+
+    let drawn_effects = game.server.particles();
+    assert!(
+        !drawn_effects.is_empty(),
+        "a burn ticked and nothing was drawn"
+    );
+    assert_eq!(
+        drawn(&drawn_effects[0]),
+        Particle::Flame,
+        "the affliction drew something other than the picture it names"
+    );
+}

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -114,6 +114,7 @@ ACTION_RELEASE_USE_ITEM = 5
 S2C_CONTAINER_SET_SLOT = 0x14
 S2C_DISCONNECT = 0x20
 S2C_KEEP_ALIVE = 0x2C
+S2C_LEVEL_PARTICLES = 0x2F
 S2C_LOGIN = 0x31
 S2C_PLAYER_POSITION = 0x48
 S2C_SET_ACTION_BAR_TEXT = 0x57
@@ -162,6 +163,26 @@ def take_lp_vec3(payload, offset):
         unpack(buffer >> (3 + LP_DATA_BITS)) * scale,
         unpack(buffer >> (3 + 2 * LP_DATA_BITS)) * scale,
     ), offset
+
+
+def take_particles(payload):
+    """`ClientboundLevelParticlesPacket`, as far as this file cares about it.
+
+    Fixed-width up to the particle, then a var int type id and whatever that
+    type's own codec writes. The body is not read: which particle arrived and
+    how many of it are what a kit declares, and the body shapes are already
+    held against Mojang's own encoder by `play_particles.rs`.
+
+    Returns `(particle_id, position, count)`, position in blocks.
+    """
+    override_limiter = payload[0]
+    always_show = payload[1]
+    x, y, z, x_dist, y_dist, z_dist, max_speed, count = struct.unpack(
+        ">dddffffi", payload[2:46]
+    )
+    particle_id, _ = take_var_int(payload, 46)
+    del override_limiter, always_show, x_dist, y_dist, z_dist, max_speed
+    return particle_id, (x, y, z), count
 
 
 def take_sound(payload):
@@ -650,6 +671,7 @@ class Match:
             self.proof["the server published its ability registry"] = None
             self.proof["every declared ability did what it declared"] = None
             self.proof["every declared ability was heard"] = None
+            self.proof["every declared ability was seen"] = None
             self.proof["cooldowns refused a second use"] = None
         self.proof.update({
             "four in play": None,
@@ -678,10 +700,16 @@ class Match:
         # Abilities whose declared sound never arrived, and any sound that
         # arrived in a form a client could not resolve.
         self.sound_failures = []
+        # Abilities that drew nothing a client could see.
+        self.particle_failures = []
         # Velocity packets seen this window, keyed by entity id. Collected from
         # every client rather than one, because a player is not always in their
         # own broadcast channel and the caster's own launch has to be visible.
         self.window_motions = {}
+        # Particle packets seen this window, from every client for the same
+        # reason motions are: the caster is not always in their own broadcast
+        # channel, and an effect drawn at the caster has to be visible.
+        self.window_particles = []
         self.motions = []
         self.deaths = []
         self.respawns = []
@@ -832,6 +860,13 @@ class Match:
             client.log(
                 "<- sound %s at (%.1f, %.1f, %.1f) vol %.2f pitch %.2f"
                 % ((sound_id,) + at + (volume, pitch))
+            )
+        elif packet_id == S2C_LEVEL_PARTICLES:
+            particle_id, at, count = take_particles(payload)
+            self.window_particles.append((particle_id, at, count))
+            client.log(
+                "<- particles %d x%d at (%.1f, %.1f, %.1f)"
+                % ((particle_id, count) + at)
             )
         elif packet_id == S2C_SET_ACTION_BAR_TEXT:
             text, _ = take_nbt_string(payload, 0)
@@ -1073,6 +1108,16 @@ class Match:
                 "%d abilities fired by a real client, each one answered by a "
                 "ClientboundSoundPacket carrying the vanilla sound event its own "
                 "registry entry names" % len(self.manifest),
+            )
+        if self.particle_failures:
+            for line in self.particle_failures:
+                self.log("PARTICLE FAILED %s" % line)
+        else:
+            self.prove(
+                "every declared ability was seen",
+                "%d abilities fired by a real client, each one answered by a "
+                "ClientboundLevelParticlesPacket with a non-zero count"
+                % len(self.manifest),
             )
         if self.cooldown_failures:
             for line in self.cooldown_failures:
@@ -1353,6 +1398,7 @@ class Match:
         # makes reads as the ability having hurt somebody.
         melee = self.measure_melee() if "buffs_melee" in entry["proves"] else 0.0
         self.window_motions.clear()
+        self.window_particles.clear()
         for client in self.clients:
             client.action_bar.clear()
             client.teleported_to.clear()
@@ -1512,6 +1558,7 @@ class Match:
         outstanding = list(entry["proves"])
         evidence = []
         heard = False
+        seen = False
 
         for attempt in range(SWEEP_ATTEMPTS):
             if not outstanding and heard:
@@ -1540,7 +1587,21 @@ class Match:
                 if not heard:
                     evidence.append("heard: %s" % entry["sound"])
                 heard = True
-            if outstanding or not heard:
+            # Every ability draws something. Which particle is the kit's
+            # business and not this file's, so the claim is only that a real
+            # client was sent one and that it carries a real count -- a
+            # `level_particles` with a count of zero is a packet that spends
+            # bandwidth and draws nothing.
+            drawn = [seen_at for seen_at in self.window_particles if seen_at[2] > 0]
+            if drawn:
+                if not seen:
+                    particle_id, at, count = drawn[0]
+                    evidence.append(
+                        "seen: particle %d x%d at (%.1f, %.1f, %.1f)"
+                        % ((particle_id, count) + at)
+                    )
+                seen = True
+            if outstanding or not heard or not seen:
                 self.wait(entry["cooldown"] + 0.5)
 
         if outstanding:
@@ -1551,6 +1612,10 @@ class Match:
             self.sound_failures.append(
                 "%s declares the sound %s and firing it sent no such packet"
                 % (label, entry["sound"])
+            )
+        if not seen:
+            self.particle_failures.append(
+                "%s fired and sent no level_particles a client could draw" % label
             )
         self.sweep_results.append(
             "%-42s %s" % (label, "; ".join(evidence) or "nothing reached a client")


### PR DESCRIPTION
The seam half of the effects work, following #1030. `Cue` is deleted; an ability now names any of the 125 particles and composes its own shape.

**The abilities agent should rebase on this.** It touches 22 files, 15 of them kits, and every kit change is one line plus an import.

## Why `Cue` had to go rather than grow

It was three variants when written and five by tonight. It was also the *only* thing an ability could ask to be seen as, so Bone Explosion, Water Splash and Fish Flurry all drew `Cue::Explosion` and bones, water and fish were one grey puff. The enum was never really the problem — the protocol layer under it could spell five particles, so five was all there was to ask for. #1030 removed that constraint.

```rust
// before
cast.server.cue(cast.position.0, Cue::Explosion);

// after
cast.server.particles(visuals::blast(cast.position.0));

// or, when a kit has something of its own to say
cast.server.particles(
    Particles::sphere(Particle::Item { item_stack: bone }, at, 2.0).points(30).speed(0.1),
);
```

`Server::particles(Particles)` replaces `Server::cue`. `Particles` is `hyperion::effects::Effect<'static>`, re-exported through `server.rs` for the same reason `Text` is: a second copy of a builder is a second thing to keep in step. `play_cue` and the adapter's table of which particle each variant meant are gone, because that mapping was only ever a hosting decision standing in for a missing vocabulary.

## `module::visuals` is not the same enum renamed

One function per recurring moment — `blast`, `teleport`, `death`, `burn`, `venom` — so an ability going off looks the same wherever it happens. The difference from `Cue` is that these are plain functions returning a `Particles`, not a closed set: a kit that wants something else writes it inline and does not have to widen anything.

`teleport` is a 40-point sphere rather than a puff, because a teleport has a shape and the eye reads a shell as an arrival and a scatter as damage.

## The two placeholders are closed

`Cue::Burn` was pinned to `crit` and `Cue::Venom` to half-power `dragon_breath`, both marked `[PLACEHOLDER]`, because the proto carried neither real particle. They are now `minecraft:flame` and `minecraft:entity_effect` in vanilla's own poison green (`0x4E9331`). That is items 3 on the abilities agent's list.

`Shows.cue` becomes `Shows.effect: fn(Vec3) -> Particles` — a bare `fn` for the same reason `projectile::Payload::on_hit` is one: it is built in a `const` and has nowhere to put a capture. It also means an affliction picks its own shape and density, not just its colour.

## Wire assertion

`tools/smash-match.py` gains a sixth sweep claim, **"every declared ability was seen"**: each of the 51 abilities, fired by a real client, must be answered by a `ClientboundLevelParticlesPacket` with a non-zero count. It sits beside the sound claim it already made and is collected the same way, from every client rather than one, because the caster is not always in their own broadcast channel.

That is the gate #1030 could not have: an effect needs something to emit it, and until this PR nothing did.

## Guards broken, and what they said

Five new ones. The harness now refuses a mutant that fails to compile, after that produced two false "passes" in #1030.

| # | Mutation | Failure |
|---|---|---|
| 19 | an affliction draws nothing | `a burn ticked and nothing was drawn` |
| 20 | a poison goes back to looking like a burn | `a poison is a tinted potion effect, not a shape`, and `assertion left != right failed / left: Flame` |
| 21 | a burn reverts to the old `crit` placeholder | `assertion left == right failed / left: Crit right: Flame` |
| 22 | a visual drawn at the world origin, not the victim | `teleport drew a particle 64.32 blocks from Vec3(12.5, 64.0, -3.5), at Vec3(0.0, 1.0, 0.0)` |
| 23 | an effect sends a packet with a count of zero | `blast sends a packet that draws nothing` |

**Guard 19 did not exist until breaking it showed that.** The first attempt at it reported `GUARD DID NOT FIRE`: deleting `Cue` moved the picture from a field the compiler checks to a function pointer it also checks, but *nothing anywhere asserted the picture still arrived*. An affliction whose particle call was dropped would tick, hurt, make its noise, be invisible, and pass the entire suite. `tests/visuals.rs` and `MockServer::particles()` exist because of that.

## Checks

- `nix run .#test` — 741 passed, 1 skipped
- `nix run .#lint`, `.#fmt` — clean
- `checks.minecraft-literals` — green

Rebased on `54de2ba`. The seven kit conflicts with #1032 were resolved by taking main's body wholesale and re-applying the mechanical rewrite to it, so none of that PR's tuning is dropped.

## Note for the registry charter

`Particles` crossing the seam means `events/smash/src/server.rs` now names `hyperion::effects` as well as `hyperion_minecraft_proto`. The seam's doc claims the game is host-agnostic; that was already only half true, since `Text` comes from the proto crate. If strict host-agnosticism is wanted back, the move is to put `Effect`/`Shape` in `hyperion-minecraft-proto` — they are pure data over a particle and a point — which needs `glam` in that crate or its own `Vec3`. Flagging rather than doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
