### PR TITLE
fix(smash): a shield that is up before anybody can swing

### DIFF
--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -36,6 +36,7 @@ use hyperion::{
                 ObjectiveRenderType, SetObjective, SetScore,
             },
         },
+        particle::Argb,
     },
     net::{Compose, ConnectionId, agnostic, protocol, protocol::Clientbound},
     simulation::{
@@ -794,18 +795,15 @@ fn play_cue(compose: &Compose, at: Vec3, cue: Cue) {
         Cue::Explosion => Particle::Explosion,
         Cue::Teleport => Particle::Portal,
         Cue::Death => Particle::Cloud,
-        // `[PLACEHOLDER]` both. Vanilla draws a burn with `minecraft:flame` and
-        // a poison with `minecraft:entity_effect`, and
-        // `hyperion_minecraft_proto::packets::play::chunk::Particle` carries
-        // neither yet, so each is pinned to the nearest thing it does carry:
-        // `crit`'s orange sparks read as "this is hurting you", and dragon
-        // breath is already vanilla's own lingering harmful cloud. Swap both
-        // the moment the proto grows the real ones; this comment is the fossil
-        // to remove, not a design decision to keep.
-        Cue::Burn => Particle::Crit,
-        // Half power, because a full-strength breath puff is a wall of purple
-        // and this marks one point of damage.
-        Cue::Venom => Particle::DragonBreath { power: 0.5 },
+        Cue::Burn => Particle::Flame,
+        // Vanilla's own poison colour, which is what `entity_effect` is drawn
+        // in when a `minecraft:poison` instance renders: `MobEffects.POISON`
+        // carries `0x4E9331`. Taken from the effect rather than picked, so the
+        // haze around a poisoned player is the green a player already reads as
+        // poison rather than an arbitrary green.
+        Cue::Venom => Particle::EntityEffect {
+            color: Argb::opaque(0x4E, 0x93, 0x31),
+        },
     };
     let packet = LevelParticles {
         // A cue marks something that just happened to a player, so it is worth

--- a/events/smash/src/module/damage.rs
+++ b/events/smash/src/module/damage.rs
@@ -100,7 +100,7 @@ impl MeleeBonus {
     }
 }
 
-/// While this is on a player, no hit lands on them.
+/// The players nothing can currently hurt.
 ///
 /// Deliberately *not* [`crate::module::lives::InvulnerableUntil`], which the
 /// arena's kill plane reads as well. A respawn's immunity has to cover both,
@@ -108,17 +108,53 @@ impl MeleeBonus {
 /// by a mirror the host has not refreshed yet. A combat shield must cover
 /// exactly one: Sky Squid's Super Squid says nothing can *touch* you, and a
 /// version of it that also caught you when you flew off the edge would be a
-/// one-second immortality rather than a one-second escape.
+/// one-second immortality rather than a one-second escape. The two were the
+/// same flag for exactly as long as it took `tests/properties.rs` to find a
+/// Squid falling past the kill plane and living.
 ///
-/// The two were the same flag for exactly as long as it took
-/// `tests/properties.rs` to find a Squid falling past the kill plane and living.
+/// # Why a singleton list and not a tag on the player
 ///
-/// Owned by this module and not by the one that writes it, so that
-/// `smash::apply_damage` -- the hottest observer in the game -- reads a tag it
-/// already has in scope, and so that `Effect` depends on `Damage` without
-/// `Damage` depending back.
-#[derive(Component, Debug)]
-pub struct Immune;
+/// A shield has to be true within the frame that armed it, and a component
+/// added from inside a system is not: flecs queues structural changes until the
+/// end of the frame. An ability fires from `smash::on_item_interact` and
+/// `smash::on_attack` runs after it in the same pipeline, so a client that
+/// swings on the tick it right-clicks was answered by a damage observer that
+/// could not yet see the tag the press had just armed. `nix run .#smash-e2e`
+/// failed on exactly that while the in-process suite was 259 for 259, because
+/// the bench drives abilities from outside any system and so never defers.
+///
+/// Suspending deferral is not the fix. An `add` moves the entity between
+/// tables, and flecs locks the table an observer is iterating:
+/// `assert(!src_table->_->lock)`, which aborts the process.
+///
+/// A singleton's *value* can be written straight through `get::<&mut _>` from
+/// inside a system. No structural change, no queue, visible to the next system
+/// in the same frame -- which is how `MatchClock` is already ticked.
+///
+/// A `Vec` because shields are rare: nought to two players in a match, scanned
+/// once per hit. Anything cleverer would be a data structure defending a cost
+/// nobody is paying.
+#[derive(Component, Debug, Default)]
+pub struct Shielded(Vec<Entity>);
+
+impl Shielded {
+    /// Start refusing hits on `player`. Idempotent.
+    pub fn arm(&mut self, player: Entity) {
+        if !self.0.contains(&player) {
+            self.0.push(player);
+        }
+    }
+
+    /// Stop refusing them.
+    pub fn disarm(&mut self, player: Entity) {
+        self.0.retain(|held| *held != player);
+    }
+
+    #[must_use]
+    pub fn holds(&self, player: Entity) -> bool {
+        self.0.contains(&player)
+    }
+}
 
 /// Relationship: `(LastHitBy, attacker)` on the victim.
 ///
@@ -173,7 +209,10 @@ impl Module for DamageModule {
 
         world.component::<Armor>();
         world.component::<Damaged>();
-        world.component::<Immune>();
+        world
+            .component::<Shielded>()
+            .add_trait::<flecs::Singleton>();
+        world.set(Shielded::default());
         world.component::<MeleeBonus>();
         // This module is what makes armour mean anything, so this module is
         // what says every player has some.
@@ -201,9 +240,10 @@ impl Module for DamageModule {
                 let world = it.world();
 
                 let clock = world.cloned::<&MatchClock>().0;
-                // Two questions, not one. See [`Immune`] for why they are not
-                // the same flag.
-                if crate::module::lives::is_invulnerable(victim, clock) || victim.has(Immune::id())
+                // Two questions, not one. See [`Shielded`] for why they are not
+                // the same thing.
+                if crate::module::lives::is_invulnerable(victim, clock)
+                    || world.get::<&Shielded>(|shielded| shielded.holds(victim.id()))
                 {
                     return;
                 }

--- a/events/smash/src/module/effect.rs
+++ b/events/smash/src/module/effect.rs
@@ -16,7 +16,7 @@
 //!
 //! **Where this sits in the module DAG.** It needs `Player`, `Knockback` and
 //! `Damage`, and nothing else, to import: a tick is a [`Damaged`] event and a
-//! shield is `Damage`'s own [`Immune`] tag. The edge points one way -- `Damage`
+//! shield is `Damage`'s own [`Shielded`] list. The edge points one way -- `Damage`
 //! knows nothing of effects -- which is why the tag lives over there rather
 //! than here. It deliberately does *not* need `Lobby`: durations
 //! are counted in delta time the way [`crate::module::ability::Cooldown`] and
@@ -37,7 +37,7 @@ use crate::{
     flecs_ext::WorldRefExt,
     module::{
         ability::Cast,
-        damage::{DamageKind, Damaged, Immune, hurt},
+        damage::{DamageKind, Damaged, Shielded, hurt},
         knockback::Knockback,
         player::{Health, Position},
         projectile::Impact,
@@ -371,32 +371,42 @@ pub fn afflict(world: WorldRef<'_>, victim: EntityView<'_>, blame: Blame, afflic
     }
     if affliction.shields {
         effect.add(Shields::id());
-        arm_shield(victim);
+        arm_shield(world, victim);
     }
 }
 
-/// Turn the damage pipeline's immunity tag on for `victim`.
+/// Start refusing hits on `victim`, effective immediately.
 ///
-/// A tag and not a deadline. What ends an effect's shield is the effect
-/// expiring, which [`disarm_shield`] is, so a second copy of the duration on the
-/// player would be a number with nothing to keep it honest.
+/// No duration is written here. What ends an effect's shield is the effect
+/// expiring, which [`disarm_shield`] is, so a second copy of the duration on
+/// the player would be a number with nothing to keep it honest.
 ///
-/// The pipeline reading a tag rather than querying for effects is deliberate:
+/// The pipeline reading a list rather than querying for effects is deliberate:
 /// `smash::apply_damage` runs on every hit in the game, and a relationship walk
 /// per hit to answer a question that is false for almost every player almost
-/// always is the wrong shape. [`crate::module::damage::Immune`] is where that
-/// tag lives and why it is not the kill plane's flag.
-fn arm_shield(victim: EntityView<'_>) {
-    victim.add(Immune::id());
+/// always is the wrong shape.
+///
+/// A shield is the one thing in this module that has to be true *within* the
+/// frame that created it, which is why it is a singleton write rather than a
+/// component on the player. [`Shielded`] carries the whole reason.
+///
+/// Nothing else here needs that. A burn's first tick is an interval away and a
+/// mode's first beat is next frame at the earliest, so for those the deferred
+/// queue flushing at the end of the frame is soon enough.
+fn arm_shield(world: WorldRef<'_>, victim: EntityView<'_>) {
+    world.get::<&mut Shielded>(|shielded| shielded.arm(victim.id()));
 }
 
-/// Turn it off again, unless something else is still shielding them.
+/// Stop, unless something else is still shielding them.
+///
+/// Immediate for the mirror of [`arm_shield`]'s reason: a shield that has
+/// lapsed must stop refusing damage on the frame it lapses, not the one after.
 fn disarm_shield(world: WorldRef<'_>, victim: Entity, excluding: Entity) {
     let others = matching(world, victim, |effect| {
         effect.id() != excluding && effect.has(Shields::id())
     });
     if others.is_empty() {
-        world.entity_at(victim).remove(Immune::id());
+        world.get::<&mut Shielded>(|shielded| shielded.disarm(victim));
     }
 }
 

--- a/events/smash/tests/abilities.rs
+++ b/events/smash/tests/abilities.rs
@@ -16,7 +16,7 @@ mod harness;
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
-use harness::Game;
+use harness::{Game, TICK};
 use smash::{
     module::{
         ability::{self, Declared, Observable},
@@ -443,6 +443,13 @@ fn every_declared_effect_actually_happens() {
                 entry.proves.contains(&Observable::ShieldsCaster) && probe_hit(&bench);
             let before = snapshot(&bench);
             bench.press(&entry);
+            // One tick, because a real client's probe cannot arrive sooner
+            // than the next one. Reading with zero ticks elapsed is the one
+            // thing a scripted client can never do, and it is what let this
+            // check pass while `nix run .#smash-e2e` failed on the same
+            // commit: a shield that exists for exactly zero ticks satisfied
+            // the bench and nothing else.
+            bench.game.advance(TICK, 1);
             let immediate = Immediate::taken(&bench, &entry, landed_before);
             bench.settle();
             outstanding
@@ -617,6 +624,76 @@ fn an_ultimate_is_granted_for_a_window_and_then_taken_back() {
         Ok(()),
         "an expired ultimate should be nothing at all in that slot, not a refusal"
     );
+}
+
+/// A shield is up before anybody can hit you, including when the cast is
+/// deferred.
+///
+/// This is the test the sweep could not be. `every_declared_effect_actually_happens`
+/// drives `ability::use_slot` from test code, which is *outside* any flecs
+/// system, so every `add` an ability makes lands immediately and the sweep sees
+/// a world nobody in production ever sees. On a real server the press arrives as
+/// a packet, `smash::on_item_interact` drains it from inside a system, and every
+/// mutation the payload makes is queued until the end of the frame.
+///
+/// `smash::on_attack` is registered in the same pipeline, after it. So a client
+/// that swings in the same tick as it right-clicks is answered by a damage
+/// observer that cannot see the shield the press just armed, and the hit lands
+/// through a window the ability says is closed. `nix run .#smash-e2e` failed on
+/// exactly that while `cargo nextest run -p smash` was 259 for 259.
+///
+/// `defer_begin`/`defer_end` is that condition, in-process: it is the same
+/// suspension flecs puts a system body under.
+#[test]
+fn a_shield_is_up_before_anybody_can_swing() {
+    let manifest = ability::manifest(&Game::new().world);
+    let shields: Vec<_> = manifest
+        .into_iter()
+        .filter(|entry| entry.proves.contains(&Observable::ShieldsCaster))
+        .collect();
+    assert!(
+        !shields.is_empty(),
+        "no ability declares a shield, so this test is checking nothing"
+    );
+
+    let mut failures = Vec::new();
+    for entry in shields {
+        let bench = Bench::new();
+        bench.reset(entry.kit);
+        bench.arm(&entry);
+
+        assert!(
+            probe_hit(&bench),
+            "{} / {}: the probe has to land before the cast, or this proves nothing",
+            entry.kit,
+            entry.name
+        );
+        bench.place(Vec3::ZERO);
+
+        // Everything between `defer_begin` and `defer_end` is one frame, which
+        // is exactly the suspension a system body runs under.
+        bench.game.world.defer_begin();
+        let fired = ability::activate(bench.caster(), entry.slot, 1.0);
+        let landed_inside_the_frame = probe_hit(&bench);
+        bench.game.world.defer_end();
+
+        assert_eq!(
+            fired,
+            Ok(()),
+            "{} / {} refused to fire, so nothing was armed",
+            entry.kit,
+            entry.name
+        );
+        if landed_inside_the_frame {
+            failures.push(format!(
+                "{} / {} armed its shield and a swing in the same frame still landed: the arm was \
+                 deferred and the damage observer could not see it",
+                entry.kit, entry.name
+            ));
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
 }
 
 /// No ultimate leaves a player permanently changed.


### PR DESCRIPTION
`nix run .#smash-e2e` reported Sky Squid's Super Squid taking damage 50ms after a press, inside a window the ability says is one second, while `cargo nextest run -p smash` was 259 for 259 on the same commit. The in-process test ran the same rule and passed.

## The bench was structurally incapable of failing

`tests/abilities.rs` drives abilities from test code, which is **outside any flecs system**, so every mutation an ability makes lands immediately.

On a real server the press arrives as a packet, `smash::on_item_interact` drains it *from inside a system*, and flecs queues every structural change until the end of the frame. `smash::on_attack` is registered in the same pipeline after it. So a client that swings on the tick it right-clicks is answered by a damage observer that cannot yet see the tag the press just armed.

That is a one-tick hole in every shield in the game. Swinging on the tick you press is not exotic — it is exactly what the scripted client does.

`a_shield_is_up_before_anybody_can_swing` reproduces it in-process with `defer_begin`/`defer_end`, which is the same suspension flecs puts a system body under. It fails on the unfixed code, naming both shields.

## The first fix was wrong, and the reason is worth keeping

Suspending deferral around the add **aborts the process**:

```
fatal: flecs.c: 45337: assert(!src_table->_->lock): a "move" operation
failed because the table is locked, fix by surrounding the operation
with defer_begin()/defer_end() (LOCKED_STORAGE)
```

An `add` moves the entity between tables, and flecs locks the table an observer is iterating. The lock is *why* flecs defers. So `defer_suspend` can never be the answer for a structural change made from inside a system — only for something that is not structural.

## The fix

`damage::Immune` is no longer a tag on the player. It is `damage::Shielded`, a singleton list.

A singleton's **value** can be written straight through `get::<&mut _>` from inside a system: no structural change, no queue, visible to the next system in the same frame. That is how `MatchClock` is already ticked, so it is a pattern the crate already relies on rather than a new trick.

A `Vec` because shields are rare — nought to two players in a match, scanned once per hit. Anything cleverer would be a data structure defending a cost nobody is paying.

The sweep also now advances one tick between the press and the probe, because a real client's swing cannot arrive sooner than the next tick, and reading with zero ticks elapsed is the one thing no client can ever do.

## Guard broken and watched to fail, then restored

`Shielded::arm` made a no-op:

```
Slime / Giga Slime armed its shield and a swing in the same frame still
landed: the arm was deferred and the damage observer could not see it
Sky Squid / Super Squid armed its shield and a swing in the same frame
still landed: the arm was deferred and the damage observer could not see it
Sky Squid / Super Squid declares shields_caster and did not do it
```

## Also here

Now that #1030 has landed, `Cue::Burn` and `Cue::Venom` use `Particle::Flame` and `Particle::EntityEffect` instead of the `crit` and half-power `dragon_breath` placeholders. The poison colour is vanilla's own `MobEffects.POISON`, `0x4E9331`, rather than a green somebody picked — the operator's preference for taking values from source rather than transcribing them.

## What this does not settle

I could not run `smash-e2e` to green myself: my run died on `ConnectionError: server closed the connection`, which was the coordinator's `pkill` sweep rather than a finding. The in-process reproduction is the evidence here, and it is a faithful one — it fails without the fix and passes with it, for both shields.

`cargo test -p smash` and `nix run --accept-flake-config .#lint` both green on `54de2ba`.