### PR TITLE
refactor(ecs): systems under their module, and a name on every observer

### DIFF
--- a/crates/hyperion/src/effects/particle.rs
+++ b/crates/hyperion/src/effects/particle.rs
@@ -285,7 +285,7 @@ impl Module for ParticleModule {
         world.component::<ParticleEmitter>();
 
         world
-            .system_named::<&mut ParticleEmitter>("hyperion::draw_particle_emitters")
+            .system_named::<&mut ParticleEmitter>("draw_particle_emitters")
             .each_iter(|it, index, emitter| {
                 let entity = it.entity(index);
                 emitter.current().emit(it.world());

--- a/crates/hyperion/src/effects/spawn.rs
+++ b/crates/hyperion/src/effects/spawn.rs
@@ -136,7 +136,7 @@ impl Module for SpawnModule {
         world.component::<Lifetime>();
 
         world
-            .system_named::<&mut Lifetime>("hyperion::expire_temporary_entities")
+            .system_named::<&mut Lifetime>("expire_temporary_entities")
             .each_iter(|it, index, lifetime| {
                 lifetime.seconds -= it.delta_time();
                 if lifetime.seconds <= 0.0 {
@@ -156,7 +156,7 @@ impl Module for SpawnModule {
         // was never unspawned: the server forgot it and every client kept
         // drawing it where it died, forever.
         world
-            .observer::<flecs::OnRemove, ()>()
+            .observer_named::<flecs::OnRemove, ()>("despawn_removed_entity")
             .with_enum_wildcard::<EntityKind>()
             .without(id::<ConnectionId>())
             .each_entity(|entity, ()| {

--- a/crates/hyperion/src/egress/boss_bar.rs
+++ b/crates/hyperion/src/egress/boss_bar.rs
@@ -248,7 +248,7 @@ impl Module for BossBarModule {
         // a query-match observer, which fires on any table transition that
         // still satisfies the query rather than on the removal itself.
         world
-            .observer::<flecs::OnRemove, ()>()
+            .observer_named::<flecs::OnRemove, ()>("boss_bar_teardown")
             .with((id::<Sent>(), id::<flecs::Wildcard>()))
             .each_iter(|it, row, ()| {
                 let world = it.world();

--- a/crates/hyperion/src/egress/channel.rs
+++ b/crates/hyperion/src/egress/channel.rs
@@ -29,7 +29,7 @@ pub struct ChannelModule;
 impl Module for ChannelModule {
     fn module(world: &World) {
         world
-            .observer::<flecs::OnAdd, ()>()
+            .observer_named::<flecs::OnAdd, ()>("channel_added")
             .with(id::<Channel>())
             .each_entity(|entity, ()| {
                 let packet = RemoveEntities(vec![entity.minecraft_id()]);
@@ -50,7 +50,7 @@ impl Module for ChannelModule {
             });
 
         world
-            .observer::<flecs::OnRemove, ()>()
+            .observer_named::<flecs::OnRemove, ()>("channel_removed")
             .with(id::<Channel>())
             .each_entity(|entity, ()| {
                 entity.world().get::<&Compose>(|compose| {

--- a/crates/hyperion/src/egress/player_join/roster.rs
+++ b/crates/hyperion/src/egress/player_join/roster.rs
@@ -319,7 +319,7 @@ impl Module for RosterModule {
         // login is picked up by [`announce`] instead, which is both cheaper and
         // the only order that works: there is nothing to remove yet.
         world
-            .observer::<flecs::OnSet, &PlayerSkin>()
+            .observer_named::<flecs::OnSet, &PlayerSkin>("refresh_skin")
             .with(id::<Channel>())
             .each_entity(|entity, _| {
                 entity.world().get::<&Compose>(|compose| {
@@ -332,7 +332,7 @@ impl Module for RosterModule {
         // A flecs enum is an exclusive pair, so a change arrives as an add of
         // the new constant rather than as a set of a value.
         world
-            .observer::<flecs::OnAdd, ()>()
+            .observer_named::<flecs::OnAdd, ()>("broadcast_gamemode")
             .with((id::<Gamemode>(), id::<flecs::Wildcard>()))
             .with(id::<Channel>())
             .each_entity(|entity, ()| {
@@ -361,7 +361,7 @@ impl Module for RosterModule {
             });
 
         world
-            .observer::<flecs::OnRemove, &Uuid>()
+            .observer_named::<flecs::OnRemove, &Uuid>("remove_from_roster")
             .with_enum(crate::simulation::PacketState::Play)
             .each_entity(|entity, uuid| {
                 let uuid = uuid.0;

--- a/crates/hyperion/src/ingress/mod.rs
+++ b/crates/hyperion/src/ingress/mod.rs
@@ -42,7 +42,7 @@ impl Default for ServerPingResponse {
 
 fn remove_player_from_visibility(world: &World) {
     world
-        .observer::<flecs::OnRemove, ()>()
+        .observer_named::<flecs::OnRemove, ()>("remove_player_from_visibility")
         .with_enum(PacketState::Play)
         .each_entity(|entity, ()| {
             let world = entity.world();

--- a/crates/hyperion/src/lib.rs
+++ b/crates/hyperion/src/lib.rs
@@ -387,7 +387,7 @@ impl HyperionCore {
 
         #[rustfmt::skip]
         world
-            .observer::<flecs::OnSet, (&GameServerEndpoint, &AsyncRuntime, &Crypto, &CommandChannel)>()
+            .observer_named::<flecs::OnSet, (&GameServerEndpoint, &AsyncRuntime, &Crypto, &CommandChannel)>("bootstrap_network")
             .term_at(1).filter()
             .term_at(2).filter()
             .term_at(3).filter()
@@ -436,7 +436,7 @@ impl HyperionCore {
 
         // add yaw and pitch
         world
-            .observer::<flecs::OnAdd, ()>()
+            .observer_named::<flecs::OnAdd, ()>("default_player_yaw")
             .with(id::<Player>())
             .without(id::<Yaw>())
             .each_entity(|entity, ()| {
@@ -444,7 +444,7 @@ impl HyperionCore {
             });
 
         world
-            .observer::<flecs::OnAdd, ()>()
+            .observer_named::<flecs::OnAdd, ()>("default_player_pitch")
             .with(id::<Player>())
             .without(id::<Pitch>())
             .each_entity(|entity, ()| {

--- a/crates/hyperion/src/net/protocol/join.rs
+++ b/crates/hyperion/src/net/protocol/join.rs
@@ -257,7 +257,7 @@ impl Module for JoinModule {
             });
 
         world
-            .observer::<flecs::OnRemove, ()>()
+            .observer_named::<flecs::OnRemove, ()>("log_leave_without_uuid")
             .with_enum(crate::simulation::PacketState::Play)
             .each_entity(|entity, ()| {
                 if entity.try_get::<&crate::simulation::Uuid>(|_| ()).is_none() {

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -432,7 +432,7 @@ fn register_observers(world: &World, prefabs: MetadataPrefabs) {
     // behind the login handler's and lands last. The player ended up
     // wearing an id their own client had never been told. See ENG-10813.
     world
-        .observer::<flecs::OnAdd, ()>()
+        .observer_named::<flecs::OnAdd, ()>("assign_entity_uuid")
         .with_enum_wildcard::<EntityKind>()
         .without(id::<Uuid>())
         .without(id::<crate::net::ConnectionId>())
@@ -442,7 +442,7 @@ fn register_observers(world: &World, prefabs: MetadataPrefabs) {
         });
 
     world
-        .observer::<flecs::OnSet, ()>()
+        .observer_named::<flecs::OnSet, ()>("apply_entity_prefab")
         .with_enum_wildcard::<EntityKind>()
         .each_entity(move |entity, ()| {
             entity.get::<&EntityKind>(|kind| match kind {

--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -288,7 +288,7 @@ impl Module for SmashAdapterModule {
         // that changes which mob you are dresses you correctly, including a
         // path nobody has written yet.
         world
-            .observer::<flecs::OnAdd, ()>()
+            .observer_named::<flecs::OnAdd, ()>("wear_kit_skin")
             .with((Playing, id::<flecs::Wildcard>()))
             .each_entity(|player, ()| {
                 let Some(skin) = kit::skin_of(player) else {
@@ -311,7 +311,7 @@ impl Module for SmashAdapterModule {
         // state sync run in OnStore, so the writes have to already be on the
         // components by then or they wait a further tick.
         world
-            .system_named::<(&OpQueue, &Compose)>("smash::apply_server_ops")
+            .system_named::<(&OpQueue, &Compose)>("apply_server_ops")
             .kind(id::<flecs::pipeline::PostUpdate>())
             .each_iter(|it, _, (queue, compose)| {
                 let world = it.world();

--- a/events/smash/src/input.rs
+++ b/events/smash/src/input.rs
@@ -47,7 +47,7 @@ impl Module for InputModule {
         // where a real 26.2 client reads the id against the configuration
         // table and drops the connection.
         world
-            .observer::<flecs::OnAdd, ()>()
+            .observer_named::<flecs::OnAdd, ()>("promote_to_smash_player")
             .with_enum(hyperion::simulation::PacketState::Play)
             .each_entity(|entity, ()| {
                 entity.set(player_id(entity.id())).add(Player::id());
@@ -58,14 +58,14 @@ impl Module for InputModule {
         // reads as bare life counts. hyperion learns the username during login;
         // copying it onto the flecs name is what makes those lines legible.
         world
-            .observer::<flecs::OnSet, &Name>()
+            .observer_named::<flecs::OnSet, &Name>("copy_player_name")
             .with(Player::id())
             .each_entity(|entity, name| {
                 entity.set_name(name);
             });
 
         world
-            .system_named::<&mut EventQueue<event::ItemInteract>>("smash::on_item_interact")
+            .system_named::<&mut EventQueue<event::ItemInteract>>("on_item_interact")
             .each_iter(|it, _, queue| {
                 let world = it.world();
                 for event in queue.drain() {
@@ -80,7 +80,7 @@ impl Module for InputModule {
         // Every entity in the world reaches this and `selector::click_mob`
         // answers for the fifteen that are standing on podiums.
         world
-            .system_named::<&mut EventQueue<event::EntityInteract>>("smash::on_entity_interact")
+            .system_named::<&mut EventQueue<event::EntityInteract>>("on_entity_interact")
             .each_iter(|it, _, queue| {
                 let world = it.world();
                 for event in queue.drain() {
@@ -95,7 +95,7 @@ impl Module for InputModule {
         // thing. Every block in the world reaches this, and `selector::click`
         // answers for the handful that are podiums.
         world
-            .system_named::<&mut EventQueue<event::BlockInteract>>("smash::on_block_interact")
+            .system_named::<&mut EventQueue<event::BlockInteract>>("on_block_interact")
             .each_iter(|it, _, queue| {
                 let world = it.world();
                 for event in queue.drain() {
@@ -107,7 +107,7 @@ impl Module for InputModule {
             });
 
         world
-            .system_named::<&mut EventQueue<event::ReleaseUseItem>>("smash::on_release_use_item")
+            .system_named::<&mut EventQueue<event::ReleaseUseItem>>("on_release_use_item")
             .each_iter(|it, _, queue| {
                 let world = it.world();
                 for event in queue.drain() {
@@ -122,7 +122,7 @@ impl Module for InputModule {
         // the attacker is holding never enters into it -- which is also why
         // hyperion's own `damage` field on the event is ignored here.
         world
-            .system_named::<&mut EventQueue<event::AttackEntity>>("smash::on_attack")
+            .system_named::<&mut EventQueue<event::AttackEntity>>("on_attack")
             .each_iter(|it, _, queue| {
                 let world = it.world();
                 for event in queue.drain() {
@@ -157,7 +157,7 @@ impl Module for InputModule {
         // every one of those deferred operations has been committed.
         world.component::<HotbarStale>();
         world
-            .observer::<flecs::OnAdd, ()>()
+            .observer_named::<flecs::OnAdd, ()>("on_kit_change_mark_hotbar")
             .with((Playing, id::<flecs::Wildcard>()))
             .with(Player::id())
             .each_entity(|player, ()| {
@@ -180,16 +180,16 @@ impl Module for InputModule {
             }
         };
         world
-            .observer::<flecs::OnAdd, ()>()
+            .observer_named::<flecs::OnAdd, ()>("on_grant_mark_hotbar")
             .with((ability::Grants, id::<flecs::Wildcard>()))
             .each_entity(mark_stale);
         world
-            .observer::<flecs::OnRemove, ()>()
+            .observer_named::<flecs::OnRemove, ()>("on_revoke_mark_hotbar")
             .with((ability::Grants, id::<flecs::Wildcard>()))
             .each_entity(mark_stale);
 
         world
-            .system_named::<&PlayerId>("smash::push_stale_hotbars")
+            .system_named::<&PlayerId>("push_stale_hotbars")
             .kind(id::<flecs::pipeline::PostUpdate>())
             .with(Player::id())
             .with(HotbarStale::id())
@@ -212,7 +212,7 @@ impl Module for InputModule {
         // game's number rather than hyperion's. Pushing it on change instead of
         // every tick keeps this off the hot path.
         world
-            .observer::<flecs::OnSet, &crate::module::player::Health>()
+            .observer_named::<flecs::OnSet, &crate::module::player::Health>("mirror_health_to_host")
             .with(Player::id())
             .each_entity(|entity, health| {
                 let Some(id) = entity.try_get::<&PlayerId>(|id| *id) else {

--- a/events/smash/src/mirror.rs
+++ b/events/smash/src/mirror.rs
@@ -35,7 +35,7 @@ impl Module for MirrorModule {
                 &mut OnGround,
                 &mut Velocity,
                 &mut SelectedSlot,
-            )>("smash::mirror_player_state")
+            )>("mirror_player_state")
             .kind(id::<flecs::pipeline::OnLoad>())
             .with(Player::id())
             .each(

--- a/events/smash/src/module/ability.rs
+++ b/events/smash/src/module/ability.rs
@@ -503,7 +503,7 @@ impl Module for AbilityModule {
         world.component::<GrantedFor>();
 
         world
-            .system_named::<&mut Cooldown>("smash::tick_cooldowns")
+            .system_named::<&mut Cooldown>("tick_cooldowns")
             .each_iter(|it, _, cooldown| {
                 if cooldown.remaining > 0.0 {
                     cooldown.remaining = (cooldown.remaining - it.delta_time()).max(0.0);
@@ -511,7 +511,7 @@ impl Module for AbilityModule {
             });
 
         world
-            .system_named::<&mut Charging>("smash::tick_charge")
+            .system_named::<&mut Charging>("tick_charge")
             .each_iter(|it, _, charging| {
                 charging.held += it.delta_time();
             });
@@ -520,7 +520,7 @@ impl Module for AbilityModule {
         // system because taking the grant back edits the holder's type, and
         // flecs refuses that from inside the query that found it.
         world
-            .system_named::<()>("smash::expire_grants")
+            .system_named::<()>("expire_grants")
             .run(|mut it| {
                 while it.next() {
                     let world = it.world();
@@ -547,7 +547,7 @@ impl Module for AbilityModule {
             // `Player` is a tag, so it is named as a filter term rather than a
             // data term: asking for `&Player` fails a const assertion deep in
             // flecs with no mention of the tag. See the API notes.
-            .observer_named::<UseSlot, ()>("smash::on_use_slot")
+            .observer_named::<UseSlot, ()>("on_use_slot")
             .with(Player::id())
             .each_iter(|it, index, ()| {
                 let slot = it.param().0;
@@ -574,7 +574,7 @@ impl Module for AbilityModule {
             });
 
         world
-            .observer_named::<ReleaseSlot, ()>("smash::on_release_slot")
+            .observer_named::<ReleaseSlot, ()>("on_release_slot")
             .with(Player::id())
             .each_iter(|it, index, ()| {
                 let slot = it.param().0;

--- a/events/smash/src/module/arena.rs
+++ b/events/smash/src/module/arena.rs
@@ -88,7 +88,7 @@ impl Module for ArenaModule {
         // Health reaching zero is the rarer path but a real one: hunger and
         // lava both get there.
         world
-            .system_named::<()>("smash::death_checks")
+            .system_named::<()>("death_checks")
             .run(|mut it| {
                 while it.next() {
                     let world = it.world();

--- a/events/smash/src/module/damage.rs
+++ b/events/smash/src/module/damage.rs
@@ -232,7 +232,7 @@ impl Module for DamageModule {
         // the borrow is gone. The query therefore does not name `Health` at
         // all.
         world
-            .observer_named::<Damaged, (&Armor, &Position, &PlayerId)>("smash::apply_damage")
+            .observer_named::<Damaged, (&Armor, &Position, &PlayerId)>("apply_damage")
             .with(Player::id())
             .each_iter(|it, index, (armor, position, player)| {
                 let event = *it.param();

--- a/events/smash/src/module/effect.rs
+++ b/events/smash/src/module/effect.rs
@@ -542,7 +542,7 @@ impl Module for EffectModule {
         // that from inside the query that found the effect. Everything is
         // decided first and applied afterwards.
         world
-            .system_named::<()>("smash::tick_effects")
+            .system_named::<()>("tick_effects")
             .run(|mut it| {
                 while it.next() {
                     let world = it.world();

--- a/events/smash/src/module/hud.rs
+++ b/events/smash/src/module/hud.rs
@@ -534,7 +534,7 @@ impl Module for HudModule {
             .component::<Player>()
             .add_trait::<(flecs::With, Shown)>();
 
-        world.system_named::<()>("smash::update_hud").run(|mut it| {
+        world.system_named::<()>("update_hud").run(|mut it| {
             while it.next() {
                 let world = it.world();
                 let lobby = world.cloned::<&Lobby>();

--- a/events/smash/src/module/kits/creeper.rs
+++ b/events/smash/src/module/kits/creeper.rs
@@ -95,7 +95,7 @@ impl Module for Creeper {
         // or a contact skill and not on a melee hit, which is why `DamageKind`
         // travels with every hit rather than being reconstructed at the far end.
         world
-            .observer_named::<crate::module::damage::Damaged, ()>("smash::kits::creeper::arm")
+            .observer_named::<crate::module::damage::Damaged, ()>("arm")
             .with(Player::id())
             .each_iter(|it, index, ()| {
                 let event = *it.param();

--- a/events/smash/src/module/kits/guardian.rs
+++ b/events/smash/src/module/kits/guardian.rs
@@ -120,7 +120,7 @@ impl Module for Guardian {
         // The mark lapses on its own, and lapsing costs the victim three more
         // damage whether or not the Guardian is still nearby.
         world
-            .system_named::<(&Marked, &PlayerId)>("smash::kits::guardian::laser_expiry")
+            .system_named::<(&Marked, &PlayerId)>("laser_expiry")
             .each_entity(|guardian, (marked, _)| {
                 let world = guardian.world();
                 let now = world.get::<&MatchClock>(|clock| clock.0);

--- a/events/smash/src/module/kits/wolf.rs
+++ b/events/smash/src/module/kits/wolf.rs
@@ -109,7 +109,7 @@ impl Module for Wolf {
         // Ravage. A melee hit by a Wolf adds a stack; the stack decays rather
         // than being cleared, so a Wolf who keeps pressure on keeps the bonus.
         world
-            .observer_named::<Damaged, ()>("smash::kits::wolf::ravage")
+            .observer_named::<Damaged, ()>("ravage")
             .with(Player::id())
             .each_iter(|it, _index, ()| {
                 let event = *it.param();

--- a/events/smash/src/module/knockback.rs
+++ b/events/smash/src/module/knockback.rs
@@ -247,7 +247,7 @@ impl Module for KnockbackModule {
 
         world
             .observer_named::<Smashed, (&Health, &KnockbackTaken, &Position, &OnGround, &PlayerId)>(
-                "smash::apply_knockback",
+                "apply_knockback",
             )
             .with(Player::id())
             .each_iter(|it, _index, (health, taken, position, ground, player)| {

--- a/events/smash/src/module/lives.rs
+++ b/events/smash/src/module/lives.rs
@@ -304,7 +304,7 @@ impl Module for LivesModule {
         world.component::<EliminatedEvent>();
 
         world
-            .system_named::<()>("smash::assign_life_tier")
+            .system_named::<()>("assign_life_tier")
             .run(|mut it| {
                 while it.next() {
                     let world = it.world();
@@ -330,7 +330,7 @@ impl Module for LivesModule {
             });
 
         world
-            .observer_named::<Died, (&mut Lives, &PlayerId, &mut Health)>("smash::on_death")
+            .observer_named::<Died, (&mut Lives, &PlayerId, &mut Health)>("on_death")
             .with(Player::id())
             .each_iter(|it, index, (lives, player, health)| {
                 let cause = it.param().cause;
@@ -401,7 +401,7 @@ impl Module for LivesModule {
 
         world
             .system_named::<(&RespawnAt, &mut Health, &mut Position, &PlayerId, &Arena)>(
-                "smash::respawn",
+                "respawn",
             )
             .each_entity(|player, (respawn, health, position, id, arena)| {
                 let world = player.world();

--- a/events/smash/src/module/lobby.rs
+++ b/events/smash/src/module/lobby.rs
@@ -352,7 +352,7 @@ impl Module for LobbyModule {
         world.set(Lobby::default());
         world.set(LobbyConfig::from_env());
 
-        world.system_named::<()>("smash::lobby_tick").run(|mut it| {
+        world.system_named::<()>("lobby_tick").run(|mut it| {
             while it.next() {
                 let world = it.world();
                 let dt = it.delta_time();

--- a/events/smash/src/module/player.rs
+++ b/events/smash/src/module/player.rs
@@ -167,7 +167,7 @@ impl Module for PlayerModule {
             .add_trait::<(flecs::With, SelectedSlot)>();
 
         world
-            .system_named::<(&OnGround, &mut JumpsLeft)>("smash::restore_double_jump")
+            .system_named::<(&OnGround, &mut JumpsLeft)>("restore_double_jump")
             .each(|(ground, jumps)| {
                 if ground.0 {
                     jumps.0 = 1;
@@ -175,7 +175,7 @@ impl Module for PlayerModule {
             });
 
         world
-            .system_named::<&mut Energy>("smash::regen_energy")
+            .system_named::<&mut Energy>("regen_energy")
             .each_iter(|it, _, energy| {
                 energy.current =
                     (energy.regen.mul_add(it.delta_time(), energy.current)).min(energy.max);

--- a/events/smash/src/module/projectile.rs
+++ b/events/smash/src/module/projectile.rs
@@ -108,7 +108,7 @@ impl Module for ProjectileModule {
         world.component::<FiredBy>().add(flecs::Exclusive);
 
         world
-            .system_named::<(&mut Flight, &Payload)>("smash::fly")
+            .system_named::<(&mut Flight, &Payload)>("fly")
             .each_iter(|it, index, (flight, payload)| {
                 let dt = it.delta_time();
                 let projectile = it.entity(index);

--- a/events/smash/src/module/scoreboard.rs
+++ b/events/smash/src/module/scoreboard.rs
@@ -187,7 +187,7 @@ impl Module for ScoreboardModule {
         world.set(Drawn::default());
 
         world
-            .system_named::<()>("smash::update_scoreboard")
+            .system_named::<()>("update_scoreboard")
             .run(|mut it| {
                 while it.next() {
                     let world = it.world();
@@ -242,7 +242,7 @@ impl Module for ScoreboardModule {
         // last life, not on the next one.
         world
             .observer_named::<crate::module::lives::EliminatedEvent, &PlayerId>(
-                "smash::spectate_on_elimination",
+                "spectate_on_elimination",
             )
             .with(Player::id())
             .each_iter(|it, _index, id| {

--- a/events/smash/src/terrain.rs
+++ b/events/smash/src/terrain.rs
@@ -197,7 +197,7 @@ impl Module for MapModule {
         // at all, and putting it in the hub rather than on an arena is what
         // stops a joiner from landing in the middle of a running match.
         world
-            .observer::<flecs::OnSet, &Hub>()
+            .observer_named::<flecs::OnSet, &Hub>("place_joiner_at_hub")
             .with(id::<Uuid>())
             .without(id::<hyperion::simulation::Position>())
             .each_entity(|entity, hub| {

--- a/events/smash/tests/system_paths.rs
+++ b/events/smash/tests/system_paths.rs
@@ -1,0 +1,76 @@
+//! Every game system sits directly under its module, with no phantom node.
+//!
+//! `world.module::<Self>("smash::Ability")` sets the module scope to
+//! `smash.Ability`; a `system_named("smash::tick_cooldowns")` then resolves the
+//! `smash::` prefix *relative to that scope* and creates a
+//! `smash.Ability.smash.tick_cooldowns` path -- a phantom `smash` node the flecs
+//! explorer draws as a real tree row that corresponds to nothing. The fix is to
+//! name a system by its leaf alone and let the module scope supply the rest.
+//!
+//! This test is the guard. It fails if any module grows a child literally named
+//! `smash`, which is what a re-introduced prefix produces, and it pins the
+//! handful of clean paths so a reader can see the intended shape.
+
+use flecs_ecs::prelude::*;
+use smash::SmashModule;
+
+/// No module in the game tree has a child named `smash`.
+///
+/// The only legitimate `smash` entity is the game module itself, at `::smash`.
+/// Anything else called `smash` is a redundant-prefix phantom.
+#[test]
+fn no_phantom_smash_scope() {
+    let world = World::new();
+    world.import::<SmashModule>();
+
+    let mut phantoms = Vec::new();
+    world
+        .query::<()>()
+        .with((id::<flecs::ChildOf>(), id::<flecs::Wildcard>()))
+        .build()
+        .each_entity(|entity, ()| {
+            if entity.name() == "smash" && entity.path().as_deref() != Some("::smash") {
+                phantoms.push(entity.path().unwrap_or_default());
+            }
+        });
+
+    assert!(
+        phantoms.is_empty(),
+        "a redundant `smash::` prefix put a phantom node in the module tree: {phantoms:?}"
+    );
+}
+
+/// A representative system from each layer resolves at the clean path, and the
+/// phantom spelling it used to have resolves to nothing.
+#[test]
+fn systems_sit_directly_under_their_module() {
+    let world = World::new();
+    world.import::<SmashModule>();
+
+    for clean in [
+        "smash::Ability::tick_cooldowns",
+        "smash::Effect::tick_effects",
+        "smash::Damage::apply_damage",
+        "smash::Lives::respawn",
+        "smash::Knockback::apply_knockback",
+        "smash::Scoreboard::spectate_on_elimination",
+        "smash::kits::Guardian::laser_expiry",
+        "smash::kits::Creeper::arm",
+        "smash::kits::Wolf::ravage",
+    ] {
+        assert!(
+            world.try_lookup(clean).is_some(),
+            "expected a system at `{clean}`, found none"
+        );
+    }
+
+    for phantom in [
+        "smash::Ability::smash::tick_cooldowns",
+        "smash::Effect::smash::tick_effects",
+    ] {
+        assert!(
+            world.try_lookup(phantom).is_none(),
+            "the phantom path `{phantom}` still resolves"
+        );
+    }
+}


### PR DESCRIPTION
## What

flecs resolves the string in `system_named("smash::tick_cooldowns")` **relative to the module scope** that `world.module::<Self>("smash::Ability")` already set. So the redundant `smash::` prefix created a phantom `smash` node and buried every game system at `smash.Ability.smash.tick_cooldowns`. On the live world the explorer drew **17 phantom `smash` rows** that correspond to nothing, plus the same defect in two hyperion effects modules.

This drops the redundant prefix so the module scope supplies the path, and names every previously anonymous observer across hyperion and smash.

- 24 systems/observers in smash + 3 kits: `smash::X` prefix removed -> clean `smash.Module.leaf`.
- hyperion `effects/spawn` and `effects/particle`: same `hyperion::` phantom removed.
- **Terrain left untouched**: it already resolved cleanly to `smash.rotate_map` (verified on the live REST endpoint, HTTP 200 at `smash/rotate_map`, 404 at `MapModule/smash/rotate_map`), and stripping its prefix would have *moved* it out of the `smash` tree.
- Every `.observer::<...>()` in hyperion + smash is now `observer_named` with a meaningful leaf, so the explorer stops listing them as `#NNN` and the flecs borrow-panic can print the observer's name (the `docs/flecs-rust-api-notes.md` note asked for this; it was dead for observers with no name).

Behaviour is unchanged: only name strings and observer names moved, no logic.

## Proof

`events/smash/tests/system_paths.rs` is the guard. It imports `SmashModule` and fails if any module grows a child literally named `smash`.

Broken on purpose (re-added a `smash::` prefix to one system), the guard fires with the intended message:

```
thread 'no_phantom_smash_scope' panicked at events/smash/tests/system_paths.rs:37:5:
a redundant `smash::` prefix put a phantom node in the module tree: ["::smash::Ability::smash"]
test no_phantom_smash_scope ... FAILED
test systems_sit_directly_under_their_module ... FAILED
```

Restored, both pass:

```
test no_phantom_smash_scope ... ok
test systems_sit_directly_under_their_module ... ok
```

- `cargo clippy -p smash -p hyperion --all-targets --all-features -- -D warnings`: clean.
- `cargo test -p smash`: all pass.
- `cargo test -p hyperion`: all pass.
