### PR TITLE
fix(hyperion): a single movement packet can no longer crash the server (ENG-10914)

### DIFF
--- a/crates/hyperion/src/simulation/blocks/mod.rs
+++ b/crates/hyperion/src/simulation/blocks/mod.rs
@@ -271,12 +271,28 @@ impl Blocks {
     {
         const START_Y: i32 = -64;
 
-        let start_xz = IVec2::new(start.x, start.z);
-        let end_xz = IVec2::new(end.x, end.z);
+        // Chunk columns are keyed by `i16` (`self.chunk_cache` is an
+        // `I16Vec2` map), so a block whose chunk coordinate does not fit in
+        // `i16` has no column here. Clamp the requested horizontal range into
+        // the representable block window before deriving chunk coordinates:
+        // `as_i16vec2()` below *silently wraps* on an out-of-range value
+        // (ENG-10914), which turns a far-away query into a bogus chunk range
+        // -- a `debug_assert` failure here in debug, a wrapped `cx` loop and
+        // narrowing `unwrap`s in release. The move handler already rejects
+        // such positions (see `handlers::within_representable_bounds`), so in
+        // practice this only ever clamps internally-generated coordinates; it
+        // is what keeps this walk total regardless of caller.
+        const MIN_BLOCK: i32 = (i16::MIN as i32) << 4;
+        const MAX_BLOCK: i32 = ((i16::MAX as i32) << 4) | 0b1111;
+        let clamp_xz = |v: IVec2| v.clamp(IVec2::splat(MIN_BLOCK), IVec2::splat(MAX_BLOCK));
+
+        let start_xz = clamp_xz(IVec2::new(start.x, start.z));
+        let end_xz = clamp_xz(IVec2::new(end.x, end.z));
 
         let start_chunk_pos: IVec2 = start_xz >> 4;
         let end_chunk_pos: IVec2 = end_xz >> 4;
 
+        // In range after the clamp, so this no longer wraps.
         let start_chunk_pos = start_chunk_pos.as_i16vec2();
         let end_chunk_pos = end_chunk_pos.as_i16vec2();
 

--- a/crates/hyperion/src/simulation/handlers.rs
+++ b/crates/hyperion/src/simulation/handlers.rs
@@ -13,6 +13,16 @@
 // Every handler shares one signature so that `route` can hand back a function
 // pointer, which leaves several of them returning a Result they never fail.
 #![allow(clippy::unnecessary_wraps)]
+// The class gate for ENG-10914. Everything in this module runs on bytes a
+// client chose, so a panic reachable from any of it is a remote crash of the
+// whole process for every connected player. Denying these here makes the next
+// `unwrap`/`expect`/`panic!` on client input a build failure rather than a P0:
+// a handler that cannot represent a value must return `Err` (the shared
+// signature already carries one) and let the caller kick the connection, not
+// abort the server. Fallible conversions that genuinely cannot fail get an
+// `#[expect(clippy::unwrap_used, reason = "...")]` naming the invariant, so the
+// exception is visible in review rather than silent.
+#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use anyhow::bail;
 use flecs_ecs::core::{Entity, EntityView, EntityViewGet, World, id};
@@ -30,7 +40,7 @@ use hyperion_minecraft_proto::{
     types::{Direction, HumanoidArm, InteractionHand},
 };
 use hyperion_utils::EntityExt;
-use tracing::warn;
+use tracing::{debug, warn};
 use valence_generated::{
     block::{BlockKind, BlockState, PropName},
     item::ItemKind,
@@ -749,6 +759,35 @@ const fn hand(hand: InteractionHand) -> Hand {
     }
 }
 
+/// The horizontal block coordinate this server can actually represent, with a
+/// full chunk of margin.
+///
+/// Chunk columns are keyed by `i16` here: [`Blocks`](crate::simulation::blocks)
+/// stores them in an `I16Vec2` map and [`Position::to_chunk`] returns one. A
+/// block whose chunk coordinate (`block >> 4`) does not fit in `i16` therefore
+/// has no column to live in. This is a *tighter* limit than the world border
+/// above -- `i16::MAX * 16 == 524_272` blocks versus 29,999,984 -- which is the
+/// whole point of ENG-10914: the crashing packet's `x = 2_000_000` is far
+/// inside the border yet its chunk key `2_000_000 >> 4 == 125_000` overflows
+/// `i16` and wraps. The one-chunk margin (`i16::MAX - 1`) leaves room for the
+/// player's bounding box, whose floor/ceil push the queried block range out by
+/// up to a block on each side, to be converted without reaching `i16::MAX`.
+const MAX_SAFE_BLOCK: f32 = ((i16::MAX as i32 - 1) * 16) as f32; // 524_256
+
+/// Whether a proposed position is one the server will accept from a client.
+///
+/// A `MovePlayerPos` carries three client-supplied `f64`s and nothing upstream
+/// bounds them. A coordinate outside the representable chunk range (or a
+/// non-finite one) is fed straight into the chunk math -- [`Position::to_chunk`]
+/// and the block-range walk in `Blocks::get_blocks`, both reached from the
+/// handlers below every tick -- where it used to crash the whole process: a
+/// `debug_assert` in a debug build, a narrowing `unwrap` / silent `as_i16vec2`
+/// wrap in release. This is the load-bearing safety bound; making those
+/// downstream conversions total is defence in depth behind it.
+fn within_representable_bounds(proposed: Vec3) -> bool {
+    proposed.is_finite() && proposed.x.abs() <= MAX_SAFE_BLOCK && proposed.z.abs() <= MAX_SAFE_BLOCK
+}
+
 // #[instrument(skip_all)]
 fn change_position_or_correct_client(
     query: &mut PacketSwitchQuery<'_>,
@@ -756,6 +795,23 @@ fn change_position_or_correct_client(
     on_ground: bool,
 ) {
     let pose = &mut *query.position;
+
+    // Reject a move outside the world border before it reaches any chunk math,
+    // and snap the client back to where it legitimately was. This matches
+    // vanilla, which refuses movement past the border rather than clamping the
+    // player onto it; a silent clamp would teleport a cheating or buggy client
+    // to a surprising place, whereas a correction leaves them exactly where the
+    // server last agreed they were. Crucially this returns *before*
+    // `**pose = proposed` below, so the out-of-bounds coordinate is never
+    // stored and never seen by the per-tick chunk conversions.
+    if !within_representable_bounds(proposed) {
+        debug!("rejecting out-of-border move to {proposed:?}");
+        query
+            .id
+            .entity_view(query.world)
+            .set(PendingTeleportation::new(**pose));
+        return;
+    }
 
     if let Err(e) = try_change_position(proposed, pose, *query.size, query.blocks) {
         // Send error message to player

--- a/crates/hyperion/src/simulation/pose.rs
+++ b/crates/hyperion/src/simulation/pose.rs
@@ -49,18 +49,29 @@ impl Position {
     }
 
     /// Get the chunk position of the center of the player's bounding box.
+    ///
+    /// Chunk coordinates are `i16` on the wire (`SetChunkCacheCenter` and
+    /// friends), so this is a narrowing conversion. It is total by clamping
+    /// rather than panicking: it runs every tick for every player on a
+    /// position ultimately derived from client input, and one out-of-range
+    /// coordinate used to abort the whole process here via
+    /// `try_from().unwrap()`. The move handler already rejects positions
+    /// outside the world border (see
+    /// `handlers::change_position_or_correct_client`); this clamp is
+    /// the belt-and-braces that keeps the conversion itself incapable of
+    /// crashing whoever calls it.
     #[must_use]
     #[expect(clippy::cast_possible_truncation)]
     pub fn to_chunk(&self) -> I16Vec2 {
-        let x = self.x as i32;
-        let z = self.z as i32;
-        let x = x >> 4;
-        let z = z >> 4;
+        // `as i32` on a float saturates (and maps NaN to 0), so a huge or
+        // infinite coordinate lands at i32::MIN/MAX rather than wrapping; the
+        // clamp then brings it into the representable i16 chunk range.
+        let to_chunk_axis = |coord: f32| -> i16 {
+            let block = (coord as i32) >> 4;
+            block.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16
+        };
 
-        let x = i16::try_from(x).unwrap();
-        let z = i16::try_from(z).unwrap();
-
-        I16Vec2::new(x, z)
+        I16Vec2::new(to_chunk_axis(self.x), to_chunk_axis(self.z))
     }
 }
 
@@ -242,4 +253,33 @@ pub fn get_direction_from_rotation(yaw: f32, pitch: f32) -> Vec3 {
         -pitch_rad.sin(),                 // y = -sin(pitch)
         pitch_rad.cos() * yaw_rad.cos(),  // z = cos(pitch) * cos(yaw)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression: a position past the i16 chunk range (|coord| > 32767 * 16)
+    // used to make `to_chunk`'s `i16::try_from(..).unwrap()` panic, and it runs
+    // every tick for every player from a client-supplied position, so one
+    // packet took down the whole process. It must now be total.
+    #[test]
+    fn to_chunk_is_total_for_out_of_border_positions() {
+        for coord in [
+            1.0e9_f32,
+            -1.0e9,
+            f32::MAX,
+            f32::MIN,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            f32::NAN,
+            29_999_984.0,
+            -29_999_984.0,
+        ] {
+            let chunk = Position::new(coord, 100.0, coord).to_chunk();
+            // The whole point is that it returned rather than panicking; the
+            // clamped value is representable by construction.
+            let _ = chunk;
+        }
+    }
 }

--- a/crates/hyperion/tests/oob_position.rs
+++ b/crates/hyperion/tests/oob_position.rs
@@ -1,0 +1,58 @@
+//! A single client-supplied movement packet must not be able to crash the
+//! server. ENG-10914: `MovePlayerPos { x: 2_000_000.0, .. }` sits far inside
+//! the Minecraft world border yet its chunk key `2_000_000 >> 4 == 125_000`
+//! overflows the `i16` this server keys chunks by. That overflow reached the
+//! chunk math and took the whole process down for every connected player:
+//! a `debug_assert` in `Blocks::get_blocks` in a debug build, a narrowing
+//! `unwrap` / silent `as_i16vec2` wrap in release.
+//!
+//! The load-bearing fix is a bound in the move handler, exercised end-to-end
+//! by the `oob-move-e2e` wire gate (a client sends this exact packet and the
+//! server keeps ticking). These unit checks pin the defence-in-depth layer:
+//! the coordinate conversions themselves are now total, so they cannot crash
+//! whatever calls them.
+
+use glam::IVec3;
+use hyperion::{
+    HyperionCore,
+    simulation::{Position, blocks::Blocks},
+};
+
+/// The horizontal block coordinate from the ENG-10914 crashing packet.
+const CRASH_BLOCK: i32 = 2_000_000;
+
+#[test]
+fn to_chunk_does_not_panic_on_the_crashing_coordinate() {
+    // Runs every tick for every player; used to `try_from().unwrap()` panic.
+    let _ = Position::new(CRASH_BLOCK as f32, 65.0, 4.0).to_chunk();
+    // And the extremes, for good measure.
+    let _ = Position::new(f32::MAX, 65.0, f32::MIN).to_chunk();
+    let _ = Position::new(f32::INFINITY, 65.0, f32::NAN).to_chunk();
+}
+
+#[test]
+fn get_blocks_does_not_panic_on_the_crashing_coordinate() {
+    let world = flecs_ecs::core::World::new();
+    world.import::<HyperionCore>();
+
+    let blocks = Blocks::empty(&world);
+
+    // The block range a player's bounding box at the crashing position would
+    // ask about. Before the fix this panicked (debug) or walked a wrapped
+    // chunk range (release); now it must simply return, touching nothing,
+    // because no chunk near there is loaded.
+    let start = IVec3::new(CRASH_BLOCK, 64, 4);
+    let end = IVec3::new(CRASH_BLOCK + 1, 66, 5);
+
+    let mut visited = 0_usize;
+    let outcome: Option<()> = blocks.get_blocks(start, end, |_, _| {
+        visited += 1;
+        Some(())
+    });
+    assert_eq!(
+        outcome,
+        Some(()),
+        "the walk ran to completion without panicking"
+    );
+    assert_eq!(visited, 0, "no chunk is loaded near the out-of-range query");
+}

--- a/flake.nix
+++ b/flake.nix
@@ -382,6 +382,12 @@
             smash-hotbar-e2e = 7000;
             smash-hud-e2e = 8000;
             bedwars-bow-e2e = 9000;
+            # Not 10000: gameServerPort - proxyPort == 10000, so an offset of
+            # 10000 aliases this gate's player port onto the base game-server
+            # port (35565), which a running dev server or `nix run .#run` holds.
+            # Kept under 10000 so every player port stays below that base, the
+            # invariant the offsets 1000..9000 already rely on. See ENG-10933.
+            oob-move-e2e = 9500;
           };
 
           # The accounts `smash-hud-e2e` runs its `Admin` commands as.
@@ -868,6 +874,27 @@
               '';
             };
 
+            # A denial-of-service gate: a single connected client sends the
+            # movement packets ENG-10914 proved could crash the whole server --
+            # a finite coordinate past the i16 chunk range, then NaN and +inf --
+            # and the run passes only if the server refuses them and keeps
+            # ticking. Drives the proven client-26.2.py + bedwars pair the `e2e`
+            # gate uses, so reaching play is not in question; the crash is in the
+            # shared movement handler, so the event it runs against is incidental.
+            oob-move-e2e = {
+              deps = [
+                pkgs.git
+                pkgs.python3
+              ];
+              text = ''
+                export HYPERION_EVENT=bedwars
+                export HYPERION_E2E_CLIENT="tools/client-26.2.py --name oob --oob-move"
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.oob-move-e2e)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.oob-move-e2e)}}"
+                exec "${lib.getExe runners.e2e}" "$@"
+              '';
+            };
+
             # The bow, on bedwars, read off the wire by the client that fired it.
             #
             # The only gate here that is not a smash gate, because the bow is
@@ -1072,6 +1099,32 @@
               timeout = 420;
             };
 
+            # The denial-of-service regression from ENG-10914. One client
+            # reaches play and sends the movement packets that used to crash
+            # the whole server for everyone -- a finite coordinate past the i16
+            # chunk range (x = 2_000_000), then NaN and +inf -- and the gate is
+            # green only if the server refuses each and keeps ticking. The
+            # client keys its exit code on survival alone, so the event it runs
+            # against does not matter. Reverting the move-handler bound turns
+            # this red. bedwars is used because it is the pair the proven `e2e`
+            # gate already drives.
+            oob-move-e2e = e2e.mkCheck {
+              name = "hyperion-oob-move-e2e";
+              gameServer = gameBinaries.bedwars;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "client-26.2.py";
+              clientArgs = [
+                "--name"
+                "oob"
+                "--oob-move"
+              ];
+              # The same proven client + server pair the `e2e` gate drives, so
+              # reaching play is not in question; bedwars downloads its world at
+              # boot, so the sandbox is handed one.
+              needsGenMap = true;
+              timeout = 300;
+            };
+
             # `checks.e2e` above took the names the two app wrappers used to
             # hold, and those wrappers still have to pass shellcheck.
             e2e-app = scripts.e2e;
@@ -1081,6 +1134,7 @@
             smash-identity-e2e-app = scripts.smash-identity-e2e;
             smash-hotbar-e2e-app = scripts.smash-hotbar-e2e;
             smash-hud-e2e-app = scripts.smash-hud-e2e;
+            oob-move-e2e-app = scripts.oob-move-e2e;
 
             # Every kit's skin, checked offline against Mojang's committed
             # public keys. A derivation rather than only an app, because the

--- a/tools/client-26.2.py
+++ b/tools/client-26.2.py
@@ -640,12 +640,43 @@ NEVER_ON_JOIN = frozenset(
 )
 
 
+# The movement packets a crash test fires once it is in the world. Each is a
+# `MovePlayerPos` (play id 0x1E) the server must refuse without dying:
+#   - x = 2_000_000 is finite and sits far inside the Minecraft world border
+#     (29,999,984), yet its chunk key 2_000_000 >> 4 == 125_000 overflows the
+#     i16 this server keys chunks by. This is the confirmed ENG-10914 repro.
+#   - NaN and +inf are the non-finite vectors: `NaN as i32` is 0 (a silent
+#     teleport to origin) and `inf as i32` saturates and then wraps on >> 4.
+# The server's own reply proves survival: a refused move triggers a teleport
+# correction (PlayerPosition), so receiving one after the last hostile packet
+# means the server ticked past all of them and is still talking.
+OOB_MOVE_PACKETS = (
+    ("x=2_000_000 (finite, past the i16 chunk range; ENG-10914)",
+     struct.pack(">dddb", 2_000_000.0, 65.0, 4.0, 1)),
+    ("x=NaN (non-finite)",
+     struct.pack(">dddb", float("nan"), 65.0, 4.0, 1)),
+    ("x=+inf (non-finite)",
+     struct.pack(">dddb", float("inf"), 65.0, 4.0, 1)),
+)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=25565)
     parser.add_argument("--name", default="Prober")
     parser.add_argument("--seconds", type=float, default=15.0)
+    parser.add_argument(
+        "--oob-move",
+        action="store_true",
+        help=(
+            "after reaching play, send movement packets no client should ever "
+            "send -- a finite coordinate past the i16 chunk range and the "
+            "non-finite NaN/inf vectors -- and verify the server keeps ticking "
+            "rather than crashing (ENG-10914). The exit code becomes the answer "
+            "to that question alone."
+        ),
+    )
     parser.add_argument(
         "--status-only",
         action="store_true",
@@ -680,6 +711,10 @@ def main():
     seen = {}
     moved = False
     lost_after_move = False
+    oob_queue = list(OOB_MOVE_PACKETS) if args.oob_move else []
+    oob_total = len(oob_queue)
+    hostiles_sent = 0
+    survived_hostile = False
 
     while time.time() < deadline:
         try:
@@ -692,6 +727,11 @@ def main():
             break
 
         seen[packet_id] = seen.get(packet_id, 0) + 1
+
+        # Any packet that arrives once every hostile move has been sent proves
+        # the server ticked past all of them without crashing.
+        if args.oob_move and oob_total and hostiles_sent == oob_total:
+            survived_hostile = True
 
         if packet_id == S2C_PLAY_LOGIN:
             client.entity_id = struct.unpack(">i", payload[:4])[0]
@@ -721,6 +761,17 @@ def main():
             )
             moved = True
             log("-> MovePlayerPos (%.1f, %.1f, %.1f)" % (x + 0.2, y, z))
+
+            # In crash-test mode, follow the legitimate step with the packets
+            # no client should send. The first fires here; each refusal sends
+            # back a teleport correction (another PlayerPosition), on which the
+            # next one fires -- so the whole sequence drains through this branch.
+            if oob_queue:
+                desc, hostile = oob_queue.pop(0)
+                client.send(C2S_PLAY_MOVE_PLAYER_POS, hostile)
+                hostiles_sent += 1
+                log("-> hostile MovePlayerPos #%d/%d: %s"
+                    % (hostiles_sent, oob_total, desc))
         elif packet_id == S2C_PLAY_SET_DEFAULT_SPAWN:
             log("<- SetDefaultSpawnPosition")
         elif packet_id == S2C_PLAY_KEEP_ALIVE:
@@ -728,6 +779,41 @@ def main():
         elif packet_id == S2C_PLAY_DISCONNECT:
             log("<- Disconnect %s" % printable(payload))
             break
+
+    # In crash-test mode the exit code answers one question: did the server
+    # survive the hostile movement packets? Everything a bedwars world would
+    # also check (terrain, tags) is irrelevant here and would only couple this
+    # gate to a particular event, so it returns before any of that.
+    if args.oob_move:
+        if not client.joined:
+            log("RESULT: never reached play state; the crash test never ran")
+            return 1
+        if lost_after_move:
+            log(
+                "RESULT: the server dropped the connection after a movement "
+                "packet. A single malformed MovePlayerPos crashed it for every "
+                "connected player (ENG-10914)."
+            )
+            return 1
+        if hostiles_sent < oob_total:
+            log(
+                "RESULT: only %d of %d hostile moves were sent (the server may "
+                "have stopped responding mid-sequence); inconclusive"
+                % (hostiles_sent, oob_total)
+            )
+            return 1
+        if not survived_hostile:
+            log(
+                "RESULT: the server sent nothing after the hostile moves, so it "
+                "cannot be confirmed to have survived them"
+            )
+            return 1
+        log(
+            "RESULT: the server refused %d out-of-bounds / non-finite "
+            "MovePlayerPos packets and kept ticking (ENG-10914 fixed)"
+            % hostiles_sent
+        )
+        return 0
 
     log("packets received in play state, by id:")
     unknown = []


### PR DESCRIPTION
## The bug (ENG-10914): a single movement packet crashes the whole server

`move_player_pos` / `move_player_pos_rot` take three client-supplied `f64`s and
apply them with only a block-collision check, **no coordinate bound**. A joined
client sending one `MovePlayerPos { x: 2_000_000.0, y: 65.0, z: 4.0 }` takes the
process down for every connected player.

`x = 2_000_000` is far *inside* the Minecraft world border (29,999,984) but its
chunk key `2_000_000 >> 4 = 125_000` overflows the `i16` this server keys chunks
by. That overflow reaches the chunk math two ways from the same packet:

- **Debug build** (the dev server): `Blocks::get_blocks`, reached synchronously
  from the move handler's collision check, does `as_i16vec2()` which silently
  wraps, and the wrapped range trips `debug_assert!(start.x >= start_xz.x)` at
  `blocks/mod.rs:297`.
- **Release build** (production): the asserts vanish; the position is stored and
  the next tick's `Position::to_chunk` does `i16::try_from(125_000).unwrap()` and
  panics.

## The fix

Two defects, fixed at two layers:

1. **Load-bearing — bound the coordinate at the move handler.**
   `change_position_or_correct_client` now rejects a proposed position that is
   non-finite or outside the representable chunk range *before* it reaches any
   chunk math, and snaps the client back with a teleport correction (matching
   vanilla, which refuses movement past the border rather than clamping onto it).
   The enforced bound is the **`i16` chunk-range safety limit** (`MAX_SAFE_BLOCK`
   = `(i16::MAX - 1) * 16` = 524,256), *not* the world border — the crashing
   packet is inside the border, so the border alone would still admit it. The
   non-finite check comes first, because `NaN as i32` is 0 (a silent teleport to
   origin) and `inf as i32` saturates and then wraps.

2. **Defence in depth — make the conversions total.**
   `Position::to_chunk` now clamps instead of `try_from().unwrap()`, and
   `Blocks::get_blocks` clamps its query into the representable block window
   before deriving chunk coordinates, so the `as_i16vec2()` wrap can no longer
   turn a far query into a bogus chunk range. A coordinate-to-chunk conversion
   that can crash is wrong regardless of who calls it.

## Gate the class, not the instance

`unwrap`/`expect`/`panic!` on client-derived values is a class of remote-crash
bug. `handlers.rs` — the serverbound play-packet module, where every byte comes
from a client — now carries
`#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]`. The next
such call in that module is a build failure, not a P0. **Proven it fires:**
injecting `Some(1).unwrap()` into `move_player_pos` failed clippy with
`used unwrap() on an Option value`, pointing at the deny.

Enumeration of the class downstream of client input (see the report for detail):
fixed the client-reachable sites in `pose.rs::to_chunk` and
`blocks/mod.rs::get_blocks` (the `as_i16vec2` wraps). The remaining `unwrap`s in
`blocks/mod.rs` (chunk-relative indices `0..=15`, block-offset `& 15`) are
infallible by loop/bit invariants and left in place. One `expect` in the
proto NBT decoder (`nbt/mod.rs:609,623`) is flagged for a follow-up fuzz/property
gate on the decoder rather than fixed here (out of tested scope).

## Wire assertion (the regression test)

New `oob-move-e2e` gate (`nix run .#oob-move-e2e`, `checks.oob-move-e2e`): a
scripted client reaches play and sends the ENG-10914 packet plus the NaN and
`+inf` vectors, then asserts the **server keeps ticking** (it answers a teleport
correction after every hostile move, and the driver confirms the game server is
still listening) — not merely a return value.

**Broke the guard and watched it fail.** With the fix reverted, the first hostile
packet crashed the server:

```
thread 'main' panicked at crates/hyperion/src/simulation/blocks/mod.rs:297:17:
assertion failed: start.x >= start_xz.x
```
```
[oob] -> hostile MovePlayerPos #1/3: x=2_000_000 (finite, past the i16 chunk range; ENG-10914)
[oob] connection lost: server closed the connection
[oob] RESULT: the server dropped the connection after a movement packet. A single malformed MovePlayerPos crashed it for every connected player (ENG-10914).
the game server stopped listening during the session   (RUNEXIT=1)
```

With the fix restored:
```
[oob] -> hostile MovePlayerPos #1/3: x=2_000_000 (finite, past the i16 chunk range; ENG-10914)
[oob] -> hostile MovePlayerPos #2/3: x=NaN (non-finite)
[oob] -> hostile MovePlayerPos #3/3: x=+inf (non-finite)
[oob] RESULT: the server refused 3 out-of-bounds / non-finite MovePlayerPos packets and kept ticking (ENG-10914 fixed)   (RUNEXIT=0)
```

Unit/integration coverage in `crates/hyperion/tests/oob_position.rs` and a
`to_chunk` unit test pin the defence-in-depth layer.

## Note

The new gate's port offset was first set to 10000, which aliases onto the base
game-server port (`gameServerPort - proxyPort == 10000`); filed as ENG-10933 and
worked around with offset 9500. See the comment in `flake.nix`.

Closes ENG-10914.
