### PR TITLE
feat(ecs): the uncontested relations become relationships, not tags

### DIFF
--- a/crates/hyperion/src/egress/boss_bar.rs
+++ b/crates/hyperion/src/egress/boss_bar.rs
@@ -232,11 +232,17 @@ impl Module for BossBarModule {
         // default and it is spelled out because the teardown observer below is
         // built on it: it is the difference between one player disconnecting
         // and every player losing the bar.
+        // Relationship on both: each is only ever the first half of a pair --
+        // `(ShownTo, viewer)` and `(Sent, viewer)` -- so adding either as a
+        // bare tag is a panic at the call site rather than a silent no-op no
+        // query matches.
         world
             .component::<ShownTo>()
+            .add_trait::<flecs::Relationship>()
             .add_trait::<(flecs::OnDeleteTarget, flecs::Remove)>();
         world
             .component::<Sent>()
+            .add_trait::<flecs::Relationship>()
             .add_trait::<(flecs::OnDeleteTarget, flecs::Remove)>();
 
         // The whole of teardown. A bar stops being shown in three ways -- the

--- a/crates/hyperion/tests/boss_bar_traits.rs
+++ b/crates/hyperion/tests/boss_bar_traits.rs
@@ -1,0 +1,90 @@
+//! `ShownTo` and `Sent` are relationships, proven the same two ways as the smash
+//! relations in `events/smash/tests/relationship_traits.rs`: a structural check
+//! that the module declared the trait, and a subprocess check that a bare-tag
+//! `add` really aborts. flecs enforces the constraint with `abort()` (SIGABRT),
+//! not a catchable panic, so the behavioural half runs in a child process.
+
+use std::process::Command;
+
+use flecs_ecs::prelude::*;
+use hyperion::{
+    HyperionCore,
+    egress::boss_bar::{Sent, ShownTo},
+};
+
+/// A world with hyperion's real module declarations in place. `HyperionCore`
+/// imports `EgressModule`, which imports `BossBarModule`, so the boss-bar
+/// relationship traits are applied here exactly as they are on a server.
+fn core() -> World {
+    let world = World::new();
+    world.import::<HyperionCore>();
+    world
+}
+
+#[test]
+fn boss_bar_edges_are_declared_relationships() {
+    let world = core();
+    assert!(
+        world.component::<ShownTo>().has(id::<flecs::Relationship>()),
+        "ShownTo lost its `flecs::Relationship` trait"
+    );
+    assert!(
+        world.component::<Sent>().has(id::<flecs::Relationship>()),
+        "Sent lost its `flecs::Relationship` trait"
+    );
+}
+
+/// The child half: with `HYPERION_VIOLATION` set, add a boss-bar relationship as
+/// a bare tag, which flecs aborts on. Unset -- every normal run -- it is a
+/// passing no-op.
+#[test]
+fn violation_child() {
+    let Ok(which) = std::env::var("HYPERION_VIOLATION") else {
+        return;
+    };
+    let world = core();
+    match which.as_str() {
+        "shownto_bare" => {
+            world.entity().add(id::<ShownTo>());
+        }
+        other => panic!("unknown violation case: {other}"),
+    }
+    eprintln!("NO_ABORT");
+    std::process::exit(0);
+}
+
+fn assert_aborts_on_constraint(case: &str) {
+    let exe = std::env::current_exe().expect("test binary path");
+    let output = Command::new(exe)
+        .args(["--exact", "violation_child", "--nocapture"])
+        .env("HYPERION_VIOLATION", case)
+        .env("RUST_BACKTRACE", "0")
+        .output()
+        .expect("spawn the violation child");
+    // flecs writes its abort diagnostic to stdout; NO_ABORT goes to stderr.
+    let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
+    log.push_str(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        !output.status.success(),
+        "{case}: the bare-tag add was accepted, not aborted.\noutput:\n{log}"
+    );
+    assert!(
+        !log.contains("NO_ABORT"),
+        "{case}: flecs accepted the illegal state.\noutput:\n{log}"
+    );
+    assert!(
+        log.contains("CONSTRAINT_VIOLATED"),
+        "{case}: the child died, but not on a flecs constraint.\noutput:\n{log}"
+    );
+}
+
+/// `ShownTo` is a tag relationship, so a bare-tag `add` compiles and flecs
+/// aborts on it. `Sent` carries pair data, so `add(id::<Sent>())` does not even
+/// compile -- the crate's non-ZST assertion refuses it before flecs would --
+/// which is why only `ShownTo` has a behavioural case here. `Sent`'s trait is
+/// covered by the structural check above; there is no bare-tag spelling of it
+/// left for a caller to reach.
+#[test]
+fn a_boss_bar_edge_added_as_a_bare_tag_aborts() {
+    assert_aborts_on_constraint("shownto_bare");
+}

--- a/events/smash/src/module/lives.rs
+++ b/events/smash/src/module/lives.rs
@@ -285,15 +285,28 @@ impl Module for LivesModule {
         world.component::<LifeTier>();
         world.component::<Tint>();
         world.component::<AtMost>();
-        // Exclusive is what makes "in exactly one band" a property of the
-        // world rather than of the code that writes the edge: adding the new
-        // tier removes the old one, with no window in between where a player
-        // is in two.
-        world.component::<ShownAs>().add_trait::<flecs::Exclusive>();
+        // Three traits, each foreclosing a different way the edge could be
+        // wrong. `Relationship`: `ShownAs` is only ever the relationship half
+        // of `(ShownAs, tier)`, so adding it as a bare tag is a panic at the
+        // call site rather than a silent no-op no query matches. `Exclusive`:
+        // adding the new tier removes the old one atomically, so "in exactly
+        // one band" is a property of the world, with no window where a player
+        // is in two. `(OneOf, LifeTier)`: the target must be a child of
+        // `LifeTier`, so `(ShownAs, <a player>)` or `(ShownAs, <a kit>)` is a
+        // panic rather than an edge pointing at something that is not a band.
+        world
+            .component::<ShownAs>()
+            .add_trait::<flecs::Relationship>()
+            .add_trait::<flecs::Exclusive>()
+            .add_trait::<(flecs::OneOf, LifeTier)>();
+        // A child of `LifeTier`, which is what `(OneOf, LifeTier)` above
+        // requires of every `ShownAs` target, and what draws the five bands as
+        // a readable subtree under the tier component in the explorer.
         for (name, at_most, tint) in TIERS {
             world
                 .entity_named(name)
                 .add(LifeTier::id())
+                .child_of(LifeTier::id())
                 .set(AtMost(at_most))
                 .set(Tint(tint));
         }

--- a/events/smash/src/module/selector.rs
+++ b/events/smash/src/module/selector.rs
@@ -525,10 +525,15 @@ impl Module for SelectorModule {
 
         world.component::<Podium>();
         world.component::<Plinth>();
-        // Exclusive: a podium offers exactly one mob, so re-pointing one is a
-        // single `add` rather than a remove-then-add pair that can be
-        // interrupted halfway and leave a podium offering two kits.
-        world.component::<Offers>().add(flecs::Exclusive);
+        // Relationship: `Offers` is only ever the first half of `(Offers, kit)`,
+        // so adding it as a bare tag is a panic rather than a silent no-op that
+        // no query matches. Exclusive: a podium offers exactly one mob, so
+        // re-pointing one is a single `add` rather than a remove-then-add pair
+        // that can be interrupted halfway and leave a podium offering two kits.
+        world
+            .component::<Offers>()
+            .add_trait::<flecs::Relationship>()
+            .add(flecs::Exclusive);
         // Exclusive for the same reason: a mob stands on one podium, and a mob
         // that claimed to stand on two would offer two kits from one click.
         //
@@ -539,6 +544,7 @@ impl Module for SelectorModule {
         // extend when a podium grows a second thing attached to it.
         world
             .component::<StandsOn>()
+            .add_trait::<flecs::Relationship>()
             .add(flecs::Exclusive)
             .add_trait::<(flecs::OnDeleteTarget, flecs::Delete)>();
     }

--- a/events/smash/tests/relationship_traits.rs
+++ b/events/smash/tests/relationship_traits.rs
@@ -1,0 +1,135 @@
+//! The relationship traits, and proof they refuse the states they forbid.
+//!
+//! `flecs::Relationship` and `(flecs::OneOf, LifeTier)` do not make an invalid
+//! write unlikely; they make it a `CONSTRAINT_VIOLATED` abort at the call site.
+//! That abort is a process `abort()` (SIGABRT), not a Rust panic, so it cannot
+//! be caught with `#[should_panic]` -- it would take the whole test binary down.
+//! The proof therefore comes in two halves:
+//!
+//! * **Structural, in-process.** Each relation carries the trait its module
+//!   declared. This is the guard that fails the moment someone deletes a trait
+//!   from a module, and it is load-immune -- it reads the world, it does not
+//!   race a clock.
+//! * **Behavioural, in a subprocess.** A representative violation of each trait
+//!   really aborts, with `CONSTRAINT_VIOLATED` on stderr. This is what proves
+//!   the trait has teeth rather than merely being present. It runs the offending
+//!   `add` in a child process and asserts the child died on the constraint.
+
+use std::process::Command;
+
+use flecs_ecs::prelude::*;
+use smash::{
+    SmashModule,
+    module::{
+        lives::{LifeTier, ShownAs},
+        selector::{Offers, StandsOn},
+    },
+};
+
+/// A game world with every relation's real trait declaration in place.
+fn game() -> World {
+    let world = World::new();
+    world.import::<SmashModule>();
+    world
+}
+
+// --- Structural: the module declared the trait ---------------------------
+
+#[test]
+fn relations_are_declared_relationships() {
+    let world = game();
+    for (name, present) in [
+        ("ShownAs", world.component::<ShownAs>().has(id::<flecs::Relationship>())),
+        ("Offers", world.component::<Offers>().has(id::<flecs::Relationship>())),
+        ("StandsOn", world.component::<StandsOn>().has(id::<flecs::Relationship>())),
+    ] {
+        assert!(present, "{name} lost its `flecs::Relationship` trait");
+    }
+}
+
+#[test]
+fn shownas_targets_are_confined_to_life_tiers() {
+    let world = game();
+    assert!(
+        world
+            .component::<ShownAs>()
+            .has((id::<flecs::OneOf>(), id::<LifeTier>())),
+        "ShownAs lost its `(OneOf, LifeTier)` trait"
+    );
+}
+
+// --- Behavioural: a violation really aborts ------------------------------
+
+/// The child half of the subprocess guards. When `SMASH_VIOLATION` names a
+/// case, it performs that illegal `add`, which flecs aborts on. If flecs did
+/// *not* abort, this returns and the child exits 0, which the parent reads as a
+/// missing guard. With the variable unset -- every normal `cargo test` run --
+/// it is an ordinary passing no-op.
+#[test]
+fn violation_child() {
+    let Ok(which) = std::env::var("SMASH_VIOLATION") else {
+        return;
+    };
+    let world = game();
+    match which.as_str() {
+        // A relationship used as a bare tag.
+        "shownas_bare" => {
+            world.entity().add(id::<ShownAs>());
+        }
+        "offers_bare" => {
+            world.entity().add(id::<Offers>());
+        }
+        "standson_bare" => {
+            world.entity().add(id::<StandsOn>());
+        }
+        // A `(ShownAs, x)` whose target is not a life tier.
+        "shownas_wrong_target" => {
+            let stray = world.entity_named("not_a_tier");
+            world.entity().add((id::<ShownAs>(), stray));
+        }
+        other => panic!("unknown violation case: {other}"),
+    }
+    // Reached only if flecs accepted the illegal state.
+    eprintln!("NO_ABORT");
+    std::process::exit(0);
+}
+
+/// Run `violation_child` in a subprocess with `case` selected, and assert it
+/// died on a flecs constraint.
+fn assert_aborts_on_constraint(case: &str) {
+    let exe = std::env::current_exe().expect("test binary path");
+    let output = Command::new(exe)
+        .args(["--exact", "violation_child", "--nocapture"])
+        .env("SMASH_VIOLATION", case)
+        .env("RUST_BACKTRACE", "0")
+        .output()
+        .expect("spawn the violation child");
+    // flecs writes its `abort()` diagnostic to stdout; the child's own
+    // `NO_ABORT` marker goes to stderr. Read both.
+    let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
+    log.push_str(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        !output.status.success(),
+        "{case}: the illegal add was accepted, not aborted.\noutput:\n{log}"
+    );
+    assert!(
+        !log.contains("NO_ABORT"),
+        "{case}: flecs accepted the illegal state before aborting elsewhere.\noutput:\n{log}"
+    );
+    assert!(
+        log.contains("CONSTRAINT_VIOLATED"),
+        "{case}: the child died, but not on a flecs constraint.\noutput:\n{log}"
+    );
+}
+
+#[test]
+fn a_relationship_added_as_a_bare_tag_aborts() {
+    assert_aborts_on_constraint("shownas_bare");
+    assert_aborts_on_constraint("offers_bare");
+    assert_aborts_on_constraint("standson_bare");
+}
+
+#[test]
+fn a_shownas_pointing_outside_the_tiers_aborts() {
+    assert_aborts_on_constraint("shownas_wrong_target");
+}


### PR DESCRIPTION
## What

The second slice of the ECS trait pass: the relations whose files are **not** the abilities agent's hot set. Each gains `flecs::Relationship`, and `ShownAs` also gains `(flecs::OneOf, LifeTier)`.

`flecs::Relationship` turns `add(Offers::id())` — a relation added as a bare tag — from a silent no-op that no query matches into a `CONSTRAINT_VIOLATED` abort at the call site. This is the "invalid state unrepresentable" the project keeps asking for, applied to:

- `Offers`, `StandsOn` (`selector.rs`)
- `ShownAs` (`lives.rs`) — plus `(OneOf, LifeTier)`: the target must be a child of `LifeTier`, so `(ShownAs, <a player>)` or `(ShownAs, <a kit>)` cannot be written. A life band is the only thing a player can be shown as. The five tier entities become children of `LifeTier` to satisfy it, which also draws them as a readable subtree in the explorer.
- `ShownTo`, `Sent` (`boss_bar.rs`, hyperion)

## Proof — two halves, because flecs aborts rather than panics

flecs enforces these constraints with `abort()` (SIGABRT), **not** a catchable Rust panic, so `#[should_panic]` cannot express the guard — it would take the whole test binary down. Each trait is therefore proven twice:

- **Structural, in-process** (load-immune): each relation carries the trait its module declared. Fails the instant a module drops a trait.
- **Behavioural, in a subprocess**: a representative violation really aborts, with `CONSTRAINT_VIOLATED` in the child's output. `events/smash/tests/relationship_traits.rs` and `crates/hyperion/tests/boss_bar_traits.rs`.

`Sent` carries pair data, so a bare-tag `add(id::<Sent>())` does not even compile (the crate's non-ZST assertion refuses it before flecs would); its trait is covered structurally.

### Guards broken on purpose, and they fired

Removing `flecs::Relationship`/`(OneOf, LifeTier)` from each declaration, the guards fail with the intended messages:

```
ShownAs lost its `flecs::Relationship` trait
ShownAs lost its `(OneOf, LifeTier)` trait
shownas_wrong_target: the illegal add was accepted, not aborted. ... NO_ABORT
Offers lost its `flecs::Relationship` trait
offers_bare: the illegal add was accepted, not aborted.
ShownTo lost its `flecs::Relationship` trait
shownto_bare: the bare-tag add was accepted, not aborted. ... NO_ABORT
```

Restored, all pass.

- `cargo clippy -p smash -p hyperion --all-targets --all-features -- -D warnings`: clean.
- `cargo test -p smash`, `cargo test -p hyperion --lib --test boss_bar_traits`: all pass — behaviour unchanged (the two-Blazes-two-burns property in #1039 still holds; the tier reparenting is queried by tag, not path).

The hot-file relations (`Playing`, `Grants`, `Upon`, `InflictedBy`, `Source`, `FiredBy`) follow in the next PR now that those files are released.
