### PR TITLE
feat(ecs): the hot relations become sparse, cascading relationships

### DIFF
--- a/events/smash/src/module/ability.rs
+++ b/events/smash/src/module/ability.rs
@@ -499,7 +499,9 @@ impl Module for AbilityModule {
         world.component::<Charging>();
         world.component::<UseSlot>();
         world.component::<ReleaseSlot>();
-        world.component::<Grants>();
+        world
+            .component::<Grants>()
+            .add_trait::<flecs::Relationship>();
         world.component::<Proves>();
         world.component::<GrantedFor>();
 

--- a/events/smash/src/module/effect.rs
+++ b/events/smash/src/module/effect.rs
@@ -562,12 +562,31 @@ impl Module for EffectModule {
         world.component::<Shields>();
         world.component::<Repeats>();
         world.component::<Ends>();
-        // Exclusive: an effect afflicts exactly one player, comes from one
-        // place and is owed to one attacker. A second target would silently
-        // double every tick it deals.
-        world.component::<Upon>().add(flecs::Exclusive);
-        world.component::<InflictedBy>().add(flecs::Exclusive);
-        world.component::<Source>().add(flecs::Exclusive);
+        // All three are relationships and all three are exclusive: an effect
+        // afflicts exactly one player, comes from one place and is owed to one
+        // attacker, and none may be added as a bare tag. `Upon` carries two
+        // more traits its siblings do not. `DontFragment`: its target is a
+        // player, so a fragmenting relationship makes flecs mint an archetype
+        // per victim, and Arrow Storm alone spawns a fresh effect every 0.3s
+        // for eight seconds -- the churn a sparse pair avoids. `(OnDeleteTarget,
+        // Delete)`: an effect dies with the player it is on, so a disconnect
+        // takes its burns with it and the `tick_effects` loop below no longer
+        // needs a branch that finds a victimless effect and cleans it up. That
+        // is the same teardown-by-policy egress::boss_bar is built on.
+        world
+            .component::<Upon>()
+            .add_trait::<flecs::Relationship>()
+            .add(flecs::Exclusive)
+            .add_trait::<flecs::DontFragment>()
+            .add_trait::<(flecs::OnDeleteTarget, flecs::Delete)>();
+        world
+            .component::<InflictedBy>()
+            .add_trait::<flecs::Relationship>()
+            .add(flecs::Exclusive);
+        world
+            .component::<Source>()
+            .add_trait::<flecs::Relationship>()
+            .add(flecs::Exclusive);
 
         // Applying and expiring are one `run` rather than two per-entity
         // systems, for the reason `smash::expire_grants` is: hurting a victim
@@ -588,16 +607,18 @@ impl Module for EffectModule {
                     .with(Effect::id())
                     .build()
                     .each_entity(|effect, expires| {
-                        let Some(victim) = effect.target(Upon, 0) else {
-                            // The player it was put on has gone. Collected
-                            // so the entity does not leak for the rest of
-                            // the match.
-                            finished.push(effect.id());
-                            return;
-                        };
+                        // `(Upon, OnDeleteTarget, Delete)` deletes an effect
+                        // with the player it is on, so a live effect has a live
+                        // victim -- a disconnect took its burns with it before
+                        // this system ran. There is no victimless-effect branch
+                        // any more; flecs owns that teardown, the way it owns
+                        // egress::boss_bar's.
+                        let victim = effect
+                            .target(Upon, 0)
+                            .expect("an effect outlived its victim; (Upon, Delete) forbids it");
 
                         expires.remaining -= dt;
-                        if expires.remaining <= 0.0 || !victim.is_alive() {
+                        if expires.remaining <= 0.0 {
                             finished.push(effect.id());
                             return;
                         }

--- a/events/smash/src/module/kit.rs
+++ b/events/smash/src/module/kit.rs
@@ -708,6 +708,9 @@ impl Module for KitModule {
         world.component::<KitMob>();
         world.component::<KitSkin>();
         world.component::<Ultimate>();
-        world.component::<Playing>().add(flecs::Exclusive);
+        world
+            .component::<Playing>()
+            .add_trait::<flecs::Relationship>()
+            .add(flecs::Exclusive);
     }
 }

--- a/events/smash/src/module/projectile.rs
+++ b/events/smash/src/module/projectile.rs
@@ -105,7 +105,19 @@ impl Module for ProjectileModule {
         world.component::<Projectile>();
         world.component::<Flight>();
         world.component::<Payload>();
-        world.component::<FiredBy>().add(flecs::Exclusive);
+        // Relationship, so `(FiredBy, shooter)` can never be a bare tag.
+        // Exclusive, because a projectile has one shooter. `DontFragment`,
+        // because the target is a player and a fragmenting relationship would
+        // mint an archetype per shooter as volleys fly. `(OnDeleteTarget,
+        // Delete)`: a projectile dies with the player who fired it, so a
+        // shooter disconnecting mid-flight takes their arrows with them rather
+        // than leaving them to land crediting nobody.
+        world
+            .component::<FiredBy>()
+            .add_trait::<flecs::Relationship>()
+            .add(flecs::Exclusive)
+            .add_trait::<flecs::DontFragment>()
+            .add_trait::<(flecs::OnDeleteTarget, flecs::Delete)>();
 
         world
             .system_named::<(&mut Flight, &Payload)>("fly")

--- a/events/smash/tests/relationship_traits.rs
+++ b/events/smash/tests/relationship_traits.rs
@@ -18,10 +18,15 @@
 use std::process::Command;
 
 use flecs_ecs::prelude::*;
+use glam::Vec3;
 use smash::{
     SmashModule,
     module::{
+        ability::Grants,
+        effect::{self, Affliction, Blame, Effect, InflictedBy, Source, Upon},
+        kit::Playing,
         lives::{LifeTier, ShownAs},
+        projectile::{self, FiredBy, Flight, Payload, Projectile},
         selector::{Offers, StandsOn},
     },
 };
@@ -42,8 +47,43 @@ fn relations_are_declared_relationships() {
         ("ShownAs", world.component::<ShownAs>().has(id::<flecs::Relationship>())),
         ("Offers", world.component::<Offers>().has(id::<flecs::Relationship>())),
         ("StandsOn", world.component::<StandsOn>().has(id::<flecs::Relationship>())),
+        ("Playing", world.component::<Playing>().has(id::<flecs::Relationship>())),
+        ("Grants", world.component::<Grants>().has(id::<flecs::Relationship>())),
+        ("Upon", world.component::<Upon>().has(id::<flecs::Relationship>())),
+        ("InflictedBy", world.component::<InflictedBy>().has(id::<flecs::Relationship>())),
+        ("Source", world.component::<Source>().has(id::<flecs::Relationship>())),
+        ("FiredBy", world.component::<FiredBy>().has(id::<flecs::Relationship>())),
     ] {
         assert!(present, "{name} lost its `flecs::Relationship` trait");
+    }
+}
+
+/// The two player-targeted relations are stored sparsely and delete their
+/// source with their target. `DontFragment` keeps a volley of arrows or a
+/// stream of burns from minting one archetype per victim; `(OnDeleteTarget,
+/// Delete)` is what lets `tick_effects` and the fly system carry no
+/// victimless/ownerless cleanup branch of their own.
+#[test]
+fn player_targeted_relations_are_sparse_and_cascade() {
+    let world = game();
+    for (name, dont_fragment, cascades) in [
+        (
+            "Upon",
+            world.component::<Upon>().has(id::<flecs::DontFragment>()),
+            world
+                .component::<Upon>()
+                .has((id::<flecs::OnDeleteTarget>(), id::<flecs::Delete>())),
+        ),
+        (
+            "FiredBy",
+            world.component::<FiredBy>().has(id::<flecs::DontFragment>()),
+            world
+                .component::<FiredBy>()
+                .has((id::<flecs::OnDeleteTarget>(), id::<flecs::Delete>())),
+        ),
+    ] {
+        assert!(dont_fragment, "{name} lost its `flecs::DontFragment` trait");
+        assert!(cascades, "{name} lost its `(OnDeleteTarget, Delete)` trait");
     }
 }
 
@@ -81,6 +121,24 @@ fn violation_child() {
         }
         "standson_bare" => {
             world.entity().add(id::<StandsOn>());
+        }
+        "playing_bare" => {
+            world.entity().add(id::<Playing>());
+        }
+        "grants_bare" => {
+            world.entity().add(id::<Grants>());
+        }
+        "upon_bare" => {
+            world.entity().add(id::<Upon>());
+        }
+        "inflictedby_bare" => {
+            world.entity().add(id::<InflictedBy>());
+        }
+        "source_bare" => {
+            world.entity().add(id::<Source>());
+        }
+        "firedby_bare" => {
+            world.entity().add(id::<FiredBy>());
         }
         // A `(ShownAs, x)` whose target is not a life tier.
         "shownas_wrong_target" => {
@@ -124,9 +182,85 @@ fn assert_aborts_on_constraint(case: &str) {
 
 #[test]
 fn a_relationship_added_as_a_bare_tag_aborts() {
-    assert_aborts_on_constraint("shownas_bare");
-    assert_aborts_on_constraint("offers_bare");
-    assert_aborts_on_constraint("standson_bare");
+    for case in [
+        "shownas_bare",
+        "offers_bare",
+        "standson_bare",
+        "playing_bare",
+        "grants_bare",
+        "upon_bare",
+        "inflictedby_bare",
+        "source_bare",
+        "firedby_bare",
+    ] {
+        assert_aborts_on_constraint(case);
+    }
+}
+
+/// `(Upon, OnDeleteTarget, Delete)`: deleting the victim deletes the effect,
+/// so there is nothing left for `tick_effects` to find victimless. Destructing
+/// outside a system applies at once, so no tick is needed to observe it.
+#[test]
+fn an_effect_dies_with_its_victim() {
+    let world = game();
+    let attacker = world.entity_named("attacker");
+    let victim = world.entity_named("victim");
+    effect::afflict(
+        (&world).into(),
+        victim,
+        Blame {
+            source: attacker.id(),
+            attacker: attacker.id(),
+        },
+        Affliction::shield(5.0),
+    );
+    assert_eq!(count::<Effect>(&world), 1, "the affliction was not created");
+
+    victim.destruct();
+    assert_eq!(
+        count::<Effect>(&world),
+        0,
+        "the effect outlived the victim it was on"
+    );
+}
+
+/// `(FiredBy, OnDeleteTarget, Delete)`: deleting the shooter deletes their
+/// projectiles in flight, so the fly system never meets an ownerless one.
+#[test]
+fn a_projectile_dies_with_its_shooter() {
+    let world = game();
+    let shooter = world.entity_named("shooter");
+    projectile::fire(
+        (&world).into(),
+        shooter,
+        Flight {
+            position: Vec3::ZERO,
+            velocity: Vec3::X,
+            gravity: 0.0,
+            seconds_left: 10.0,
+            radius: 0.4,
+        },
+        Payload::new(1.0, 0.0),
+    );
+    assert_eq!(count::<Projectile>(&world), 1, "the projectile was not fired");
+
+    shooter.destruct();
+    assert_eq!(
+        count::<Projectile>(&world),
+        0,
+        "the projectile outlived the shooter who fired it"
+    );
+}
+
+/// Count entities carrying `T`.
+fn count<T: ComponentId>(world: &World) -> i32 {
+    let mut n = 0;
+    world
+        .query::<()>()
+        .with(T::id())
+        .build()
+        .each_entity(|_, ()| n += 1);
+    n
 }
 
 #[test]


### PR DESCRIPTION
## What

The hot-file half of the trait pass, now that `effect.rs`, `ability.rs`, `kit.rs` and `projectile.rs` are quiescent (abilities agent confirmed). Six relations gain `flecs::Relationship`; the two whose target is a **player** gain two more traits each.

- `Playing` (`kit.rs`), `Grants` (`ability.rs`), `InflictedBy`, `Source` (`effect.rs`): `flecs::Relationship`. A bare-tag `add` is now a `CONSTRAINT_VIOLATED` abort, not a silent no-op.
- `Upon` (`effect.rs`) and `FiredBy` (`projectile.rs`): `flecs::Relationship` + `flecs::DontFragment` + `(flecs::OnDeleteTarget, flecs::Delete)`.
  - **DontFragment** because the target is a player, so a fragmenting relationship mints an archetype per victim/shooter — Arrow Storm alone spawns an effect every 0.3s for eight seconds. Sparse storage avoids the churn. The two-Blazes-two-burns property (#1039) still holds.
  - **(OnDeleteTarget, Delete)** so an effect dies with its victim and a projectile with its shooter. This is the point of the change: `tick_effects` **no longer needs the branch that found a victimless effect and cleaned it up** — flecs owns that teardown now, the same shape `egress::boss_bar` is built on. The branch is deleted; a live effect now asserts a live victim.

## Why player-`IsA`-kit stays rejected (for the record, per the audit)

`Grants` deliberately keeps flecs's default `Override` on instantiation, not `Inherit`: a player's ability instances must each carry their own `Cooldown`. Making a player `IsA` their kit would inherit `(Grants, <ability prefab>)` and collapse every player's cooldown onto the shared prefab — confirmed by reading `ecs_get_target` in the vendored flecs C, which follows `IsA` only for ids flagged `OnInstantiateInherit`. The relation that carries the most weight is exactly the one you'd have to stop inheriting to make `IsA` safe, which is the argument against it.

## Proof — flecs aborts (SIGABRT), so guards are structural + subprocess

`events/smash/tests/relationship_traits.rs`, extended:

- **Structural** (in-process, load-immune): every relation carries its declared trait; `Upon`/`FiredBy` carry `DontFragment` and `(OnDeleteTarget, Delete)`.
- **Subprocess abort**: a bare-tag add of each of the six aborts with `CONSTRAINT_VIOLATED`.
- **Behavioural** (in-process): an effect dies with its victim; a projectile dies with its shooter — the invariant that lets the cleanup branches be deleted.

### Guards broken on purpose, and they fired

```
Playing lost its `flecs::Relationship` trait
playing_bare: the illegal add was accepted, not aborted.

Upon lost its `flecs::DontFragment` trait
an_effect_dies_with_its_victim ... FAILED: the effect outlived the victim it was on

FiredBy lost its `(OnDeleteTarget, Delete)` trait
a_projectile_dies_with_its_shooter ... FAILED: the projectile outlived the shooter who fired it
```

Restored, all 8 pass.

- `cargo clippy -p smash -p hyperion --all-targets --all-features -- -D warnings`: clean.
- `cargo test -p smash`: all pass (21 binaries), including #1039's two-burns property.
