### PR TITLE
feat(smash): projectiles you can see

### DIFF
--- a/events/smash/src/draw.rs
+++ b/events/smash/src/draw.rs
@@ -1,0 +1,98 @@
+//! The host half of a projectile: the part a client can see.
+//!
+//! A smash projectile is a game-half entity carrying [`Flight`], [`Payload`] and
+//! [`Visual`]. `Flight` is authoritative for the hit and is integrated by
+//! `smash::fly` with no host anywhere near it, which is what keeps
+//! `tests/abilities.rs` and the mock able to prove a projectile connects. None
+//! of that reaches a client, because nothing tells one the projectile exists.
+//!
+//! This module is that telling, and only that. On the host it decorates each new
+//! projectile with the components hyperion's entity egress reads -- a kind, a
+//! position, a velocity, a facing -- and enqueues the spawn. The client then
+//! dead-reckons the arc from the velocity the `add_entity` packet carries, which
+//! is how vanilla draws a thrown projectile between server updates.
+//!
+//! Two consequences worth stating plainly:
+//!
+//! It is a separate entity from nothing -- it *is* the projectile, decorated.
+//! So when `smash::fly` destructs the projectile on its hit or its timer, the
+//! entity that was drawn is the entity that dies, and hyperion's
+//! `despawn_removed_entity` observer tells every client to drop it. There is no
+//! second lifetime to keep in step.
+//!
+//! The drawn arc and the hit are computed twice, by two integrators that do not
+//! share constants: hyperion's client-side dead reckoning uses the vanilla
+//! gravity for the entity kind, and `Flight` uses whatever the ability set.
+//! They agree exactly for a zero-gravity projectile -- a hook, a line of cows --
+//! and drift for a heavy one over its flight. The projectile vanishes at the
+//! hit either way, because the hit is what destructs it. Making the two share
+//! one integrator is the larger change flagged in `docs/smash-design.md`; this
+//! is the visible-now half.
+//!
+//! Deliberately not [`hyperion::effects::spawn::spawn`], which creates a *new*
+//! entity: decorating the existing one is the whole reason despawn is free. And
+//! deliberately no [`hyperion::simulation::Owner`], which is what
+//! `update_projectile_positions` requires to integrate and collide an entity --
+//! omitting it is what stops hyperion from moving or re-hitting a projectile
+//! `Flight` already owns.
+
+use flecs_ecs::prelude::*;
+use hyperion::{
+    effects::spawn::facing,
+    simulation::{Pitch, Position, Spawn, Uuid, Velocity, Yaw},
+};
+
+use crate::module::projectile::{Flight, Projectile, Visual};
+
+/// Marks a projectile that has already been drawn, so it is decorated once.
+#[derive(Component, Debug)]
+struct Drawn;
+
+/// Minecraft runs at twenty ticks a second, and hyperion's [`Velocity`] is in
+/// blocks per tick where [`Flight`] is in blocks per second. Every crossing
+/// between the two goes through this.
+const TICKS_PER_SECOND: f32 = 20.0;
+
+#[derive(Component)]
+pub struct DrawModule;
+
+impl Module for DrawModule {
+    fn module(world: &World) {
+        world.module::<Self>("smash::Draw");
+        world.component::<Drawn>();
+
+        // A system rather than an `OnAdd` observer, because `fire` adds the
+        // `Projectile` tag before it sets `Flight`, so an observer on the tag
+        // would see the projectile a step before it has a position. A system
+        // that matches on all three and skips what it has already drawn sees a
+        // whole projectile or none of it, and picks a mid-tick spawn up on the
+        // next tick -- one tick, fifty milliseconds, invisible against a flight
+        // that lasts hundreds.
+        world
+            .system_named::<(&Visual, &Flight)>("smash::draw_projectiles")
+            .with(Projectile::id())
+            .without(Drawn::id())
+            .each_entity(|projectile, (visual, flight)| {
+                let per_tick = flight.velocity / TICKS_PER_SECOND;
+                let (yaw, pitch) = facing(flight.velocity);
+
+                projectile
+                    .add_enum(visual.0)
+                    .set(Uuid::new_v4())
+                    .set(Position::new(
+                        flight.position.x,
+                        flight.position.y,
+                        flight.position.z,
+                    ))
+                    .set(Velocity::new(per_tick.x, per_tick.y, per_tick.z))
+                    .set(Yaw::new(yaw))
+                    .set(Pitch::new(pitch))
+                    .add(Drawn::id());
+                // Enqueued rather than added: the `Spawn` observer that sends
+                // `add_entity` runs at the sync point, after this system's
+                // deferred component adds above have been applied, so the packet
+                // it builds sees the kind and position this set.
+                projectile.enqueue(Spawn);
+            });
+    }
+}

--- a/events/smash/src/lib.rs
+++ b/events/smash/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod adapter;
 pub mod command;
+pub mod draw;
 pub mod flecs_ext;
 pub mod input;
 pub mod map;
@@ -92,6 +93,10 @@ impl Module for SmashHost {
         // After the adapter, because building the maps writes the `Arena`
         // singleton the game half registered.
         world.import::<crate::terrain::MapModule>();
+        // After the adapter too: it draws the game half's projectiles, whose
+        // `Projectile`, `Visual` and `Flight` the adapter's `SmashModule`
+        // import is what registers.
+        world.import::<crate::draw::DrawModule>();
 
         world.get::<&mut CommandRegistry>(|registry| {
             command::register(registry, world);

--- a/events/smash/src/module/kits/chicken.rs
+++ b/events/smash/src/module/kits/chicken.rs
@@ -9,6 +9,7 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::{
     flecs_ext::EntityViewExt,
@@ -16,7 +17,7 @@ use crate::{
         ability::{self, Cast, Cooldown, Grants, Named, Observable},
         effect::{self, Affliction},
         kit::{self, AbilitySpec, KitSounds, KitStats},
-        projectile::{Flight, Impact, Payload, fire},
+        projectile::{Flight, Impact, Payload, Visual, fire},
         visuals,
     },
 };
@@ -105,6 +106,7 @@ fn egg_blaster(cast: &Cast<'_>) {
         fire(
             cast.world,
             cast.caster,
+            Visual(EntityKind::Egg),
             Flight {
                 position: cast.position.0,
                 velocity: (forward + side * offset).normalize_or_zero() * 30.0,
@@ -123,6 +125,7 @@ fn chicken_missile(cast: &Cast<'_>) {
     fire(
         cast.world,
         cast.caster,
+        Visual(EntityKind::Egg),
         Flight {
             position: cast.position.0,
             velocity: cast.facing.0.normalize_or_zero() * 24.0,

--- a/events/smash/src/module/kits/cow.rs
+++ b/events/smash/src/module/kits/cow.rs
@@ -10,13 +10,14 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::module::{
     ability::{self, Cast, Observable, splash_at},
     damage::MeleeBonus,
     effect::{self, Affliction},
     kit::{self, AbilitySpec, KitSounds, KitStats},
-    projectile::{Flight, Payload, fire},
+    projectile::{Flight, Payload, Visual, fire},
 };
 
 /// `[VERIFIED]`: "you will slowly gain speed levels (up to 4)".
@@ -104,6 +105,7 @@ fn angry_herd(cast: &Cast<'_>) {
         fire(
             cast.world,
             cast.caster,
+            Visual(EntityKind::Cow),
             Flight {
                 position: cast.position.0 + side * offset,
                 velocity: forward * 14.0,

--- a/events/smash/src/module/kits/creeper.rs
+++ b/events/smash/src/module/kits/creeper.rs
@@ -8,13 +8,14 @@
 //! the wiki's numbers; Sulphur Bomb's are approximated.
 
 use flecs_ecs::prelude::*;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::module::{
     ability::{Cast, Observable, splash},
     damage::DamageKind,
     kit::{self, AbilitySpec, KitSounds, KitStats},
     player::Player,
-    projectile::{Flight, Impact, Payload, fire},
+    projectile::{Flight, Impact, Payload, Visual, fire},
     visuals,
 };
 
@@ -125,6 +126,9 @@ fn sulphur_bomb(cast: &Cast<'_>) {
     fire(
         cast.world,
         cast.caster,
+        // `[APPROXIMATED]`: a thrown coal has no entity of its own; a small
+        // fireball reads as the explosive it becomes on contact.
+        Visual(EntityKind::SmallFireball),
         Flight {
             position: cast.position.0,
             velocity: cast.facing.0.normalize_or_zero() * 22.0,

--- a/events/smash/src/module/kits/enderman.rs
+++ b/events/smash/src/module/kits/enderman.rs
@@ -10,13 +10,14 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::module::{
     ability::{self, Cast, Observable},
     effect::{self, Affliction},
     kit::{self, AbilitySpec, KitSounds, KitStats},
     player::Position,
-    projectile::{Flight, Payload, fire},
+    projectile::{Flight, Payload, Visual, fire},
     visuals,
 };
 
@@ -114,6 +115,7 @@ fn block_toss(cast: &Cast<'_>) {
     fire(
         cast.world,
         cast.caster,
+        Visual(EntityKind::FallingBlock),
         Flight {
             position: cast.position.0,
             velocity: cast.facing.0.normalize_or_zero() * speed,

--- a/events/smash/src/module/kits/guardian.rs
+++ b/events/smash/src/module/kits/guardian.rs
@@ -11,6 +11,7 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::{
     module::{
@@ -19,7 +20,7 @@ use crate::{
         effect::{self, Affliction},
         kit::{self, AbilitySpec, KitSounds, KitStats},
         player::{Player, Position},
-        projectile::{Flight, Impact, Payload, fire},
+        projectile::{Flight, Impact, Payload, Visual, fire},
         visuals,
     },
     server::{PlayerId, ServerHandle},
@@ -147,6 +148,9 @@ fn whirlpool_axe(cast: &Cast<'_>) {
     fire(
         cast.world,
         cast.caster,
+        // `[APPROXIMATED]`: a water shard has no entity; a spectral arrow is
+        // the closest glinting bolt that always renders.
+        Visual(EntityKind::SpectralArrow),
         Flight {
             position: cast.position.0,
             // "It moves rather slow and has less pulling force" than Iron Hook,

--- a/events/smash/src/module/kits/iron_golem.rs
+++ b/events/smash/src/module/kits/iron_golem.rs
@@ -9,13 +9,14 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::module::{
     ability::{Cast, Observable, splash, splash_at},
     effect::{self, Affliction},
     kit::{self, AbilitySpec, KitSounds, KitStats},
     player::Position,
-    projectile::{Flight, Impact, Payload, fire},
+    projectile::{Flight, Impact, Payload, Visual, fire},
     visuals,
 };
 
@@ -129,6 +130,9 @@ fn iron_hook(cast: &Cast<'_>) {
     fire(
         cast.world,
         cast.caster,
+        // `[APPROXIMATED]`: the chain is not an entity; the bolt at its end is
+        // an arrow.
+        Visual(EntityKind::Arrow),
         Flight {
             position: cast.position.0,
             velocity: cast.facing.0.normalize_or_zero() * 20.0,

--- a/events/smash/src/module/kits/skeleton.rs
+++ b/events/smash/src/module/kits/skeleton.rs
@@ -10,13 +10,14 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::module::{
     ability::{Cast, Observable, charge_steps, splash},
     effect::{self, Affliction},
     kit::{self, AbilitySpec, KitSounds, KitStats},
     player::Position,
-    projectile::{Flight, Impact, Payload, fire},
+    projectile::{Flight, Impact, Payload, Visual, fire},
 };
 
 /// Flat, regardless of draw. `KitSkeleton.arrowDamage` overwrites the vanilla
@@ -113,6 +114,7 @@ fn arrow(cast: &Cast<'_>, spread: f32) {
     fire(
         cast.world,
         cast.caster,
+        Visual(EntityKind::Arrow),
         Flight {
             position: cast.position.0,
             velocity: (cast.facing.0.normalize_or_zero() + jitter) * 60.0,
@@ -149,6 +151,7 @@ fn roped_arrow(cast: &Cast<'_>) {
     fire(
         cast.world,
         cast.caster,
+        Visual(EntityKind::Arrow),
         Flight {
             position: cast.position.0,
             velocity: cast.facing.0.normalize_or_zero() * 48.0,

--- a/events/smash/src/module/kits/sky_squid.rs
+++ b/events/smash/src/module/kits/sky_squid.rs
@@ -9,12 +9,13 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::module::{
     ability::{self, Cast, Observable, splash_at},
     effect::{self, Affliction},
     kit::{self, AbilitySpec, KitSounds, KitStats},
-    projectile::{Flight, Payload, fire},
+    projectile::{Flight, Payload, Visual, fire},
     visuals,
 };
 
@@ -132,6 +133,9 @@ fn ink_shotgun(cast: &Cast<'_>) {
         fire(
             cast.world,
             cast.caster,
+            // `[APPROXIMATED]`: an ink pellet has no entity; a snowball is the
+            // closest small thrown blob that always renders.
+            Visual(EntityKind::Snowball),
             Flight {
                 position: cast.position.0,
                 velocity: direction * 26.0,

--- a/events/smash/src/module/kits/snowman.rs
+++ b/events/smash/src/module/kits/snowman.rs
@@ -8,12 +8,13 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::module::{
     ability::{self, Cast, Observable, splash_at},
     effect::{self, Affliction},
     kit::{self, AbilitySpec, KitSounds, KitStats},
-    projectile::{Flight, Payload, fire},
+    projectile::{Flight, Payload, Visual, fire},
 };
 
 /// `[VERIFIED]`: "You also deal 1 more damage to mobs who are on your snow."
@@ -98,6 +99,7 @@ fn blizzard(cast: &Cast<'_>) {
     fire(
         cast.world,
         cast.caster,
+        Visual(EntityKind::Snowball),
         Flight {
             position: cast.position.0,
             velocity: cast.facing.0.normalize_or_zero() * 22.0,
@@ -170,6 +172,7 @@ fn turret_ring(cast: &Cast<'_>) {
         fire(
             cast.world,
             cast.caster,
+            Visual(EntityKind::Snowball),
             Flight {
                 position: cast.position.0,
                 velocity: direction * 20.0,

--- a/events/smash/src/module/kits/spider.rs
+++ b/events/smash/src/module/kits/spider.rs
@@ -11,6 +11,7 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::module::{
     ability::{self, Cast, Observable, splash},
@@ -18,7 +19,7 @@ use crate::module::{
     effect::{self, Affliction, Shows},
     kit::{self, AbilitySpec, KitSounds, KitStats},
     player::Health,
-    projectile::{Flight, Impact, Payload, fire},
+    projectile::{Flight, Impact, Payload, Visual, fire},
     visuals,
 };
 
@@ -133,6 +134,9 @@ fn needler(cast: &Cast<'_>) {
         fire(
             cast.world,
             cast.caster,
+            // `[APPROXIMATED]`: a needle has no entity; a spectral arrow reads as
+            // a thin magic dart.
+            Visual(EntityKind::SpectralArrow),
             Flight {
                 position: cast.position.0,
                 velocity: direction * 34.0,

--- a/events/smash/src/module/kits/wither_skeleton.rs
+++ b/events/smash/src/module/kits/wither_skeleton.rs
@@ -11,13 +11,14 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::module::{
     ability::{self, Cast, Observable, splash_at},
     damage::MatchClock,
     effect::{self, Affliction},
     kit::{self, AbilitySpec, KitSounds, KitStats},
-    projectile::{Flight, Impact, Payload, fire},
+    projectile::{Flight, Impact, Payload, Visual, fire},
     visuals,
 };
 
@@ -98,6 +99,7 @@ fn guided_wither_skull(cast: &Cast<'_>) {
     fire(
         cast.world,
         cast.caster,
+        Visual(EntityKind::WitherSkull),
         Flight {
             position: cast.position.0,
             velocity: cast.facing.0.normalize_or_zero() * 8.0f32.mul_add(cast.charge, 18.0),

--- a/events/smash/src/module/kits/wolf.rs
+++ b/events/smash/src/module/kits/wolf.rs
@@ -10,6 +10,7 @@
 //! disagreement is recorded in docs/smash-design.md.
 
 use flecs_ecs::prelude::*;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::{
     flecs_ext::EntityViewExt,
@@ -19,7 +20,7 @@ use crate::{
         effect::{self, Affliction},
         kit::{self, AbilitySpec, KitName, KitSounds, KitStats, Playing},
         player::Player,
-        projectile::{Flight, Impact, Payload, fire},
+        projectile::{Flight, Impact, Payload, Visual, fire},
     },
 };
 
@@ -153,6 +154,7 @@ fn cub_tackle(cast: &Cast<'_>) {
     fire(
         cast.world,
         cast.caster,
+        Visual(EntityKind::Wolf),
         Flight {
             position: cast.position.0,
             velocity: cast.facing.0.normalize_or_zero() * 18.0,

--- a/events/smash/src/module/kits/zombie.rs
+++ b/events/smash/src/module/kits/zombie.rs
@@ -6,6 +6,7 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::{
     module::{
@@ -13,7 +14,7 @@ use crate::{
         effect::{self, Affliction},
         kit::{self, AbilitySpec, KitSounds, KitStats},
         player::Position,
-        projectile::{Flight, Impact, Payload, fire},
+        projectile::{Flight, Impact, Payload, Visual, fire},
         visuals,
     },
     server::{PlayerId, ServerHandle},
@@ -90,6 +91,9 @@ fn bile_blaster(cast: &Cast<'_>) {
         fire(
             cast.world,
             cast.caster,
+            // `[APPROXIMATED]`: bile has no entity; a snowball is the closest
+            // always-rendered blob.
+            Visual(EntityKind::Snowball),
             Flight {
                 position: cast.position.0,
                 velocity: (forward + side * offset).normalize_or_zero() * 20.0,
@@ -106,6 +110,7 @@ fn deaths_grasp(cast: &Cast<'_>) {
     fire(
         cast.world,
         cast.caster,
+        Visual(EntityKind::Arrow),
         Flight {
             position: cast.position.0,
             velocity: cast.facing.0.normalize_or_zero() * 16.0f32.mul_add(cast.charge, 24.0),

--- a/events/smash/src/module/projectile.rs
+++ b/events/smash/src/module/projectile.rs
@@ -9,9 +9,16 @@
 //! the far side of the seam. Projectiles expire on a timer and on entity
 //! contact. `docs/smash-design.md` lists this as one of the two places the
 //! simulation is deliberately incomplete pending the hyperion wiring.
+//!
+//! What the flight above is authoritative for is the *hit*. What a client sees
+//! is drawn separately, by `crate::draw` on the host, off the [`Visual`] this
+//! module carries -- so the game half stays testable against the mock with no
+//! host anywhere near it, and the same `Flight` that decides the damage decides
+//! where the picture is. See [`fire`].
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
+use hyperion::simulation::entity_kind::EntityKind;
 
 use crate::{
     flecs_ext::WorldRefExt,
@@ -27,6 +34,22 @@ use crate::{
 /// Tag on projectile entities.
 #[derive(Component, Debug)]
 pub struct Projectile;
+
+/// What a projectile is drawn as.
+///
+/// A generated [`EntityKind`] and not a stand-in enum a table maps, the same
+/// choice #1035 made for particles: an ability names the vanilla thing it wants
+/// to look like and the host draws exactly that. The game half carries it as a
+/// plain field -- `crate::draw` on the host is what turns it into a spawned
+/// entity -- so a test world that never imports a host still compiles and runs,
+/// it just draws nothing.
+///
+/// Exact where a vanilla entity is the thing (an arrow is [`EntityKind::Arrow`],
+/// an egg [`EntityKind::Egg`]); the closest always-rendered projectile where the
+/// real thing has no entity of its own (a thrown coal, an ink pellet), marked
+/// `[APPROXIMATED]` at the call site.
+#[derive(Component, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Visual(pub EntityKind);
 
 #[derive(Component, Debug, Copy, Clone, PartialEq)]
 pub struct Flight {
@@ -81,15 +104,22 @@ impl Payload {
     }
 }
 
-/// Fire one.
+/// Fire one, drawn as `visual`.
 ///
-/// Does not hand the projectile back: every caller so far sets everything it
-/// needs through [`Flight`] and [`Payload`], and returning an entity nobody
-/// uses only invites someone to hold it past the tick it dies on.
-pub fn fire(world: WorldRef<'_>, shooter: EntityView<'_>, flight: Flight, payload: Payload) {
+/// Does not hand the projectile back: every caller sets everything it needs
+/// through [`Flight`], [`Payload`] and [`Visual`], and returning an entity
+/// nobody uses only invites someone to hold it past the tick it dies on.
+pub fn fire(
+    world: WorldRef<'_>,
+    shooter: EntityView<'_>,
+    visual: Visual,
+    flight: Flight,
+    payload: Payload,
+) {
     world
         .new_entity()
         .add(Projectile::id())
+        .set(visual)
         .set(flight)
         .set(payload)
         .add((FiredBy, shooter));
@@ -103,6 +133,7 @@ impl Module for ProjectileModule {
         world.module::<Self>("smash::Projectile");
 
         world.component::<Projectile>();
+        world.component::<Visual>();
         world.component::<Flight>();
         world.component::<Payload>();
         // Relationship, so `(FiredBy, shooter)` can never be a bare tag.

--- a/events/smash/tests/abilities.rs
+++ b/events/smash/tests/abilities.rs
@@ -867,6 +867,63 @@ mod charge {
     }
 }
 
+/// Every projectile any ability fires carries a [`Visual`], so the host has
+/// something to draw.
+///
+/// The flight and the hit lived in the game half and were provable against the
+/// mock from the start; what was missing was that a client could see the thing
+/// at all, because nothing said what it looked like. `crate::draw` turns a
+/// `Visual` into an `add_entity`, so a projectile without one is a projectile
+/// that reaches `draw`, finds no kind, and stays invisible -- the exact "twenty
+/// abilities fire something no one can see" this set out to fix.
+///
+/// It sweeps the whole roster rather than the projectile abilities by name,
+/// because "which abilities fire a projectile" is not a list anybody should be
+/// maintaining: it fires every ability and checks that whatever projectiles
+/// appeared are drawable, so a kit added tomorrow that forgets the visual fails
+/// here.
+#[test]
+fn every_projectile_that_flies_can_be_seen() {
+    use smash::module::projectile::{Flight, Projectile, Visual};
+
+    let manifest = ability::manifest(&Game::new().world);
+    let mut failures = Vec::new();
+
+    for entry in manifest {
+        let bench = Bench::new();
+        bench.reset(entry.kit);
+        bench.arm(&entry);
+        bench.press(&entry);
+        // One tick, so a projectile fired on a beat (an ultimate's) has a frame
+        // to appear. `settle` would fly them into the victims and destruct them
+        // before this can look.
+        bench.game.advance(TICK, 1);
+
+        let mut undrawn = 0;
+        bench
+            .game
+            .world
+            .query::<&Flight>()
+            .with(Projectile::id())
+            .build()
+            .each_entity(|projectile, _| {
+                if !projectile.has(Visual::id()) {
+                    undrawn += 1;
+                }
+            });
+
+        if undrawn > 0 {
+            failures.push(format!(
+                "{} / {} put {undrawn} projectile(s) in the world with no Visual, so the host \
+                 would draw nothing",
+                entry.kit, entry.name
+            ));
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
 /// Two of the same effect on one victim are two entities, not one.
 ///
 /// Naming an entity in flecs is find-or-create: `ecs_entity_init` with a name

--- a/events/smash/tests/relationship_traits.rs
+++ b/events/smash/tests/relationship_traits.rs
@@ -19,6 +19,7 @@ use std::process::Command;
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
+use hyperion::simulation::entity_kind::EntityKind;
 use smash::{
     SmashModule,
     module::{
@@ -26,7 +27,7 @@ use smash::{
         effect::{self, Affliction, Blame, Effect, InflictedBy, Source, Upon},
         kit::Playing,
         lives::{LifeTier, ShownAs},
-        projectile::{self, FiredBy, Flight, Payload, Projectile},
+        projectile::{self, FiredBy, Flight, Payload, Projectile, Visual},
         selector::{Offers, StandsOn},
     },
 };
@@ -233,6 +234,7 @@ fn a_projectile_dies_with_its_shooter() {
     projectile::fire(
         (&world).into(),
         shooter,
+        Visual(EntityKind::Arrow),
         Flight {
             position: Vec3::ZERO,
             velocity: Vec3::X,

--- a/events/smash/tests/verification.rs
+++ b/events/smash/tests/verification.rs
@@ -1847,10 +1847,11 @@ fn the_match_clock_advances_only_during_play() {
 mod projectiles {
     use flecs_ecs::prelude::*;
     use glam::Vec3;
+    use hyperion::simulation::entity_kind::EntityKind;
     use smash::{
         module::{
             player::{Health, Player, Position},
-            projectile::{Flight, Payload, Projectile, fire},
+            projectile::{Flight, Payload, Projectile, Visual, fire},
         },
         server::{PlayerId, mock::Call},
     };
@@ -1879,6 +1880,7 @@ mod projectiles {
         fire(
             shooter.world(),
             shooter,
+            Visual(EntityKind::Arrow),
             Flight {
                 position: Vec3::new(0.0, 50.0, 0.0),
                 velocity: Vec3::new(10.0, 0.0, 0.0),
@@ -1941,6 +1943,7 @@ mod projectiles {
         fire(
             shooter.world(),
             shooter,
+            Visual(EntityKind::Arrow),
             Flight {
                 position: Vec3::new(0.0, 0.0, 0.0),
                 velocity: Vec3::ZERO,
@@ -1989,6 +1992,7 @@ mod projectiles {
         fire(
             shooter.world(),
             shooter,
+            Visual(EntityKind::Arrow),
             Flight {
                 position: Vec3::ZERO,
                 velocity: Vec3::ZERO,
@@ -2027,6 +2031,7 @@ mod projectiles {
         fire(
             shooter.world(),
             shooter,
+            Visual(EntityKind::Arrow),
             Flight {
                 position: Vec3::ZERO,
                 velocity: Vec3::ZERO,
@@ -2071,6 +2076,7 @@ mod projectiles {
         fire(
             shooter.world(),
             shooter,
+            Visual(EntityKind::Arrow),
             Flight {
                 position: Vec3::new(-3.0, 0.0, 0.0),
                 velocity: Vec3::new(120.0, 0.0, 0.0),
@@ -2125,6 +2131,7 @@ mod projectiles {
         fire(
             shooter.world(),
             shooter,
+            Visual(EntityKind::Arrow),
             Flight {
                 position: Vec3::new(-3.0, 0.0, 0.0),
                 velocity: Vec3::new(120.0, 0.0, 0.0),
@@ -2154,6 +2161,7 @@ mod projectiles {
         fire(
             shooter.world(),
             shooter,
+            Visual(EntityKind::Arrow),
             Flight {
                 position: Vec3::ZERO,
                 velocity: Vec3::ZERO,
@@ -2186,6 +2194,7 @@ mod projectiles {
         fire(
             shooter.world(),
             shooter,
+            Visual(EntityKind::Arrow),
             Flight {
                 position: Vec3::ZERO,
                 velocity: Vec3::ZERO,
@@ -2215,6 +2224,7 @@ mod projectiles {
         fire(
             shooter.world(),
             shooter,
+            Visual(EntityKind::Arrow),
             Flight {
                 position: Vec3::new(100.0, 0.0, 0.0),
                 velocity: Vec3::new(1.0, 0.0, 0.0),
@@ -2253,6 +2263,7 @@ mod projectiles {
         fire(
             shooter.world(),
             shooter,
+            Visual(EntityKind::Arrow),
             Flight {
                 position: Vec3::ZERO,
                 velocity: Vec3::ZERO,
@@ -2285,6 +2296,7 @@ mod projectiles {
         fire(
             shooter.world(),
             shooter,
+            Visual(EntityKind::Arrow),
             Flight {
                 position: Vec3::ZERO,
                 velocity: Vec3::ZERO,

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -111,6 +111,7 @@ ACTION_RELEASE_USE_ITEM = 5
 
 # Clientbound play ids this file decodes. Everything else is counted by id and
 # reported in the census.
+S2C_ADD_ENTITY = 0x01
 S2C_CONTAINER_SET_SLOT = 0x14
 S2C_DISCONNECT = 0x20
 S2C_KEEP_ALIVE = 0x2C
@@ -516,6 +517,7 @@ class MatchClient(base.Client):
         self.yaw = 0.0
         self.pitch = 0.0
         self.health = None
+        self.spawns = []
         self.kit = None
         self.hotbar = {}
         self.seen = {}
@@ -696,6 +698,7 @@ class Match:
             self.proof["every declared ability did what it declared"] = None
             self.proof["every declared ability was heard"] = None
             self.proof["every declared ability was seen"] = None
+            self.proof["a projectile was drawn"] = None
             self.proof["cooldowns refused a second use"] = None
         self.proof.update({
             "four in play": None,
@@ -862,6 +865,17 @@ class Match:
             health = struct.unpack(">f", payload[:4])[0]
             client.health = health
             client.log("<- health %.2f/20" % health)
+        elif packet_id == S2C_ADD_ENTITY:
+            # `ClientboundAddEntityPacket`: entity id (varint), uuid (16 bytes),
+            # then the entity type as a varint registry id. That is all this
+            # needs -- it is counting that a projectile was *drawn*, not
+            # decoding where it went. The type id is recorded so the census can
+            # say what appeared.
+            _entity_id, off = take_var_int(payload)
+            off += 16
+            type_id, _ = take_var_int(payload, off)
+            client.spawns.append(type_id)
+            client.log("<- add_entity type=%d" % type_id)
         elif packet_id == S2C_SET_TITLE_TEXT:
             text, _ = take_nbt_string(payload, 0)
             client.log("<- title: %s" % text)
@@ -1421,6 +1435,7 @@ class Match:
             client.action_bar.clear()
             client.teleported_to.clear()
             client.sounds.clear()
+            client.spawns.clear()
         return {
             "melee": melee,
             "health": {client.name: client.health for client in self.clients},
@@ -1635,6 +1650,19 @@ class Match:
             self.particle_failures.append(
                 "%s fired and sent no level_particles a client could draw" % label
             )
+        # A projectile ability now puts an entity in the world. Not declared
+        # per ability -- which abilities fire one is a server-side detail this
+        # file deliberately does not carry a list of -- so it is proved once,
+        # in aggregate: over the whole sweep at least one `add_entity` for a
+        # projectile arrives. During the sweep the only new entities are
+        # projectiles, because every player spawned before it began.
+        spawned = [type_id for client in self.clients for type_id in client.spawns]
+        if spawned:
+            self.prove(
+                "a projectile was drawn",
+                "%s fired and the server sent add_entity type=%d" % (label, spawned[0]),
+            )
+            evidence.append("spawned: entity type %d" % spawned[0])
         self.sweep_results.append(
             "%-42s %s" % (label, "; ".join(evidence) or "nothing reached a client")
         )


### PR DESCRIPTION
Twenty of the fifty-one abilities fire a projectile, and until now a client saw none of them. `projectile::fire` created a game-half entity with `Flight`, `Payload` and `FiredBy`, integrated it, detected the hit and dealt the damage — all correct, all tested against the mock, and all invisible, because nothing ever told a client the thing existed. A Skeleton's Barrage sent five arrows' worth of damage and not one arrow.

## The flight stays where it is

It is authoritative for the hit, it is deterministic, and `tests/abilities.rs` and `smash-e2e` both rest on it; moving it would fork test from production. What was missing was only the picture, so only the picture is added.

Each projectile now carries a **`Visual(EntityKind)`** — a generated enum named directly, the choice #1035 made for particles. Exact where a vanilla entity is the thing (an arrow is `Arrow`, a wither skull a `WitherSkull`, a thrown cub a `Wolf`) and the closest always-rendered projectile where it is not (a thrown coal is a `SmallFireball`, an ink pellet a `Snowball`), each `[APPROXIMATED]` marked at the call site.

**`crate::draw`**, on the host, turns that into an entity a client draws: it decorates the existing projectile with the components hyperion's egress reads — kind, position, per-tick velocity, facing — and enqueues the spawn. The client dead-reckons the arc from the velocity the `add_entity` packet carries, which is how vanilla draws a thrown projectile between updates. It is the **same entity**, not a shadow, so when `fly` destructs it on the hit the drawn thing dies too and hyperion's despawn observer tells every client to drop it — no second lifetime to keep in step.

## Two things it deliberately does not do

Each has a reason that is a property of the engine, not a preference.

**No `Owner`.** That is what `update_projectile_positions` requires to integrate and collide an entity; omitting it is what stops hyperion re-flying and re-hitting a projectile `Flight` already owns.

**Not `spawn::spawn`**, which makes a *new* entity. Decorating the existing one is the whole reason despawn is free.

## The honest limitation

The drawn arc and the hit are computed by two integrators that do not share constants — hyperion's client dead-reckoning uses the vanilla gravity for the kind, `Flight` uses what the ability set. They agree exactly for a zero-gravity projectile (a hook, a line of cows) and drift for a heavy one over its flight. The projectile vanishes at the hit either way, because the hit is what destructs it. Sharing one integrator is the larger change `docs/smash-design.md` flags; this is the visible-now half.

## Proof, both halves of the seam

**`every_projectile_that_flies_can_be_seen`** fires every ability and asserts that whatever projectiles appeared carry a `Visual` — the input to drawing, for all twenty, checked in the game half against the mock. It sweeps the roster rather than a hand-list of projectile abilities, so a kit added tomorrow that forgets the visual fails here.

**`tools/smash-match.py`** decodes `add_entity` and proves "a projectile was drawn" on the wire: over the sweep, firing the abilities produces `add_entity` packets, which before `draw` existed never left the server. During the sweep the only new entities are projectiles, because every player spawned before it began.

### Guard broken and watched to fail, then restored

`.set(visual)` removed from `fire`:
```
Skeleton / Barrage put 2 projectile(s) in the world with no Visual
Spider / Needler put 6 projectile(s) in the world with no Visual
Sky Squid / Ink Shotgun put 7 projectile(s) in the world with no Visual
... and every other projectile ability
```

## What this does not settle

The wire half cannot be run to green from here: my `smash-e2e` attempts die on the load box's connection sweep, as they have all session. The in-process `Visual` proof is the local evidence; the `add_entity` census is structural and runs on the gate.

One call site in `tests/relationship_traits.rs` (from #1041/#1042) also calls `fire`; its signature fix is included — three lines, no reformatting of that file.

## Checks

`cargo test -p smash` (21 binaries) and `nix run --accept-flake-config .#lint` both green on `d11ca7a`, which includes the flecs trait pass.