### PR TITLE
feat(ecs): final leaf kinds, and podiums as a named ring

### DIFF
--- a/events/smash/src/module/player.rs
+++ b/events/smash/src/module/player.rs
@@ -143,7 +143,9 @@ impl Module for PlayerModule {
     fn module(world: &World) {
         world.module::<Self>("smash::Player");
 
-        world.component::<Player>();
+        // Final: a player is a leaf, not a base to inherit from. `is_a(Player)`
+        // is now a CONSTRAINT_VIOLATED abort rather than a quiet mistake.
+        world.component::<Player>().add_trait::<flecs::Final>();
         world.component::<Position>();
         world.component::<Velocity>();
         world.component::<Facing>();

--- a/events/smash/src/module/selector.rs
+++ b/events/smash/src/module/selector.rs
@@ -226,6 +226,15 @@ pub fn build(world: &World, origin: IVec3) {
         world.entity_from_id(podium).destruct();
     }
 
+    // One `ring` parent for the whole selector, found-or-created so a rebuild
+    // reuses it rather than minting a second. The podiums hang off it, so the
+    // explorer draws the ring as a subtree -- `smash.Selector.ring.Skeleton`,
+    // `.Blaze`, ... -- rather than a scatter of bare ids at the root.
+    let selector = world.component::<SelectorModule>();
+    let ring_parent = selector
+        .try_lookup("ring")
+        .unwrap_or_else(|| world.entity().child_of(selector).set_name("ring"));
+
     let kits = kit::registry(world);
     let mut placed: Vec<IVec3> = Vec::with_capacity(kits.len());
 
@@ -237,8 +246,18 @@ pub fn build(world: &World, origin: IVec3) {
         );
         placed.push(base);
 
+        // Named after the mob it offers, so a podium reads as its kit in the
+        // explorer. Its identity is stable -- one per kit, made once at init --
+        // which is what makes naming it safe where naming a short-lived effect
+        // or projectile would collapse two that must coexist.
+        let name = world
+            .entity_from_id(*kit)
+            .try_get::<&KitName>(|n| n.0)
+            .unwrap_or("kit");
         world
             .entity()
+            .child_of(ring_parent)
+            .set_name(name)
             .add(Podium::id())
             .set(Plinth { base })
             .add((Offers, *kit));
@@ -523,7 +542,9 @@ impl Module for SelectorModule {
     fn module(world: &World) {
         world.module::<Self>("smash::Selector");
 
-        world.component::<Podium>();
+        // Final: a podium is a leaf, never an inheritance base. `is_a(Podium)`
+        // is now a CONSTRAINT_VIOLATED abort rather than a quiet mistake.
+        world.component::<Podium>().add_trait::<flecs::Final>();
         world.component::<Plinth>();
         // Relationship: `Offers` is only ever the first half of `(Offers, kit)`,
         // so adding it as a bare tag is a panic rather than a silent no-op that

--- a/events/smash/tests/final_and_podiums.rs
+++ b/events/smash/tests/final_and_podiums.rs
@@ -1,0 +1,143 @@
+//! `Final` on the leaf entity kinds, and podiums as a named ring.
+//!
+//! `Final` asserts a kind is never inherited from: `is_a(Player)` or
+//! `is_a(Podium)` becomes a `CONSTRAINT_VIOLATED` abort rather than a quiet
+//! mistake. flecs enforces it with `abort()` (SIGABRT), so -- as in
+//! `relationship_traits.rs` -- the proof is a structural check plus a
+//! subprocess abort check. Naming is proven in-process: after the selector is
+//! built, each podium is a named child of one `ring` parent.
+
+use std::process::Command;
+
+use flecs_ecs::prelude::*;
+use glam::IVec3;
+use smash::{
+    SmashModule,
+    module::{
+        player::Player,
+        selector::{self, Podium},
+    },
+};
+
+fn game() -> World {
+    let world = World::new();
+    world.import::<SmashModule>();
+    world
+}
+
+// --- Final: structural -----------------------------------------------------
+
+#[test]
+fn leaf_kinds_are_final() {
+    let world = game();
+    for (name, present) in [
+        (
+            "Player",
+            world.component::<Player>().has(id::<flecs::Final>()),
+        ),
+        (
+            "Podium",
+            world.component::<Podium>().has(id::<flecs::Final>()),
+        ),
+    ] {
+        assert!(present, "{name} lost its `flecs::Final` trait");
+    }
+}
+
+// --- Final: behavioural (subprocess, because flecs aborts) -----------------
+
+#[test]
+fn violation_child() {
+    let Ok(which) = std::env::var("SMASH_FINAL_VIOLATION") else {
+        return;
+    };
+    let world = game();
+    match which.as_str() {
+        "isa_player" => {
+            world.entity().is_a(id::<Player>());
+        }
+        "isa_podium" => {
+            world.entity().is_a(id::<Podium>());
+        }
+        other => panic!("unknown violation case: {other}"),
+    }
+    eprintln!("NO_ABORT");
+    std::process::exit(0);
+}
+
+fn assert_aborts_on_constraint(case: &str) {
+    let exe = std::env::current_exe().expect("test binary path");
+    let output = Command::new(exe)
+        .args(["--exact", "violation_child", "--nocapture"])
+        .env("SMASH_FINAL_VIOLATION", case)
+        .env("RUST_BACKTRACE", "0")
+        .output()
+        .expect("spawn the violation child");
+    let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
+    log.push_str(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        !output.status.success(),
+        "{case}: inheriting from a Final kind was accepted, not aborted.\noutput:\n{log}"
+    );
+    assert!(
+        !log.contains("NO_ABORT"),
+        "{case}: flecs accepted the illegal is_a.\noutput:\n{log}"
+    );
+    assert!(
+        log.contains("CONSTRAINT_VIOLATED"),
+        "{case}: the child died, but not on a flecs constraint.\noutput:\n{log}"
+    );
+}
+
+#[test]
+fn inheriting_from_a_leaf_kind_aborts() {
+    assert_aborts_on_constraint("isa_player");
+    assert_aborts_on_constraint("isa_podium");
+}
+
+// --- Podiums: a named ring -------------------------------------------------
+
+/// After the selector is built, every podium is a named child of one `ring`
+/// parent, so the explorer shows `smash.Selector.ring.<Kit>` rather than a
+/// scatter of bare ids.
+#[test]
+fn podiums_are_named_children_of_the_ring() {
+    let world = game();
+    selector::build(&world, IVec3::new(0, 64, 0));
+
+    let ring = world
+        .try_lookup("smash::Selector::ring")
+        .expect("the selector built a `ring` parent under its module");
+
+    let mut podiums = 0;
+    let mut anonymous = Vec::new();
+    let mut wrong_parent = Vec::new();
+    world
+        .query::<()>()
+        .with(id::<Podium>())
+        .build()
+        .each_entity(|podium, ()| {
+            podiums += 1;
+            if podium.name().is_empty() {
+                anonymous.push(podium.id());
+            }
+            if podium.parent().map(|p| p.id()) != Some(ring.id()) {
+                wrong_parent.push(podium.id());
+            }
+        });
+
+    assert!(podiums > 0, "the selector built no podiums");
+    assert!(anonymous.is_empty(), "unnamed podiums: {anonymous:?}");
+    assert!(
+        wrong_parent.is_empty(),
+        "podiums not parented to the ring: {wrong_parent:?}"
+    );
+
+    // The Skeleton podium reads at its qualified path, which is the whole point.
+    assert!(
+        world
+            .try_lookup("smash::Selector::ring::Skeleton")
+            .is_some_and(|e| e.has(id::<Podium>())),
+        "the Skeleton podium is not at smash.Selector.ring.Skeleton"
+    );
+}


### PR DESCRIPTION
## What

The audit items clear of the abilities agent's hot files:

- **`Final` on the leaf entity kinds** in clear files: `Player` (`player.rs`) and `Podium` (`selector.rs`). `is_a(Player)` / `is_a(Podium)` is now a `CONSTRAINT_VIOLATED` abort — these are leaf kinds, never inheritance bases. This is the player-`IsA`-kit rejection stated as a trait. `Kit`, `Ability`, `Effect`, `Projectile` are also leaf kinds but live in the held hot files, so they come with that release.
- **Podiums are a named ring.** The selector's podiums now hang off one found-or-created `ring` parent and are named after the mob each offers, so the explorer draws `smash.Selector.ring.Skeleton`, `.Blaze`, … instead of a scatter of bare ids. Safe because a podium has stable identity — one per kit, made once at init — which is exactly the distinction from a short-lived effect or projectile, where `entity_named`'s find-or-create would collapse two that must coexist.

`Final` confirmed by probe: components are **not** final by default (plain `is_a` succeeds), `Final` makes `is_a(Component)` abort, and it does **not** block is_a'ing an entity that merely carries the tag — so ability-prefab instantiation is unaffected.

## Proof

`events/smash/tests/final_and_podiums.rs`:
- **Structural**: `Player` and `Podium` carry `Final`.
- **Subprocess abort** (flecs aborts with SIGABRT, not a catchable panic): `is_a(Player)` and `is_a(Podium)` die with `CONSTRAINT_VIOLATED`.
- **In-process**: after `selector::build`, every podium is a named child of the `ring`, and the Skeleton podium resolves at `smash.Selector.ring.Skeleton`.

### Guards broken on purpose, and they fired

```
Player lost its `flecs::Final` trait
inheriting_from_a_leaf_kind_aborts ... FAILED (isa_player: NO_ABORT)
podiums_are_named_children_of_the_ring ... FAILED: unnamed podiums: [Entity(777), ... (15)]
```

Restored, all 4 pass.

- `cargo clippy -p smash --all-targets --all-features -- -D warnings`: clean.
- `cargo test -p smash`: all pass.
- `cargo fmt -p smash --check`: my three files (`player.rs`, `selector.rs`, `final_and_podiums.rs`) are clean — I formatted the new test file so it does not add to ENG-10938's existing drift.
