### PR TITLE
feat(ecs): final leaf kinds, inherited ability data, teardown by policy

### DIFF
--- a/events/smash/src/module/ability.rs
+++ b/events/smash/src/module/ability.rs
@@ -453,21 +453,9 @@ pub fn manifest(world: &World) -> Vec<Declared> {
 /// Take back a grant that has run out: unlink it from whoever holds it and
 /// destroy the instance.
 fn expire(world: WorldRef<'_>, expired: &[Entity]) {
-    let mut edges = Vec::new();
-    world
-        .query::<()>()
-        .with(Player::id())
-        .build()
-        .each_entity(|player, ()| {
-            player.each_target_view(Grants, |ability| {
-                if expired.contains(&ability.id()) {
-                    edges.push((player.id(), ability.id()));
-                }
-            });
-        });
-    for (player, ability) in edges {
-        world.entity_at(player).remove((Grants, ability));
-    }
+    // Just destroy the ability entities. `(Grants, OnDeleteTarget, Remove)`
+    // takes the `(Grants, ability)` edge off whoever held it, so there is no
+    // scan of every player to unlink them first -- flecs owns that teardown.
     for ability in expired {
         let ability = world.entity_at(*ability);
         if ability.is_alive() {
@@ -483,26 +471,54 @@ impl Module for AbilityModule {
     fn module(world: &World) {
         world.module::<Self>("smash::Ability");
 
-        world.component::<Ability>();
-        world.component::<Slot>();
-        world.component::<Item>();
-        world.component::<Named>();
-        world.component::<Description>();
-        world.component::<CooldownSpec>();
+        // Final: the Ability *tag* is a leaf -- is_a(Ability) aborts. This does
+        // not touch prefab instantiation: an instance is is_a(<a prefab that
+        // carries Ability>), and Final on a component only forbids inheriting
+        // from that component, not from an entity that merely has it.
+        world.component::<Ability>().add_trait::<flecs::Final>();
+        // An ability's declaration is shared, immutable data. A player's
+        // instance is `is_a(<the kit's prefab>)`, and these ten components are
+        // read back through that IsA edge rather than copied onto every
+        // instance -- flecs' default `Override` duplicates them per player, one
+        // ability at a time, for data that never diverges. `(OnInstantiate,
+        // Inherit)` leaves the one copy on the prefab; `try_get`/`has` follow
+        // IsA to resolve it, checked by the hotbar and manifest tests that read
+        // these off instances. This is the same storage choice `sound.rs` makes
+        // for its four relations. `Cooldown` and `Charging` are the exceptions:
+        // they are per-player state and stay on the instance (default Override).
+        for component in [
+            world.component::<Slot>().id(),
+            world.component::<Item>().id(),
+            world.component::<Named>().id(),
+            world.component::<Description>().id(),
+            world.component::<CooldownSpec>().id(),
+            world.component::<EnergyCost>().id(),
+            world.component::<OnActivate>().id(),
+            world.component::<OnRelease>().id(),
+            world.component::<ChargeTime>().id(),
+            world.component::<Proves>().id(),
+        ] {
+            world
+                .entity_from_id(component)
+                .add((flecs::OnInstantiate, flecs::Inherit));
+        }
         world.component::<Cooldown>();
-        world.component::<EnergyCost>();
         world.component::<RequiresGround>();
         world.component::<RefundsOnHit>();
-        world.component::<OnActivate>();
-        world.component::<OnRelease>();
-        world.component::<ChargeTime>();
         world.component::<Charging>();
         world.component::<UseSlot>();
         world.component::<ReleaseSlot>();
+        // Relationship, so a bare `Grants` add aborts. `(OnDeleteTarget,
+        // Remove)` -- flecs' default, spelled out because the teardown below is
+        // built on it -- means destroying an ability entity removes the
+        // `(Grants, ability)` edge from whoever held it, so `expire` and
+        // `kit::revoke` destroy the ability and let the edge go rather than
+        // unlinking it by hand first. Same lesson as boss_bar and tick_effects:
+        // the fact and its cleanup are one fact.
         world
             .component::<Grants>()
-            .add_trait::<flecs::Relationship>();
-        world.component::<Proves>();
+            .add_trait::<flecs::Relationship>()
+            .add_trait::<(flecs::OnDeleteTarget, flecs::Remove)>();
         world.component::<GrantedFor>();
 
         world

--- a/events/smash/src/module/effect.rs
+++ b/events/smash/src/module/effect.rs
@@ -555,7 +555,8 @@ impl Module for EffectModule {
     fn module(world: &World) {
         world.module::<Self>("smash::Effect");
 
-        world.component::<Effect>();
+        // Final: an effect is a leaf, never an inheritance base.
+        world.component::<Effect>().add_trait::<flecs::Final>();
         world.component::<Expires>();
         world.component::<Ticks>();
         world.component::<Shows>();

--- a/events/smash/src/module/kit.rs
+++ b/events/smash/src/module/kit.rs
@@ -563,8 +563,9 @@ pub fn ultimate_name(player: EntityView<'_>) -> Option<&'static str> {
 pub fn revoke(player: EntityView<'_>) {
     let mut granted = Vec::new();
     player.each_target_view(Grants, |ability| granted.push(ability.id()));
+    // Destroying the ability is enough: `(Grants, OnDeleteTarget, Remove)`
+    // takes the edge with it, so there is no `remove((Grants, ability))` first.
     for ability in granted {
-        player.remove((Grants, ability));
         player.world().entity_from_id(ability).destruct();
     }
 }
@@ -698,9 +699,15 @@ impl Module for KitModule {
         // that module declares, so a component reached for and never registered
         // aborts there rather than on a server.
         world.component::<SuggestionLabel>();
-        world.component::<Kit>().set(SuggestionLabel(|kit| {
-            kit.try_get::<&KitName>(|name| name.0.to_owned())
-        }));
+        // Final: a kit prefab is instantiated onto a player by copying, never
+        // inherited via IsA -- see `kit::apply` and the refutation in the Grants
+        // commit. is_a(Kit) is now a CONSTRAINT_VIOLATED abort.
+        world
+            .component::<Kit>()
+            .add_trait::<flecs::Final>()
+            .set(SuggestionLabel(|kit| {
+                kit.try_get::<&KitName>(|name| name.0.to_owned())
+            }));
         world.component::<KitStats>();
         world.component::<KitName>();
         world.component::<KitCost>();

--- a/events/smash/src/module/projectile.rs
+++ b/events/smash/src/module/projectile.rs
@@ -132,7 +132,8 @@ impl Module for ProjectileModule {
     fn module(world: &World) {
         world.module::<Self>("smash::Projectile");
 
-        world.component::<Projectile>();
+        // Final: a projectile is a leaf, never an inheritance base.
+        world.component::<Projectile>().add_trait::<flecs::Final>();
         world.component::<Visual>();
         world.component::<Flight>();
         world.component::<Payload>();

--- a/events/smash/tests/final_and_podiums.rs
+++ b/events/smash/tests/final_and_podiums.rs
@@ -14,7 +14,11 @@ use glam::IVec3;
 use smash::{
     SmashModule,
     module::{
+        ability::Ability,
+        effect::Effect,
+        kit::Kit,
         player::Player,
+        projectile::Projectile,
         selector::{self, Podium},
     },
 };
@@ -39,6 +43,19 @@ fn leaf_kinds_are_final() {
             "Podium",
             world.component::<Podium>().has(id::<flecs::Final>()),
         ),
+        ("Kit", world.component::<Kit>().has(id::<flecs::Final>())),
+        (
+            "Ability",
+            world.component::<Ability>().has(id::<flecs::Final>()),
+        ),
+        (
+            "Effect",
+            world.component::<Effect>().has(id::<flecs::Final>()),
+        ),
+        (
+            "Projectile",
+            world.component::<Projectile>().has(id::<flecs::Final>()),
+        ),
     ] {
         assert!(present, "{name} lost its `flecs::Final` trait");
     }
@@ -58,6 +75,18 @@ fn violation_child() {
         }
         "isa_podium" => {
             world.entity().is_a(id::<Podium>());
+        }
+        "isa_kit" => {
+            world.entity().is_a(id::<Kit>());
+        }
+        "isa_ability" => {
+            world.entity().is_a(id::<Ability>());
+        }
+        "isa_effect" => {
+            world.entity().is_a(id::<Effect>());
+        }
+        "isa_projectile" => {
+            world.entity().is_a(id::<Projectile>());
         }
         other => panic!("unknown violation case: {other}"),
     }
@@ -91,8 +120,16 @@ fn assert_aborts_on_constraint(case: &str) {
 
 #[test]
 fn inheriting_from_a_leaf_kind_aborts() {
-    assert_aborts_on_constraint("isa_player");
-    assert_aborts_on_constraint("isa_podium");
+    for case in [
+        "isa_player",
+        "isa_podium",
+        "isa_kit",
+        "isa_ability",
+        "isa_effect",
+        "isa_projectile",
+    ] {
+        assert_aborts_on_constraint(case);
+    }
 }
 
 // --- Podiums: a named ring -------------------------------------------------

--- a/events/smash/tests/inherit_and_grants.rs
+++ b/events/smash/tests/inherit_and_grants.rs
@@ -1,0 +1,134 @@
+//! `(OnInstantiate, Inherit)` on an ability's static data, and `(Grants,
+//! OnDeleteTarget, Remove)` on the grant edge.
+//!
+//! Inherit means a player's ability instance reads the kit prefab's `Named`,
+//! `Item`, ... through its `IsA` edge rather than carrying a copy; only the
+//! per-player `Cooldown` is owned. The grant-edge trait means destroying an
+//! ability entity removes the `(Grants, ability)` edge from whoever held it,
+//! which is what lets `expire` and `kit::revoke` destroy an ability without
+//! unlinking it by hand first.
+
+mod harness;
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use harness::Game;
+use smash::module::{
+    ability::{Cooldown, Grants, Named},
+    kit,
+};
+
+/// The ten static components inherit; the per-player `Cooldown` does not.
+#[test]
+fn static_ability_data_is_declared_inheritable() {
+    let game = Game::new();
+    let inherit = (id::<flecs::OnInstantiate>(), id::<flecs::Inherit>());
+    for name in [
+        "Slot",
+        "Item",
+        "Named",
+        "Description",
+        "CooldownSpec",
+        "EnergyCost",
+        "OnActivate",
+        "OnRelease",
+        "ChargeTime",
+        "Proves",
+    ] {
+        let component = game
+            .world
+            .try_lookup(&format!("smash::Ability::{name}"))
+            .unwrap_or_else(|| panic!("{name} is registered"));
+        assert!(
+            component.has(inherit),
+            "{name} is not (OnInstantiate, Inherit)"
+        );
+    }
+    assert!(
+        !game.world.component::<Cooldown>().has(inherit),
+        "Cooldown must stay per-player (Override), not inherited"
+    );
+}
+
+/// The grant edge is declared `(OnDeleteTarget, Remove)`. This is flecs'
+/// default, but declaring it is what documents the reliance -- and this
+/// structural check fails if someone changes it to a harmful policy like
+/// `Delete` (which would kill the holder) or drops it.
+#[test]
+fn grants_edge_is_declared_remove_on_delete() {
+    let game = Game::new();
+    assert!(
+        game.world
+            .component::<Grants>()
+            .has((id::<flecs::OnDeleteTarget>(), id::<flecs::Remove>())),
+        "Grants lost its explicit (OnDeleteTarget, Remove) declaration"
+    );
+}
+
+/// A player's ability instance inherits its declaration and owns only its
+/// cooldown. `owns` is the direct question: is the component on this entity, or
+/// resolved through `IsA`?
+#[test]
+fn an_instance_inherits_its_declaration_and_owns_its_cooldown() {
+    let mut game = Game::new();
+    let player = game.player("player", Vec3::ZERO);
+    let blaze = kit::by_name(&game.world, "Blaze").expect("the registry has Blaze");
+    kit::apply(&game.world, game.world.entity_from_id(player), blaze);
+
+    let instance = game
+        .world
+        .entity_from_id(player)
+        .target(Grants, 0)
+        .expect("the kit granted an ability");
+
+    assert!(
+        !instance.owns(id::<Named>()),
+        "the instance carries its own Named copy instead of inheriting it"
+    );
+    assert!(
+        instance.try_get::<&Named>(|n| !n.0.is_empty()) == Some(true),
+        "the instance cannot read its inherited Named"
+    );
+    assert!(
+        instance.owns(id::<Cooldown>()),
+        "the instance does not own its per-player Cooldown"
+    );
+}
+
+/// Destroying an ability removes the `(Grants, ability)` edge from its holder,
+/// so `expire`/`revoke` can drop the manual unlink. The player survives.
+#[test]
+fn destroying_an_ability_removes_its_grant_edge() {
+    let mut game = Game::new();
+    let player = game.player("player", Vec3::ZERO);
+    let blaze = kit::by_name(&game.world, "Blaze").expect("the registry has Blaze");
+    kit::apply(&game.world, game.world.entity_from_id(player), blaze);
+
+    let count = |g: &Game| {
+        let mut n = 0;
+        g.world
+            .entity_from_id(player)
+            .each_target(Grants, |_| n += 1);
+        n
+    };
+    let before = count(&game);
+    assert!(before > 0, "the kit granted no abilities");
+
+    let victim = game
+        .world
+        .entity_from_id(player)
+        .target(Grants, 0)
+        .expect("an ability to destroy")
+        .id();
+    game.world.entity_from_id(victim).destruct();
+
+    assert!(
+        game.world.entity_from_id(player).is_alive(),
+        "the player died with the ability"
+    );
+    assert_eq!(
+        count(&game),
+        before - 1,
+        "the grant edge to the destroyed ability was not removed"
+    );
+}


### PR DESCRIPTION
## What

The rest of the audit's trait/inheritance work, now that the held hot files are quiescent (abilities agent in bounds). Four small, additive changes:

- **`Final` on the four remaining leaf kinds** — `Kit`, `Ability`, `Effect`, `Projectile`. `is_a(<kind>)` is now a `CONSTRAINT_VIOLATED` abort. Probed first: `Final` on a component forbids `is_a(Component)` but **not** is_a'ing an entity that merely carries the tag, so ability-prefab instantiation (`is_a(<prefab>)`) is untouched. `Final` on `Kit` is the player-`IsA`-kit refutation stated as a trait.
- **`(OnInstantiate, Inherit)` on the ten static ability components** (`Slot`, `Item`, `Named`, `Description`, `CooldownSpec`, `EnergyCost`, `OnActivate`, `OnRelease`, `ChargeTime`, `Proves`). A player's ability instance reads these through its `IsA` edge to the kit prefab instead of the per-player copy flecs' default `Override` makes — one copy on the prefab, not one per player per ability. `Cooldown`/`Charging` stay per-player (`Override`). Probed that `try_get`/`has` follow `IsA` so `hotbar()`/`manifest()` keep working; same storage choice `sound.rs` already makes.
- **`(Grants, OnDeleteTarget, Remove)`** — flecs' default, spelled out so the reliance is visible (as `boss_bar` does). Destroying an ability removes the `(Grants, ability)` edge from its holder.
- **The manual unlink loops are deleted.** `expire` no longer scans every player to unlink an ability before destroying it; `revoke` no longer calls `remove((Grants, ability))` first. Both just destroy the ability and let flecs drop the edge — the same teardown-by-policy lesson as `boss_bar` and `tick_effects`.

## Deferred — Effect `ChildOf` conflicts with PR3's `DontFragment`

I did **not** add `ChildOf` to effects. It conflicts with the `DontFragment` PR3 put on `Upon`: `ChildOf` is inherently fragmenting, so `child_of(victim)` would mint an archetype per victim again — exactly what `DontFragment` was added to avoid. The two directives are at odds; flagging for your call rather than silently undoing PR3. Options: (a) add `ChildOf`, drop `Upon`'s `DontFragment` (tree, back to fragmenting); (b) keep sparse `Upon`, get the indexed lookup by querying `(Upon, victim)` directly instead of `matching()`'s full scan (perf win, no explorer tree). PR3 already retired the leak branch, so this is the lower-value item anyway.

## Proof

Two new/extended guard files; flecs aborts with SIGABRT so Final proofs are structural + subprocess-abort:
- `final_and_podiums.rs`: `Kit`/`Ability`/`Effect`/`Projectile` carry `Final`; `is_a(<each>)` aborts with `CONSTRAINT_VIOLATED`.
- `inherit_and_grants.rs`: the ten components are `(OnInstantiate, Inherit)` and `Cooldown` is not; an instance inherits its declaration (`owns(Named)==false`, `try_get` works) and owns its `Cooldown`; `Grants` is declared `(OnDeleteTarget, Remove)`; destroying an ability removes its grant edge while the holder survives.

### Guards broken on purpose, and they fired
```
Kit lost its `flecs::Final` trait            /  isa_kit: the child died, but not on a flecs constraint
Named is not (OnInstantiate, Inherit)        /  the instance carries its own Named copy instead of inheriting it
Grants lost its explicit (OnDeleteTarget, Remove) declaration
```
(The Grants structural guard confirms the default does not materialize the pair — removing the explicit trait fails it.) Restored, all pass.

- `cargo clippy -p smash --all-targets --all-features -- -D warnings`: clean.
- `cargo test -p smash`: all pass (23 binaries), including the two-Blazes-two-burns property, hotbar, manifest, and revoke/expire suites — behaviour unchanged.
- `cargo fmt -p smash --check`: clean; I formatted my two new test files. Note: smash now reports zero fmt drift on this base, which differs from ENG-10938's earlier measurement — worth re-checking before the repo-wide sweep.
