### PR TITLE
feat(smash): a lobby you cannot jump out of

### DIFF
--- a/events/smash/maps/hub.map
+++ b/events/smash/maps/hub.map
@@ -14,6 +14,16 @@ author hyperion (reconstruction of the SSM waiting lobby)
 # plane is a lobby where a bug leaves someone falling forever.
 kill_y 20
 
+# The box a player is kept inside. The platform is a radius-20 disc with a
+# three-high glass wall, so the double jump clears the wall and lets a player
+# drift off into the sky -- which is exactly what the operator asked not to be
+# possible. These corners sit a block outside the disc so standing on the very
+# edge is not "out", with a ceiling well above the pillars (y69) so an ordinary
+# jump is never touched and only a launch that would carry someone over the wall
+# is pushed back. The floor is a block under the quartz (y65), so a fall through
+# the world recovers upward here rather than dropping to the kill plane.
+bounds -21 64 -21 21 80 21
+
 # Eight standing spots around the centre, so a full lobby is not one pile.
 spawn 0 65 -6
 spawn 4 65 -4

--- a/events/smash/src/map.rs
+++ b/events/smash/src/map.rs
@@ -63,6 +63,13 @@ pub struct MapSpec {
     pub author: &'static str,
     /// Below this Y a player is dead.
     pub kill_y: f32,
+    /// The box a player must stay inside, as `(min, max)` world corners.
+    ///
+    /// `Some` only for a map that keeps players in rather than letting them
+    /// fall out -- the hub. An arena has no walls (falling off is the game), so
+    /// it leaves this `None` and its `kill_y` floor is the whole of its bounds.
+    /// See [`crate::module::arena::Bounds`].
+    pub bounds: Option<(Vec3, Vec3)>,
     pub spawns: Vec<Vec3>,
     /// Where the Smash Crystal can land. Mineplex's map spec asks for exactly
     /// three of these ("3 red data points for areas where the Smash Crystal
@@ -192,6 +199,7 @@ pub fn parse(source: &'static str) -> Result<MapSpec, ParseError> {
     let mut name = "";
     let mut author = "";
     let mut kill_y = None;
+    let mut bounds = None;
     let mut spawns = Vec::new();
     let mut crystals = Vec::new();
     let mut brushes = Vec::new();
@@ -226,6 +234,22 @@ pub fn parse(source: &'static str) -> Result<MapSpec, ParseError> {
                 continue;
             }
             "kill_y" => kill_y = Some(cursor.float("kill_y")?),
+            // `bounds minx miny minz maxx maxy maxz`: the box a player is kept
+            // inside. The hub declares one; an arena does not, because its only
+            // edge is the floor its `kill_y` already names.
+            "bounds" => {
+                let min = Vec3::new(
+                    cursor.float("a min x")?,
+                    cursor.float("a min y")?,
+                    cursor.float("a min z")?,
+                );
+                let max = Vec3::new(
+                    cursor.float("a max x")?,
+                    cursor.float("a max y")?,
+                    cursor.float("a max z")?,
+                );
+                bounds = Some((min, max));
+            }
             "spawn" | "crystal" => {
                 let x = cursor.float("an x")?;
                 let y = cursor.float("a y")?;
@@ -320,6 +344,7 @@ pub fn parse(source: &'static str) -> Result<MapSpec, ParseError> {
         name,
         author,
         kill_y,
+        bounds,
         spawns,
         crystals,
         brushes,

--- a/events/smash/src/module/arena.rs
+++ b/events/smash/src/module/arena.rs
@@ -1,10 +1,24 @@
-//! The map: floating platforms over a lethal nothing.
+//! The map's edges, and what happens when a player crosses one.
 //!
-//! Mineplex's maps have no walls. The kill plane is the map's own configured
-//! minimum Y, and water counts as the same thing — the game set
-//! `WorldWaterDamage = 1000`, so an ocean under the platforms kills exactly
-//! like a void does. Fall damage is switched off entirely, which is why a
-//! purely vertical launch is survivable and a horizontal one is not.
+//! Every playable region is a box a player is meant to stay inside, and every
+//! box carries a [`Policy`] for the moment somebody leaves it. There are two,
+//! and they are opposites: the arena eliminates you (falling off is how the
+//! game is won and lost), and the hub shoves you back in (a lobby you can jump
+//! out of is a lobby, briefly, with nobody in it).
+//!
+//! That is the whole of it, and it is why there is no longer a phase check
+//! gating a kill plane. The gate existed only because the hub shares one world
+//! with the arena, so the arena's floor reached up into the lobby and had to be
+//! switched off there. Expressed as "which bounds is this player in, and what
+//! is its policy", the lobby case stops being an exception and becomes the
+//! other policy: the phase selects the region everyone currently occupies --
+//! the game moves them all together, so it is one region at a time -- and the
+//! region's own policy decides what its edge does.
+//!
+//! Mineplex's maps have no walls; the kill plane is the map's configured
+//! minimum Y, and water is the same thing (`WorldWaterDamage = 1000`). Fall
+//! damage is off, which is why a vertical launch is survivable and a horizontal
+//! one is not.
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
@@ -17,7 +31,68 @@ use crate::{
         lobby::{Lobby, Phase},
         player::{Health, Player, Position},
     },
+    server::{Particle, Particles, PlayerId, ServerHandle, Sound, SoundCategory},
 };
+
+/// What the edge of a region does to a player who crosses it.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Policy {
+    /// Shove them back inside with velocity. The hub. Never lethal.
+    PushBack,
+    /// Take a life. The arena, where leaving the floor is how the game is
+    /// played.
+    Eliminate,
+}
+
+/// A region a player is meant to stay inside, and what its edge does.
+///
+/// An axis-aligned box, because "nearest point on the boundary" -- which is
+/// what a push has to aim back through -- is one `clamp` for a box and a
+/// projection-per-face for anything else, and no arena needs the difference.
+/// The arena's box is a floor and nothing else: infinite horizontally, open at
+/// the top, bounded only below at `kill_y`, because the only edge an arena has
+/// is the one you fall through.
+#[derive(Component, Debug, Copy, Clone, PartialEq)]
+pub struct Bounds {
+    pub min: Vec3,
+    pub max: Vec3,
+    pub policy: Policy,
+}
+
+impl Bounds {
+    /// Whether `at` is inside.
+    #[must_use]
+    pub fn contains(&self, at: Vec3) -> bool {
+        at.cmpge(self.min).all() && at.cmple(self.max).all()
+    }
+
+    /// A unit vector pointing from `at` back to the nearest point on the box,
+    /// or `None` when `at` is already inside.
+    ///
+    /// The nearest-point normal and not a direction toward the centre: a player
+    /// who jumps out over one wall should be shoved straight back through that
+    /// wall, not sent on a diagonal toward the middle that a non-square arena
+    /// would make land somewhere they were not. `clamp` gives the nearest point
+    /// on the box for free, and the vector to it is that normal.
+    #[must_use]
+    pub fn back_inside(&self, at: Vec3) -> Option<Vec3> {
+        let nearest = at.clamp(self.min, self.max);
+        let toward = nearest - at;
+        (toward.length_squared() > f32::EPSILON).then(|| toward.normalize())
+    }
+}
+
+/// The hub's bounds, as a singleton.
+///
+/// Static -- there is one hub -- and read from `map::HUB` at boot rather than
+/// from a hand-written constant, for the same reason [`Arena::default`] reads a
+/// real map: there is then no second copy of the numbers to drift from the
+/// geometry a player actually stands on. The hub is region zero at the world
+/// origin, so its declared bounds are already world coordinates and need no
+/// offset; an arena's would, which is one more reason the arena carries its
+/// edge as a `kill_y` the terrain offsets rather than as one of these.
+#[derive(Component, Debug, Copy, Clone, PartialEq)]
+pub struct HubBounds(pub Bounds);
 
 /// The arena, as a singleton.
 #[derive(Component, Debug, Clone, PartialEq)]
@@ -67,11 +142,62 @@ impl Arena {
         self.spawns[usize::try_from(index % len).unwrap_or(0)]
     }
 
+    /// The arena as a [`Bounds`]: a floor at `kill_y` and nothing else.
+    ///
+    /// Everything above the floor and anywhere horizontally is inside, so
+    /// [`Bounds::contains`] is false exactly when a player has fallen below the
+    /// kill plane -- which is what [`is_out_of_bounds`](Self::is_out_of_bounds)
+    /// meant, now stated as the general thing every region is.
+    #[must_use]
+    pub const fn bounds(&self) -> Bounds {
+        Bounds {
+            min: Vec3::new(f32::NEG_INFINITY, self.kill_y, f32::NEG_INFINITY),
+            max: Vec3::splat(f32::INFINITY),
+            policy: Policy::Eliminate,
+        }
+    }
+
     #[must_use]
     pub fn is_out_of_bounds(&self, at: Vec3) -> bool {
         at.y < self.kill_y
     }
 }
+
+/// The bounds every player is currently inside, or `None` when nothing is
+/// enforced.
+///
+/// The phase is the honest name for which region players occupy, because the
+/// game moves them all together: they are in the hub through `Waiting` and
+/// `Countdown`, scattered onto the arena at `Preparing`, and left on it through
+/// `Playing`. `Ended` is the one phase with players in the arena and no edge
+/// enforced -- the match is decided, the results screen is up, and a player who
+/// slid off in the last instant is about to be teleported home rather than
+/// eliminated a second time.
+#[must_use]
+fn governing(phase: Phase, hub: Option<HubBounds>, arena: &Arena) -> Option<Bounds> {
+    match phase {
+        Phase::Waiting | Phase::Countdown => hub.map(|hub| hub.0),
+        Phase::Preparing | Phase::Playing => Some(arena.bounds()),
+        Phase::Ended => None,
+    }
+}
+
+/// How hard the hub shoves a player back over its wall, in blocks per tick.
+///
+/// Applied straight to velocity and deliberately **not** through the knockback
+/// model's `1 + 0.1 * missing` health term: that term throws a nearly-dead
+/// player further, and a wall that throws a nearly-dead player further is a
+/// wall that kills them -- which turns a fence into a hazard and the lobby into
+/// something you can die in. A fixed shove is a fence.
+///
+/// Firmer than a double jump (0.42) so it always wins against the launch that
+/// carried the player out, and short of an ability's launch so it reads as a
+/// bump and not a catapult.
+const PUSH_IMPULSE: f32 = 0.9;
+
+/// The shove's sound. A shield's block is the closest vanilla has to the thud
+/// of hitting a wall you cannot pass.
+const PUSH_SOUND: &str = "minecraft:item.shield.block";
 
 #[derive(Component)]
 pub struct ArenaModule;
@@ -80,53 +206,100 @@ impl Module for ArenaModule {
     fn module(world: &World) {
         world.module::<Self>("smash::Arena");
         world.component::<Arena>().add_trait::<flecs::Singleton>();
+        world.component::<Bounds>();
+        world
+            .component::<HubBounds>()
+            .add_trait::<flecs::Singleton>();
         world.set(Arena::default());
 
-        // Both death checks read `Health`, and killing someone writes it from
-        // the `Died` observer. flecs catches that overlap at runtime, so the
-        // victims are collected first and killed once the query has finished.
-        // Health reaching zero is the rarer path but a real one: hunger and
-        // lava both get there.
-        world.system_named::<()>("death_checks").run(|mut it| {
+        // The hub's own bounds, read from the map it is built from. Parsed here
+        // rather than handed over by `terrain.rs` so the game half has it with
+        // no host -- `tests/` exercise the push against the mock -- and because
+        // the hub is region zero at the origin, the map's coordinates are
+        // already world ones.
+        let hub = crate::map::parse(crate::map::HUB)
+            .expect("the hub map parses; `tests/maps.rs` proves it")
+            .bounds
+            .expect("the hub map declares `bounds`; without it the lobby has no walls");
+        world.set(HubBounds(Bounds {
+            min: hub.0,
+            max: hub.1,
+            policy: Policy::PushBack,
+        }));
+
+        // One system for both edges. It reads which region the phase puts
+        // players in, then applies that region's policy -- eliminate at the
+        // arena floor, shove at the hub wall -- so the lobby and the kill plane
+        // are the same mechanism with opposite policies rather than one
+        // mechanism and a special case.
+        //
+        // Collected-then-applied for the reason it always was: killing a player
+        // and shoving one both write components a query is reading (`Health`,
+        // and the velocity the server pushes), and flecs refuses that from
+        // inside the query that found them.
+        world.system_named::<()>("bounds_checks").run(|mut it| {
             while it.next() {
                 let world = it.world();
-                // The arena is only lethal while a match is running.
-                // Mineplex got this for free because its hub was a separate
-                // world; hyperion serves one set of chunks, so the hub is a
-                // region of the same world and the kill plane would
-                // otherwise reach it. Without this gate a player standing in
-                // the lobby with a kill plane above them dies on the tick
-                // they connect, four times, and is eliminated before the
-                // game starts.
-                if !matches!(
+                let Some(bounds) = governing(
                     world.cloned::<&Lobby>().phase,
-                    Phase::Preparing | Phase::Playing
-                ) {
+                    world.try_cloned::<&HubBounds>(),
+                    &world.cloned::<&Arena>(),
+                ) else {
                     continue;
-                }
-                let arena = world.cloned::<&Arena>();
+                };
                 let clock = world.cloned::<&MatchClock>().0;
+
                 let mut doomed = Vec::new();
+                let mut shoved = Vec::new();
 
                 world
-                    .query::<(&Position, &Health)>()
+                    .query::<(&Position, &Health, &PlayerId)>()
                     .with(Player::id())
                     .without(Eliminated::id())
                     .without(RespawnAt::id())
                     .build()
-                    .each_entity(|player, (position, health)| {
+                    .each_entity(|player, (position, health, id)| {
                         if lives::is_invulnerable(player, clock) {
                             return;
                         }
-                        if health.is_dead() {
-                            doomed.push((player.id(), DeathCause::Damage));
-                        } else if arena.is_out_of_bounds(position.0) {
-                            doomed.push((player.id(), DeathCause::Void));
+                        match bounds.policy {
+                            Policy::Eliminate => {
+                                if health.is_dead() {
+                                    doomed.push((player.id(), DeathCause::Damage));
+                                } else if !bounds.contains(position.0) {
+                                    doomed.push((player.id(), DeathCause::Void));
+                                }
+                            }
+                            Policy::PushBack => {
+                                if let Some(normal) = bounds.back_inside(position.0) {
+                                    shoved.push((*id, position.0, normal));
+                                }
+                            }
                         }
                     });
 
                 for (player, cause) in doomed {
                     lives::kill(world.entity_at(player), cause);
+                }
+
+                if !shoved.is_empty() {
+                    world.get::<&ServerHandle>(|server| {
+                        for (id, at, normal) in shoved {
+                            server.add_velocity(id, normal * PUSH_IMPULSE);
+                            // The shove is a thing that happened to the player,
+                            // so it is seen and heard where it happened: the
+                            // sparks say "you hit something" and the thud says
+                            // it was solid, which is the difference between a
+                            // wall and the game rubber-banding a rejected move.
+                            server.particles(
+                                Particles::burst(Particle::Crit, at)
+                                    .count(12)
+                                    .offset(Vec3::splat(0.3))
+                                    .speed(0.1),
+                            );
+                            server.play_sound(at, Sound::new(PUSH_SOUND, SoundCategory::Players));
+                        }
+                    });
                 }
             }
         });

--- a/events/smash/tests/arena.rs
+++ b/events/smash/tests/arena.rs
@@ -1,0 +1,198 @@
+//! The map's edges: the hub shoves you back, the arena drops you.
+//!
+//! One system, two policies. These drive it against the mock -- no host -- so
+//! what they read is the seam call the adapter would have turned into a packet:
+//! an `add_velocity` pointing back inside for the hub, and a life lost for the
+//! arena. `nix run .#smash-e2e` proves the same on the wire, where a test that
+//! only checked the player ended up in bounds would also pass for the teleport
+//! the operator ruled out; here and there, the assertion is on the push.
+
+mod harness;
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use harness::Game;
+use smash::{
+    module::{
+        arena::{Arena, Bounds, HubBounds, Policy},
+        lives::Lives,
+        lobby::{Lobby, Phase},
+        player::Position,
+    },
+    server::{PlayerId, mock::Call},
+};
+
+/// A finite hub, so the push has a wall to act at. The harness defaults this to
+/// an infinite box -- see its comment -- so a test that wants the wall says so.
+fn walled_hub(game: &Game) {
+    game.world.set(HubBounds(Bounds {
+        min: Vec3::new(-21.0, 64.0, -21.0),
+        max: Vec3::new(21.0, 80.0, 21.0),
+        policy: Policy::PushBack,
+    }));
+}
+
+/// Put the lobby in `phase` without waiting the state machine into it.
+fn phase(game: &Game, phase: Phase) {
+    game.world.set(Lobby { phase, timer: 0.0 });
+}
+
+/// The velocity the server was told to add to `player` this run, summed.
+fn pushed(game: &Game, player: Entity) -> Vec3 {
+    let id = game.world.entity_from_id(player).cloned::<&PlayerId>();
+    game.server.total_velocity(id)
+}
+
+/// A player who jumps out of the hub is shoved back through the nearest wall.
+#[test]
+fn the_hub_shoves_a_player_back_over_the_wall() {
+    let mut game = Game::new();
+    walled_hub(&game);
+    phase(&game, Phase::Waiting);
+
+    // Over the east wall (x past the box) and above it, as a double jump that
+    // cleared the glass would leave them.
+    let escapee = game.player("escapee", Vec3::new(25.0, 70.0, 0.0));
+    game.world
+        .entity_from_id(escapee)
+        .set(Position(Vec3::new(25.0, 70.0, 0.0)));
+
+    game.advance(0.05, 1);
+
+    let push = pushed(&game, escapee);
+    assert!(
+        push.x < -1e-3,
+        "a player east of the box should be shoved west, back inside; got {push:?}"
+    );
+    // Nearest-face, not toward-centre: they left over one wall and only that
+    // wall pushes, so the shove is along -x with no z of its own.
+    assert!(
+        push.z.abs() < 1e-3,
+        "the shove is the nearest-wall normal, so a player who left over the east wall gets no z \
+         component; got {push:?}"
+    );
+}
+
+/// The push is seen and heard, so it reads as a wall and not a glitch.
+#[test]
+fn the_shove_is_visible_and_audible() {
+    let mut game = Game::new();
+    walled_hub(&game);
+    phase(&game, Phase::Waiting);
+
+    let escapee = game.player("escapee", Vec3::new(0.0, 95.0, 0.0));
+    game.world
+        .entity_from_id(escapee)
+        .set(Position(Vec3::new(0.0, 95.0, 0.0)));
+
+    game.advance(0.05, 1);
+
+    let calls = game.server.calls();
+    assert!(
+        calls.iter().any(|call| matches!(call, Call::Particles(_))),
+        "the shove drew no particles, so it reads as the game rubber-banding rather than a wall"
+    );
+    assert!(
+        calls.iter().any(|call| matches!(call, Call::Sound(..))),
+        "the shove made no sound"
+    );
+}
+
+/// A player standing safely inside the hub is left alone.
+#[test]
+fn the_hub_leaves_a_player_inside_it_alone() {
+    let mut game = Game::new();
+    walled_hub(&game);
+    phase(&game, Phase::Waiting);
+
+    let inside = game.player("inside", Vec3::new(0.0, 66.0, 0.0));
+    game.world
+        .entity_from_id(inside)
+        .set(Position(Vec3::new(0.0, 66.0, 0.0)));
+
+    game.advance(0.05, 1);
+
+    assert_eq!(
+        pushed(&game, inside),
+        Vec3::ZERO,
+        "a player standing in the middle of the hub was pushed"
+    );
+}
+
+/// The hub never eliminates: a player who somehow gets below its floor is
+/// shoved up, not killed. A lobby you can die in is not a lobby.
+#[test]
+fn the_hub_does_not_eliminate() {
+    let mut game = Game::new();
+    walled_hub(&game);
+    phase(&game, Phase::Waiting);
+
+    let fallen = game.player("fallen", Vec3::new(0.0, 40.0, 0.0));
+    game.world
+        .entity_from_id(fallen)
+        .set(Position(Vec3::new(0.0, 40.0, 0.0)));
+    let before = game.world.entity_from_id(fallen).cloned::<&Lives>().0;
+
+    game.advance(0.05, 1);
+
+    assert_eq!(
+        game.world.entity_from_id(fallen).cloned::<&Lives>().0,
+        before,
+        "the hub took a life"
+    );
+    assert!(
+        pushed(&game, fallen).y > 1e-3,
+        "a player below the hub floor should be shoved up, not left to fall"
+    );
+}
+
+/// The arena still eliminates a player who falls below its kill plane, and does
+/// it with no phase gate of its own -- the phase only chose the arena's bounds.
+#[test]
+fn the_arena_eliminates_below_the_kill_plane() {
+    let mut game = Game::new();
+    phase(&game, Phase::Playing);
+
+    let arena = game.world.cloned::<&Arena>();
+    let faller = game.player("faller", Vec3::new(0.0, arena.kill_y - 10.0, 0.0));
+    game.world
+        .entity_from_id(faller)
+        .set(Position(Vec3::new(0.0, arena.kill_y - 10.0, 0.0)));
+    let before = game.world.entity_from_id(faller).cloned::<&Lives>().0;
+
+    game.advance(0.05, 1);
+
+    assert!(
+        game.world.entity_from_id(faller).cloned::<&Lives>().0 < before,
+        "the kill plane did not fire below y={}",
+        arena.kill_y
+    );
+}
+
+/// The results screen enforces neither edge: a player sliding off in the last
+/// instant is teleported home, not eliminated a second time.
+#[test]
+fn nothing_is_enforced_on_the_results_screen() {
+    let mut game = Game::new();
+    phase(&game, Phase::Ended);
+
+    let arena = game.world.cloned::<&Arena>();
+    let slid = game.player("slid", Vec3::new(0.0, arena.kill_y - 10.0, 0.0));
+    game.world
+        .entity_from_id(slid)
+        .set(Position(Vec3::new(0.0, arena.kill_y - 10.0, 0.0)));
+    let before = game.world.entity_from_id(slid).cloned::<&Lives>().0;
+
+    game.advance(0.05, 1);
+
+    assert_eq!(
+        game.world.entity_from_id(slid).cloned::<&Lives>().0,
+        before,
+        "the results screen eliminated somebody"
+    );
+    assert_eq!(
+        pushed(&game, slid),
+        Vec3::ZERO,
+        "the results screen pushed somebody"
+    );
+}

--- a/events/smash/tests/harness/mod.rs
+++ b/events/smash/tests/harness/mod.rs
@@ -51,6 +51,20 @@ impl Game {
         // anything uses it.
         world.import::<SmashModule>();
         world.set(ServerHandle(server.clone()));
+        // The hub's push-back wall is off in the harness: every test here that
+        // is not about bounds puts players at arbitrary positions in the
+        // default `Waiting` phase and launches them past any real hub box, and
+        // a wall shoving them back would be velocity none of those tests asked
+        // for. An infinite box is never crossed, so `Waiting` and `Countdown`
+        // stay inert exactly as they were before bounds existed. `tests/arena`
+        // sets a real finite box to prove the push.
+        world.set(smash::module::arena::HubBounds(
+            smash::module::arena::Bounds {
+                min: Vec3::splat(f32::NEG_INFINITY),
+                max: Vec3::splat(f32::INFINITY),
+                policy: smash::module::arena::Policy::PushBack,
+            },
+        ));
         Self {
             world,
             server,

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -386,6 +386,10 @@ SWEEP_Y = 65.0
 SWEEP_Z = -11.0
 SWEEP_YAW = 0.0
 
+# How far past the hub's east wall (x=21) the boundary probe walks a client.
+# Far enough to be unambiguously outside; the server should shove it back.
+BEYOND_WALL_X = 25.0
+
 # How far in front of the attacker the two victims stand.
 #
 # Neither is a whole number, and neither is a distance an ability centres its
@@ -699,6 +703,7 @@ class Match:
             self.proof["every declared ability was heard"] = None
             self.proof["every declared ability was seen"] = None
             self.proof["a projectile was drawn"] = None
+            self.proof["the hub shoves you back inside"] = None
             self.proof["cooldowns refused a second use"] = None
         self.proof.update({
             "four in play": None,
@@ -1161,6 +1166,76 @@ class Match:
                 "cooldown with %r on the action bar"
                 % (len(self.cooldown_results), COOLDOWN_REFUSAL),
             )
+
+        self.prove_boundary()
+
+    def prove_boundary(self):
+        """Walk a client past the hub wall and prove it is shoved back.
+
+        The load-bearing assertion, and the reason it is on the packet and not
+        on where the player ends up: a bounds check that teleported a stray
+        player back would also leave them in bounds, and read to a test that
+        only checked position exactly like this one. What the operator ruled out
+        is the teleport -- it rubber-bands and reads as lag -- so what is proved
+        is the shove itself: a `ClientboundSetEntityMotion` pointing back
+        inside. A control client standing in the middle proves the wall does not
+        grab someone who never left.
+        """
+        if len(self.clients) < 2:
+            return
+        escapee, control = self.clients[0], self.clients[1]
+        if escapee.entity_id is None or control.entity_id is None:
+            return
+
+        self.window_motions.clear()
+        # Up over the glass wall, out past x=21, and hold there. The steps stay
+        # inside hyperion's speed check; a client claiming a position is not
+        # collision-checked against the wall, which is the whole point -- a real
+        # double jump clears it too.
+        escapee.walk(
+            [
+                (escapee.position[0], HUB_CLEAR_Y, escapee.position[2]),
+                (BEYOND_WALL_X, HUB_CLEAR_Y, 0.0),
+                (BEYOND_WALL_X, SWEEP_Y + 1.0, 0.0),
+            ],
+            note="past the hub's east wall",
+        )
+        self.wait_until(lambda: escapee.arrived(), 15.0)
+        # Long enough for the bounds system to see the mirror out of bounds and
+        # for the motion packet to come back.
+        self.wait(1.0)
+
+        push = self.window_motions.get(escapee.entity_id)
+        control_push = self.window_motions.get(control.entity_id)
+
+        if push is not None and push[0] < -1e-4:
+            self.prove(
+                "the hub shoves you back inside",
+                "%s walked to x=%.0f past the hub wall and the server sent "
+                "SetEntityMotion (%.3f, %.3f, %.3f), pointing back inside"
+                % (escapee.name, BEYOND_WALL_X, push[0], push[1], push[2]),
+            )
+        else:
+            self.sweep_failures.append(
+                "a client walked past the hub wall and the server did not shove "
+                "it back: motion=%r" % (push,)
+            )
+        if control_push is not None and abs(control_push[0]) > 1e-4:
+            self.sweep_failures.append(
+                "%s never left the hub and was shoved anyway: motion=%r"
+                % (control.name, control_push)
+            )
+
+        # Back to a sweep spot, so nothing after this reads a client stranded
+        # outside.
+        escapee.walk(
+            [
+                (BEYOND_WALL_X, HUB_CLEAR_Y, 0.0),
+                (SWEEP_X, HUB_CLEAR_Y, SWEEP_Z),
+                (SWEEP_X, SWEEP_Y, SWEEP_Z),
+            ]
+        )
+        self.wait_until(lambda: escapee.arrived(), 15.0)
 
     def spares(self, testing):
         """A mob for each victim that is not the one being tested.


### PR DESCRIPTION
The operator asked for one last thing: you should not be able to jump out of bounds in the lobby, and trying should shove you back rather than teleport you — a rejected move rubber-bands and reads as lag.

## One mechanism, two policies — the phase gate is gone

The map already had two kinds of edge and one mechanism for them, gated by phase: `death_checks` ran the arena's kill plane only during a match, because the hub shares one world with the arena and the kill plane would otherwise reach up into the lobby and eliminate everyone the moment they connected.

That gate is deleted. Every region is now a **`Bounds` with a `Policy`**: the arena **eliminates** (falling off is how the game is won), the hub **shoves you back** (a lobby you can leave is a lobby with nobody in it). The phase names which region players occupy — the game moves them all together, so it is one at a time — and the region's own policy decides what its edge does. The lobby stops being an exception the kill plane is switched off for and becomes the other policy.

## The shape

`Bounds` is an axis-aligned box with `back_inside`, which returns the **nearest-face normal** (one `clamp`): a player who jumps out over one wall is shoved straight back through it, not sent on a diagonal toward the middle that a non-square arena would land somewhere they were not. The arena's box is a floor and nothing else — infinite horizontally, open at the top, bounded below at `kill_y` — because the only edge an arena has is the one you fall through.

The hub declares its box in a new **`bounds` map directive**, because `MapSpec` carried only `kill_y` and a wall is not a floor — and the escape the operator named is vertical, a double jump over the three-high glass, which no floor plane catches. `ArenaModule` reads it from `map::HUB` itself rather than waiting for the terrain to hand it over, so the game half has it with no host and the tests exercise the push against the mock. The hub is region zero at the origin, so its declared coordinates are already world ones.

## The shove is a fence, not a hazard

Applied straight to velocity and **deliberately not through the knockback model's `1 + 0.1 * missing` health term**: that term throws a nearly-dead player further, and a wall that throws a nearly-dead player further is a wall that kills them. A fence is a fixed shove. It is also seen and heard — crit sparks and a shield-block thud — so it reads as a wall and not as the game rubber-banding a rejected move.

## Wire proof is on the packet, not the position

A bounds check that *teleported* a stray player back would also leave them in bounds and pass a test that only checked where they ended up — which is exactly the teleport the operator ruled out. So `smash-match.py` walks a real client past the wall and asserts a `ClientboundSetEntityMotion` comes back pointing inside, with a control client in the middle proving the wall does not grab someone who never left.

`tests/arena.rs` proves the same against the mock, plus: the nearest-face direction (no spurious z when you leave over the x wall), that the hub never eliminates (a player below its floor is shoved *up*), that the arena still eliminates below its kill plane with no phase gate of its own, and that the results screen enforces neither edge.

The shared test harness sets an infinite hub box, so every test that is not about bounds keeps launching players around the default `Waiting` phase without a wall shoving them — `Waiting` and `Countdown` stay inert exactly as they were before bounds existed.

## Guard broken and watched to fail, then restored

`back_inside` forced to `None` (the push disabled):
```
a player east of the box should be shoved west, back inside; got Vec3(0.0, 0.0, 0.0)
a player below the hub floor should be shoved up, not left to fall
the shove drew no particles / made no sound
```

## Ownership and constraints

Stayed in `arena.rs`, `map.rs`, `tests/`, `hub.map`, `smash-match.py` — no `lobby.rs` or `terrain.rs` edit, which is why the selection is phase-based rather than a per-player `(Within, region)` relation: the assignment points (scatter, join, return-to-hub) live in those two files, and terrain.rs is the flecs agent's for podium-naming. Phase is the honest selector anyway — it *is* which region the game has put everyone in.

Rebased onto `e7c7e85` (#1046); its only arena.rs change was a reformat ("No syntactic changes"), superseded by this rewrite. `nix run .#fmt -- --check` shows no diff in any file this PR touches; the pre-existing drift in other files is left for your sweep. `cargo test -p smash` (24 binaries) and `.#lint` green.

## What this does not settle

The wire half runs on the gate; my local `smash-e2e` attempts die on the load box's connection sweep as they have all session, so the mock proof is the local evidence and the `SetEntityMotion` assertion is structural.