### PR TITLE
perf(ecs): effects looked up by victim, not by scanning them all

### DIFF
--- a/events/smash/src/module/effect.rs
+++ b/events/smash/src/module/effect.rs
@@ -449,6 +449,13 @@ fn disarm_shield(world: WorldRef<'_>, victim: Entity, excluding: Entity) {
 /// "which effects point at this player" with a different filter, and three
 /// copies of a relationship traversal is three places to get the direction of
 /// the edge wrong.
+///
+/// The `(Upon, victim)` term names the concrete victim, so flecs hands back the
+/// effects on that one player rather than making us scan every effect in the
+/// world and discard the ones pointing elsewhere. `Upon` is `DontFragment`, so
+/// there is no archetype per victim to fragment -- the sparse relation is
+/// queried by its target directly, which is the indexed lookup a `ChildOf`
+/// tree would also have bought without the per-victim fragmentation it costs.
 fn matching(
     world: WorldRef<'_>,
     victim: Entity,
@@ -457,10 +464,10 @@ fn matching(
     let mut found = Vec::new();
     world
         .query::<()>()
-        .with(Effect::id())
+        .with((Upon, victim))
         .build()
         .each_entity(|effect, ()| {
-            if effect.target(Upon, 0).map(|target| target.id()) == Some(victim) && keep(effect) {
+            if keep(effect) {
                 found.push(effect.id());
             }
         });

--- a/events/smash/tests/effect_lookup.rs
+++ b/events/smash/tests/effect_lookup.rs
@@ -1,0 +1,53 @@
+//! `effect::on`/`from_source` return the effects on *one* victim.
+//!
+//! The lookup is a direct `(Upon, victim)` query rather than a scan of every
+//! effect, so this pins the property that would break if the victim term were
+//! ever dropped: effects on one player must not show up in another's lookup.
+
+mod harness;
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use harness::Game;
+use smash::module::effect::{self, Affliction, Blame};
+
+#[test]
+fn effects_are_looked_up_per_victim() {
+    let mut game = Game::new();
+    let attacker = game.player("attacker", Vec3::ZERO);
+    let v1 = game.player("v1", Vec3::new(1.0, 0.0, 0.0));
+    let v2 = game.player("v2", Vec3::new(2.0, 0.0, 0.0));
+    let world = (&game.world).into();
+
+    // Two distinct-source afflictions on v1 (distinct sources so they coexist
+    // rather than replacing one another), one on v2.
+    for _ in 0..2 {
+        let source = game.world.entity().id();
+        effect::afflict(
+            world,
+            game.world.entity_from_id(v1),
+            Blame { source, attacker },
+            Affliction::shield(9.0),
+        );
+    }
+    effect::afflict(
+        world,
+        game.world.entity_from_id(v2),
+        Blame {
+            source: attacker,
+            attacker,
+        },
+        Affliction::shield(9.0),
+    );
+
+    assert_eq!(
+        effect::on(world, v1).len(),
+        2,
+        "v1's afflictions were miscounted"
+    );
+    assert_eq!(
+        effect::on(world, v2).len(),
+        1,
+        "v2's lookup returned effects that are not on v2 -- the victim term was lost"
+    );
+}


### PR DESCRIPTION
## What

The last flecs audit item, per your option (b): keep `Upon`'s `DontFragment` and replace `matching()`'s full scan with a direct `(Upon, victim)` query.

`matching()` — the one walker behind `effect::on`, `from_source` and `clear` — used to scan **every** `Effect` in the world and discard the ones whose `Upon` target wasn't this victim. It now names the concrete victim in the query term, so flecs hands back only that player's effects. `Upon` is `DontFragment`, so this is a sparse relation queried by its target directly: the indexed lookup a `ChildOf` tree would also have given, **without** the archetype-per-victim fragmentation `ChildOf` costs and PR3's `DontFragment` was added to avoid (Arrow Storm minting an archetype every 0.3s). So this captures the perf win and drops only the cosmetic explorer-tree half — which was the lowest-value part anyway, since effects are the short-lived duplicable entities that can't be named legibly regardless.

Behaviour is unchanged: `on`/`from_source`/`clear` return the same effects, and the two-Blazes-two-burns dedup (which rides on `from_source`) still holds.

## Proof

- Probed that a concrete-target query on the sparse `Upon` returns exactly what the scan did (v1: 3 effects, v2: 1) before changing anything.
- `tests/effect_lookup.rs` pins the property the query must keep: two victims afflicted, each `effect::on` returns only its own. **Broken on purpose** (victim term replaced with `Effect::id()`, i.e. scan-all), it fails — `v2's lookup returned effects that are not on v2 -- the victim term was lost`. Restored, it passes.
- `cargo clippy -p smash --all-targets --all-features -- -D warnings`: clean.
- `cargo test -p smash`: all pass (24 binaries), including the effect/ability suites that exercise `on`/`from_source`/`clear`.
- `cargo fmt -p smash --check`: clean (formatted the new test file).
