### PR TITLE
feat(smash): Cub Tackle's slow is real, not just a marker

### DIFF
--- a/crates/hyperion/src/effects/status.rs
+++ b/crates/hyperion/src/effects/status.rs
@@ -242,3 +242,79 @@ pub fn clear(entity: EntityView<'_>, effect: MobEffect) {
         }
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use flecs_ecs::prelude::*;
+    use hyperion_proxy_proto::ArchivedServerToProxyMessage;
+
+    use super::*;
+    use crate::{
+        HyperionCore,
+        simulation::{Player, Velocity, entity_kind::EntityKind},
+    };
+
+    /// A slow reaches the victim's own client.
+    ///
+    /// The whole reason a status beats a faked impulse is that the client owns
+    /// its movement prediction, so the effect has to arrive at the *victim's*
+    /// screen to be felt rather than only seen by bystanders. A broadcast that
+    /// excluded the victim -- the way a game often excludes the actor of an
+    /// event to avoid echoing it back -- would slow everyone's view of them and
+    /// leave the one player who needs it moving at full speed.
+    ///
+    /// So this drives [`Status::apply`] against a captured proxy channel and
+    /// asserts the effect leaves as a *local* broadcast around the victim that
+    /// excludes nobody (`exclude == 0`, the sentinel for [`None`]), which is
+    /// exactly the client that owns the prediction being included.
+    #[test]
+    fn a_slow_broadcasts_to_the_victims_own_client() {
+        let world = World::new();
+        world.import::<HyperionCore>();
+
+        let victim = world
+            .entity()
+            .add_enum(EntityKind::Player)
+            .add(Player::id())
+            .set(Position::new(1.5, 64.0, -2.5))
+            .set(Velocity::default())
+            .id();
+
+        // Swap in a Compose whose proxy channels we hold, so what a broadcast
+        // would send is readable here rather than lost to a socket. Done after
+        // the entity exists, so only the slow -- not the spawn -- lands on it.
+        let (compose, mut near, _far) = crate::net::tests::two_proxies();
+        world.set(compose);
+
+        Status::new(MobEffect::Slowness, 5)
+            .seconds(5.0)
+            .apply(world.entity_from_id(victim));
+
+        let bytes = near
+            .try_recv()
+            .expect("apply broadcast nothing to the victim's proxy");
+        // `encode_proxy_message` writes an eight-byte big-endian length before
+        // the rkyv body; the body is what the archived message reads through.
+        let body = &bytes[size_of::<u64>()..];
+        let message = unsafe { rkyv::access_unchecked::<ArchivedServerToProxyMessage<'_>>(body) };
+        match message {
+            ArchivedServerToProxyMessage::BroadcastLocal(local) => {
+                assert_eq!(
+                    local.exclude.to_native(),
+                    0,
+                    "a slow that excludes the victim never reaches the client that has to feel it"
+                );
+            }
+            _ => panic!("a slow must leave as a local broadcast around the victim"),
+        }
+        assert!(
+            near.try_recv().is_err(),
+            "one apply must be one packet, not several"
+        );
+
+        // Drop the world while the proxy receivers are still alive: tearing it
+        // down fires an `OnRemove` broadcast for the victim, and a receiver
+        // already gone would turn that teardown into a `SendError` panic.
+        drop(world);
+    }
+}

--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -54,7 +54,7 @@ use crate::{
     module::kit::{self, Playing},
     server::{
         BarColour, BossBar, Channel, Experience, HotbarItem, Particles, PlayerId, Server,
-        SidebarLine, Sound, SoundCategory, Text, Title,
+        SidebarLine, Sound, SoundCategory, Status, Text, Title,
     },
 };
 
@@ -75,6 +75,10 @@ enum Op {
         player: Entity,
         health: f32,
         max: f32,
+    },
+    Status {
+        player: Entity,
+        status: Status,
     },
     SetHotbar {
         player: Entity,
@@ -173,6 +177,13 @@ impl Server for HyperionServer {
             player: entity_of(player),
             health,
             max,
+        });
+    }
+
+    fn status(&self, player: PlayerId, status: Status) {
+        self.push(Op::Status {
+            player: entity_of(player),
+            status,
         });
     }
 
@@ -380,6 +391,16 @@ fn apply(world: WorldRef<'_>, compose: &Compose, op: Op, bars: &HashMap<Entity, 
             };
             let _unused =
                 protocol::send(compose, connection, PacketId::SetHealth.to_raw(), &packet);
+        }
+        Op::Status { player, status } => {
+            let entity = world.entity_from_id(player);
+            if !entity.is_alive() {
+                return;
+            }
+            // `Status::apply` broadcasts locally around the victim with nobody
+            // excluded, so the victim's own client -- the one that owns the
+            // movement prediction a slow has to change -- is in the broadcast.
+            status.apply(entity);
         }
         Op::SetHotbar { player, items } => {
             let entity = world.entity_from_id(player);

--- a/events/smash/src/module/kits/wolf.rs
+++ b/events/smash/src/module/kits/wolf.rs
@@ -10,7 +10,8 @@
 //! disagreement is recorded in docs/smash-design.md.
 
 use flecs_ecs::prelude::*;
-use hyperion::simulation::entity_kind::EntityKind;
+use hyperion::{effects::Status, simulation::entity_kind::EntityKind};
+use hyperion_minecraft_proto::generated::registry::MobEffect;
 
 use crate::{
     flecs_ext::EntityViewExt,
@@ -22,6 +23,7 @@ use crate::{
         player::Player,
         projectile::{Flight, Impact, Payload, Visual, fire},
     },
+    server::{PlayerId, ServerHandle},
 };
 
 /// Damage added per landed melee hit, and the ceiling it climbs to.
@@ -37,6 +39,21 @@ pub struct Tackled(pub f32);
 
 /// Seconds of near-immobility a cub leaves behind.
 pub const TACKLE_SLOW_SECS: f32 = 5.0;
+
+/// The Slowness amplifier Cub Tackle applies. Zero-based on the wire, the way
+/// the game counts it, so `5` is Slowness VI -- the level at which a player can
+/// no longer move, which is what the tooltip's "can barely move" means. See
+/// [`hyperion::effects::Status`].
+pub const TACKLE_SLOW_AMPLIFIER: u8 = 5;
+
+/// The immobilising slow a cub leaves on whoever it lands on.
+///
+/// Exposed so a wire test can assert the exact effect the ability sends rather
+/// than a re-derivation of it, the way `hyperion`'s own `play_mob_effect`
+/// differential pins the bytes against Mojang's encoder.
+pub fn tackle_slow() -> Status {
+    Status::new(MobEffect::Slowness, TACKLE_SLOW_AMPLIFIER).seconds(TACKLE_SLOW_SECS)
+}
 
 #[derive(Component)]
 pub struct Wolf;
@@ -170,7 +187,18 @@ fn tackle(impact: &Impact<'_>) {
     let now = impact
         .world
         .get::<&crate::module::damage::MatchClock>(|clock| clock.0);
+    // The marker Wolf Strike reads to know its combo target is still slowed.
     impact.victim.set(Tackled(now + TACKLE_SLOW_SECS));
+
+    // And the real slow, alongside the marker rather than instead of it: a
+    // `Slowness VI` the client applies to its own movement prediction, so the
+    // victim actually can barely move rather than only appearing to a bystander.
+    let Some(player) = impact.victim.try_get::<&PlayerId>(|id| *id) else {
+        return;
+    };
+    impact
+        .world
+        .get::<&ServerHandle>(|server| server.status(player, tackle_slow()));
 }
 
 /// The wiki: base knockback dealt 200%, rising to 300% against a target still

--- a/events/smash/src/server.rs
+++ b/events/smash/src/server.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
-pub use hyperion::effects::{Effect, Shape};
+pub use hyperion::effects::{Effect, Shape, Status};
 pub use hyperion_minecraft_proto::{
     particle::{Argb, Particle, ParticleKind},
     text::{Component, Decoration, NamedColor, Rgb24, Run, Style, TextColor},
@@ -338,6 +338,14 @@ pub trait Server: Send + Sync + 'static {
 
     /// Push the game's authoritative health onto the client's health bar.
     fn set_health(&self, player: PlayerId, health: f32, max: f32);
+
+    /// Apply a potion effect to `player`, broadcast to everyone near them --
+    /// including the player's own client. That inclusion is the whole point of
+    /// a status over a faked impulse: the client owns its movement prediction,
+    /// so a slow is *felt* rather than merely seen only once it reaches the
+    /// player's own screen. Ended by its own duration, or early with a matching
+    /// clear.
+    fn status(&self, player: PlayerId, status: Status);
 
     /// Replace the hotbar wholesale. Called on kit selection and on respawn.
     fn set_hotbar(&self, player: PlayerId, items: &[HotbarItem]);

--- a/events/smash/src/server/mock.rs
+++ b/events/smash/src/server/mock.rs
@@ -11,7 +11,7 @@ use glam::Vec3;
 
 use super::{
     BossBar, Channel, Experience, HotbarItem, Particles, PlayerId, Server, SidebarLine, Sound,
-    Text, Title,
+    Status, Text, Title,
 };
 
 /// One thing the game asked the server to do.
@@ -20,6 +20,8 @@ pub enum Call {
     AddVelocity(PlayerId, Vec3),
     Teleport(PlayerId, Vec3),
     SetHealth(PlayerId, f32, f32),
+    /// A potion effect applied to a player.
+    Status(PlayerId, Status),
     SetHotbar(PlayerId, Vec<HotbarItem>),
     Message(PlayerId, Channel, Text),
     Broadcast(Channel, Text),
@@ -74,6 +76,18 @@ impl MockServer {
                 _ => None,
             })
             .sum()
+    }
+
+    /// Every status effect applied to `player`, oldest first.
+    #[must_use]
+    pub fn statuses_of(&self, player: PlayerId) -> Vec<Status> {
+        self.calls()
+            .iter()
+            .filter_map(|call| match call {
+                Call::Status(id, status) if *id == player => Some(*status),
+                _ => None,
+            })
+            .collect()
     }
 
     /// What was said to `player`, as the words without the styling.
@@ -197,6 +211,10 @@ impl Server for MockServer {
 
     fn set_health(&self, player: PlayerId, health: f32, max: f32) {
         self.push(Call::SetHealth(player, health, max));
+    }
+
+    fn status(&self, player: PlayerId, status: Status) {
+        self.push(Call::Status(player, status));
     }
 
     fn set_hotbar(&self, player: PlayerId, items: &[HotbarItem]) {

--- a/events/smash/tests/cub_tackle.rs
+++ b/events/smash/tests/cub_tackle.rs
@@ -1,0 +1,90 @@
+//! Cub Tackle leaves a real slow, not just a marker.
+//!
+//! The tooltip promises "whoever it lands on can barely move for five seconds".
+//! Wolf Strike already read a [`Tackled`] marker for its combo, but nothing was
+//! ever sent to slow the victim -- the tooltip lied. This pins both halves: the
+//! marker the combo needs, and the `Slowness VI` the client applies to its own
+//! movement prediction so the victim actually can barely move.
+//!
+//! Two tests, because they fail differently. One drives the whole ability
+//! through the mock seam and asserts the victim was slowed; the other pins the
+//! exact bytes the effect encodes to, the way `hyperion`'s own
+//! `play_mob_effect` differential pins them against Mojang's encoder.
+
+mod harness;
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use harness::Game;
+use hyperion_minecraft_proto::{Encode, Writer};
+use smash::{
+    module::{
+        ability,
+        damage::MatchClock,
+        kit,
+        kits::wolf::{self, Tackled},
+    },
+    server::PlayerId,
+};
+
+fn encoded(value: &impl Encode) -> Vec<u8> {
+    let mut writer = Writer::new();
+    value.encode(&mut writer).expect("encode");
+    writer.into_vec()
+}
+
+/// Fired at a victim standing in front, the cub lands and the victim is slowed
+/// with exactly the effect [`wolf::tackle_slow`] describes -- and the combo
+/// marker is still there beside it, not replaced by it.
+#[test]
+fn a_cub_slows_whoever_it_lands_on_and_still_marks_them() {
+    let mut game = Game::new();
+    let caster = game.player("wolf", Vec3::ZERO);
+    // Straight down the caster's +X facing, close enough that the cub lands
+    // almost at once and well inside the tick budget below.
+    let victim = game.player("victim", Vec3::new(3.5, 0.0, 0.0));
+
+    let wolf_kit = kit::by_name(&game.world, "Wolf").expect("the registry has Wolf");
+    kit::apply(&game.world, game.world.entity_from_id(caster), wolf_kit);
+    // A non-zero match clock so the marker's deadline is a real future time.
+    game.world.set(MatchClock(1.0));
+
+    let entry = ability::manifest(&game.world)
+        .into_iter()
+        .find(|entry| entry.kit == "Wolf" && entry.name == "Cub Tackle")
+        .expect("Wolf declares Cub Tackle");
+    ability::use_slot(game.world.entity_from_id(caster), entry.slot);
+
+    // Long enough for the cub to cross 3.5 blocks at 18 blocks a second.
+    game.advance(1.5, 30);
+
+    let victim_id: PlayerId = game.world.entity_from_id(victim).cloned::<&PlayerId>();
+    let slowed = game.server.statuses_of(victim_id);
+    assert_eq!(
+        slowed,
+        vec![wolf::tackle_slow()],
+        "the cub landed and the victim was not slowed as the tooltip promises: {slowed:?}"
+    );
+    assert!(
+        game.world.entity_from_id(victim).has(Tackled::id()),
+        "the real slow replaced the combo marker instead of joining it"
+    );
+
+    // The caster threw the cub; it did not slow themselves.
+    let caster_id: PlayerId = game.world.entity_from_id(caster).cloned::<&PlayerId>();
+    assert!(
+        game.server.statuses_of(caster_id).is_empty(),
+        "the thrower slowed themselves"
+    );
+}
+
+/// The effect encodes byte-for-byte to the layout `hyperion`'s `play_mob_effect`
+/// differential pins against Mojang's own encoder: entity id, effect id
+/// (`Slowness` is 1), amplifier (`5` is level VI, where a player can no longer
+/// move), duration in ticks (five seconds is 100), and the flag byte
+/// (visible | show-icon = `0b110`).
+#[test]
+fn the_slow_is_slowness_six_for_five_seconds_on_the_wire() {
+    let packet = wolf::tackle_slow().packet(0x2A);
+    assert_eq!(encoded(&packet), [0x2A, 0x01, 0x05, 0x64, 0x06]);
+}


### PR DESCRIPTION
Closes the Cub Tackle "movement tooltip" gap: the tooltip promises "whoever it lands on can barely move for five seconds", but only a `Tackled` marker was set -- no slow was ever sent. This lands `Slowness VI` for 5s alongside the marker, through a new `Server::status` seam (so the game stays testable in a bare world, since `Status::apply` needs `Compose` that only `SmashHost` carries).

Tests: focused mock-seam + byte-for-byte wire test in `events/smash/tests/cub_tackle.rs`, and a hyperion test that `Status::apply` broadcasts to the victim's own client (previously untested). Both guards were broken and watched to fail before restoring.

The other three held "movement" tooltips (Guided Wither Skull, Ice Path, Spin Web) were verified as **not** victim-slows and are handled separately -- see report.