### PR TITLE
fix(proto): record two force-merged sound literals in the baseline

### DIFF
--- a/nix/minecraft-literal-baseline.json
+++ b/nix/minecraft-literal-baseline.json
@@ -168,6 +168,9 @@
       "minecraft:fall",
       "minecraft:fall"
     ],
+    "events/smash/src/module/arena.rs": [
+      "minecraft:item.shield.block"
+    ],
     "events/smash/src/module/kit.rs": [
       "minecraft:armor_stand",
       "minecraft:stick"
@@ -421,6 +424,9 @@
       "minecraft:stick",
       "minecraft:stick",
       "minecraft:stone"
+    ],
+    "events/smash/tests/visuals.rs": [
+      "minecraft:entity.player.hurt_on_fire"
     ]
   }
 }


### PR DESCRIPTION
## Effect

`nix run .#minecraft-literals` is green on main again (324/324). It went red because two PRs force-merged past a queued CI each added a raw `minecraft:` sound string without updating the baseline:

- **#1047** (bounds) — `minecraft:item.shield.block` in `arena.rs`, the push-back thud.
- **#1035** (seam) — `minecraft:entity.player.hurt_on_fire` in `visuals.rs`.

## Why the baseline, not ALLOWED or a migration

Both are `Shows.sound` / `play_sound` strings — the identical stringly-typed sound debt already tracked in the baseline for all fifteen kits' hurt sounds. The baseline is "debt with a name on it"; ALLOWED is for literals that are correct to keep. So they belong in the baseline. Resynced with the checker's own `--write`, which added exactly those two and nothing else.

## The real fix, deferred with a name

Migrating `Shows.sound: &'static str` and the `play_sound` call sites to the generated `SoundEvent` enum retires this whole baseline section — both of these have variants (`SoundEvent::ItemShieldBlock`, `SoundEvent::EntityPlayerHurtOnFire`). That is the generate-from-source follow-up, not this gate unblock.

## Note for the class

This is the second gate (after fmt) that force-merging against slow CI left red on main by landing past a queued check. ENG-10938 already recommends making the Formatting gate non-skippable under `--admin`; the same argument applies to `minecraft-literals` and `lint`. fmt itself is now clean again (`cargo fmt --all --check` rc=0), paid down by #1043's style commit, so no sweep is needed — only the permanent gate.

## Checks
`python3 nix/check-minecraft-literals.py --root . --baseline nix/minecraft-literal-baseline.json` → 324/324, rc=0. `cargo fmt --all --check` → rc=0. Baseline-only change, no code touched.