### PR TITLE
test(ecs): retry the abort-guard child through the ecs_init flake (ENG-10852)

### DIFF
--- a/crates/hyperion/tests/boss_bar_traits.rs
+++ b/crates/hyperion/tests/boss_bar_traits.rs
@@ -55,28 +55,51 @@ fn violation_child() {
     std::process::exit(0);
 }
 
+/// The child imports a full hyperion world, whose `ecs_init` segfaults on the
+/// order of 1 in 100 runs -- a pre-existing flake, ENG-10852, unrelated to the
+/// trait under test. A segfault kills the child before it reaches the bare-tag
+/// add, so it produces neither the flecs `CONSTRAINT_VIOLATED` diagnostic nor
+/// the `NO_ABORT` marker: a silent non-zero death with empty output. That is
+/// exactly the shape we retry, and only that shape.
+///
+/// The two verdicts that end the loop are both decisive and neither is masked
+/// by the retry: `NO_ABORT` means flecs *accepted* the illegal add (the guard
+/// is broken) and fails at once; `CONSTRAINT_VIOLATED` means it aborted on the
+/// constraint (the guard holds) and passes. Only a no-verdict crash is retried,
+/// and if every attempt crashes without a verdict the assertion still fails --
+/// so a child that could never initialise surfaces as a failure, it is not
+/// swept under the retry.
+const CONSTRAINT_ATTEMPTS: usize = 8;
+
 fn assert_aborts_on_constraint(case: &str) {
     let exe = std::env::current_exe().expect("test binary path");
-    let output = Command::new(exe)
-        .args(["--exact", "violation_child", "--nocapture"])
-        .env("HYPERION_VIOLATION", case)
-        .env("RUST_BACKTRACE", "0")
-        .output()
-        .expect("spawn the violation child");
-    // flecs writes its abort diagnostic to stdout; NO_ABORT goes to stderr.
-    let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
-    log.push_str(&String::from_utf8_lossy(&output.stderr));
-    assert!(
-        !output.status.success(),
-        "{case}: the bare-tag add was accepted, not aborted.\noutput:\n{log}"
-    );
-    assert!(
-        !log.contains("NO_ABORT"),
-        "{case}: flecs accepted the illegal state.\noutput:\n{log}"
-    );
-    assert!(
-        log.contains("CONSTRAINT_VIOLATED"),
-        "{case}: the child died, but not on a flecs constraint.\noutput:\n{log}"
+    let mut crashes = 0usize;
+    for _ in 0..CONSTRAINT_ATTEMPTS {
+        let output = Command::new(&exe)
+            .args(["--exact", "violation_child", "--nocapture"])
+            .env("HYPERION_VIOLATION", case)
+            .env("RUST_BACKTRACE", "0")
+            .output()
+            .expect("spawn the violation child");
+        // flecs writes its abort diagnostic to stdout; NO_ABORT goes to stderr.
+        let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
+        log.push_str(&String::from_utf8_lossy(&output.stderr));
+
+        assert!(
+            !log.contains("NO_ABORT") && !output.status.success(),
+            "{case}: the bare-tag add was accepted, not aborted.\noutput:\n{log}"
+        );
+        if log.contains("CONSTRAINT_VIOLATED") {
+            return;
+        }
+        // No verdict either way: the child died before reaching the add, which
+        // is the ENG-10852 `ecs_init` segfault, not the trait. Retry.
+        crashes += 1;
+    }
+    panic!(
+        "{case}: the violation child crashed before reaching the constraint on all \
+         {CONSTRAINT_ATTEMPTS} attempts ({crashes} no-verdict deaths). Either ecs_init is failing \
+         every time (not the ~1/100 ENG-10852 flake) or the trait no longer aborts."
     );
 }
 

--- a/events/smash/tests/final_and_podiums.rs
+++ b/events/smash/tests/final_and_podiums.rs
@@ -94,27 +94,40 @@ fn violation_child() {
     std::process::exit(0);
 }
 
+/// The child imports a full smash world, whose `ecs_init` segfaults on the
+/// order of 1 in 100 runs -- ENG-10852, a pre-existing flake unrelated to the
+/// trait under test. Such a crash kills the child before it reaches the illegal
+/// operation, producing neither `CONSTRAINT_VIOLATED` nor `NO_ABORT`: a silent
+/// non-zero death. Only that no-verdict shape is retried. `NO_ABORT` (the add
+/// was accepted -- guard broken) fails at once and `CONSTRAINT_VIOLATED` (the
+/// guard held) passes, so the retry masks neither verdict; and if every attempt
+/// crashes with no verdict the assertion still fails.
+const CONSTRAINT_ATTEMPTS: usize = 8;
+
 fn assert_aborts_on_constraint(case: &str) {
     let exe = std::env::current_exe().expect("test binary path");
-    let output = Command::new(exe)
-        .args(["--exact", "violation_child", "--nocapture"])
-        .env("SMASH_FINAL_VIOLATION", case)
-        .env("RUST_BACKTRACE", "0")
-        .output()
-        .expect("spawn the violation child");
-    let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
-    log.push_str(&String::from_utf8_lossy(&output.stderr));
-    assert!(
-        !output.status.success(),
-        "{case}: inheriting from a Final kind was accepted, not aborted.\noutput:\n{log}"
-    );
-    assert!(
-        !log.contains("NO_ABORT"),
-        "{case}: flecs accepted the illegal is_a.\noutput:\n{log}"
-    );
-    assert!(
-        log.contains("CONSTRAINT_VIOLATED"),
-        "{case}: the child died, but not on a flecs constraint.\noutput:\n{log}"
+    for _ in 0..CONSTRAINT_ATTEMPTS {
+        let output = Command::new(&exe)
+            .args(["--exact", "violation_child", "--nocapture"])
+            .env("SMASH_FINAL_VIOLATION", case)
+            .env("RUST_BACKTRACE", "0")
+            .output()
+            .expect("spawn the violation child");
+        let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
+        log.push_str(&String::from_utf8_lossy(&output.stderr));
+        assert!(
+            !log.contains("NO_ABORT") && !output.status.success(),
+            "{case}: inheriting from a Final kind was accepted, not aborted.\noutput:\n{log}"
+        );
+        if log.contains("CONSTRAINT_VIOLATED") {
+            return;
+        }
+        // No verdict: the child died in ecs_init (ENG-10852), not on the is_a. Retry.
+    }
+    panic!(
+        "{case}: the violation child crashed before reaching the constraint on all \
+         {CONSTRAINT_ATTEMPTS} attempts -- ecs_init failing every time, or the trait no longer \
+         aborts."
     );
 }
 

--- a/events/smash/tests/relationship_traits.rs
+++ b/events/smash/tests/relationship_traits.rs
@@ -194,29 +194,42 @@ fn violation_child() {
 
 /// Run `violation_child` in a subprocess with `case` selected, and assert it
 /// died on a flecs constraint.
+/// The child imports a full smash world, whose `ecs_init` segfaults on the
+/// order of 1 in 100 runs -- ENG-10852, a pre-existing flake unrelated to the
+/// trait under test. Such a crash kills the child before it reaches the illegal
+/// operation, producing neither `CONSTRAINT_VIOLATED` nor `NO_ABORT`: a silent
+/// non-zero death. Only that no-verdict shape is retried. `NO_ABORT` (the add
+/// was accepted -- guard broken) fails at once and `CONSTRAINT_VIOLATED` (the
+/// guard held) passes, so the retry masks neither verdict; and if every attempt
+/// crashes with no verdict the assertion still fails.
+const CONSTRAINT_ATTEMPTS: usize = 8;
+
 fn assert_aborts_on_constraint(case: &str) {
     let exe = std::env::current_exe().expect("test binary path");
-    let output = Command::new(exe)
-        .args(["--exact", "violation_child", "--nocapture"])
-        .env("SMASH_VIOLATION", case)
-        .env("RUST_BACKTRACE", "0")
-        .output()
-        .expect("spawn the violation child");
-    // flecs writes its `abort()` diagnostic to stdout; the child's own
-    // `NO_ABORT` marker goes to stderr. Read both.
-    let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
-    log.push_str(&String::from_utf8_lossy(&output.stderr));
-    assert!(
-        !output.status.success(),
-        "{case}: the illegal add was accepted, not aborted.\noutput:\n{log}"
-    );
-    assert!(
-        !log.contains("NO_ABORT"),
-        "{case}: flecs accepted the illegal state before aborting elsewhere.\noutput:\n{log}"
-    );
-    assert!(
-        log.contains("CONSTRAINT_VIOLATED"),
-        "{case}: the child died, but not on a flecs constraint.\noutput:\n{log}"
+    for _ in 0..CONSTRAINT_ATTEMPTS {
+        let output = Command::new(&exe)
+            .args(["--exact", "violation_child", "--nocapture"])
+            .env("SMASH_VIOLATION", case)
+            .env("RUST_BACKTRACE", "0")
+            .output()
+            .expect("spawn the violation child");
+        // flecs writes its `abort()` diagnostic to stdout; the child's own
+        // `NO_ABORT` marker goes to stderr. Read both.
+        let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
+        log.push_str(&String::from_utf8_lossy(&output.stderr));
+        assert!(
+            !log.contains("NO_ABORT") && !output.status.success(),
+            "{case}: the illegal add was accepted, not aborted.\noutput:\n{log}"
+        );
+        if log.contains("CONSTRAINT_VIOLATED") {
+            return;
+        }
+        // No verdict: the child died in ecs_init (ENG-10852), not on the add. Retry.
+    }
+    panic!(
+        "{case}: the violation child crashed before reaching the constraint on all \
+         {CONSTRAINT_ATTEMPTS} attempts -- ecs_init failing every time, or the trait no longer \
+         aborts."
     );
 }
 


### PR DESCRIPTION
## Effect

Three subprocess-abort guard tests were reddening main across commits — the Tests and Code Coverage jobs failed on `a_boss_bar_edge_added_as_a_bare_tag_aborts` (#1043) and the `final_and_podiums` / `relationship_traits` equivalents (#1045, #1046). This makes all three robust to the pre-existing flake that caused it.

## Root cause, from evidence not reasoning

The CI failure prints the child's output, and it was **empty** — the child died non-zero with no `CONSTRAINT_VIOLATED` and no `NO_ABORT`. A flecs constraint abort writes a diagnostic to stdout; a silent non-zero death is a **segfault in `ecs_init` (ENG-10852)**, the pre-existing ~1/100 crash, hit when the re-exec'd child spins up a full hyperion/smash world.

It is not the trait. The structural half (`..._are_declared_relationships`) passes, and the behavioural test passed **25/25 locally** under nextest. It flaked in CI.

A first attempt to lighten boss_bar's child to `BossBarModule` alone was tried and **reverted** — flecs manual-registration needs prerequisite components the full world registers first, so the child panicked in registration. That is why the original imports the full core; the child has to.

## The fix, applied to the whole class

All three `assert_aborts_on_constraint` helpers now retry the child, and only on a **no-verdict death**:

- `NO_ABORT` (the illegal add was *accepted* — guard broken) → fail immediately.
- `CONSTRAINT_VIOLATED` (aborted on the constraint — guard holds) → pass.
- neither (silent crash in `ecs_init`) → retry, up to 8.
- all attempts crash with no verdict → **still fails**, with a message saying ecs_init is failing every time — so a child that genuinely cannot initialise surfaces rather than being masked.

Neither real verdict is weakened; only the known init flake is tolerated.

## The proper fix is ENG-10852

`ecs_init` should not segfault. Until that lands, this stops a known flake from reddening main on every force-merge. Noted in the code and the commit.

## Verified

Each of the three tests green repeatedly under `cargo nextest` (CI's runner); `cargo clippy -p hyperion -p smash --tests --all-features -- -D warnings` rc=0; `cargo fmt --all --check` rc=0.