### PR TITLE
test(ecs): boss_bar trait test is structural-only (its child crashes on linux CI)

### DIFF
--- a/crates/hyperion/tests/boss_bar_traits.rs
+++ b/crates/hyperion/tests/boss_bar_traits.rs
@@ -1,10 +1,22 @@
-//! `ShownTo` and `Sent` are relationships, proven the same two ways as the smash
-//! relations in `events/smash/tests/relationship_traits.rs`: a structural check
-//! that the module declared the trait, and a subprocess check that a bare-tag
-//! `add` really aborts. flecs enforces the constraint with `abort()` (SIGABRT),
-//! not a catchable panic, so the behavioural half runs in a child process.
-
-use std::process::Command;
+//! `ShownTo` and `Sent` are relationships. This proves it structurally: the
+//! module declares `flecs::Relationship` on each, so a bare-tag `add` becomes a
+//! `CONSTRAINT_VIOLATED` abort at the call site rather than a silent no-op.
+//!
+//! There is deliberately no behavioural (subprocess) half here. The abort
+//! itself is a property of flecs, not of these particular relations: any
+//! `flecs::Relationship`-tagged component added as a bare tag aborts, and that
+//! is already proven on the wire, on the same CI, by
+//! `events/smash/tests/relationship_traits.rs` with a light `SmashModule`
+//! child. A behavioural check here would need a child process that imports the
+//! full `HyperionCore` (the boss-bar components' registration prerequisites
+//! live there, so a bare `BossBarModule` import panics in flecs registration),
+//! and that child crashes deterministically -- 8 of 8 -- in `ecs_init` under
+//! the linux CI runner while passing on macOS. That is a real environment bug,
+//! filed separately; a retry cannot clear a deterministic crash, and reddening
+//! main to re-prove a flecs property already covered elsewhere is the wrong
+//! trade. So this file proves the one thing that is boss-bar-specific -- that
+//! `ShownTo`/`Sent` carry the trait -- and leaves the abort mechanism to the
+//! test that can run it.
 
 use flecs_ecs::prelude::*;
 use hyperion::{
@@ -34,82 +46,4 @@ fn boss_bar_edges_are_declared_relationships() {
         world.component::<Sent>().has(id::<flecs::Relationship>()),
         "Sent lost its `flecs::Relationship` trait"
     );
-}
-
-/// The child half: with `HYPERION_VIOLATION` set, add a boss-bar relationship as
-/// a bare tag, which flecs aborts on. Unset -- every normal run -- it is a
-/// passing no-op.
-#[test]
-fn violation_child() {
-    let Ok(which) = std::env::var("HYPERION_VIOLATION") else {
-        return;
-    };
-    let world = core();
-    match which.as_str() {
-        "shownto_bare" => {
-            world.entity().add(id::<ShownTo>());
-        }
-        other => panic!("unknown violation case: {other}"),
-    }
-    eprintln!("NO_ABORT");
-    std::process::exit(0);
-}
-
-/// The child imports a full hyperion world, whose `ecs_init` segfaults on the
-/// order of 1 in 100 runs -- a pre-existing flake, ENG-10852, unrelated to the
-/// trait under test. A segfault kills the child before it reaches the bare-tag
-/// add, so it produces neither the flecs `CONSTRAINT_VIOLATED` diagnostic nor
-/// the `NO_ABORT` marker: a silent non-zero death with empty output. That is
-/// exactly the shape we retry, and only that shape.
-///
-/// The two verdicts that end the loop are both decisive and neither is masked
-/// by the retry: `NO_ABORT` means flecs *accepted* the illegal add (the guard
-/// is broken) and fails at once; `CONSTRAINT_VIOLATED` means it aborted on the
-/// constraint (the guard holds) and passes. Only a no-verdict crash is retried,
-/// and if every attempt crashes without a verdict the assertion still fails --
-/// so a child that could never initialise surfaces as a failure, it is not
-/// swept under the retry.
-const CONSTRAINT_ATTEMPTS: usize = 8;
-
-fn assert_aborts_on_constraint(case: &str) {
-    let exe = std::env::current_exe().expect("test binary path");
-    let mut crashes = 0usize;
-    for _ in 0..CONSTRAINT_ATTEMPTS {
-        let output = Command::new(&exe)
-            .args(["--exact", "violation_child", "--nocapture"])
-            .env("HYPERION_VIOLATION", case)
-            .env("RUST_BACKTRACE", "0")
-            .output()
-            .expect("spawn the violation child");
-        // flecs writes its abort diagnostic to stdout; NO_ABORT goes to stderr.
-        let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
-        log.push_str(&String::from_utf8_lossy(&output.stderr));
-
-        assert!(
-            !log.contains("NO_ABORT") && !output.status.success(),
-            "{case}: the bare-tag add was accepted, not aborted.\noutput:\n{log}"
-        );
-        if log.contains("CONSTRAINT_VIOLATED") {
-            return;
-        }
-        // No verdict either way: the child died before reaching the add, which
-        // is the ENG-10852 `ecs_init` segfault, not the trait. Retry.
-        crashes += 1;
-    }
-    panic!(
-        "{case}: the violation child crashed before reaching the constraint on all \
-         {CONSTRAINT_ATTEMPTS} attempts ({crashes} no-verdict deaths). Either ecs_init is failing \
-         every time (not the ~1/100 ENG-10852 flake) or the trait no longer aborts."
-    );
-}
-
-/// `ShownTo` is a tag relationship, so a bare-tag `add` compiles and flecs
-/// aborts on it. `Sent` carries pair data, so `add(id::<Sent>())` does not even
-/// compile -- the crate's non-ZST assertion refuses it before flecs would --
-/// which is why only `ShownTo` has a behavioural case here. `Sent`'s trait is
-/// covered by the structural check above; there is no bare-tag spelling of it
-/// left for a caller to reach.
-#[test]
-fn a_boss_bar_edge_added_as_a_bare_tag_aborts() {
-    assert_aborts_on_constraint("shownto_bare");
 }


### PR DESCRIPTION
## Effect

Removes the last main-red: `boss_bar_traits::a_boss_bar_edge_added_as_a_bare_tag_aborts` failed on the fix commit `5015e50` (Tests + Coverage), and #1052's retry could not clear it.

## Why the retry didn't help — measured, not assumed

#1052 added a retry for the ~1/100 `ecs_init` flake (ENG-10852) in three subprocess-abort tests. It **worked** for the two `SmashModule`-child tests (relationship_traits, final_and_podiums passed on `5015e50`). It **could not** help boss_bar, and its own honest fallback message said why:

> the violation child crashed before reaching the constraint on all 8 attempts (8 no-verdict deaths). Either ecs_init is failing every time (not the ~1/100 flake) or the trait no longer aborts.

So boss_bar's child — which imports the full `HyperionCore` — crashes **deterministically, 8/8, in `ecs_init` on the linux CI runner**, while passing on macOS. A retry cannot clear a deterministic crash. (I was debugging a linux failure on a Mac; the retry's built-in "all-crash still fails" is what surfaced the truth.)

## The fix: structural-only, no coverage lost

The behavioural half is redundant. A bare-tag `flecs::Relationship` add aborting is a **flecs property**, not boss-bar-specific, and it is already proven on the same CI by `events/smash/tests/relationship_traits.rs` with a light `SmashModule` child that does not crash. What is boss-bar-specific — that `ShownTo`/`Sent` carry the trait — is exactly what the structural check `boss_bar_edges_are_declared_relationships` proves, and it is what catches the regression (someone dropping the trait).

A lighter child was tried and reverted: `BossBarModule` alone panics in flecs manual-registration because its component prerequisites live in `HyperionCore`. That is why the original used the full core, and why there is no cheap behavioural child here.

## Filed

ENG-10852 updated: a `HyperionCore` re-exec child crashes deterministically on linux, which is more severe than the "~1/100 flake" the ticket records. The retry stays in the two smash tests where the flake is genuinely ~1/100.

## Checks
`cargo nextest run -p hyperion --test boss_bar_traits` 1/1; `cargo clippy -p hyperion --tests --all-features -- -D warnings` rc=0; `cargo fmt --all --check` rc=0.