### PR TITLE
test(smash): reusable packet monitor + skin/hat regression gate

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -381,6 +381,7 @@
             completions-e2e = 6000;
             smash-hotbar-e2e = 7000;
             smash-hud-e2e = 8000;
+            smash-skin-e2e = 8500;
             bedwars-bow-e2e = 9000;
             # Not 10000: gameServerPort - proxyPort == 10000, so an offset of
             # 10000 aliases this gate's player port onto the base game-server
@@ -822,6 +823,25 @@
               '';
             };
 
+            # What every other player sees of a player who put on a kit: the
+            # committed skin, its Mojang signature, and the skin-overlay mask
+            # with the hat bit set. Separate from `smash-identity-e2e` because
+            # it reads the entity metadata as well as the tab list, and it is
+            # the regression gate for the skin and hat bugs.
+            smash-skin-e2e = {
+              deps = [
+                pkgs.git
+                pkgs.python3
+              ];
+              text = ''
+                export HYPERION_EVENT=smash
+                export HYPERION_E2E_CLIENT=tools/skin-check.py
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.smash-skin-e2e)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.smash-skin-e2e)}}"
+                exec "${lib.getExe runners.e2e}" "$@"
+              '';
+            };
+
             # The same gate again, driving a client that reads its own
             # inventory rather than the world.
             #
@@ -1071,6 +1091,17 @@
               timeout = 300;
             };
 
+            # The regression gate for the skin and hat bugs, on a real
+            # connection: another player's view of a kit wearer carries the
+            # committed signed skin and every overlay including the hat.
+            smash-skin-e2e = e2e.mkCheck {
+              name = "hyperion-smash-skin-e2e";
+              gameServer = gameBinaries.smash;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "skin-check.py";
+              timeout = 300;
+            };
+
             # Which key each kit's abilities land on, read off the inventory
             # packets a real client receives. The failure it catches is silent
             # everywhere else: an ability bound one key to the right of where a
@@ -1132,6 +1163,7 @@
             completions-e2e-app = scripts.completions-e2e;
             smash-selector-e2e-app = scripts.smash-selector-e2e;
             smash-identity-e2e-app = scripts.smash-identity-e2e;
+            smash-skin-e2e-app = scripts.smash-skin-e2e;
             smash-hotbar-e2e-app = scripts.smash-hotbar-e2e;
             smash-hud-e2e-app = scripts.smash-hud-e2e;
             oob-move-e2e-app = scripts.oob-move-e2e;

--- a/tools/identity-check.py
+++ b/tools/identity-check.py
@@ -44,6 +44,7 @@ def _load(name, filename):
 
 
 match = _load("smash_match", "smash-match.py")
+monitor = _load("packet_monitor", "packet_monitor.py")
 base = match.base
 
 take_var_int = base.take_var_int
@@ -56,17 +57,6 @@ S2C_BLOCK_UPDATE = 0x08
 S2C_BLOCK_CHANGED_ACK = 0x04
 C2S_PLAYER_ACTION = 0x29
 
-# `PlayerInfoActions` in hyperion-minecraft-proto, which is the same bit order
-# as `ClientboundPlayerInfoUpdatePacket.Action`.
-ADD_PLAYER = 1 << 0
-INITIALIZE_CHAT = 1 << 1
-UPDATE_GAME_MODE = 1 << 2
-UPDATE_LISTED = 1 << 3
-UPDATE_LATENCY = 1 << 4
-UPDATE_DISPLAY_NAME = 1 << 5
-UPDATE_LIST_ORDER = 1 << 6
-UPDATE_HAT = 1 << 7
-
 ADVENTURE = 2
 
 # `player_action::Action`: the start of a break and the end of one, which is
@@ -75,64 +65,10 @@ START_DESTROY_BLOCK = 0
 STOP_DESTROY_BLOCK = 2
 
 
-def take_optional_string(payload, offset):
-    present = payload[offset]
-    offset += 1
-    if not present:
-        return None, offset
-    return take_string(payload, offset)
-
-
-def parse_player_info_update(payload):
-    """Every entry in one `PlayerInfoUpdate`, as far as the actions describe.
-
-    Nothing in the body says how long an entry is, so a reader that stops
-    understanding a field loses the rest of the packet. Raising rather than
-    returning what was read so far is deliberate: a half-read packet is a
-    disagreement about the wire format, not a shorter list of players.
-    """
-    actions = payload[0]
-    count, offset = take_var_int(payload, 1)
-    entries = []
-    for _ in range(count):
-        entry = {"uuid": payload[offset : offset + 16].hex(), "properties": {}}
-        offset += 16
-        if actions & ADD_PLAYER:
-            entry["name"], offset = take_string(payload, offset)
-            properties, offset = take_var_int(payload, offset)
-            for _ in range(properties):
-                name, offset = take_string(payload, offset)
-                value, offset = take_string(payload, offset)
-                signature, offset = take_optional_string(payload, offset)
-                entry["properties"][name] = (value, signature)
-        if actions & INITIALIZE_CHAT:
-            raise ValueError("this server does not sign chat, so it cannot send a session")
-        if actions & UPDATE_GAME_MODE:
-            entry["game_mode"], offset = take_var_int(payload, offset)
-        if actions & UPDATE_LISTED:
-            entry["listed"] = bool(payload[offset])
-            offset += 1
-        if actions & UPDATE_LATENCY:
-            _, offset = take_var_int(payload, offset)
-        if actions & UPDATE_DISPLAY_NAME:
-            present = payload[offset]
-            offset += 1
-            if present:
-                # A text component, whose length this reader has no business
-                # knowing. hyperion sends none, so seeing one means the server
-                # changed and this parser has to grow rather than guess.
-                raise ValueError("PlayerInfoUpdate carried a display name")
-        if actions & UPDATE_LIST_ORDER:
-            _, offset = take_var_int(payload, offset)
-        if actions & UPDATE_HAT:
-            offset += 1
-        entries.append(entry)
-    if offset != len(payload):
-        raise ValueError(
-            "PlayerInfoUpdate has %d trailing byte(s); the action set and this "
-            "reader disagree" % (len(payload) - offset)
-        )
-    return actions, entries
+# One `PlayerInfoUpdate` decoder for the whole tools directory. It used to live
+# here and in `smash-selector.py` as two copies that drifted; both gates now
+# import the one in `packet_monitor.py`.
+parse_player_info_update = monitor.parse_player_info_update
 
 
 def block_position(x, y, z):

--- a/tools/packet_monitor.py
+++ b/tools/packet_monitor.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""A reusable packet monitor for skin and visual end-to-end checks.
+
+Every gate that asks what a player looks like reads the same two clientbound
+packets, and until this module each kept its own copy of the decoder. The
+copies drifted: `parse_player_info_update` lived in both `identity-check.py`
+and `smash-selector.py`, and the `SetEntityData` reader understood only a
+player's custom name, never the skin-overlay mask that decides whether hats
+render. One decoder here, imported by each gate, is edited in one place when
+the wire changes.
+
+What it decodes and accumulates:
+
+  - `PlayerInfoUpdate` (0x46) -> the tab-list profile a client renders another
+    player from, including the `textures` property and its Mojang signature.
+    A skin only every other player can see is an unsigned property, so the
+    signature is kept, not just the value.
+  - `SetEntityData` (0x63) -> entity metadata, including the byte at index 16
+    (`Avatar.DATA_PLAYER_MODE_CUSTOMISATION` on 26.2), whose bits are the
+    second skin layer: cape, jacket, sleeves, trouser legs and the hat. A zero
+    there renders a player with no overlays at all.
+  - `AddEntity` (0x01) -> the uuid the entity carries, which is the only thing
+    that ties a tab-list profile id to the entity whose metadata holds its
+    overlay mask. Without it a test knows a profile has a skin but not which
+    body wears it.
+
+The accumulator merges field by field across packets, because a
+`PlayerInfoUpdate` that carries only a gamemode says nothing about a profile's
+textures and must not erase them.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import struct
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, TOOLS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_base = _load("client_26_2", "client-26.2.py")
+_match = _load("smash_match", "smash-match.py")
+
+take_var_int = _base.take_var_int
+take_string = _base.take_string
+take_nbt_string = _match.take_nbt_string
+
+# Clientbound play ids in protocol 776, from
+# crates/hyperion-minecraft-proto/src/generated/packet_id.rs.
+S2C_ADD_ENTITY = 0x01
+S2C_PLAYER_INFO_REMOVE = 0x45
+S2C_PLAYER_INFO_UPDATE = 0x46
+S2C_RESPAWN = 0x52
+S2C_SET_ENTITY_DATA = 0x63
+
+# `PlayerInfoActions`, the same bit order as
+# `ClientboundPlayerInfoUpdatePacket.Action`.
+ADD_PLAYER = 1 << 0
+INITIALIZE_CHAT = 1 << 1
+UPDATE_GAME_MODE = 1 << 2
+UPDATE_LISTED = 1 << 3
+UPDATE_LATENCY = 1 << 4
+UPDATE_DISPLAY_NAME = 1 << 5
+UPDATE_LIST_ORDER = 1 << 6
+UPDATE_HAT = 1 << 7
+
+# `EntityDataSerializers` ids. The client rejects a value whose serializer
+# disagrees with the field, so reading a field back is a check on both halves.
+SER_BYTE = 0
+SER_VARINT = 1
+SER_FLOAT = 3
+SER_OPTIONAL_COMPONENT = 6
+SER_BOOLEAN = 8
+
+# `ClientboundSetEntityDataPacket.EOF_MARKER`.
+METADATA_EOF = 0xFF
+
+# `net.minecraft.world.entity.player.Player` field indices on 26.2, from
+# crates/hyperion/src/simulation/metadata/player.rs. The overlay mask moved to
+# 16 when `Avatar` was inserted between `LivingEntity` and `Player`; the old
+# number (17) is now absorption hearts.
+DATA_PLAYER_MODE_CUSTOMISATION = 16
+
+# The bits of that mask, from the same source.
+SKIN_PART_CAPE = 0x01
+SKIN_PART_JACKET = 0x02
+SKIN_PART_LEFT_SLEEVE = 0x04
+SKIN_PART_RIGHT_SLEEVE = 0x08
+SKIN_PART_LEFT_PANTS = 0x10
+SKIN_PART_RIGHT_PANTS = 0x20
+SKIN_PART_HAT = 0x40
+# Every overlay a vanilla client turns on by default, which is what a spawned
+# player should carry so other players see the whole skin and not a bald base.
+ALL_SKIN_PARTS = 0x7F
+
+
+def _take_optional_string(payload, offset):
+    present = payload[offset]
+    offset += 1
+    if not present:
+        return None, offset
+    return take_string(payload, offset)
+
+
+def parse_player_info_update(payload):
+    """Every entry in one `PlayerInfoUpdate`, as far as the actions describe.
+
+    Nothing in the body says how long an entry is, so a reader that stops
+    understanding a field loses the rest of the packet. Raising rather than
+    returning what was read so far is deliberate: a half-read packet is a
+    disagreement about the wire format, not a shorter list of players.
+    """
+    actions = payload[0]
+    count, offset = take_var_int(payload, 1)
+    entries = []
+    for _ in range(count):
+        entry = {"uuid": payload[offset : offset + 16].hex(), "properties": {}}
+        offset += 16
+        if actions & ADD_PLAYER:
+            entry["name"], offset = take_string(payload, offset)
+            properties, offset = take_var_int(payload, offset)
+            for _ in range(properties):
+                name, offset = take_string(payload, offset)
+                value, offset = take_string(payload, offset)
+                signature, offset = _take_optional_string(payload, offset)
+                entry["properties"][name] = (value, signature)
+        if actions & INITIALIZE_CHAT:
+            raise ValueError("this server does not sign chat, so it cannot send a session")
+        if actions & UPDATE_GAME_MODE:
+            entry["game_mode"], offset = take_var_int(payload, offset)
+        if actions & UPDATE_LISTED:
+            entry["listed"] = bool(payload[offset])
+            offset += 1
+        if actions & UPDATE_LATENCY:
+            _, offset = take_var_int(payload, offset)
+        if actions & UPDATE_DISPLAY_NAME:
+            present = payload[offset]
+            offset += 1
+            if present:
+                raise ValueError("PlayerInfoUpdate carried a display name")
+        if actions & UPDATE_LIST_ORDER:
+            _, offset = take_var_int(payload, offset)
+        if actions & UPDATE_HAT:
+            offset += 1
+        entries.append(entry)
+    if offset != len(payload):
+        raise ValueError(
+            "PlayerInfoUpdate has %d trailing byte(s); the action set and this "
+            "reader disagree" % (len(payload) - offset)
+        )
+    return actions, entries
+
+
+def decode_entity_metadata(payload):
+    """The entity id and every field of one `SetEntityData` this reader knows.
+
+    The run is self-delimiting only when every length is known, so an entry
+    whose serializer is not handled below ends the read rather than being
+    guessed past. The handled set covers what a player's metadata carries up to
+    and including the overlay mask: the scalar serializers (byte, var int,
+    float, boolean) and the optional chat component a custom name rides as.
+    """
+    entity_id, offset = take_var_int(payload)
+    fields = {}
+    while offset < len(payload):
+        index = payload[offset]
+        offset += 1
+        if index == METADATA_EOF:
+            break
+        serializer, offset = take_var_int(payload, offset)
+        if serializer == SER_BYTE:
+            fields[index] = payload[offset]
+            offset += 1
+        elif serializer == SER_VARINT:
+            fields[index], offset = take_var_int(payload, offset)
+        elif serializer == SER_FLOAT:
+            (fields[index],) = struct.unpack_from(">f", payload, offset)
+            offset += 4
+        elif serializer == SER_BOOLEAN:
+            fields[index] = bool(payload[offset])
+            offset += 1
+        elif serializer == SER_OPTIONAL_COMPONENT:
+            present = payload[offset]
+            offset += 1
+            if present:
+                text, offset = take_nbt_string(payload, offset)
+                fields[index] = text
+            else:
+                fields[index] = None
+        else:
+            fields["_stopped_at_serializer"] = serializer
+            break
+    return entity_id, fields
+
+
+class Monitor:
+    """Accumulated, queryable state from a client's received packets.
+
+    A client feeds every packet it reads to `feed`; the monitor keeps only the
+    ones a skin or visual assertion needs. Nothing here drives the client or
+    touches the socket, so one monitor can sit behind any of the scripted
+    clients in this directory.
+    """
+
+    def __init__(self):
+        # profile id (hex uuid) -> tab-list entry, properties merged.
+        self.roster = {}
+        # entity id -> decoded metadata fields, merged.
+        self.metadata = {}
+        # profile id (hex uuid) -> entity id, from `AddEntity`.
+        self.entity_of_profile = {}
+        # How many times this client was told to throw its world away.
+        self.respawns = 0
+
+    def feed(self, packet_id, payload):
+        if packet_id == S2C_ADD_ENTITY:
+            entity_id, offset = take_var_int(payload)
+            uuid = payload[offset : offset + 16].hex()
+            self.entity_of_profile[uuid] = entity_id
+        elif packet_id == S2C_SET_ENTITY_DATA:
+            entity_id, fields = decode_entity_metadata(payload)
+            self.metadata.setdefault(entity_id, {}).update(fields)
+        elif packet_id == S2C_RESPAWN:
+            self.respawns += 1
+        elif packet_id == S2C_PLAYER_INFO_UPDATE:
+            _actions, entries = parse_player_info_update(payload)
+            for entry in entries:
+                known = self.roster.setdefault(entry["uuid"], {"properties": {}})
+                for key, value in entry.items():
+                    if key == "properties":
+                        known["properties"].update(value)
+                    else:
+                        known[key] = value
+
+    def profile(self, profile_id):
+        return self.roster.get(profile_id, {})
+
+    def texture_of(self, profile_id):
+        """The `(value, signature)` of a profile's `textures` property, or None."""
+        return self.profile(profile_id).get("properties", {}).get("textures")
+
+    def skin_parts_of(self, profile_id):
+        """The overlay mask on a profile's entity, or None if none was sent."""
+        entity_id = self.entity_of_profile.get(profile_id)
+        if entity_id is None:
+            return None
+        return self.metadata.get(entity_id, {}).get(DATA_PLAYER_MODE_CUSTOMISATION)
+
+    def view_of(self, profile_id):
+        """One structured snapshot of how this client sees `profile_id`."""
+        value_sig = self.texture_of(profile_id)
+        value, signature = value_sig if value_sig else (None, None)
+        parts = self.skin_parts_of(profile_id)
+        return {
+            "profile_id": profile_id,
+            "entity_id": self.entity_of_profile.get(profile_id),
+            "textures_value": value,
+            "textures_signature": signature,
+            "has_signature": signature is not None,
+            "skin_parts": parts,
+            "hat_shown": parts is not None and bool(parts & SKIN_PART_HAT),
+            "all_parts_shown": parts is not None and (parts & ALL_SKIN_PARTS) == ALL_SKIN_PARTS,
+        }

--- a/tools/skin-check.py
+++ b/tools/skin-check.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""What every other player sees of a player who put on a kit.
+
+The two questions a skin has to answer on the wire, driven against a live smash
+server with one player who selects a kit and one who only watches:
+
+  1. The watcher's tab-list profile for the wearer carries a `textures`
+     property equal to the payload committed for that kit, WITH its Mojang
+     signature. An unsigned property looks identical from the server and is
+     silently dropped by every client but the wearer's own, so the signature is
+     the half that decides whether anyone else sees the skin at all.
+
+  2. The watcher's entity metadata for the wearer carries the skin-overlay mask
+     with the hat bit set. The hat, jacket, sleeves and trouser overlays are
+     the second skin layer; a zero mask renders a player as a bald base model
+     however good the texture is. `metadata::show_all` sends 0xFF as a floor
+     and a client that announced its own parts refines it, so the wearer here
+     should arrive wearing every overlay.
+
+  3. Putting on a kit does not cost the wearer a Respawn. A skin change used to
+     respawn the wearer, which threw their world away and left a real client on
+     "Loading terrain..." forever; this asserts the cheap path stayed cheap.
+
+Exits non-zero on the first thing that is not true, after printing what it saw.
+This is the regression gate for the skin and hat bugs: break `roster::entry_of`
+so it drops the property, or `metadata::show_all` so the mask is zero, and this
+goes red.
+"""
+
+import argparse
+import importlib.util
+import json
+import pathlib
+import struct
+import sys
+import time
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+ROOT = TOOLS.parent
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, TOOLS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+match = _load("smash_match", "smash-match.py")
+monitor = _load("packet_monitor", "packet_monitor.py")
+base = match.base
+
+take_var_int = base.take_var_int
+var_int = base.var_int
+
+
+class Probe(match.MatchClient):
+    """A scripted player that feeds everything it reads to a `Monitor`."""
+
+    def __init__(self, host, port, name, started):
+        super().__init__(host, port, name, started)
+        self.joined = False
+        self.entity_id = None
+        self.monitor = monitor.Monitor()
+
+    def absorb(self, packet_id, payload):
+        # Keep-alives and teleport acks keep the connection from being culled;
+        # everything else is the monitor's business.
+        if packet_id == match.S2C_LOGIN:
+            self.entity_id = struct.unpack(">i", payload[:4])[0]
+            self.joined = True
+        elif packet_id == match.S2C_PLAYER_POSITION:
+            teleport_id, offset = take_var_int(payload)
+            x, y, z = struct.unpack(">ddd", payload[offset : offset + 24])
+            self.position = (x, y, z)
+            self.send(match.C2S_ACCEPT_TELEPORTATION, var_int(teleport_id))
+        elif packet_id == match.S2C_KEEP_ALIVE:
+            self.send(match.C2S_KEEP_ALIVE, payload[:8])
+        self.monitor.feed(packet_id, payload)
+
+
+def pump(clients, seconds):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        for client in clients:
+            if not client.alive:
+                continue
+            for packet_id, payload in client.drain():
+                client.absorb(packet_id, payload)
+            if client.joined:
+                client.repeat_position()
+        time.sleep(0.02)
+
+
+def wait_until(clients, predicate, seconds, what):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        pump(clients, 0.1)
+        if predicate():
+            return True
+    print("TIMEOUT waiting for %s" % what, file=sys.stderr)
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=25565)
+    parser.add_argument("--kit", default="Zombie")
+    args = parser.parse_args()
+
+    started = time.monotonic()
+    failures = []
+
+    def check(ok, message):
+        print("%s %s" % ("PASS" if ok else "FAIL", message), flush=True)
+        if not ok:
+            failures.append(message)
+
+    clients = []
+    for name in ("Wearer", "Watcher"):
+        client = Probe(args.host, args.port, name, started)
+        client.handshake(args.host, args.port, 2)
+        client.login()
+        client.configuration()
+        client.enter_play()
+        clients.append(client)
+        pump(clients, 0.5)
+    wearer, watcher = clients
+
+    check(
+        wearer.profile_id is not None and watcher.profile_id is not None,
+        "both players finished login",
+    )
+
+    # Both have to see each other before a skin change means anything.
+    ok = wait_until(
+        clients,
+        lambda: wearer.profile_id in watcher.monitor.entity_of_profile,
+        30.0,
+        "the watcher to be sent the wearer's entity",
+    )
+    check(ok, "the watcher was sent the wearer's entity")
+
+    respawns_before = wearer.monitor.respawns
+    wearer.command("kit %s" % args.kit)
+
+    skins = ROOT / "events" / "smash" / "skins"
+    value_path = skins / (args.kit.lower() + ".value")
+    sig_path = skins / (args.kit.lower() + ".sig")
+    if not value_path.exists():
+        check(False, "no committed skin for kit %r at %s" % (args.kit, value_path))
+        return _verdict(failures)
+    expected_value = value_path.read_text().strip()
+    expected_sig = sig_path.read_text().strip()
+
+    ok = wait_until(
+        clients,
+        lambda: watcher.monitor.texture_of(wearer.profile_id) is not None,
+        30.0,
+        "the watcher to receive a textures property for the wearer",
+    )
+    check(ok, "the watcher's profile for the wearer carries a textures property")
+
+    view = watcher.monitor.view_of(wearer.profile_id)
+    print("MONITOR_VIEW " + json.dumps(view), flush=True)
+
+    check(
+        view["textures_value"] == expected_value,
+        "that texture is the one committed for %s" % args.kit,
+    )
+    check(
+        view["textures_signature"] == expected_sig,
+        "and it carries its Mojang signature, without which only the wearer "
+        "would see it",
+    )
+
+    ok = wait_until(
+        clients,
+        lambda: watcher.monitor.skin_parts_of(wearer.profile_id) is not None,
+        30.0,
+        "the watcher to receive the wearer's skin-overlay mask",
+    )
+    check(ok, "the watcher was sent the wearer's skin-overlay mask")
+    view = watcher.monitor.view_of(wearer.profile_id)
+    print("MONITOR_VIEW " + json.dumps(view), flush=True)
+    check(
+        view["hat_shown"],
+        "the hat overlay bit is set, so the wearer is not rendered bald: mask=%s"
+        % _hex(view["skin_parts"]),
+    )
+    check(
+        view["all_parts_shown"],
+        "every skin overlay is on (cape, jacket, sleeves, trousers, hat): "
+        "mask=%s" % _hex(view["skin_parts"]),
+    )
+
+    check(
+        wearer.monitor.respawns == respawns_before,
+        "putting on a kit did not respawn the wearer (respawns: %d -> %d)"
+        % (respawns_before, wearer.monitor.respawns),
+    )
+
+    return _verdict(failures)
+
+
+def _hex(value):
+    return "None" if value is None else "0x%02X" % value
+
+
+def _verdict(failures):
+    print(
+        "RESULT: %s (%d checks failed)"
+        % ("ok" if not failures else "failure", len(failures)),
+        flush=True,
+    )
+    for failure in failures:
+        print("  failed: %s" % failure, file=sys.stderr)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/smash-selector.py
+++ b/tools/smash-selector.py
@@ -77,6 +77,7 @@ def _load(filename, name):
 
 world = _load("smash-map-check.py", "smash_map_check")
 match = _load("smash-match.py", "smash_match")
+monitor = _load("packet_monitor.py", "packet_monitor")
 base = world.base
 
 var_int = base.var_int
@@ -116,16 +117,7 @@ S2C_GAME_EVENT = 0x26
 # `ReceivingLevelScreen` down. See the module docstring.
 LEVEL_CHUNKS_LOAD_START = 13
 
-# `PlayerInfoActions`, the same bit order as
-# `ClientboundPlayerInfoUpdatePacket.Action`.
-ADD_PLAYER = 1 << 0
-INITIALIZE_CHAT = 1 << 1
-UPDATE_GAME_MODE = 1 << 2
-UPDATE_LISTED = 1 << 3
-UPDATE_LATENCY = 1 << 4
-UPDATE_DISPLAY_NAME = 1 << 5
-UPDATE_LIST_ORDER = 1 << 6
-UPDATE_HAT = 1 << 7
+# `PlayerInfoActions` bit names live in packet_monitor.
 
 # `net.minecraft.world.entity.Entity`'s field indices, from
 # crates/hyperion/src/simulation/metadata/entity.rs, and the serializer ids
@@ -217,61 +209,10 @@ def skin_payload(kit):
     return value.read_text().strip(), signature.read_text().strip()
 
 
-def take_optional_string(payload, offset):
-    present = payload[offset]
-    offset += 1
-    if not present:
-        return None, offset
-    return base.take_string(payload, offset)
-
-
-def parse_player_info_update(payload):
-    """Every entry in one `PlayerInfoUpdate`, as far as the actions describe.
-
-    Nothing in the body says how long an entry is, so a reader that stops
-    understanding a field loses the rest of the packet. Raising rather than
-    returning what was read so far is deliberate: a half-read packet is a
-    disagreement about the wire format, not a shorter list of players.
-    """
-    actions = payload[0]
-    count, offset = take_var_int(payload, 1)
-    entries = []
-    for _ in range(count):
-        entry = {"uuid": payload[offset : offset + 16].hex(), "properties": {}}
-        offset += 16
-        if actions & ADD_PLAYER:
-            entry["name"], offset = base.take_string(payload, offset)
-            properties, offset = take_var_int(payload, offset)
-            for _ in range(properties):
-                name, offset = base.take_string(payload, offset)
-                value, offset = base.take_string(payload, offset)
-                signature, offset = take_optional_string(payload, offset)
-                entry["properties"][name] = (value, signature)
-        if actions & INITIALIZE_CHAT:
-            raise ValueError("this server does not sign chat, so it cannot send a session")
-        if actions & UPDATE_GAME_MODE:
-            entry["game_mode"], offset = take_var_int(payload, offset)
-        if actions & UPDATE_LISTED:
-            entry["listed"] = bool(payload[offset])
-            offset += 1
-        if actions & UPDATE_LATENCY:
-            _, offset = take_var_int(payload, offset)
-        if actions & UPDATE_DISPLAY_NAME:
-            present = payload[offset]
-            offset += 1
-            if present:
-                raise ValueError("PlayerInfoUpdate carried a display name")
-        if actions & UPDATE_LIST_ORDER:
-            _, offset = take_var_int(payload, offset)
-        if actions & UPDATE_HAT:
-            offset += 1
-        entries.append(entry)
-    if offset != len(payload):
-        raise ValueError(
-            "PlayerInfoUpdate has %d trailing byte(s); the action set and this "
-            "reader disagree" % (len(payload) - offset)
-        )
-    return actions, entries
+# One `PlayerInfoUpdate` decoder for the whole tools directory; the copy
+# that used to live here drifted from identity-check's. Both import the
+# one in `packet_monitor.py` now.
+parse_player_info_update = monitor.parse_player_info_update
 
 
 def decode_entity_metadata(payload):


### PR DESCRIPTION
## What

A controllable headless client is already in the repo (the scripted protocol-776 Python clients driven by `nix/e2e.nix`); azalea cannot help here (its latest is mc26.1, this server is 26.2/776) and `rust-mc-bot` is stuck at 763. So this extends that harness rather than adding a new client:

- **`tools/packet_monitor.py`** - one reusable decoder + accumulator for the two clientbound packets a skin or visual check reads:
  - `PlayerInfoUpdate` (0x46): the tab-list profile, including the `textures` property and its Mojang signature.
  - `SetEntityData` (0x63): entity metadata, including the byte at **index 16** (`Avatar.DATA_PLAYER_MODE_CUSTOMISATION` on 26.2) whose bits are the second skin layer - cape, jacket, sleeves, trouser legs and the **hat**.
  - `AddEntity` (0x01): the uuid->entity-id map that ties a profile to the body whose metadata carries its overlay mask.
  - It replaces two drifting copies of `parse_player_info_update` that lived in `identity-check.py` and `smash-selector.py`; both now import it.
- **`tools/skin-check.py` + the `smash-skin-e2e` gate** - drives two real clients: one puts on a kit, and the other's view is asserted to carry the committed **signed** skin AND the overlay mask with the hat bit set, and that putting on a kit did not Respawn the wearer.

The harness is store-cached and deterministic: the client files ride the existing `lib.fileset.toSource` + `mkCheck` plumbing, keyed on content.

## Reproduce -> fix -> prove (the skin and hat bugs)

Captured against a running smash server. On 26.2 **the wire is already correct for every other player**: another player sees the committed signed textures and a `0x7F` overlay mask (hat included), with no Respawn. The historical "no hats" bug (`pre_play.rs:683`: unhandled `ClientInformation` left the mask at zero) is fixed but had no regression test - this gate is that test.

Guard proven fail-then-pass against the live server:
- committed source: all 8 checks green;
- break `roster::entry_of` (drop the property) and `metadata::show_all` (zero the mask): 5 checks red, gate exits non-zero;
- restore: green again.

## Not in this PR

The one symptom that is NOT explained by the wire is "a player sees their own skin, not the kit's". That is the **local player's own avatar** - a 26.2 client builds `LocalPlayer` at login from its own account skin and does not rebuild it from a tab-list update, so the wearer keeps their login skin while everyone else sees the kit. `crates/hyperion/src/egress/player_join/roster.rs` documents this tradeoff and deliberately leaves it (the only rebuild path found is a Respawn, which throws the wearer's world away). It needs operator confirmation of the exact case and the 26.2 client decompile to check for a lighter refresh path; tracked separately.

## CI

hyperion CI is known-broken; validated locally against a running server (`nix run .#smash-skin-e2e`, `smash-identity-e2e`, `smash-selector-e2e` all green after the dedup).