### PR TITLE
fix(arrow): drop the last wrong-convention rotation helper + wire-level heading gate (#1057)

### DIFF
--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -81,7 +81,7 @@ pub use flight::{Flight, FlyingSpeed, MovementTracking};
 pub use lookup::{DeferredMap, IgnMap, PlayerUuidLookup, StreamLookup};
 pub use pose::{
     ChunkPosition, EntitySize, PLAYER_SPAWN_POSITION, PendingTeleportation, Pitch, Position,
-    Velocity, Yaw, aabb, block_bounds, get_direction_from_rotation, get_rotation_from_velocity,
+    Velocity, Yaw, aabb, block_bounds, get_direction_from_rotation,
 };
 pub use xp::{Xp, XpVisual};
 

--- a/crates/hyperion/src/simulation/pose.rs
+++ b/crates/hyperion/src/simulation/pose.rs
@@ -236,13 +236,6 @@ impl PendingTeleportation {
 }
 
 #[must_use]
-pub fn get_rotation_from_velocity(velocity: Vec3) -> (f32, f32) {
-    let yaw = (-velocity.x).atan2(velocity.z).to_degrees(); // Correct yaw calculation
-    let pitch = (-velocity.y).atan2(velocity.length()).to_degrees(); // Correct pitch calculation
-    (yaw, pitch)
-}
-
-#[must_use]
 pub fn get_direction_from_rotation(yaw: f32, pitch: f32) -> Vec3 {
     // Convert angles from degrees to radians
     let yaw_rad = yaw.to_radians();

--- a/flake.nix
+++ b/flake.nix
@@ -1035,6 +1035,24 @@
               needsGenMap = true;
             };
 
+            # The bow read off the wire, as a store-cached gate rather than
+            # only the `nix run .#bedwars-bow-e2e` runner. `bow-check.py` fires
+            # a real draw and reads the arrow's `ClientboundAddEntity`: its
+            # velocity (the charge curve), and since this change its two
+            # rotation bytes -- the client-visible heading. An off-axis shot
+            # proves the heading is vanilla's projectile convention
+            # (`yaw = atan2(dx, dz)`), not the shooter's own look yaw that
+            # rendered every arrow mirrored. Same bedwars server and world as
+            # the `e2e` gate above.
+            bedwars-bow-e2e = e2e.mkCheck {
+              name = "hyperion-bedwars-bow-e2e";
+              gameServer = gameBinaries.bedwars;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "bow-check.py";
+              clientArgs = [ "--name" "Archer" ];
+              needsGenMap = true;
+            };
+
             smash-e2e = e2e.mkCheck {
               name = "hyperion-smash-e2e";
               gameServer = gameBinaries.smash;

--- a/tools/bow-check.py
+++ b/tools/bow-check.py
@@ -46,6 +46,7 @@ Exits non-zero on the first thing that is not true, after printing what it saw.
 
 import argparse
 import importlib.util
+import math
 import pathlib
 import struct
 import sys
@@ -81,6 +82,28 @@ MAX_ARROW_SPEED = 3.0
 
 # `LastFireTime::can_fire`, in seconds.
 FIRE_COOLDOWN = 0.150
+
+
+def look_angles(motion):
+    """Vanilla's projectile facing for a velocity, the server's own `look_angles`.
+
+    A projectile stores `yaw = atan2(dx, dz)` and `pitch = atan2(dy, horizontal)`
+    (`AbstractArrow.tick`), which is the sign-flip of the look convention a
+    shooter's own yaw uses. Kept here rather than imported, so changing the Rust
+    cannot also change what proves it.
+    """
+    mx, my, mz = motion
+    horizontal = math.hypot(mx, mz)
+    yaw = math.degrees(math.atan2(mx, mz))
+    pitch = math.degrees(math.atan2(my, horizontal))
+    return yaw, pitch
+
+
+def angle_delta(a, b):
+    """The shorter arc between two angles in degrees, so 179 and -179 are two
+    apart rather than 358."""
+    d = (a - b) % 360.0
+    return min(d, 360.0 - d)
 
 
 def entity_type_id(name):
@@ -150,18 +173,27 @@ class Archer(match.MatchClient):
         offset += 24
         motion, offset = match.take_lp_vec3(payload, offset)
         speed = (motion[0] ** 2 + motion[1] ** 2 + motion[2] ** 2) ** 0.5
+        # Since 26.2 the facing rides right after the velocity: a signed byte
+        # of pitch then one of yaw, each 1/256 of a turn (`Mth.packDegrees`).
+        # This is the client-visible heading the rotation gate below reads.
+        (x_rot, y_rot) = struct.unpack(">bb", payload[offset : offset + 2])
+        offset += 2
+        wire_pitch = x_rot * 360.0 / 256.0
+        wire_yaw = y_rot * 360.0 / 256.0
         entry = {
             "id": entity_id,
             "type": type_id,
             "position": (x, y, z),
             "motion": motion,
             "speed": speed,
+            "wire_yaw": wire_yaw,
+            "wire_pitch": wire_pitch,
         }
         self.spawned.append(entry)
         self.log(
             "<- AddEntity id=%d type=%d at (%.2f, %.2f, %.2f) motion=(%.3f, "
-            "%.3f, %.3f) |v|=%.3f"
-            % ((entity_id, type_id, x, y, z) + motion + (speed,))
+            "%.3f, %.3f) |v|=%.3f yaw=%.1f pitch=%.1f"
+            % ((entity_id, type_id, x, y, z) + motion + (speed, wire_yaw, wire_pitch))
         )
 
     def absorb_slot(self, payload):
@@ -365,6 +397,51 @@ def main():
         "two releases %d ms apart fire once, not twice (got %d arrows)"
         % (int(FIRE_COOLDOWN / 3.0 * 1000), len(burst)),
     )
+
+    # --- the heading on the wire --------------------------------------
+    #
+    # The arc was always right; what a bystander saw was not. A projectile
+    # stores yaw = atan2(dx, dz), pitch = atan2(dy, horizontal) -- the
+    # sign-flip of the shooter's own look -- and hyperion used to send the
+    # shooter's own yaw instead, so every arrow rendered mirrored across its
+    # line of flight. Fire off a coordinate axis so the sign shows, and read
+    # the two rotation bytes straight out of the AddEntity. Nothing here is
+    # inferred: this is the number the client turns the arrow model by.
+    pump(client, 0.5)
+    client.aim(35.0, -20.0)
+    client.send_position()
+    pump(client, 0.3)
+    angled = draw(1.5, "(full draw, aimed yaw 35 pitch -20)")
+    check(
+        len(angled) == 1,
+        "an off-axis full draw fires exactly one arrow (got %d)" % len(angled),
+    )
+    if angled:
+        launch = angled[0][0]
+        exp_yaw, exp_pitch = look_angles(launch["motion"])
+        wire_yaw = launch["wire_yaw"]
+        wire_pitch = launch["wire_pitch"]
+        # One angle byte is 360/256 = 1.40625 degrees; allow two steps for the
+        # quantisation plus the f32 the server aims in.
+        tol = 2.0 * 360.0 / 256.0
+        check(
+            angle_delta(wire_yaw, exp_yaw) < tol,
+            "the arrow's wire yaw is atan2(dx, dz) = %.1f (got %.1f)"
+            % (exp_yaw, wire_yaw),
+        )
+        check(
+            angle_delta(wire_pitch, exp_pitch) < tol,
+            "the arrow's wire pitch is atan2(dy, horizontal) = %.1f (got %.1f)"
+            % (exp_pitch, wire_pitch),
+        )
+        # And it is the projectile convention, not the shooter's look: the old
+        # bug sent the player's own +35 where vanilla sends its sign-flip. This
+        # is the assertion that fails loudly if the mirrored heading returns.
+        check(
+            angle_delta(wire_yaw, 35.0) > 10.0,
+            "the wire yaw is not the shooter's look yaw of 35 (the mirrored-"
+            "heading bug); got %.1f" % wire_yaw,
+        )
 
     print(
         "RESULT: %s (%d checks failed)"


### PR DESCRIPTION
Two follow-ups to #1058 (closes the remaining items on #1057).

## 1. Remove the last wrong-convention rotation helper

`simulation::get_rotation_from_velocity` was dead (no callers once `facing` was removed in #1058) and carried a *third* rotation convention, wrong for both a projectile and a look: `atan2(-dx, dz)` for yaw and `atan2(-dy, |v|)` (full length, not horizontal distance) for pitch. A future caller reaching for the obvious name would have silently reintroduced the mirrored, miscomputed heading. Deleted with its re-export.

`simulation::projectile_motion::look_angles` is now the single way to derive a projectile's rotation from velocity. Enumerated the other velocity->angle sites from the source: a mob facing the hub (`smash/terrain.rs`) and a knockback direction (`bedwars/attack.rs`) are the look convention on purpose and are left alone.

## 2. Prove the heading on the wire

The differential gate proves the physics but not that the number leaves the server. `tools/bow-check.py` already fires a real bow and reads the arrow's `ClientboundAddEntity`; it now also decodes the two rotation bytes after the velocity (`Mth.unpackDegrees`) and, firing **off a coordinate axis** (yaw 35, pitch -20) so the sign shows, asserts the wire yaw/pitch are `look_angles(velocity)` and that the yaw is *not* the shooter's own look. New `checks.bedwars-bow-e2e` store-cached `mkCheck` gate runs it against the real bedwars server + proxy.

`packet_monitor.py` was considered but its `AddEntity` decoder only extracts the uuid (for skin correlation); `bow-check.py`'s purpose-built decoder already reads velocity, so extending it (the existing bow gate) is the minimal correct change.

## Proven fail-then-pass at the wire

With the old player-convention heading the gate fails:
```
FAIL the arrow's wire yaw is atan2(dx, dz) = -35.0 (got 33.8)
FAIL the arrow's wire pitch is atan2(dy, horizontal) = 20.0 (got -21.1)
FAIL the wire yaw is not the shooter's look yaw of 35 (the mirrored-heading bug); got 33.8
```
and passes with the fix.

## Verification (aarch64-darwin)

- `nix build .#checks.aarch64-darwin.bedwars-bow-e2e` -- builds and passes (fails as above when `look_angles` is flipped to the buggy convention)
- `cargo check -p hyperion` and `cargo clippy -p hyperion --all-targets -- -D warnings` -- clean after the deletion
- `nix run .#fmt`
