### PR TITLE
refactor(e2e): one AddEntity decoder for the skin and bow gates (#1057)

### DIFF
--- a/tools/bow-check.py
+++ b/tools/bow-check.py
@@ -64,6 +64,7 @@ def _load(name, filename):
 
 
 match = _load("smash_match", "smash-match.py")
+monitor = _load("packet_monitor", "packet_monitor.py")
 base = match.base
 
 take_var_int = base.take_var_int
@@ -80,8 +81,6 @@ HOTBAR_START_SLOT = match.HOTBAR_START_SLOT
 # that changing the constant in Rust cannot also change what proves it.
 MAX_ARROW_SPEED = 3.0
 
-# `LastFireTime::can_fire`, in seconds.
-FIRE_COOLDOWN = 0.150
 
 
 def look_angles(motion):
@@ -160,40 +159,35 @@ class Archer(match.MatchClient):
             self.alive = False
 
     def absorb_add_entity(self, payload):
-        """`ClientboundAddEntityPacket#STREAM_CODEC`, field for field.
+        """Decode one AddEntity with the shared `packet_monitor` decoder.
 
-        Since 26.2 this packet carries the entity's velocity itself, through
-        the same packed codec `set_entity_motion` uses, which is the whole
-        reason a launch speed is checkable from a client at all.
+        The launch velocity (the charge curve) and the two rotation bytes (the
+        client-visible heading) both come from that one decoder, so this gate
+        and the skin gates read the packet the same way. `wire_yaw`/`wire_pitch`
+        are its `yaw`/`pitch`, named for what the heading assertions below ask.
         """
-        entity_id, offset = take_var_int(payload)
-        offset += 16  # uuid
-        type_id, offset = take_var_int(payload, offset)
-        x, y, z = struct.unpack(">ddd", payload[offset : offset + 24])
-        offset += 24
-        motion, offset = match.take_lp_vec3(payload, offset)
+        entity = monitor.decode_add_entity(payload)
+        motion = entity["motion"]
         speed = (motion[0] ** 2 + motion[1] ** 2 + motion[2] ** 2) ** 0.5
-        # Since 26.2 the facing rides right after the velocity: a signed byte
-        # of pitch then one of yaw, each 1/256 of a turn (`Mth.packDegrees`).
-        # This is the client-visible heading the rotation gate below reads.
-        (x_rot, y_rot) = struct.unpack(">bb", payload[offset : offset + 2])
-        offset += 2
-        wire_pitch = x_rot * 360.0 / 256.0
-        wire_yaw = y_rot * 360.0 / 256.0
         entry = {
-            "id": entity_id,
-            "type": type_id,
-            "position": (x, y, z),
+            "id": entity["id"],
+            "type": entity["type"],
+            "position": entity["position"],
             "motion": motion,
             "speed": speed,
-            "wire_yaw": wire_yaw,
-            "wire_pitch": wire_pitch,
+            "wire_yaw": entity["yaw"],
+            "wire_pitch": entity["pitch"],
         }
         self.spawned.append(entry)
         self.log(
             "<- AddEntity id=%d type=%d at (%.2f, %.2f, %.2f) motion=(%.3f, "
             "%.3f, %.3f) |v|=%.3f yaw=%.1f pitch=%.1f"
-            % ((entity_id, type_id, x, y, z) + motion + (speed, wire_yaw, wire_pitch))
+            % (
+                (entry["id"], entry["type"])
+                + entry["position"]
+                + motion
+                + (speed, entry["wire_yaw"], entry["wire_pitch"])
+            )
         )
 
     def absorb_slot(self, payload):
@@ -386,16 +380,20 @@ def main():
     client.spawned.clear()
     client.use_slot(bow_slot, "(nock, first of two)")
     pump(client, 1.2)
+    # Both releases before the next socket read, so the server sees them
+    # within a tick of each other, far inside `LastFireTime::can_fire`'s 150 ms
+    # window. An earlier version slept 50 ms between them -- still inside the
+    # window, but a loaded server could stall the two releases more than 150 ms
+    # apart and fire both, a wall-clock race that failed the gate under load.
+    # Back to back asserts the same thing without the race.
     client.release_slot(bow_slot, "(first release)")
-    # Deliberately inside `LastFireTime::can_fire`'s 150 ms window.
-    time.sleep(FIRE_COOLDOWN / 3.0)
     client.release_slot(bow_slot, "(second release, inside the cooldown)")
     pump(client, 1.0)
     burst = arrows_seen()
     check(
         len(burst) == 1,
-        "two releases %d ms apart fire once, not twice (got %d arrows)"
-        % (int(FIRE_COOLDOWN / 3.0 * 1000), len(burst)),
+        "two releases inside the 150 ms cooldown fire once, not twice "
+        "(got %d arrows)" % len(burst),
     )
 
     # --- the heading on the wire --------------------------------------

--- a/tools/packet_monitor.py
+++ b/tools/packet_monitor.py
@@ -19,10 +19,11 @@ What it decodes and accumulates:
     (`Avatar.DATA_PLAYER_MODE_CUSTOMISATION` on 26.2), whose bits are the
     second skin layer: cape, jacket, sleeves, trouser legs and the hat. A zero
     there renders a player with no overlays at all.
-  - `AddEntity` (0x01) -> the uuid the entity carries, which is the only thing
-    that ties a tab-list profile id to the entity whose metadata holds its
-    overlay mask. Without it a test knows a profile has a skin but not which
-    body wears it.
+  - `AddEntity` (0x01) -> the whole spawn, through the one `decode_add_entity`
+    every gate shares: the uuid that ties a tab-list profile id to the entity
+    whose metadata holds its overlay mask, and -- since 26.2 packs them into
+    this packet -- the velocity and the facing (yaw and pitch), which is what a
+    projectile gate reads to check the heading the client turns the model by.
 
 The accumulator merges field by field across packets, because a
 `PlayerInfoUpdate` that carries only a gamemode says nothing about a profile's
@@ -51,6 +52,7 @@ _match = _load("smash_match", "smash-match.py")
 take_var_int = _base.take_var_int
 take_string = _base.take_string
 take_nbt_string = _match.take_nbt_string
+take_lp_vec3 = _match.take_lp_vec3
 
 # Clientbound play ids in protocol 776, from
 # crates/hyperion-minecraft-proto/src/generated/packet_id.rs.
@@ -200,6 +202,40 @@ def decode_entity_metadata(payload):
     return entity_id, fields
 
 
+def decode_add_entity(payload):
+    """`ClientboundAddEntityPacket#STREAM_CODEC`, field for field.
+
+    The one decoder for this packet. Every gate that asks what a spawned entity
+    is reads the same fields, and a second copy is exactly how the skin gates
+    and the bow gate would drift apart -- the drift this module exists to end.
+    Returns the id that ties an entity to its metadata, the uuid that ties it to
+    a tab-list profile, the type, the position, the velocity (since 26.2 the
+    packet carries it, packed the same way `set_entity_motion` does), and the
+    facing -- yaw and pitch in degrees off the two `Mth.packDegrees` bytes, the
+    projectile convention the client turns the model by.
+    """
+    entity_id, offset = take_var_int(payload)
+    uuid = payload[offset : offset + 16].hex()
+    offset += 16
+    type_id, offset = take_var_int(payload, offset)
+    x, y, z = struct.unpack(">ddd", payload[offset : offset + 24])
+    offset += 24
+    motion, offset = take_lp_vec3(payload, offset)
+    # Facing rides right after the velocity: a signed byte of pitch then one of
+    # yaw, each 1/256 of a turn (`Mth.unpackDegrees`).
+    x_rot, y_rot = struct.unpack(">bb", payload[offset : offset + 2])
+    offset += 2
+    return {
+        "id": entity_id,
+        "uuid": uuid,
+        "type": type_id,
+        "position": (x, y, z),
+        "motion": motion,
+        "pitch": x_rot * 360.0 / 256.0,
+        "yaw": y_rot * 360.0 / 256.0,
+    }
+
+
 class Monitor:
     """Accumulated, queryable state from a client's received packets.
 
@@ -221,9 +257,8 @@ class Monitor:
 
     def feed(self, packet_id, payload):
         if packet_id == S2C_ADD_ENTITY:
-            entity_id, offset = take_var_int(payload)
-            uuid = payload[offset : offset + 16].hex()
-            self.entity_of_profile[uuid] = entity_id
+            entity = decode_add_entity(payload)
+            self.entity_of_profile[entity["uuid"]] = entity["id"]
         elif packet_id == S2C_SET_ENTITY_DATA:
             entity_id, fields = decode_entity_metadata(payload)
             self.metadata.setdefault(entity_id, {}).update(fields)


### PR DESCRIPTION
Last item on the arrow/bow thread (#1057), following #1058 and #1059.

## One AddEntity decoder

`packet_monitor.py` decoded only the uuid out of `ClientboundAddEntity`; `bow-check.py` kept its own copy that also read velocity + the two rotation bytes. Two decoders for one packet is the same drift the skins PR removed from the PlayerInfoUpdate parser.

`packet_monitor.decode_add_entity` is now the single decoder, returning id, uuid, type, position, velocity, and facing (yaw/pitch via `Mth.unpackDegrees`). `Monitor.feed` uses it for the uuid->entity mapping the skin gates read; `bow-check.py` imports it instead of its own copy.

## Deterministic cooldown check

The bow gate's cooldown check slept 50 ms between two releases and asserted the second was blocked. Under a loaded build machine the two releases could be processed >150 ms apart and both fire, failing the gate on a wall-clock race unrelated to what it tests (it failed twice consecutively here). Firing them back to back -- both before the next socket read -- asserts the same thing without the race.

## Verification (aarch64-darwin)

- `nix build .#checks.aarch64-darwin.bedwars-bow-e2e` -- **green** with the shared decoder (heading checks: wire yaw -35.2 vs expected -35.0, pitch 19.7 vs 20.0).
- Stays **fail-then-pass**: flipping `look_angles` to the player convention makes it fail on the wire -- `the arrow's wire yaw is atan2(dx, dz) = -35.0 (got 33.8)` and `the wire yaw is not the shooter's look yaw of 35 (the mirrored-heading bug); got 33.8`.
- `nix build .#checks.aarch64-darwin.smash-skin-e2e` -- **green**, so the shared decoder did not disturb the skin path.
- All four `packet_monitor` consumers (`packet_monitor`, `bow-check`, `identity-check`, `skin-check`, `smash-selector`) `py_compile` clean.
