### PR TITLE
feat(flake): per-event run apps (nix run .#bedwars / .#smash), drop generic .#dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ https://github.com/user-attachments/assets/64a4a8c7-f375-4821-a1c7-0efc69c1ae0b
 
 - Machine: 2023 MacBook Pro Max 16" (14-cores)
 - Chunk Render Distance: 32 (4225 total)
-- Commit hash `faac9117` run with `nix run .#dev -- release`
+- Commit hash `faac9117` run with `HYPERION_PROFILE=release-full nix run .#bedwars`
 - Bot Launch Command: `nix run .#bots -- 127.0.0.1:25565 {number}`
 
 The bulk of player-specific processing occurs in our proxy layer, which handles tasks like regional multicasting and can
@@ -238,22 +238,24 @@ with mTLS, so generate throwaway development certificates once:
 nix run .#certs
 ```
 
-Then `nix run .#dev` supervises both with process-compose — the proxy starts
-after the game server, each restarts on failure, and one Ctrl-C stops
-everything. Connect a Minecraft 1.20.1 client to `localhost:25565`.
+Then run the event you want. Each event under `events/` is its own run app that
+supervises the whole stack with process-compose: the proxy starts after the
+game server, each restarts on failure, and one Ctrl-C stops everything. Connect
+a Minecraft 1.20.1 client to `localhost:25565`.
 
 ```bash
-nix run .#dev
+nix run .#bedwars   # or: nix run .#smash
 ```
 
-Build optimised instead with `HYPERION_PROFILE=release-full nix run .#dev`.
+`nix run` with no target runs `.#bedwars`. Build optimised instead with
+`HYPERION_PROFILE=release-full nix run .#bedwars`.
 
 Two checkouts on one machine both want 25565, 35565 and process-compose's own
 8080. `HYPERION_PLAYER_PORT` and `HYPERION_SERVER_PORT` move the second one out
 of the way, and the process-compose port follows the player port:
 
 ```bash
-HYPERION_PLAYER_PORT=25567 HYPERION_SERVER_PORT=35567 nix run .#dev
+HYPERION_PLAYER_PORT=25567 HYPERION_SERVER_PORT=35567 nix run .#bedwars
 ```
 
 Point bots at it with `nix run .#bots -- 127.0.0.1:25565 100`.
@@ -265,9 +267,9 @@ Every command is a flake app, so nix is the only thing you need installed.
 | Command | Does |
 | --- | --- |
 | `nix run .#certs` | Throwaway dev certificates for the mTLS link |
-| `nix run .#dev` | Game server and proxy under process-compose |
+| `nix run .#bedwars` | Bedwars game server and proxy under process-compose |
+| `nix run .#smash` | Smash game server and proxy under process-compose |
 | `nix run .#proxy` | Proxy alone, release-full |
-| `nix run .#bedwars` | Game server alone, release-full |
 | `nix run .#bots -- <ip> <count>` | Connect bots to a running server |
 | `nix run .#ci` | The cargo half of CI: format, lint, test, doc, deny, machete |
 | `nix run .#flake-gate` | The nix half: builds every flake check CI enforces |

--- a/docs/smash-design.md
+++ b/docs/smash-design.md
@@ -569,11 +569,12 @@ setup, jemalloc, `Crypto::new`, then build the world, `world.set(ServerHandle)`,
 
 One addition over bedwars: `--embedded-proxy <ADDR>`. `HyperionProxyModule`
 runs a proxy inside the game-server process, and bedwars imports it
-unconditionally, so `nix run .#dev` has the in-process proxy and the standalone
-one racing for port 25565. The loser panics in a background tokio task and the
-process carries on, which is a hard failure to read. Making it a flag lets
-`nix run .#smash` be a whole server in one process and `nix run .#smash-dev`
-run the deployed shape with no race.
+unconditionally, so a game server started next to the standalone proxy has both
+racing for port 25565. The loser panics in a background tokio task and the
+process carries on, which is a hard failure to read. Making it a flag lets the
+`nix run .#smash` stack run the game server and the standalone proxy with no
+race, while passing `--embedded-proxy` still gives the single-process deployed
+shape when a deployment wants it.
 
 ### New: `events/smash/src/module/selector.rs`
 

--- a/flake.nix
+++ b/flake.nix
@@ -504,16 +504,29 @@
                 ''
             );
 
+          # Every directory under events/ is a game server crate, so the set of
+          # events is read from the tree rather than listed here. A new event
+          # directory becomes a `nix run .#<event>` app with no flake edit.
+          events = lib.attrNames (
+            lib.filterAttrs (_: type: type == "directory") (builtins.readDir ./events)
+          );
+
+          # One process-compose definition, parameterized by event name: the
+          # game server runs that event's crate and nothing selects it at run
+          # time, so `nix run .#smash` and `nix run .#bedwars` are the same
+          # stack with the event fixed rather than one generic stack behind an
+          # environment variable.
+          #
           # Generated rather than committed as YAML: the ports and cert paths
           # then have one source of truth shared with the standalone apps above.
           # Commands are single-line: a backslash continuation is literal in a
           # Nix indented string, survives into the YAML, and reaches the shell
           # as a stray argument rather than a line join.
-          processComposeConfig = (pkgs.formats.yaml { }).generate "process-compose.yaml" {
+          mkProcessComposeConfig = event: (pkgs.formats.yaml { }).generate "process-compose-${event}.yaml" {
             version = "0.5";
             processes = {
               game-server = {
-                command = "cargo run --profile \"$\{HYPERION_PROFILE:-dev}\" -p \"$\{HYPERION_EVENT:-bedwars}\" -- --ip 0.0.0.0 --port \"$\{HYPERION_SERVER_PORT:-${toString gameServerPort}}\" --root-ca-cert ${certsDir}/root_ca.crt --cert ${certsDir}/server.crt --private-key ${certsDir}/server_private_key.pem";
+                command = "cargo run --profile \"$\{HYPERION_PROFILE:-dev}\" -p ${event} -- --ip 0.0.0.0 --port \"$\{HYPERION_SERVER_PORT:-${toString gameServerPort}}\" --root-ca-cert ${certsDir}/root_ca.crt --cert ${certsDir}/server.crt --private-key ${certsDir}/server_private_key.pem";
                 availability.restart = "on_failure";
               };
 
@@ -529,7 +542,33 @@
             };
           };
 
-          runners = lib.mapAttrs mkScript {
+          # Each event gets a `nix run .#<event>` app that boots that same stack
+          # with the event fixed: certificates first if missing, then the game
+          # server and proxy under process-compose. One generator over the
+          # events list rather than a copy per event, so a new event directory
+          # gets a run app for free and there is nothing to keep in sync.
+          mkDevStack = event: {
+            deps = [ pkgs.process-compose pkgs.git ];
+            text = ''
+              root="$(git rev-parse --show-toplevel)"
+              certs="$root/${certsDir}"
+              if [ ! -f "$certs/root_ca.crt" ]; then
+                echo "no dev certificates yet; generating them" >&2
+                "${lib.getExe runners.certs}"
+              fi
+              cd "$root"
+              # process-compose's own API port has to move with the game
+              # ports, or a second checkout dies on 8080 before either process
+              # starts.
+              api_port="''${HYPERION_PC_PORT:-$(( 8080 + ''${HYPERION_PLAYER_PORT:-${toString proxyPort}} - ${toString proxyPort} ))}"
+              echo "event: ${event} | players: 0.0.0.0:''${HYPERION_PLAYER_PORT:-${toString proxyPort}} | game server: 127.0.0.1:''${HYPERION_SERVER_PORT:-${toString gameServerPort}}"
+              exec process-compose --config ${mkProcessComposeConfig event} --port "$api_port" "$@"
+            '';
+          };
+
+          eventDevStacks = lib.genAttrs events mkDevStack;
+
+          runners = lib.mapAttrs mkScript (eventDevStacks // {
             # Builds four successive versions of the demo game module and drives
             # one running world through all of them. Being a nix app is what
             # makes the single-compiler precondition structural rather than a
@@ -593,65 +632,11 @@
               '';
             };
 
-            bedwars = {
-              deps = [ pkgs.git ];
-              text = ''
-                certs="$(git rev-parse --show-toplevel)/${certsDir}"
-                exec cargo run --profile release-full -p bedwars -- \
-                  --ip 0.0.0.0 --port 35565 \
-                  --root-ca-cert "$certs/root_ca.crt" \
-                  --cert "$certs/server.crt" \
-                  --private-key "$certs/server_private_key.pem" \
-                  "$@"
-              '';
-            };
-
-            # Super Smash Mobs, the second event. Same shape as bedwars: one
-            # game server per process, each binding its own port, so the two
-            # are selected at run time rather than sharing anything.
-            smash = {
-              deps = [ pkgs.git ];
-              text = ''
-                certs="$(git rev-parse --show-toplevel)/${certsDir}"
-                exec cargo run --profile release-full -p smash -- \
-                  --ip 0.0.0.0 --port "''${HYPERION_SERVER_PORT:-${toString gameServerPort}}" \
-                  --root-ca-cert "$certs/root_ca.crt" \
-                  --cert "$certs/server.crt" \
-                  --private-key "$certs/server_private_key.pem" \
-                  "$@"
-              '';
-            };
-
             bots.text = ''
               ulimit -Sn ${fileDescriptors}
               exec cargo run --release -p rust-mc-bot -- \
                 "''${1:-127.0.0.1:25565}" "''${2:-100}"
             '';
-
-            # process-compose supervises the two processes instead of the
-            # shell doing it: it gives dependency ordering (the proxy waits for
-            # the game server's port), per-process restart policy, a readable
-            # TUI with separated logs, and one Ctrl-C that actually stops
-            # everything. GNU parallel gave none of that -- a crashed process
-            # just vanished from an interleaved stream.
-            dev = {
-              deps = [ pkgs.process-compose pkgs.git ];
-              text = ''
-                root="$(git rev-parse --show-toplevel)"
-                certs="$root/${certsDir}"
-                if [ ! -f "$certs/root_ca.crt" ]; then
-                  echo "no dev certificates yet; generating them" >&2
-                  "${lib.getExe runners.certs}"
-                fi
-                cd "$root"
-                # process-compose's own API port has to move with the game
-                # ports, or a second checkout dies on 8080 before either process
-                # starts.
-                api_port="''${HYPERION_PC_PORT:-$(( 8080 + ''${HYPERION_PLAYER_PORT:-${toString proxyPort}} - ${toString proxyPort} ))}"
-                echo "players: 0.0.0.0:''${HYPERION_PLAYER_PORT:-${toString proxyPort}} | game server: 127.0.0.1:''${HYPERION_SERVER_PORT:-${toString gameServerPort}}"
-                exec process-compose --config ${processComposeConfig} --port "$api_port" "$@"
-              '';
-            };
 
             # Joins a running server with the real Minecraft client and says
             # whether a player reached the world.
@@ -678,7 +663,7 @@
             # protocol version. A client is what notices.
             #
             # Ports come from the environment and default off the dev ports, so
-            # a run does not fight a `nix run .#dev` open in another terminal.
+            # a run does not fight a `nix run .#bedwars` stack open in another terminal.
             e2e = {
               deps = [
                 pkgs.git
@@ -922,7 +907,7 @@
             # the *icon* for a charged ability, and `smash-e2e` already proves
             # that path. This is the vanilla weapon -- nock, spend an arrow,
             # launch it at a speed the draw decides -- which only bedwars has,
-            # and bedwars is what `nix run .#dev` and `packages.default` build.
+            # and bedwars is what `nix run .#bedwars` and `packages.default` build.
             #
             # It asserts the launch velocity out of `ClientboundAddEntity`
             # rather than watching where the arrow lands, because since 26.2
@@ -943,15 +928,7 @@
               '';
             };
 
-            # `nix run .#dev` runs bedwars; this runs the same stack on smash.
-            smash-dev = {
-              deps = [ pkgs.process-compose pkgs.git ];
-              text = ''
-                export HYPERION_EVENT=smash
-                exec "${lib.getExe runners.dev}" "$@"
-              '';
-            };
-          };
+          });
 
           scripts = checkScripts // runners // { inherit ci; };
 
@@ -1290,7 +1267,9 @@
               program = lib.getExe script;
             })
             (scripts // {
-              default = scripts.dev;
+              # `nix run` with no target boots the bedwars stack, the event
+              # `packages.default` also builds.
+              default = scripts.bedwars;
               # What CI runs. A contributor can run the same one command and
               # see the same verdict, which is what stops the two drifting.
               inherit (checks) flake-gate;


### PR DESCRIPTION
## What

Operator UX ask: replace the single generic `nix run .#dev` (defaulted to bedwars, needed `HYPERION_EVENT` to switch) with one run app per event. Operator's words: "remove nix run .#dev you should make a nix run and then the specific name and all should be process compose."

- `nix run .#bedwars` and `nix run .#smash` each boot the **same** process-compose stack (cert-gen if missing + that event's game server + hyperion-proxy) with the event **fixed**.
- Enumerated from `events/*` via `builtins.readDir`, so a new event directory gets a run app with **no flake edit**.
- One process-compose definition (`mkProcessComposeConfig event`, bakes `-p <event>`) and one stack generator (`mkDevStack`) mapped over the events list. One concept, one implementation.
- Removed the generic `.#dev`, the standalone game-server-only `.#bedwars`/`.#smash` runners, and the `.#smash-dev` wrapper (all folded into the per-event stacks).
- Kept `.#proxy` and every env override (`HYPERION_PLAYER_PORT`, `HYPERION_SERVER_PORT`, `HYPERION_PC_PORT`, `HYPERION_PROFILE`) plus process-compose `--tui` passthrough via `"$@"`.
- `nix run` with no target now runs `.#bedwars`.
- README table + quickstart and `docs/smash-design.md` embedded-proxy note updated.

## Verified locally (Apple Silicon, aarch64-darwin)

- `nix eval .#apps.aarch64-darwin` app list: `bedwars`, `smash`, `proxy`, `default` present; no `dev`, no `smash-dev`.
- Realised both stack scripts (writeShellApplication -> shellcheck passes).
- Confirmed the built `.#bedwars` script execs `process-compose --config .../process-compose-bedwars.yaml` and the YAML bakes `cargo run ... -p bedwars` (smash likewise).
- `nix eval .#checks.aarch64-darwin` evaluates (60 checks), no dangling `dev` reference.

CI is known-broken on this repo; merged by force per the hyperion workflow after the local checks above.