### PR TITLE
fix(hyperion): freeze the daylight cycle over the wire (ENG-11000)

### DIFF
--- a/crates/hyperion-minecraft-proto/src/packets/play_login.rs
+++ b/crates/hyperion-minecraft-proto/src/packets/play_login.rs
@@ -521,6 +521,136 @@ impl Decode<'_> for GameEvent {
     }
 }
 
+// --- set time -------------------------------------------------------------
+
+/// The minimum bytes one clock update occupies on the wire: a `VarInt` clock
+/// id, a `VarLong` `total_ticks`, and two `f32`s, so `1 + 1 + 4 + 4`.
+const MIN_CLOCK_UPDATE_SIZE: usize = 10;
+
+/// The network id of the overworld clock in `minecraft:world_clock`.
+///
+/// The registry the server sends during configuration lists
+/// `minecraft:overworld` first, so it is id `0`. This is the clock that moves
+/// the sun; freezing it freezes the daylight cycle.
+pub const OVERWORLD_CLOCK_ID: i32 = 0;
+
+/// One world clock's state on the wire (`ClockNetworkState`).
+///
+/// The client advances the clock by `rate` ticks each tick and interpolates
+/// the sun with `partial_tick`, so it holds the day time without the server
+/// resending it. A `rate` of `0.0` freezes the clock: that is exactly what a
+/// paused clock -- or the `advance_time` gamerule being off -- serialises to,
+/// per `ServerClockManager.ClockInstance.packNetworkState` in 26.2.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ClockNetworkState {
+    /// The clock's accumulated ticks. For the overworld clock this is the day
+    /// time that positions the sun (`6000` noon, `18000` midnight). `VarLong`.
+    pub total_ticks: i64,
+    /// Sub-tick remainder the client interpolates from; `0.0` on a fresh sync.
+    pub partial_tick: f32,
+    /// Ticks the clock advances per server tick. `1.0` is the vanilla daylight
+    /// speed; `0.0` freezes it.
+    pub rate: f32,
+}
+
+impl ClockNetworkState {
+    /// A frozen clock parked at `total_ticks` (`partial_tick` `0.0`, `rate`
+    /// `0.0`). The client holds the sun here and never advances it.
+    #[must_use]
+    pub const fn frozen(total_ticks: i64) -> Self {
+        Self {
+            total_ticks,
+            partial_tick: 0.0,
+            rate: 0.0,
+        }
+    }
+
+    fn encode(&self, writer: &mut Writer) {
+        writer.var_long(self.total_ticks);
+        writer.f32(self.partial_tick);
+        writer.f32(self.rate);
+    }
+
+    fn decode(reader: &mut Reader<'_>) -> Result<Self> {
+        Ok(Self {
+            total_ticks: reader.var_long()?,
+            partial_tick: reader.f32()?,
+            rate: reader.f32()?,
+        })
+    }
+}
+
+/// `minecraft:set_time`, clientbound (`ClientboundSetTimePacket`).
+///
+/// 26.2 replaced the old `(gameTime, timeOfDay)` pair with a `gameTime` plus a
+/// map of per-`WorldClock` states (`ClockNetworkState`). `game_time` is the
+/// world age; each clock update carries its own day time and advance `rate`.
+///
+/// # Freezing the sun
+///
+/// With no `SetTime` at all the client free-runs its own daylight cycle and
+/// the sun drifts. Sending the overworld clock ([`OVERWORLD_CLOCK_ID`]) once
+/// with [`ClockNetworkState::frozen`] pins the day time: the client's `rate`
+/// is `0.0`, so it holds the sun without the server resending time every tick.
+///
+/// # Ids, not names
+///
+/// The map is keyed by the clock's network id in `minecraft:world_clock`,
+/// written by `ByteBufCodecs.holderRegistry(Registries.WORLD_CLOCK)`, which is
+/// a bare `VarInt` with no direct-holder escape (the same shape as
+/// [`CommonPlayerSpawnInfo::dimension_type`]). The id is positional in the
+/// registry the server sent during configuration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SetTime {
+    /// The world age (`Level.getGameTime`). Not the day time; anything that
+    /// reads game time still gets the real value while the day time is frozen.
+    pub game_time: i64,
+    /// Per-clock updates keyed by the clock's `minecraft:world_clock` network
+    /// id. A single overworld entry is enough to freeze the sky; vanilla's own
+    /// per-clock updates are one-entry maps too.
+    pub clock_updates: Vec<(i32, ClockNetworkState)>,
+}
+
+impl SetTime {
+    /// A `SetTime` that freezes the overworld daylight cycle at `day_time`
+    /// while reporting `game_time` as the world age.
+    #[must_use]
+    pub fn freeze_overworld(game_time: i64, day_time: i64) -> Self {
+        Self {
+            game_time,
+            clock_updates: vec![(OVERWORLD_CLOCK_ID, ClockNetworkState::frozen(day_time))],
+        }
+    }
+}
+
+impl Encode for SetTime {
+    fn encode(&self, writer: &mut Writer) -> Result<()> {
+        writer.i64(self.game_time);
+        write_count(writer, self.clock_updates.len())?;
+        for (clock_id, state) in &self.clock_updates {
+            writer.var_int(*clock_id);
+            state.encode(writer);
+        }
+        Ok(())
+    }
+}
+
+impl Decode<'_> for SetTime {
+    fn decode(reader: &mut Reader<'_>) -> Result<Self> {
+        let game_time = reader.i64()?;
+        let count = read_count(reader, MIN_CLOCK_UPDATE_SIZE)?;
+        let mut clock_updates = Vec::with_capacity(count);
+        for _ in 0..count {
+            let clock_id = reader.var_int()?;
+            clock_updates.push((clock_id, ClockNetworkState::decode(reader)?));
+        }
+        Ok(Self {
+            game_time,
+            clock_updates,
+        })
+    }
+}
+
 // --- teleport -------------------------------------------------------------
 
 /// Which fields of a teleport are relative to the player's current state

--- a/crates/hyperion/src/net/protocol/join.rs
+++ b/crates/hyperion/src/net/protocol/join.rs
@@ -11,8 +11,9 @@ use flecs_ecs::prelude::*;
 use hyperion_minecraft_proto::{
     generated::packet_id::play::clientbound::PacketId,
     packets::play_login::{
-        BlockPos, CommonPlayerSpawnInfo, GameEvent, GameType, GlobalPos, Login, PlayerPosition,
-        PositionMoveRotation, Relative, SetChunkCacheCenter, SetDefaultSpawnPosition, Vec3,
+        BlockPos, ClockNetworkState, CommonPlayerSpawnInfo, GameEvent, GameType, GlobalPos, Login,
+        PlayerPosition, PositionMoveRotation, Relative, SetChunkCacheCenter, SetDefaultSpawnPosition,
+        SetTime, Vec3,
     },
 };
 use hyperion_utils::EntityExt;
@@ -25,7 +26,7 @@ use crate::{
         Channel, Compose, ConnectionId,
         protocol::{registries, send},
     },
-    simulation::{Comms, MovementTracking, Pitch, Position, Yaw, gamemode},
+    simulation::{Comms, MovementTracking, Pitch, Position, WorldTime, Yaw, gamemode},
 };
 
 /// The level this server serves. Only one, so the dimension list in [`Login`]
@@ -202,6 +203,31 @@ pub fn enter_world(
         &GameEvent {
             event: GameEvent::LEVEL_CHUNKS_LOAD_START,
             param: 0.0,
+        },
+    )?;
+
+    // Freeze the daylight cycle. 26.2 makes the client advance the sun itself
+    // from the overworld clock's `rate`; with no `SetTime` at all the client
+    // never learns a rate and free-runs its own cycle, so the sky drifts. One
+    // `SetTime` with the overworld clock at `rate` 0.0 pins the sun -- the same
+    // bytes a paused clock serialises to (`ServerClockManager`) -- and there is
+    // no per-tick resend. `game_time` stays the real world age; only the day
+    // time is frozen. The clock's network id comes from the same `world_clock`
+    // registry the client was sent in configuration, so the two cannot drift.
+    let day_time = world.get::<&WorldTime>(|world_time| world_time.day_time);
+    let overworld_clock = registries::WORLD_CLOCK
+        .id_of("minecraft:overworld")
+        .ok_or_else(|| anyhow::anyhow!("world_clock registry has no minecraft:overworld"))?;
+    send(
+        compose,
+        connection_id,
+        PacketId::SetTime.to_raw(),
+        &SetTime {
+            game_time: compose.global().tick,
+            clock_updates: vec![(
+                overworld_clock,
+                ClockNetworkState::frozen(day_time),
+            )],
         },
     )?;
 

--- a/crates/hyperion/src/net/protocol/mod.rs
+++ b/crates/hyperion/src/net/protocol/mod.rs
@@ -152,6 +152,7 @@ pub struct ProtocolModule;
 
 impl Module for ProtocolModule {
     fn module(world: &World) {
+        world.import::<crate::simulation::WorldTimeModule>();
         world.import::<pre_play::PrePlayModule>();
         world.import::<join::JoinModule>();
     }

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -71,6 +71,7 @@ pub mod pose;
 pub mod projectile_motion;
 pub mod skin;
 pub mod util;
+pub mod world_time;
 pub mod xp;
 
 // Re-exported at `simulation::` rather than left behind their new module
@@ -83,6 +84,7 @@ pub use pose::{
     ChunkPosition, EntitySize, PLAYER_SPAWN_POSITION, PendingTeleportation, Pitch, Position,
     Velocity, Yaw, aabb, block_bounds, get_direction_from_rotation,
 };
+pub use world_time::{WorldTime, WorldTimeModule};
 pub use xp::{Xp, XpVisual};
 
 /// Communicates with the proxy server.

--- a/crates/hyperion/src/simulation/world_time.rs
+++ b/crates/hyperion/src/simulation/world_time.rs
@@ -1,0 +1,54 @@
+//! A static, protocol-frozen day time for the arena sky.
+//!
+//! 26.2 drives the sun from a per-world clock the client advances itself: the
+//! server sends the clock's `rate` once and the client interpolates from there
+//! (see [`hyperion_minecraft_proto::packets::play_login::SetTime`] and
+//! `ServerClockManager`). hyperion never ticks that clock, so with no `SetTime`
+//! the client free-runs its own daylight cycle and the sun drifts. Sending the
+//! overworld clock once with `rate` `0.0` freezes it at [`WorldTime::day_time`]
+//! without the server resending time every tick.
+//!
+//! This is one singleton both events share: bedwars and smash both want a fixed
+//! arena sky. The default is noon; an event overrides it before players join
+//! with `world.set(WorldTime { day_time: ... })`. The wire freeze is the whole
+//! mechanism -- the `advance_time`/`doDaylightCycle` gamerule is only the
+//! server-side toggle that makes vanilla serialise the same `rate` `0.0`, and
+//! hyperion has no gamerule state to mirror.
+
+use flecs_ecs::prelude::*;
+
+/// Ticks in a full Minecraft day; day time wraps at this.
+pub const TICKS_PER_DAY: i64 = 24_000;
+
+/// Day time with the sun at its zenith. The default frozen sky.
+pub const NOON: i64 = 6_000;
+
+/// The frozen day time for the overworld sky, in ticks `[0, 24000)`.
+///
+/// A singleton read on join to build the freeze
+/// [`SetTime`](hyperion_minecraft_proto::packets::play_login::SetTime).
+/// Override it per event with `world.set(WorldTime { day_time })`.
+#[derive(Component, Debug, Clone, Copy)]
+pub struct WorldTime {
+    /// Day time positioning the sun: `6000` noon, `18000` midnight, `0`/`24000`
+    /// sunrise. Values outside `[0, 24000)` are wrapped by the client.
+    pub day_time: i64,
+}
+
+impl Default for WorldTime {
+    fn default() -> Self {
+        Self { day_time: NOON }
+    }
+}
+
+/// Installs the default [`WorldTime`] singleton so the join path always finds
+/// one to freeze the sky at. Events that want a different sky call
+/// `world.set(WorldTime { .. })` after importing this.
+#[derive(Component)]
+pub struct WorldTimeModule;
+
+impl Module for WorldTimeModule {
+    fn module(world: &World) {
+        world.set(WorldTime::default());
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1151,6 +1151,25 @@
               timeout = 300;
             };
 
+            # The daylight cycle, frozen at the protocol level, on a real
+            # connection. 26.2 drives the sun from a per-world clock the client
+            # advances itself from a `rate` the server sends once; hyperion sent
+            # no `SetTime` at all, so a client free-ran its own cycle and the sun
+            # drifted. `world-time-check.py` joins, decodes the `SetTime` (id
+            # 113) the join path now sends, and asserts the overworld clock
+            # arrives with `rate` 0.0 at a fixed day time and never advances over
+            # several seconds of ticks. Fail-then-pass by construction: an
+            # unpatched server sends no `SetTime`, so the first assertion is red.
+            # smash rather than bedwars because the freeze lives in shared join
+            # code and smash needs no world downloaded into the sandbox.
+            world-time-e2e = e2e.mkCheck {
+              name = "hyperion-world-time-e2e";
+              gameServer = gameBinaries.smash;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "world-time-check.py";
+              timeout = 180;
+            };
+
             # `checks.e2e` above took the names the two app wrappers used to
             # hold, and those wrappers still have to pass shellcheck.
             e2e-app = scripts.e2e;

--- a/tools/world-time-check.py
+++ b/tools/world-time-check.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""The daylight cycle is frozen, read off the wire by the client that joined.
+
+26.2 stopped putting the day time in a field a server sets every tick. The sun
+is now driven by a per-world clock the client advances *itself*: the server
+sends the clock's `rate` once in a `ClientboundSetTimePacket` and the client
+interpolates from there. hyperion never ticked that clock, so it sent no
+`SetTime` at all, and a client with no clock state free-runs its own daylight
+cycle -- the sun drifts across a sky the operator wanted static.
+
+The fix sends the overworld clock once on join with `rate` 0.0, which is the
+exact wire form a paused clock takes (`ServerClockManager.ClockInstance.
+packNetworkState`): the client holds the day time and never advances it, with
+no per-tick resend.
+
+What this gate proves, all of it off the wire:
+
+  * a `SetTime` (id 113) arrives during the join sequence at all. This is the
+    fail-then-pass assertion: an unpatched server sends nothing here, so the
+    gate fails without the change and passes with it.
+  * it carries the overworld clock (network id 0 in `minecraft:world_clock`).
+  * that clock's `rate` is exactly 0.0 -- the freeze form. A non-zero rate is
+    a clock the client would advance, which is the bug.
+  * its `total_ticks` is the fixed day time the server was configured with
+    (noon, 6000, by default), not a drifting value.
+  * `game_time` is the world age, a separate field, so anything that reads game
+    time still gets a real value while only the day time is frozen.
+  * over several seconds -- many server ticks -- no further `SetTime` moves the
+    day time. With `rate` 0.0 the client holds the sun on its own; the server
+    does not (and must not) resend time every tick to keep it there.
+
+Exits non-zero on the first thing that is not true, after printing what it saw.
+"""
+
+import argparse
+import importlib.util
+import pathlib
+import struct
+import sys
+import time
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, TOOLS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+match = _load("smash_match", "smash-match.py")
+base = match.base
+
+take_var_int = base.take_var_int
+var_int = base.var_int
+
+# `ClientboundSetTimePacket`, id 113 (0x71) in protocol 776. Named in
+# tools/client-26.2.py's id table and
+# crates/hyperion-minecraft-proto/src/generated/packet_id.rs.
+S2C_SET_TIME = 0x71
+
+# The overworld clock's network id in `minecraft:world_clock`. The registry the
+# server sends during configuration lists `minecraft:overworld` first, so it is
+# 0. Kept here as the number the *test* expects rather than imported, so a
+# change to the Rust cannot also change what proves it.
+OVERWORLD_CLOCK_ID = 0
+
+# The default frozen day time hyperion sends: noon. `WorldTime::default()` in
+# crates/hyperion/src/simulation/world_time.rs. Held here as the test's own
+# expectation.
+EXPECTED_DAY_TIME = 6000
+
+
+def take_var_long(payload, offset=0):
+    """Decode one Minecraft VarLong, returning (value, new_offset).
+
+    Same continuation-bit encoding as a VarInt, but up to ten bytes and a
+    signed 64-bit result. `take_var_int` tops out at 32 bits, so `total_ticks`
+    -- a `VarLong` on the wire -- needs its own reader.
+    """
+    result = 0
+    for i in range(10):
+        byte = payload[offset]
+        offset += 1
+        result |= (byte & 0x7F) << (7 * i)
+        if not byte & 0x80:
+            break
+    else:
+        raise ValueError("VarLong ran past ten bytes")
+    if result >= (1 << 63):
+        result -= 1 << 64
+    return result, offset
+
+
+def decode_set_time(payload):
+    """Decode a `ClientboundSetTimePacket` into its game time and clock map.
+
+    Layout (protocol 776): a big-endian `long` game time, a `VarInt` count, then
+    each entry a `VarInt` clock id and a `ClockNetworkState` of a `VarLong`
+    `total_ticks`, an `f32` `partial_tick` and an `f32` `rate`.
+    """
+    game_time = struct.unpack(">q", payload[:8])[0]
+    offset = 8
+    count, offset = take_var_int(payload, offset)
+    clocks = {}
+    for _ in range(count):
+        clock_id, offset = take_var_int(payload, offset)
+        total_ticks, offset = take_var_long(payload, offset)
+        partial_tick, rate = struct.unpack(">ff", payload[offset : offset + 8])
+        offset += 8
+        clocks[clock_id] = {
+            "total_ticks": total_ticks,
+            "partial_tick": partial_tick,
+            "rate": rate,
+        }
+    return {"game_time": game_time, "clocks": clocks}
+
+
+class Watcher(match.MatchClient):
+    """A scripted player that records every SetTime it is sent."""
+
+    def __init__(self, host, port, name, started):
+        super().__init__(host, port, name, started)
+        self.entity_id = None
+        self.joined = False
+        # Every SetTime received, decoded, in arrival order.
+        self.set_times = []
+
+    def absorb(self, packet_id, payload):
+        if packet_id == match.S2C_LOGIN:
+            self.entity_id = struct.unpack(">i", payload[:4])[0]
+            self.joined = True
+            self.log("** in the world ** entity_id=%d" % self.entity_id)
+        elif packet_id == match.S2C_PLAYER_POSITION:
+            teleport_id, offset = take_var_int(payload)
+            x, y, z = struct.unpack(">ddd", payload[offset : offset + 24])
+            self.position = (x, y, z)
+            self.send(match.C2S_ACCEPT_TELEPORTATION, var_int(teleport_id))
+            self.log("<- teleported to (%.1f, %.1f, %.1f)" % (x, y, z))
+        elif packet_id == match.S2C_KEEP_ALIVE:
+            self.send(match.C2S_KEEP_ALIVE, payload[:8])
+        elif packet_id == S2C_SET_TIME:
+            decoded = decode_set_time(payload)
+            self.set_times.append(decoded)
+            self.log(
+                "<- SetTime game_time=%d clocks=%s"
+                % (decoded["game_time"], decoded["clocks"])
+            )
+        elif packet_id == match.S2C_DISCONNECT:
+            text, _ = match.take_nbt_string(payload, 0)
+            self.log("<- DISCONNECTED: %s" % text)
+            self.alive = False
+
+
+def pump(client, seconds):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if not client.alive:
+            return
+        for packet_id, payload in client.drain():
+            client.absorb(packet_id, payload)
+        if client.joined:
+            client.repeat_position()
+        time.sleep(0.01)
+
+
+def wait_until(client, predicate, seconds, what):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        pump(client, 0.05)
+        if predicate():
+            return True
+    print("TIMEOUT waiting for %s" % what, file=sys.stderr)
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=25565)
+    parser.add_argument("--name", default="Horologist")
+    args = parser.parse_args()
+
+    started = time.time()
+    failures = []
+
+    def check(ok, message):
+        print("%s %s" % ("PASS" if ok else "FAIL", message), flush=True)
+        if not ok:
+            failures.append(message)
+
+    client = Watcher(args.host, args.port, args.name, started)
+    client.handshake(args.host, args.port, 2)
+    client.login()
+    client.configuration()
+    client.enter_play()
+
+    if not wait_until(client, lambda: client.joined, 30.0, "the world"):
+        print("RESULT: failure (never joined)", flush=True)
+        return 1
+
+    # The freeze SetTime is sent in the join sequence, right after the join
+    # itself. Give it a moment to arrive, then a few seconds more to prove
+    # nothing re-sends time.
+    wait_until(
+        client,
+        lambda: len(client.set_times) >= 1,
+        10.0,
+        "a SetTime packet",
+    )
+
+    check(
+        len(client.set_times) >= 1,
+        "a SetTime (id 113) arrives on join -- an unpatched server sends none "
+        "(got %d)" % len(client.set_times),
+    )
+    if not client.set_times:
+        print("RESULT: failure (no SetTime, the sun would free-run)", flush=True)
+        return 1
+
+    first = client.set_times[0]
+    clocks = first["clocks"]
+
+    check(
+        OVERWORLD_CLOCK_ID in clocks,
+        "the SetTime carries the overworld clock (network id %d); it has %s"
+        % (OVERWORLD_CLOCK_ID, sorted(clocks)),
+    )
+    overworld = clocks.get(OVERWORLD_CLOCK_ID)
+    if overworld is None:
+        print("RESULT: failure (no overworld clock in SetTime)", flush=True)
+        return 1
+
+    check(
+        overworld["rate"] == 0.0,
+        "the overworld clock's rate is the freeze value 0.0, not a rate the "
+        "client would advance (got %r)" % overworld["rate"],
+    )
+    check(
+        overworld["total_ticks"] == EXPECTED_DAY_TIME,
+        "the frozen day time is the configured %d (noon), a fixed value "
+        "(got %d)" % (EXPECTED_DAY_TIME, overworld["total_ticks"]),
+    )
+    check(
+        overworld["partial_tick"] == 0.0,
+        "the clock is parked on a whole tick (partial_tick 0.0, got %r)"
+        % overworld["partial_tick"],
+    )
+    check(
+        first["game_time"] >= 0,
+        "game_time is a world age separate from the day time (got %d)"
+        % first["game_time"],
+    )
+
+    # Prove the day time does not advance. With rate 0.0 the client holds the
+    # sun itself, so a correct server sends no further SetTime that moves it.
+    # Watch several seconds of ticks and confirm the day time the client would
+    # render never changes.
+    baseline = overworld["total_ticks"]
+    before = len(client.set_times)
+    pump(client, 6.0)
+    moved = [
+        st["clocks"][OVERWORLD_CLOCK_ID]["total_ticks"]
+        for st in client.set_times[before:]
+        if OVERWORLD_CLOCK_ID in st["clocks"]
+        and st["clocks"][OVERWORLD_CLOCK_ID]["total_ticks"] != baseline
+    ]
+    check(
+        not moved,
+        "over 6 s of ticks the frozen day time never advances from %d "
+        "(saw moves to %s)" % (baseline, moved),
+    )
+    # And any later SetTime that does arrive must still freeze (rate 0.0),
+    # never hand the client a rate to run.
+    running = [
+        st["clocks"][OVERWORLD_CLOCK_ID]["rate"]
+        for st in client.set_times[before:]
+        if OVERWORLD_CLOCK_ID in st["clocks"]
+        and st["clocks"][OVERWORLD_CLOCK_ID]["rate"] != 0.0
+    ]
+    check(
+        not running,
+        "no later SetTime hands the client a non-zero rate (saw %s)" % running,
+    )
+
+    if failures:
+        print(
+            "RESULT: failure (%d checks failed): %s"
+            % (len(failures), "; ".join(failures)),
+            flush=True,
+        )
+        return 1
+    print("RESULT: success (the sun is frozen at day time %d)" % baseline, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes ENG-11000.

## Problem

hyperion (MC 26.2, protocol 776) sent **no `ClientboundSetTime` at all**. `PacketId::SetTime` (id 113) existed with a wire codec but nothing in `events/*` or `crates/hyperion/src` ever sent it, and there was no `SetTime` body struct. With no server time, a 26.2 client free-runs its own daylight cycle and the sun drifts across a sky the operator wanted static.

## 26.2 mechanism (verified from the decompiled server jar, not assumed)

26.2 replaced `(gameTime, timeOfDay)` with:

```
ClientboundSetTimePacket(gameTime: long, clockUpdates: Map<Holder<WorldClock>, ClockNetworkState>)
ClockNetworkState(totalTicks: VarLong, partialTick: float, rate: float)
```

The client advances the day clock by `rate` itself and interpolates the sun, so it holds the day time with no per-tick resend. `ServerClockManager.ClockInstance.packNetworkState` shows the freeze form: a paused clock (or `GameRules.ADVANCE_TIME` off) serialises with `rate = 0.0`. The map key is the clock's network id in the synced `minecraft:world_clock` registry (`holderRegistry`, a bare VarInt; `minecraft:overworld` = id 0).

So the freeze is: send the overworld clock once with `rate = 0.0` at the desired day time. The `doDaylightCycle`/`ADVANCE_TIME` gamerule is only the server-side toggle behind that wire value; the wire freeze is the mechanism.

## Change

- **proto**: add `SetTime` + `ClockNetworkState` (`Encode`/`Decode`) to `crates/hyperion-minecraft-proto/src/packets/play_login.rs`, with a `ClockNetworkState::frozen` / `SetTime::freeze_overworld` helper.
- **shared hyperion**: `WorldTime { day_time }` singleton (default noon = 6000) in `crates/hyperion/src/simulation/world_time.rs`, installed by `WorldTimeModule` (imported by `ProtocolModule`). Both smash and bedwars get a static arena sky; an event overrides the day time per arena with `world.set(WorldTime { day_time })` -- not hardcoded per event.
- **join path**: `enter_world` sends one freeze `SetTime` (overworld clock, `rate 0.0`, configured day time) with `game_time = global.tick`, so world age stays correct and only the day time is frozen.

## Verification

New store-cached gate `checks.world-time-e2e` (`tools/world-time-check.py`) drives a scripted 776 client. Built and run locally, all assertions pass:

```
<- SetTime game_time=39 clocks={0: {'total_ticks': 6000, 'partial_tick': 0.0, 'rate': 0.0}}
PASS a SetTime (id 113) arrives on join -- an unpatched server sends none (got 1)
PASS the SetTime carries the overworld clock (network id 0)
PASS the overworld clock's rate is the freeze value 0.0
PASS the frozen day time is the configured 6000 (noon)
PASS game_time is a world age separate from the day time (got 39)
PASS over 6 s of ticks the frozen day time never advances from 6000
RESULT: success (the sun is frozen at day time 6000)
```

Fail-then-pass by construction: an unpatched server sends no `SetTime`, so the first assertion is red without the change.

Generated with Claude Code.
