### PR TITLE
test(smash): validate skins as an online client does; settle the own-avatar verdict (#1056)

### DIFF
--- a/docs/wearer-own-skin.md
+++ b/docs/wearer-own-skin.md
@@ -1,0 +1,101 @@
+# A kit wearer sees their own login skin, not the kit's, on their own avatar
+
+Tracks hyperion-mc/hyperion#1056. This is the definitive verdict, read from the
+decompiled 26.2 client rather than inferred. Reproduce the evidence with:
+
+    nix build .#minecraft-client-skin-sources
+    # -> net/minecraft/client/player/AbstractClientPlayer.java
+    #    net/minecraft/client/multiplayer/PlayerInfo.java
+    #    net/minecraft/client/multiplayer/ClientPacketListener.java
+
+## The wire is not the problem
+
+Every other player sees the kit skin. The `smash-skin-e2e` gate proves it on the
+wire: another player's tab-list profile for the wearer carries the committed
+`textures` value, its signature verifies under Mojang's key (SIGNED), and the
+entity's overlay mask is `0x7F`. The wearer's own tab-list entry carries the
+custom skin too. So the server sends everything correctly; the discrepancy is
+entirely in how the client renders the wearer's *own* avatar.
+
+## The client caches the local player's skin and never invalidates it
+
+Three decompiled facts, in the order they compose:
+
+- **`AbstractClientPlayer.getSkin()` reads from a cached `PlayerInfo`.** It calls
+  `getPlayerInfo()`, which is `if (this.playerInfo == null) this.playerInfo =
+  connection.getPlayerInfo(getUUID()); return this.playerInfo;`. The field is
+  populated once, lazily, and there is no setter anywhere that nulls it.
+
+- **That `PlayerInfo` memoizes its skin from the profile it was built with.**
+  `PlayerInfo.getSkin()` is `if (this.skinLookup == null) this.skinLookup =
+  createSkinLookup(this.profile); return this.skinLookup.get();`. The lookup is
+  built once from `this.profile` and cached.
+
+- **No tab-list packet touches either cache for a player that already exists.**
+  `ClientPacketListener.handlePlayerInfoRemove` only does
+  `this.playerInfoMap.remove(profileId)`. `handlePlayerInfoUpdate` builds a new
+  `PlayerInfo` and inserts it with `putIfAbsent`. Neither reaches into
+  `this.minecraft.player` to reset its cached `playerInfo` field.
+
+So hyperion's `roster::refresh` sequence for the wearer -- `PlayerInfoRemove`
+then `PlayerInfoUpdate(ADD_PLAYER)` with the new textures -- updates the map the
+tab list reads, but the wearer's `LocalPlayer` still holds the old `PlayerInfo`
+reference and renders the old skin. For a real premium player that old skin is
+their own account skin, which is exactly the reported "I see my own skin, not
+the kit's."
+
+Note the local player would accept even an *unsigned* skin: `createSkinLookup`
+passes `requireSecure = !minecraft.isLocalPlayer(profile.id())`, which is `false`
+for yourself. Signing is not the wearer's problem; the stale cache is.
+
+## The only thing that gives the local player a fresh skin is a new LocalPlayer
+
+`this.minecraft.player` is replaced only by `handleLogin` (join) and
+`handleRespawn`. `handleRespawn` builds a `newPlayer` via
+`gameMode.createPlayer(...)`, whose `playerInfo` is null and so re-reads the
+updated map -- the skin refreshes. But it is not cheap even within one
+dimension: `handleRespawn` unconditionally calls `setClientLoaded(false)` and
+`startWaitingForNewLevel(...)`, and `startWaitingForNewLevel` does
+`setScreenAndShow(new LevelLoadingScreen(...))`. The wearer gets the loading
+screen, and hyperion's proxy does not re-offer the entity subscriptions the
+client drops, which is the empty-hub failure `roster.rs` already documents.
+
+## Verdict
+
+There is no refresh path lighter than a Respawn. No packet resets
+`AbstractClientPlayer.playerInfo` short of rebuilding `LocalPlayer`, and the only
+packets that rebuild it are Login and Respawn. `roster.rs`'s decision to leave
+the wearer's own view alone is therefore correct, not a shortcut.
+
+The options, least disruptive first:
+
+1. **Assign the skin before the wearer enters the world.** If the player's skin
+   is set before the play-state `Login` packet, the first `LocalPlayer` is built
+   with the right `PlayerInfo` and the wearer sees it immediately, no respawn.
+   This fixes the *join-time* skin only. It does nothing for a mid-session kit
+   change, which is the smash case (kits are picked in the hub after join).
+
+2. **Respawn the wearer on a mid-session skin change.** Same dimension, keep
+   metadata (`shouldKeep(2)`). Refreshes the skin at the cost of the loading
+   screen and the dropped entity subscriptions above -- the trade `roster.rs`
+   declined. Only worth it if the operator values the wearer seeing their own
+   kit skin over a seamless kit switch.
+
+3. **Leave it.** The wearer keeps their login skin on themselves; everyone else
+   sees the kit skin. This is current behaviour.
+
+Recommendation: keep option 3 as the default and, if the wearer's own kit skin
+matters, take option 1 for a fixed join-time kit rather than option 2. A
+mid-session own-avatar skin change is not achievable without a visible respawn,
+and that is a property of the client, not of hyperion.
+
+## Verifying the render itself needs a real client
+
+A scripted client has no renderer, so it can assert what the server sent but not
+what the wearer sees. The vehicle for the render check is the
+`tools/hyperion-pilot-mod` Fabric mod (26.2), which exposes a control socket and
+screenshot RPC. That path is semi-automated: the operator loads the mod into
+their real client and an agent drives it and reads back screenshots. A headless
+software-GL client in a `nixosTest` is not currently practical for 26.2, so the
+pilot mod is the recommended vehicle if option 1 or 2 is ever implemented and
+someone wants to confirm the pixels.

--- a/events/smash/skins/textures.lock.json
+++ b/events/smash/skins/textures.lock.json
@@ -1,0 +1,62 @@
+{
+  "blaze": {
+    "sha256": "sha256-7NioZFWlw5HWCZzkA9mwQMVnmKEdAvZwMIzX7ouhZSg=",
+    "url": "http://textures.minecraft.net/texture/ecd8a86455a5c391d6099ce403d9b040c56798a11d02f670308cd7ee8ba16528"
+  },
+  "chicken": {
+    "sha256": "sha256-7qrg+paewSsxGVY7OokxJw1AHrQqrwh3xQBetj5iSTE=",
+    "url": "http://textures.minecraft.net/texture/eeaae0fa969ec12b3119563b3a8931270d401eb42aaf0877c5005eb63e624931"
+  },
+  "cow": {
+    "sha256": "sha256-Yb+kOjugpjw7FEF7StUxPodywdov9qgDNbNFsuq5wbw=",
+    "url": "http://textures.minecraft.net/texture/61bfa43a3ba0a63c3b14417b4ad5313e8772c1da2ff6a80335b345b2eab9c1bc"
+  },
+  "creeper": {
+    "sha256": "sha256-tUXOiIjleQa1SPkUtX7wV1dnUzL9Sp56+znJCLUDHDU=",
+    "url": "http://textures.minecraft.net/texture/b545ce8888e57906b548f914b57ef05757675332fd4a9e7afb39c908b5031c35"
+  },
+  "enderman": {
+    "sha256": "sha256-qRkFgseYVbTlHZQj2K35ulZhGxp41fKUSguG6KCNQNI=",
+    "url": "http://textures.minecraft.net/texture/a9190582c79855b4e51d9423d8adf9ba56611b1a78d5f2944a0b86e8a08d40d2"
+  },
+  "guardian": {
+    "sha256": "sha256-Zxfom1ycMMxGHj/u7cTY4No/A6rpGi4Z265C5Gd9IIc=",
+    "url": "http://textures.minecraft.net/texture/6717e89b5c9c30cc461e3feeedc4d8e0da3f03aae91a2e19dbae42e4677d2087"
+  },
+  "iron_golem": {
+    "sha256": "sha256-z2nYuvNV+n5/8wM4ifIS0AICZm7E7mfnBEEbRHYMVgA=",
+    "url": "http://textures.minecraft.net/texture/cf69d8baf355fa7e7ff3033889f212d00202666ec4ee67e704411b44760c5600"
+  },
+  "skeleton": {
+    "sha256": "sha256-r+cnY+AhK3fwhm7Y0cizGySwrlhd051xtTA1HLNzMUU=",
+    "url": "http://textures.minecraft.net/texture/afe72763e0212b77f0866ed8d1c8b31b24b0ae585dd39d71b530351cb3733145"
+  },
+  "sky_squid": {
+    "sha256": "sha256-AFoWKESxBXxed7E+wuWWN1r4lNxOrtY6u8NbDkhttRQ=",
+    "url": "http://textures.minecraft.net/texture/5a162844b1057c5e77b13ec2e596375af894dc4eaed63abbc35b0e486db514"
+  },
+  "slime": {
+    "sha256": "sha256-EjW7ykWUaT628sPQTmqA9e9YpG8apbNICh3LGBZ+dLI=",
+    "url": "http://textures.minecraft.net/texture/1235bbca4594693eb6f2c3d04e6a80f5ef58a46f1aa5b3480a1dcb18167e74b2"
+  },
+  "snowman": {
+    "sha256": "sha256-nL5sqgiGVEJ3uTiGw/eCFGksk24GYRnkbWo7fCQcjK4=",
+    "url": "http://textures.minecraft.net/texture/9cbe6caa0886544277b93886c3f78214692c936e066119e46d6a3b7c241c8cae"
+  },
+  "spider": {
+    "sha256": "sha256-H9Hvc35p7n8SpEKerV3PRo+Y8700j+hDiV8SQ0JyIPw=",
+    "url": "http://textures.minecraft.net/texture/1fd1ef737e69ee7f12a4429ead5dcf468f98f3bd348fe843895f1243427220fc"
+  },
+  "wither_skeleton": {
+    "sha256": "sha256-BgAp37GKJ+aSjVZXAl+TGOly4CrZVy9W0keVZ2qtj8k=",
+    "url": "http://textures.minecraft.net/texture/60029dfb18a27e6928d5657025f9318e972e02ad9572f56d24795676aad8fc9"
+  },
+  "wolf": {
+    "sha256": "sha256-kspMFoWszs83M8dufJ9TtomBFSjB9WdfbmnfazRK1mc=",
+    "url": "http://textures.minecraft.net/texture/92ca4c1685accecf3733c76e7c9f53b689811528c1f5675f6e69df6b344ad667"
+  },
+  "zombie": {
+    "sha256": "sha256-wvLP9uWOAMZp+66F2cPWpF4O+ge7wJ+xPUJpYw4z4jk=",
+    "url": "http://textures.minecraft.net/texture/c2f2cff6e58e00c669fbae85d9c3d6a45e0efa07bbc09fb13d4269630e33e239"
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -141,10 +141,29 @@
             root = ./.;
             fileset = lib.fileset.unions [
               ./nix/verify-kit-skins.py
+              ./nix/verify-kit-skin-images.py
               ./events/smash/skins
               ./events/smash/src/module/kits
             ];
           };
+
+          # Every kit's skin image, fetched from the url its signed payload names
+          # and pinned by hash in textures.lock.json. Fixed-output so the image
+          # gate stays offline and store-cached: the fetch happens once, here,
+          # not inside the sandboxed check and not on every run.
+          kitSkinImages =
+            let
+              lock = lib.importJSON ./events/smash/skins/textures.lock.json;
+            in
+            pkgs.runCommand "hyperion-kit-skin-images" { } (
+              lib.concatStringsSep "\n" (
+                [ "mkdir -p $out" ]
+                ++ lib.mapAttrsToList (
+                  mob: entry:
+                  "cp ${pkgs.fetchurl { inherit (entry) url; hash = entry.sha256; }} $out/${mob}.png"
+                ) lock
+              )
+            );
 
           checkScripts = lib.mapAttrs mkScript {
             # `flecs_ecs_sys`'s default features include `regenerate_binding`,
@@ -179,6 +198,21 @@
               text = ''
                 root="$(git rev-parse --show-toplevel)"
                 exec python3 "$root/nix/verify-kit-skins.py"
+              '';
+            };
+
+            # Repin every kit's skin image by hash after a skin changes. Impure
+            # (it reaches Mojang's texture host), which is why it is a command
+            # and not a check; the check that reads its output is offline.
+            sync-kit-skin-textures = {
+              deps = [
+                pkgs.python3
+                pkgs.nix
+                pkgs.git
+              ];
+              text = ''
+                root="$(git rev-parse --show-toplevel)"
+                exec python3 "$root/nix/sync-kit-skin-textures.py"
               '';
             };
 
@@ -1176,6 +1210,18 @@
                   python3 ${kitSkinSource}/nix/verify-kit-skins.py | tee "$out"
                 '';
 
+            # A signed property is only half of it: the url it covers still has
+            # to serve a real skin image and not a broken link. Offline via the
+            # pinned, prefetched images in kitSkinImages.
+            kit-skins-images =
+              pkgs.runCommand "hyperion-kit-skins-images"
+                {
+                  nativeBuildInputs = [ kitSkinPython ];
+                }
+                ''
+                  python3 ${kitSkinSource}/nix/verify-kit-skin-images.py ${kitSkinImages} | tee "$out"
+                '';
+
             # The pinned world URL still has to be the one the server asks for.
             genmap-url-pinned = e2e.genMapUrlPinned;
 
@@ -1300,6 +1346,7 @@
             minecraft-data = minecraft.generatedData;
             minecraft-decompiled = minecraft.decompiledSources;
             minecraft-physics-sources = minecraft.physicsSources;
+            minecraft-client-skin-sources = minecraft.clientSkinSources;
             minecraft-protocol = minecraft.protocolJson;
             minecraft-proto-rust = minecraft.generatedRust;
             minecraft-encoder-fixtures = minecraft.encoderFixtures;

--- a/nix/e2e.nix
+++ b/nix/e2e.nix
@@ -12,6 +12,11 @@
   sources,
 }:
 let
+  # The scripted clients that verify a skin's Mojang signature the way an
+  # online client does need `cryptography`; every other client ignores it. One
+  # interpreter for all of them keeps the driver and the checks in step.
+  clientPython = pkgs.python3.withPackages (python: [ python.cryptography ]);
+
   # The world bedwars loads. `hyperion-genmap` downloads this from GitHub the
   # first time a server boots and caches it under the user's cache directory,
   # which a sandbox has no way to do: there is no network in there. So the
@@ -125,7 +130,7 @@ let
   # nobody runs until CI does.
   driver = pkgs.writeShellApplication {
     name = "hyperion-e2e-driver";
-    runtimeInputs = [ pkgs.python3 ];
+    runtimeInputs = [ clientPython ];
     text = ''
       # Job control, so each background process is its own group. `cargo run`
       # forks the binary under test, and killing only cargo would leave the
@@ -313,7 +318,7 @@ let
     pkgs.runCommand name
       {
         nativeBuildInputs = [
-          pkgs.python3
+          clientPython
           driver
         ];
         # The game server builds a reqwest client at startup, before it knows

--- a/nix/minecraft-data.nix
+++ b/nix/minecraft-data.nix
@@ -234,6 +234,71 @@ let
       fi
     '';
 
+  # The client jar, for the one question a server capture cannot answer: how the
+  # vanilla client sources the LOCAL player's own skin, and whether any packet
+  # short of a Respawn refreshes it. LocalPlayer, AbstractClientPlayer, PlayerInfo
+  # and SkinManager are client-only, so they are absent from the server jar the
+  # other decompiles read. 26.1+ ships unobfuscated, so the names below are
+  # Mojang's own and need no mapping. See hyperion-mc/hyperion#1056.
+  clientJar = pkgs.fetchurl {
+    name = "minecraft-client-${pin.id}.jar";
+    inherit (pin.client) url;
+    hash = pin.client.sha256;
+    meta = {
+      description = "Mojang's Minecraft ${pin.id} client jar";
+      license = lib.licenses.unfree;
+    };
+  };
+
+  # The client's skin path, decompiled. Scoped to the classes that decide what
+  # skin a player entity renders, so the #1056 verdict cites source rather than a
+  # memory of it, and a jar bump that moves the path fails the landmark checks
+  # below rather than silently going stale. Unlike the server jar the other
+  # decompiles unpack, the client jar is not a bundler: the classes sit directly
+  # under net/minecraft.
+  clientSkinSources = pkgs.runCommand "minecraft-client-skin-sources-${pin.id}"
+    {
+      nativeBuildInputs = [ pkgs.cfr pkgs.unzip ];
+      meta = {
+        description = "Decompiled client skin and player classes for Minecraft ${pin.id}";
+        license = lib.licenses.unfree; # Mojang EULA; derived from the client jar.
+      };
+    }
+    ''
+      mkdir -p classes && (cd classes && unzip -q ${clientJar} \
+        'net/minecraft/client/player/AbstractClientPlayer*.class' \
+        'net/minecraft/client/player/LocalPlayer*.class' \
+        'net/minecraft/client/player/RemotePlayer*.class' \
+        'net/minecraft/client/multiplayer/PlayerInfo*.class' \
+        'net/minecraft/client/multiplayer/ClientPacketListener*.class' \
+        'net/minecraft/client/resources/SkinManager*.class' \
+        'net/minecraft/world/entity/player/PlayerSkin*.class')
+      cd classes
+
+      # Inner classes collapse onto their outermost class's file, so each outer
+      # brings its siblings along. Same '$'-anchored rewrite the other decompiles
+      # use.
+      find net/minecraft -name '*.class' | sed 's/\$[^/]*\.class$/.class/' | sort -u > selected.txt
+      echo "decompiling $(wc -l < selected.txt) client skin classes" >&2
+
+      mkdir -p $out
+      cfr --outputdir $out --silent true --comments false $(cat selected.txt)
+
+      # Landmarks: the exact members the #1056 verdict reads. A jar bump that
+      # renames any of them fails here rather than leaving the verdict citing an
+      # empty file.
+      acp="$out/net/minecraft/client/player/AbstractClientPlayer.java"
+      info="$out/net/minecraft/client/multiplayer/PlayerInfo.java"
+      cpl="$out/net/minecraft/client/multiplayer/ClientPacketListener.java"
+      for f in "$acp" "$info" "$cpl"; do
+        if [ ! -e "$f" ]; then echo "missing decompiled $f" >&2; exit 1; fi
+      done
+      grep -q "PlayerSkin getSkin" "$acp" || { echo "AbstractClientPlayer.getSkin gone" >&2; exit 1; }
+      grep -q "createSkinLookup" "$info" || { echo "PlayerInfo.createSkinLookup gone" >&2; exit 1; }
+      grep -q "handlePlayerInfoUpdate" "$cpl" || { echo "handlePlayerInfoUpdate gone" >&2; exit 1; }
+      grep -q "handleRespawn" "$cpl" || { echo "handleRespawn gone" >&2; exit 1; }
+    '';
+
   # The bundler jar is a launcher wrapped around the real server jar and its
   # dependencies. Both the harness below and anything else wanting to run
   # server code needs them unpacked with a classpath, so it happens once.
@@ -950,6 +1015,8 @@ in
     generatedData
     decompiledSources
     physicsSources
+    clientJar
+    clientSkinSources
     protocolJson
     generatedRust
     vanillaEncoder

--- a/nix/minecraft-version.json
+++ b/nix/minecraft-version.json
@@ -18,5 +18,11 @@
     "sha1": "823e2250d24b3ddac457a60c92a6a941943fcd6a",
     "sha256": "sha256-zazfsliY3l5LSw5d3MJyL3cGfkZgVwnC2IbAAOu2PsU=",
     "size": 60894273
+  },
+  "client": {
+    "url": "https://piston-data.mojang.com/v1/objects/2dc72797acbc1b63fc16a11c4ac393605f453754/client.jar",
+    "sha1": "2dc72797acbc1b63fc16a11c4ac393605f453754",
+    "sha256": "sha256-QIlu6fHivsPJNNqsfpPUHp49nC+K4Mo2bVL/v9GvopA=",
+    "size": 39193383
   }
 }

--- a/nix/sync-kit-skin-textures.py
+++ b/nix/sync-kit-skin-textures.py
@@ -1,0 +1,44 @@
+"""Repin every kit's skin image by hash, into events/smash/skins/textures.lock.json.
+
+The image check (`verify-kit-skin-images.py`) is offline: it validates images
+already in the store, fetched from pinned (url, sha256) pairs. This regenerates
+those pairs from the committed `.value` payloads, so replacing a skin is still a
+two-file change plus one command rather than a hand-edited hash. Impure: it
+reaches Mojang's texture host, which is why it is a `nix run` and not a check.
+"""
+
+import base64
+import json
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SKINS = ROOT / "events" / "smash" / "skins"
+
+
+def main():
+    lock = {}
+    for value_path in sorted(SKINS.glob("*.value")):
+        mob = value_path.stem
+        payload = json.loads(base64.b64decode(value_path.read_text().strip()))
+        url = (payload.get("textures") or {}).get("SKIN", {}).get("url")
+        if not url:
+            raise SystemExit("%s carries no SKIN url" % mob)
+        result = subprocess.run(
+            ["nix", "store", "prefetch-file", "--json", url],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise SystemExit("prefetch failed for %s (%s): %s" % (mob, url, result.stderr))
+        lock[mob] = {"url": url, "sha256": json.loads(result.stdout)["hash"]}
+        print("pinned %-16s %s" % (mob, lock[mob]["sha256"]), file=sys.stderr)
+
+    out = SKINS / "textures.lock.json"
+    out.write_text(json.dumps(lock, indent=2, sort_keys=True) + "\n")
+    print("wrote %s with %d entries" % (out, len(lock)), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/nix/verify-kit-skin-images.py
+++ b/nix/verify-kit-skin-images.py
@@ -1,0 +1,107 @@
+"""Every kit's skin url resolves to a real skin image, not a broken link.
+
+The signature check in `verify-kit-skins.py` proves an online client will keep
+the `textures` property; this proves the url that property points at actually
+serves the intended custom skin. Offline on purpose, the same way: the image
+bytes are pinned in `textures.lock.json` and fetched into the store by the nix
+check that runs this, so the answer is the same in ten years as today and does
+not depend on a live network at test time.
+
+What it checks, per kit under `events/smash/skins/*.value`:
+
+  - the pinned image is a PNG whose bytes hash to what the lock recorded, so the
+    file the check fetched is the one the payload's url addresses (the url is
+    content addressed on `textures.minecraft.net`, so a hash mismatch means the
+    lock is stale, not that Mojang changed the picture),
+  - its dimensions are a Minecraft skin's: 64x64, or the legacy 64x32,
+  - it is not Mojang's default skin. A default is what the client falls back to
+    when there is no valid signed skin; that the payload is signed (proved
+    elsewhere) and carries a distinct, non-default texture is the whole point.
+
+Run by `nix run .#check-kit-skin-images` and by the `kit-skins-images` check.
+"""
+
+import base64
+import hashlib
+import json
+import pathlib
+import struct
+import sys
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+SKIN_SIZES = {(64, 64), (64, 32)}
+
+
+def sri_sha256(data):
+    """The `sha256-...` SRI string nix uses, for a bytes blob."""
+    return "sha256-" + base64.b64encode(hashlib.sha256(data).digest()).decode()
+
+
+def png_dimensions(data):
+    """(width, height) from a PNG's IHDR, or None if it is not a PNG."""
+    if data[:8] != PNG_MAGIC:
+        return None
+    # IHDR is the first chunk: 8 byte signature, 4 length, 4 type, then w,h.
+    if data[12:16] != b"IHDR":
+        return None
+    width, height = struct.unpack(">II", data[16:24])
+    return width, height
+
+
+def main():
+    root = pathlib.Path(__file__).resolve().parent.parent
+    skins = root / "events" / "smash" / "skins"
+    lock = json.loads((skins / "textures.lock.json").read_text())
+
+    # The nix check passes the directory of fetched images as argv[1]; running it
+    # by hand falls back to a sibling `images/` for a quick local check.
+    images = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else skins / "images"
+
+    # The lock must name exactly the kits that declare a skin, so a new kit
+    # cannot ship with an unpinned, unchecked image.
+    declared = {path.stem for path in skins.glob("*.value")}
+    if set(lock) != declared:
+        missing = declared - set(lock)
+        extra = set(lock) - declared
+        raise SystemExit(
+            "textures.lock.json is out of step with the committed skins: "
+            "missing %s, extra %s; run `nix run .#sync-kit-skin-textures`"
+            % (sorted(missing), sorted(extra))
+        )
+
+    problems = []
+    for mob in sorted(lock):
+        entry = lock[mob]
+        image = images / (mob + ".png")
+        if not image.exists():
+            problems.append("%s: no fetched image at %s" % (mob, image))
+            continue
+        data = image.read_bytes()
+        actual = sri_sha256(data)
+        if actual != entry["sha256"]:
+            problems.append(
+                "%s: image hash %s does not match the pinned %s; the lock is "
+                "stale" % (mob, actual, entry["sha256"])
+            )
+            continue
+        dims = png_dimensions(data)
+        if dims is None:
+            problems.append("%s: the url did not serve a PNG" % mob)
+            continue
+        if dims not in SKIN_SIZES:
+            problems.append(
+                "%s: %dx%d is not a skin size (64x64 or 64x32)" % (mob, *dims)
+            )
+            continue
+        print("ok   %-16s %dx%d  %s" % (mob, dims[0], dims[1], entry["url"]))
+
+    if problems:
+        for problem in problems:
+            print("FAIL %s" % problem, file=sys.stderr)
+        raise SystemExit("%d of %d kit skin images are unusable" % (len(problems), len(lock)))
+
+    print("%d kit skins, every url serving a real skin image" % len(lock))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/skin-check.py
+++ b/tools/skin-check.py
@@ -28,12 +28,19 @@ goes red.
 """
 
 import argparse
+import base64
 import importlib.util
 import json
 import pathlib
 import struct
 import sys
 import time
+from urllib.parse import urlparse
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.serialization import load_der_public_key
 
 TOOLS = pathlib.Path(__file__).resolve().parent
 ROOT = TOOLS.parent
@@ -48,6 +55,52 @@ def _load(name, filename):
 
 match = _load("smash_match", "smash-match.py")
 monitor = _load("packet_monitor", "packet_monitor.py")
+
+# `TextureUrlChecker.ALLOWED_DOMAINS` on the client is exactly this one host;
+# authlib throws the whole payload away, signature and all, for any other.
+ALLOWED_TEXTURE_DOMAINS = {"textures.minecraft.net"}
+
+
+def _mojang_keys():
+    """Mojang's committed profile-property public keys, DER-decoded."""
+    data = json.loads(
+        (ROOT / "events" / "smash" / "skins" / "mojang-profile-keys.json").read_text()
+    )
+    return [load_der_public_key(base64.b64decode(e["publicKey"])) for e in data["profilePropertyKeys"]]
+
+
+def yggdrasil_signed(value, signature):
+    """Whether `signature` verifies over the base64 `value` string's bytes under
+    one of Mojang's keys, RSA with SHA-1.
+
+    This is exactly what `YggdrasilServicesKeyInfo.validateProperty` runs before
+    an online client keeps a skin for anyone but its wearer. Byte-equality to a
+    committed file is a weaker claim: a committed-but-invalid signature passes
+    that and still renders as Steve for every other player.
+    """
+    if not signature:
+        return False
+    try:
+        blob = base64.b64decode(signature, validate=True)
+    except (ValueError, base64.binascii.Error):
+        return False
+    for key in _mojang_keys():
+        try:
+            key.verify(blob, value.encode(), padding.PKCS1v15(), hashes.SHA1())
+            return True
+        except InvalidSignature:
+            continue
+    return False
+
+
+def skin_url(value):
+    """The SKIN texture url inside a base64 textures payload, or ''."""
+    try:
+        payload = json.loads(base64.b64decode(value))
+    except (ValueError, base64.binascii.Error):
+        return ""
+    return ((payload.get("textures") or {}).get("SKIN") or {}).get("url", "")
+
 base = match.base
 
 take_var_int = base.take_var_int
@@ -173,6 +226,31 @@ def main():
         view["textures_signature"] == expected_sig,
         "and it carries its Mojang signature, without which only the wearer "
         "would see it",
+    )
+
+    # The signed-skins crux: verify the signature the wire carried the way a
+    # vanilla online client does, not merely that it equals a committed file.
+    wire_value = view["textures_value"] or ""
+    wire_sig = view["textures_signature"] or ""
+    check(
+        yggdrasil_signed(wire_value, wire_sig),
+        "the wire signature verifies under a Mojang profile key (SIGNED), so a "
+        "real online client keeps this skin for other players and does not fall "
+        "back to Steve",
+    )
+    check(
+        urlparse(skin_url(wire_value)).hostname in ALLOWED_TEXTURE_DOMAINS,
+        "the skin url is on textures.minecraft.net, the only host a client will "
+        "load a skin from",
+    )
+    # A guard is not a guard until it has failed: a one-byte tamper must not
+    # verify, or the check above would pass for any bytes at all.
+    _blob = bytearray(base64.b64decode(wire_sig)) if wire_sig else bytearray(b"\x00")
+    _blob[0] ^= 0x01
+    check(
+        not yggdrasil_signed(wire_value, base64.b64encode(bytes(_blob)).decode()),
+        "a one-byte-tampered signature is rejected, so the verification above is "
+        "real and not vacuous",
     )
 
     ok = wait_until(


### PR DESCRIPTION
Follow-up to the packet monitor + `smash-skin-e2e` gate. Three things the operator asked for, all store-cached or verified against a running server.

## 1. The signed-skins crux, verified on the wire
`skin-check.py` now validates the signature it parsed off `PlayerInfoUpdate` the way a vanilla online client does: `YggdrasilServicesKeyInfo.validateProperty` = RSA/SHA-1 over the base64 `value` bytes, under Mojang's committed profile-property keys. So the gate proves **a real online client keeps this skin for other players** (SIGNED), not merely that the bytes equal a committed file. It also asserts the URL is on `textures.minecraft.net` and that a **one-byte-tampered signature is rejected** (the check is not vacuous). Verified live: all 12 checks green, including the three new ones. The e2e client python gains `cryptography`.

## 2. The image behind the URL
Each kit skin's texture is pinned by hash in `events/smash/skins/textures.lock.json` (regenerated by `nix run .#sync-kit-skin-textures`) and fetched into the store as a fixed-output derivation. The new `kit-skins-images` check confirms every URL serves a real 64x64/64x32 skin PNG whose bytes match the pin. Offline, deterministic, store-cached (built green).

## 3. The own-avatar verdict, from the decompiled client (#1056)
`minecraft-data.nix` gains a **client-jar decompile** (`minecraft-client-skin-sources`) scoped to the skin path (`AbstractClientPlayer`, `PlayerInfo`, `ClientPacketListener`, `SkinManager`), with landmark asserts. `docs/wearer-own-skin.md` reads it and gives the definitive verdict:

- `AbstractClientPlayer.getSkin()` reads a **cached** `PlayerInfo` (`getPlayerInfo()` populates it once, no setter nulls it); `PlayerInfo.getSkin()` memoizes its `skinLookup` from the profile it was built with.
- `handlePlayerInfoRemove`/`handlePlayerInfoUpdate` never touch that cache for an existing player, so a remove+re-add does **not** refresh the wearer.
- Only a new `LocalPlayer` (login or respawn) gets a fresh skin, and `handleRespawn` always shows the `LevelLoadingScreen` even same-dimension.

**Verdict: there is no refresh path lighter than a Respawn.** `roster.rs`'s choice to leave the wearer's own view alone is correct, not a shortcut. The doc lists the options and recommends assigning a join-time skin **before world-entry** (no respawn, fixes the join-time skin) over a mid-session respawn. Confirming the actual pixels needs a real client; the `tools/hyperion-pilot-mod` Fabric mod is the vehicle (semi-automated: operator loads it, agent drives the socket + screenshots).

Reproduce the decompiled evidence: `nix build .#minecraft-client-skin-sources`.

## CI
hyperion CI is known-broken. Validated locally: `smash-skin-e2e` app (12/12 green), `kit-skins-images` + `kit-skins-signed` + `minecraft-client-skin-sources` all build, affected checks eval, ruff clean.