### PR TITLE
fix(smash): bow arrows leave the eye, fly per tick, and scale with draw

### DIFF
--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -26,9 +26,10 @@ use itertools::Either;
 
 use crate::{
     Prev,
-    net::{ChannelId, Compose, ConnectionId, DataBundle, protocol::Clientbound},
+    net::{Channel, ChannelId, Compose, ConnectionId, DataBundle, protocol::Clientbound},
     simulation::{
-        Flight, MovementTracking, Owner, PendingTeleportation, Pitch, Position, Velocity, Xp, Yaw,
+        BroadcastProjectile, Flight, MovementTracking, Owner, PendingTeleportation, Pitch,
+        Position, Velocity, Xp, Yaw,
         animation::ActiveAnimation,
         blocks::Blocks,
         entity_kind::EntityKind,
@@ -636,6 +637,38 @@ impl Module for EntityStateSyncModule {
                 }
             },
         );
+
+        // The other half of `update_projectile_positions`' broadcast, for the
+        // projectiles that carry no `Owner` because a game module integrates
+        // their own flight. The marker, not the ownership, is what says "keep
+        // telling clients where this is": a smash projectile advances its own
+        // position and only wants the send. `OnStore`, after every integrator
+        // has moved the entity this tick, and gated on `Channel` so the send
+        // has subscribers to reach.
+        system!(
+            "broadcast_marked_projectiles",
+            world,
+            &Compose,
+            &Position,
+            &Velocity,
+            &Yaw,
+            &Pitch,
+        )
+        .with(id::<BroadcastProjectile>())
+        .with(id::<Channel>())
+        .kind(id::<flecs::pipeline::OnStore>())
+        .each_iter(|it, row, (compose, position, velocity, yaw, pitch)| {
+            let entity = it.entity(row);
+            broadcast_projectile_position(
+                compose,
+                entity.into(),
+                entity.minecraft_id(),
+                **position,
+                velocity.0,
+                **yaw,
+                **pitch,
+            );
+        });
 
         track_previous::<Position>(world);
         track_previous::<Yaw>(world);

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -308,6 +308,7 @@ fn register_components(world: &World) -> MetadataPrefabs {
     world.component::<Player>();
     world.component::<Visible>();
     world.component::<Spawn>();
+    world.component::<BroadcastProjectile>();
     world.component::<Owner>();
     world.component::<PendingTeleportation>();
     world.component::<FlyingSpeed>();
@@ -556,6 +557,18 @@ fn register_observers(world: &World, prefabs: MetadataPrefabs) {
 
 #[derive(Component)]
 pub struct Spawn;
+
+/// Marks a projectile whose position hyperion broadcasts to its channel every
+/// tick, regardless of who owns it.
+///
+/// The per-tick `EntityPositionSync` used to live only inside
+/// `update_projectile_positions`, which requires an [`Owner`] to integrate and
+/// collide the entity. A game half that owns its own flight (smash decorates a
+/// projectile it is already integrating) wants the broadcast without the
+/// integration, so the two are split: this marker drives the broadcast, an
+/// [`Owner`] drives the integration, and an entity can carry either or both.
+#[derive(Component)]
+pub struct BroadcastProjectile;
 
 #[derive(Component)]
 pub struct Visible;

--- a/crates/hyperion/src/simulation/projectile_motion.rs
+++ b/crates/hyperion/src/simulation/projectile_motion.rs
@@ -102,6 +102,55 @@ pub fn look_angles(velocity: Vec3) -> (f32, f32) {
     (yaw, pitch)
 }
 
+/// A standing player's eye height, in blocks (`Player.getStandingEyeHeight`).
+///
+/// A projectile leaves the eye, not the feet the entity position tracks, so
+/// the vanilla bow and every ability that fires "from where you are looking"
+/// both add this before launching. Fire from the feet and the shot renders as
+/// one loosed from the stomach.
+pub const EYE_HEIGHT: f32 = 1.62;
+
+/// How far in front of the eye a launched projectile starts, in blocks. Vanilla
+/// nocks the arrow a half block along the look so it clears the shooter's own
+/// hitbox on the first tick.
+pub const MUZZLE_OFFSET: f32 = 0.5;
+
+/// The point a projectile launches from: the shooter's eye, a half block along
+/// `direction`. `feet` is the tracked entity [`super::Position`]; `direction`
+/// is the unit look vector from [`super::get_direction_from_rotation`]. Both
+/// events call this so the muzzle is written down once.
+#[must_use]
+pub fn muzzle(feet: Vec3, direction: Vec3) -> Vec3 {
+    Vec3::new(feet.x, feet.y + EYE_HEIGHT, feet.z) + direction * MUZZLE_OFFSET
+}
+
+/// Blocks per tick a fully drawn bow gives its arrow.
+///
+/// `BowItem.releaseUsing` passes `getPowerForTime(...) * 3.0` to the arrow and
+/// the curve saturates at 1.0, so a full draw is exactly this.
+pub const MAX_ARROW_SPEED: f32 = 3.0;
+
+/// Vanilla's `BowItem.getPowerForTime`, keyed on the draw as a fraction of a
+/// full draw rather than a raw tick count.
+///
+/// `power = (f*f + f*2) / 3`, clamped to 1.0, where `f` is `drawTicks / 20`.
+/// Returned as a fraction so the caller's `* MAX_ARROW_SPEED` lands on exactly
+/// vanilla's maximum. Both events call this rather than transcribe the curve a
+/// second time: bedwars keys `f` on the held `Duration`, smash on an ability's
+/// 0..1 charge.
+#[must_use]
+#[expect(
+    clippy::suboptimal_flops,
+    reason = "mul_add is a fused multiply-add: one rounding where Java does two. getPowerForTime \
+              evaluates `(f * f + f * 2.0F) / 3.0F` as separate float operations, and this \
+              function exists to give the same answer it does, so the two roundings are the \
+              behaviour rather than an oversight"
+)]
+pub fn bow_power(draw_fraction: f32) -> f32 {
+    let f = draw_fraction;
+    ((f * f + f * 2.0) / 3.0).min(1.0)
+}
+
 /// One tick of vanilla's rotation smoothing: `Projectile.lerpRotation`.
 ///
 /// Slides `current` by whole turns into the half-open window

--- a/events/bedwars/src/module/bow.rs
+++ b/events/bedwars/src/module/bow.rs
@@ -16,7 +16,7 @@ use hyperion::{
         handlers::PacketSwitchQuery,
         metadata::living_entity::{ArrowsInEntity, HandStates},
         packet::HandlerRegistry,
-        projectile_motion::look_angles,
+        projectile_motion::{MAX_ARROW_SPEED, bow_power, look_angles, muzzle},
     },
     storage::{EventQueue, Events},
 };
@@ -47,15 +47,6 @@ const TICKS_PER_SECOND: f32 = 20.0;
 /// runs, the other is how long the bow takes, and vanilla is free to change
 /// either without the other.
 const FULL_DRAW_TICKS: f32 = 20.0;
-
-/// Blocks per tick a fully drawn bow gives its arrow.
-///
-/// `releaseUsing` passes `f * 3.0` to `AbstractArrow#shootFromRotation`, where
-/// `f` is the fraction [`BowCharging::get_charge`] returns. This is the 3.0,
-/// and it is the same number
-/// `crates/hyperion/tests/differential/scenarios/arrow-level-shot.json` records
-/// a vanilla shot at.
-const MAX_ARROW_SPEED: f32 = 3.0;
 
 #[derive(Component)]
 pub struct BowModule;
@@ -124,17 +115,10 @@ impl BowCharging {
     /// multiply turned into 3.6 blocks a tick -- a fifth faster than a real bow
     /// can shoot -- under a comment claiming 3.0 was the maximum.
     #[must_use]
-    #[expect(
-        clippy::suboptimal_flops,
-        reason = "mul_add is a fused multiply-add: one rounding where Java does two. \
-                  getPowerForTime evaluates `(f * f + f * 2.0F) / 3.0F` as separate float \
-                  operations, and this file exists to give the same answer it does, so the two \
-                  roundings are the behaviour rather than an oversight"
-    )]
     pub fn get_charge(&self) -> f32 {
         let elapsed = self.start_time.elapsed().unwrap_or(Duration::ZERO);
         let f = elapsed.as_secs_f32() * TICKS_PER_SECOND / FULL_DRAW_TICKS;
-        ((f * f + f * 2.0) / 3.0).min(1.0)
+        bow_power(f)
     }
 }
 
@@ -248,8 +232,7 @@ impl Module for BowModule {
                         // keeps it aimed from here; this is only the launch seed.
                         let (arrow_yaw, arrow_pitch) = look_angles(velocity);
 
-                        let spawn_pos =
-                            Vec3::new(position.x, position.y + 1.62, position.z) + direction * 0.5;
+                        let spawn_pos = muzzle(**position, direction);
 
                         debug!("Arrow spawn position: {:?}", spawn_pos);
 

--- a/events/smash/src/draw.rs
+++ b/events/smash/src/draw.rs
@@ -37,8 +37,13 @@
 //! `Flight` already owns.
 
 use flecs_ecs::prelude::*;
-use hyperion::simulation::{
-    Pitch, Position, Spawn, Uuid, Velocity, Yaw, projectile_motion::look_angles,
+use glam::Vec3;
+use hyperion::{
+    net::Channel,
+    simulation::{
+        BroadcastProjectile, Pitch, Position, Spawn, Uuid, Velocity, Yaw,
+        projectile_motion::{EYE_HEIGHT, look_angles},
+    },
 };
 
 use crate::module::projectile::{Flight, Projectile, Visual};
@@ -50,7 +55,7 @@ struct Drawn;
 /// Minecraft runs at twenty ticks a second, and hyperion's [`Velocity`] is in
 /// blocks per tick where [`Flight`] is in blocks per second. Every crossing
 /// between the two goes through this.
-const TICKS_PER_SECOND: f32 = 20.0;
+pub(crate) const TICKS_PER_SECOND: f32 = 20.0;
 
 #[derive(Component)]
 pub struct DrawModule;
@@ -74,24 +79,55 @@ impl Module for DrawModule {
             .each_entity(|projectile, (visual, flight)| {
                 let per_tick = flight.velocity / TICKS_PER_SECOND;
                 let (yaw, pitch) = look_angles(flight.velocity);
+                // What a client sees leaves the shooter's eye, not the tracked
+                // feet position: a projectile drawn from the stomach is the bug
+                // this fixes. A constant vertical lift (not the rotating muzzle
+                // offset) keeps the rendered arc a clean parabola tick to tick.
+                // The `Flight` simulation is unchanged; this is the render only.
+                let seen = flight.position + Vec3::Y * EYE_HEIGHT;
 
                 projectile
                     .add_enum(visual.0)
                     .set(Uuid::new_v4())
-                    .set(Position::new(
-                        flight.position.x,
-                        flight.position.y,
-                        flight.position.z,
-                    ))
+                    .set(Position::new(seen.x, seen.y, seen.z))
                     .set(Velocity::new(per_tick.x, per_tick.y, per_tick.z))
                     .set(Yaw::new(yaw))
                     .set(Pitch::new(pitch))
+                    // A broadcast channel of its own and the marker that says
+                    // to keep sending its position: advance_drawn_projectiles
+                    // below moves the wire components each tick and hyperion's
+                    // broadcast_marked_projectiles sends them, so the client
+                    // sees the arc rather than dead-reckoning from the spawn.
+                    // No Owner, so hyperion never integrates or re-hits it;
+                    // Flight stays the one authority for where it goes.
+                    .add(Channel)
+                    .add(BroadcastProjectile)
                     .add(Drawn::id());
                 // Enqueued rather than added: the `Spawn` observer that sends
                 // `add_entity` runs at the sync point, after this system's
                 // deferred component adds above have been applied, so the packet
                 // it builds sees the kind and position this set.
                 projectile.enqueue(Spawn);
+            });
+
+        // Move the wire components each tick from the `Flight` that owns the
+        // motion, so hyperion's `broadcast_marked_projectiles` has a fresh
+        // position to send. `PostUpdate`, after `smash::fly` has integrated
+        // `Flight` this tick. The projectile points where it is going, re-aimed
+        // off its velocity every tick, the same as a hyperion-owned arrow.
+        world
+            .system_named::<(&Flight, &mut Position, &mut Velocity, &mut Yaw, &mut Pitch)>(
+                "smash::advance_drawn_projectiles",
+            )
+            .with(Projectile::id())
+            .with(Drawn::id())
+            .kind(id::<flecs::pipeline::PostUpdate>())
+            .each(|(flight, position, velocity, yaw, pitch)| {
+                let (y, p) = look_angles(flight.velocity);
+                **position = flight.position + Vec3::Y * EYE_HEIGHT;
+                velocity.0 = flight.velocity / TICKS_PER_SECOND;
+                **yaw = y;
+                **pitch = p;
             });
     }
 }

--- a/events/smash/src/module/kits/skeleton.rs
+++ b/events/smash/src/module/kits/skeleton.rs
@@ -10,14 +10,20 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
-use hyperion::simulation::entity_kind::EntityKind;
+use hyperion::simulation::{
+    entity_kind::EntityKind,
+    projectile_motion::{MAX_ARROW_SPEED, bow_power},
+};
 
-use crate::module::{
-    ability::{Cast, Observable, charge_steps, splash},
-    effect::{self, Affliction},
-    kit::{self, AbilitySpec, KitSounds, KitStats},
-    player::Position,
-    projectile::{Flight, Impact, Payload, Visual, fire},
+use crate::{
+    draw::TICKS_PER_SECOND,
+    module::{
+        ability::{Cast, Observable, charge_steps, splash},
+        effect::{self, Affliction},
+        kit::{self, AbilitySpec, KitSounds, KitStats},
+        player::Position,
+        projectile::{Flight, Impact, Payload, Visual, fire},
+    },
 };
 
 /// Flat, regardless of draw. `KitSkeleton.arrowDamage` overwrites the vanilla
@@ -111,13 +117,22 @@ impl Module for Skeleton {
 
 fn arrow(cast: &Cast<'_>, spread: f32) {
     let jitter = Vec3::new(spread, spread * 0.5, spread);
+    // A vanilla bow: the draw sets the arrow's speed through `bow_power`.
+    // `MAX_ARROW_SPEED` is blocks per tick and `Flight` is blocks per second, so
+    // it crosses the tick rate. A full draw is `1.0 * 3.0 * 20 = 60`, the speed
+    // every arrow used to leave at; a tap is now slower, and Barrage still fires
+    // more arrows the longer it is held. (The eye-height muzzle the client sees
+    // is applied to the drawn entity in `crate::draw`; the flight simulation
+    // stays keyed on the shooter's tracked position.)
+    let facing = cast.facing.0.normalize_or_zero();
+    let speed = bow_power(cast.charge) * MAX_ARROW_SPEED * TICKS_PER_SECOND;
     fire(
         cast.world,
         cast.caster,
         Visual(EntityKind::Arrow),
         Flight {
             position: cast.position.0,
-            velocity: (cast.facing.0.normalize_or_zero() + jitter) * 60.0,
+            velocity: (facing + jitter) * speed,
             gravity: 20.0,
             seconds_left: 3.0,
             radius: 0.4,

--- a/flake.nix
+++ b/flake.nix
@@ -416,6 +416,7 @@
             smash-hotbar-e2e = 7000;
             smash-hud-e2e = 8000;
             smash-skin-e2e = 8500;
+            smash-bow-e2e = 8700;
             bedwars-bow-e2e = 9000;
             # Not 10000: gameServerPort - proxyPort == 10000, so an offset of
             # 10000 aliases this gate's player port onto the base game-server
@@ -962,6 +963,26 @@
               '';
             };
 
+            # The smash bow read off the wire: one client takes the Skeleton kit
+            # in the hub, draws Barrage at two lengths and releases. Proves the
+            # arrow leaves the eye, its heading is `look_angles(velocity)`, it is
+            # broadcast per tick so it flies, and a longer draw is faster. The
+            # smash mirror of `bedwars-bow-e2e`.
+            smash-bow-e2e = {
+              deps = [
+                pkgs.git
+                pkgs.python3
+              ];
+              text = ''
+                export HYPERION_EVENT=smash
+                export HYPERION_E2E_CLIENT=tools/smash-bow-check.py
+                ${exportsFor smashGateLobby.env}
+                export HYPERION_PLAYER_PORT="''${HYPERION_PLAYER_PORT:-${toString (proxyPort + e2eOffsets.smash-bow-e2e)}}"
+                export HYPERION_SERVER_PORT="''${HYPERION_SERVER_PORT:-${toString (gameServerPort + e2eOffsets.smash-bow-e2e)}}"
+                exec "${lib.getExe runners.e2e}" "$@"
+              '';
+            };
+
           });
 
           scripts = checkScripts // runners // { inherit ci; };
@@ -1062,6 +1083,23 @@
               client = "bow-check.py";
               clientArgs = [ "--name" "Archer" ];
               needsGenMap = true;
+            };
+
+            # The smash bow, the same claims on smash's own projectile path. One
+            # client takes the Skeleton kit in the hub and draws Barrage: the
+            # arrow must leave the eye (smash fired from the feet), be broadcast
+            # every tick so it flies (a smash projectile carries no `Owner`, so
+            # `update_projectile_positions` never sent it), and a longer draw
+            # must be faster (smash fired every arrow at one fixed speed). A high
+            # `SMASH_MIN_PLAYERS` keeps one client in the hub rather than racing
+            # a match countdown. smash arenas are `include_str`, so no map.
+            smash-bow-e2e = e2e.mkCheck {
+              name = "hyperion-smash-bow-e2e";
+              gameServer = gameBinaries.smash;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "smash-bow-check.py";
+              clientArgs = [ "--name" "Archer" ];
+              serverEnv = smashGateLobby.env;
             };
 
             smash-e2e = e2e.mkCheck {
@@ -1208,6 +1246,7 @@
             # hold, and those wrappers still have to pass shellcheck.
             e2e-app = scripts.e2e;
             smash-e2e-app = scripts.smash-e2e;
+            smash-bow-e2e-app = scripts.smash-bow-e2e;
             completions-e2e-app = scripts.completions-e2e;
             smash-selector-e2e-app = scripts.smash-selector-e2e;
             smash-identity-e2e-app = scripts.smash-identity-e2e;

--- a/tools/smash-bow-check.py
+++ b/tools/smash-bow-check.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""The smash bow, read off the wire by the player who drew it.
+
+Smash's arrows are ability projectiles, not the vanilla bow bedwars grants: the
+Skeleton kit's Barrage is `item: minecraft:bow`, held to charge and released to
+fire. This gate is the smash-side mirror of `bow-check.py`: a real 776 client
+joins, takes the Skeleton kit, draws the bow for a known number of ticks, lets
+go, and reads the arrow it fired straight off the packets it was sent.
+
+Every claim below is one a client can settle for itself:
+
+  * releasing a drawn bow spawns at least one `minecraft:arrow` in an AddEntity
+  * that arrow spawns at the shooter's EYE, not their feet
+  * its launch heading is `look_angles(velocity)`, not the raw look yaw
+  * the server broadcasts the arrow's position every tick as it flies
+  * a longer draw launches faster than a shorter one (the charge curve)
+
+Exits non-zero on the first untrue claim, after printing what it saw.
+"""
+
+import argparse
+import importlib.util
+import math
+import pathlib
+import time
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, TOOLS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+match = _load("smash_match", "smash-match.py")
+monitor = _load("packet_monitor", "packet_monitor.py")
+bowcheck = _load("bow_check", "bow-check.py")
+
+Archer = bowcheck.Archer
+look_angles = bowcheck.look_angles
+angle_delta = bowcheck.angle_delta
+entity_type_id = bowcheck.entity_type_id
+pump = bowcheck.pump
+wait_until = bowcheck.wait_until
+
+# Vanilla eye height and the half-block muzzle offset bedwars fires from. The
+# number the test expects, not imported, so the Rust cannot move the oracle.
+EYE_HEIGHT = 1.62
+MUZZLE_OFFSET = 0.5
+
+# getPowerForTime(full) * 3.0 == 3.0 blocks a tick; the curve saturates at 1.0.
+MAX_ARROW_SPEED = 3.0
+
+
+def look_direction(yaw, pitch):
+    """get_direction_from_rotation: x=-cos(p)sin(y), y=-sin(p), z=cos(p)cos(y)."""
+    yr = math.radians(yaw)
+    pr = math.radians(pitch)
+    return (
+        -math.cos(pr) * math.sin(yr),
+        -math.sin(pr),
+        math.cos(pr) * math.cos(yr),
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=25565)
+    parser.add_argument("--name", default="Archer")
+    args = parser.parse_args()
+
+    started = time.time()
+    failures = []
+
+    def check(ok, message):
+        print("%s %s" % ("PASS" if ok else "FAIL", message), flush=True)
+        if not ok:
+            failures.append(message)
+
+    arrow_type = entity_type_id("minecraft:arrow")
+    print("minecraft:arrow is entity type %d" % arrow_type, flush=True)
+
+    client = Archer(args.host, args.port, args.name, started)
+    client.handshake(args.host, args.port, 2)
+    client.login()
+    client.configuration()
+    client.enter_play()
+
+    if not wait_until(client, lambda: client.joined, 30.0, "the world"):
+        return 1
+    pump(client, 1.0)
+
+    client.on_ground = True
+    client.aim(35.0, -20.0)
+    client.send_position()
+    pump(client, 0.3)
+
+    client.command("kit skeleton")
+    wait_until(
+        client,
+        lambda: client.hotbar_slot_of("minecraft:bow") is not None,
+        10.0,
+        "a bow on the bar from /kit skeleton",
+    )
+    bow_slot = client.hotbar_slot_of("minecraft:bow")
+    check(
+        bow_slot is not None,
+        "/kit skeleton puts a minecraft:bow on a visible key (key %s)" % bow_slot,
+    )
+    if bow_slot is None:
+        print("RESULT: failure (no bow to draw)", flush=True)
+        return 1
+
+    def arrows_from(spawned):
+        return [e for e in spawned if e["type"] == arrow_type]
+
+    def draw(seconds, note):
+        client.spawned.clear()
+        client.syncs.clear()
+        client.aim(35.0, -20.0)
+        client.send_position()
+        client.use_slot(bow_slot, "(nock) " + note)
+        pump(client, seconds)
+        client.release_slot(bow_slot, "(release) " + note)
+        pump(client, 1.5)
+        return arrows_from(client.spawned)
+
+    full = draw(2.6, "full draw")
+    check(
+        len(full) >= 1,
+        "a full draw spawns at least one minecraft:arrow (got %d)" % len(full),
+    )
+    if not full:
+        print("RESULT: failure (nothing was fired)", flush=True)
+        return 1
+
+    launch = full[0]
+    spawn = launch["position"]
+    motion = launch["motion"]
+    full_speed = launch["speed"]
+    feet = client.position
+
+    eye = (feet[0], feet[1] + EYE_HEIGHT, feet[2])
+    # The spawn packet arrives an unknown number of ticks into the flight (the
+    # exact count varies with server startup timing), so reconstructing the
+    # launch point tick-by-tick is fragile. Instead assert the geometry that is
+    # invariant to it: the arrow's trajectory, extrapolated backward along its
+    # launch velocity, must pass through the shooter's EYE. Measure the
+    # perpendicular distance from the eye to that line. Eye-origin gives ~0; a
+    # feet-origin leaves the line a full eye height (~1.6) above the feet.
+    def perp_distance(point):
+        mlen = math.dist((0.0, 0.0, 0.0), motion)
+        d = tuple(m / mlen for m in motion) if mlen > 1e-6 else (0.0, 0.0, 1.0)
+        w = tuple(point[i] - spawn[i] for i in range(3))
+        proj = sum(w[i] * d[i] for i in range(3))
+        return math.dist((0.0, 0.0, 0.0), tuple(w[i] - proj * d[i] for i in range(3)))
+
+    eye_line_dist = perp_distance(eye)
+    feet_line_dist = perp_distance(feet)
+    print(
+        "spawn=(%.2f,%.2f,%.2f) eye_off_line=%.3f feet_off_line=%.3f"
+        % (spawn + (eye_line_dist, feet_line_dist)),
+        flush=True,
+    )
+    check(
+        eye_line_dist < 0.4,
+        "the arrow's back-extrapolated trajectory passes through the shooter's "
+        "eye, not the feet (%.2f off the eye line; a feet-origin is ~1.6, here "
+        "%.2f)" % (eye_line_dist, feet_line_dist),
+    )
+
+    exp_yaw, exp_pitch = look_angles(motion)
+    wire_yaw = launch["wire_yaw"]
+    wire_pitch = launch["wire_pitch"]
+    tol = 2.0 * 360.0 / 256.0
+    check(
+        angle_delta(wire_yaw, exp_yaw) < tol and angle_delta(wire_pitch, exp_pitch) < tol,
+        "the arrow's wire heading is look_angles(velocity) = (%.1f, %.1f) "
+        "(got (%.1f, %.1f))" % (exp_yaw, exp_pitch, wire_yaw, wire_pitch),
+    )
+    check(
+        angle_delta(wire_yaw, 35.0) > 10.0,
+        "the wire yaw is not the shooter's raw look yaw of 35 (got %.1f)" % wire_yaw,
+    )
+
+    arrow_id = launch["id"]
+    pairs = client.syncs.get(arrow_id, [])
+    samples = [pos for pos, _vel in pairs]
+    print("flight: %d EntityPositionSync samples for arrow %d" % (len(samples), arrow_id), flush=True)
+    check(
+        len(samples) >= 12,
+        "the server broadcasts the arrow's position every tick as it flies "
+        "(got %d; 0 means it never left the muzzle on the wire)" % len(samples),
+    )
+    if len(samples) >= 2:
+        px, py, pz = samples[0]
+        v = list(pairs[0][1])
+        arc = [(px, py, pz)]
+        for _ in range(120):
+            # smash Flight integrates gravity before the move (DecayThenMove):
+            # v.y -= g*dt, then pos += v*dt. In wire units that is v.y -= 0.05
+            # then pos += v, and getting the order backwards drifts ~0.05/tick.
+            v[1] -= 0.05
+            px += v[0]
+            py += v[1]
+            pz += v[2]
+            arc.append((px, py, pz))
+
+        def dist_to_arc(point):
+            best = float("inf")
+            px0, py0, pz0 = point
+            for k in range(len(arc) - 1):
+                ax, ay, az = arc[k]
+                bx, by, bz = arc[k + 1]
+                dx, dy, dz = bx - ax, by - ay, bz - az
+                length2 = dx * dx + dy * dy + dz * dz
+                t = 0.0 if length2 == 0.0 else max(0.0, min(1.0, ((px0 - ax) * dx + (py0 - ay) * dy + (pz0 - az) * dz) / length2))
+                cx, cy, cz = ax + t * dx, ay + t * dy, az + t * dz
+                best = min(best, math.dist((px0, py0, pz0), (cx, cy, cz)))
+            return best
+
+        worst = max(dist_to_arc(s) for s in samples)
+        moved = math.dist(samples[-1], spawn)
+        print("arc: worst off-arc %.3f blocks, travelled %.1f blocks" % (worst, moved), flush=True)
+        check(
+            worst < 1.0,
+            "the arrow flies its Flight arc on the wire (worst off-arc %.3f "
+            "blocks over %d samples)" % (worst, len(samples)),
+        )
+        check(moved > 6.0, "the arrow travels a real distance (%.1f blocks)" % moved)
+
+    pump(client, 0.6)
+    short = draw(0.4, "short draw")
+    check(len(short) >= 1, "a short draw still fires (got %d arrows)" % len(short))
+    if short:
+        short_speed = short[0]["speed"]
+        print("full_speed=%.3f short_speed=%.3f" % (full_speed, short_speed), flush=True)
+        check(
+            abs(full_speed - MAX_ARROW_SPEED) < 0.1,
+            "a full draw launches at vanilla's %.1f blocks a tick (got %.3f)"
+            % (MAX_ARROW_SPEED, full_speed),
+        )
+        check(
+            short_speed < full_speed - 0.15,
+            "a shorter draw launches slower than a full one (%.3f < %.3f)"
+            % (short_speed, full_speed),
+        )
+
+    print(
+        "RESULT: %s (%d checks failed)"
+        % ("ok" if not failures else "failure", len(failures)),
+        flush=True,
+    )
+    for failure in failures:
+        import sys
+        print("  failed: %s" % failure, file=sys.stderr)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())


### PR DESCRIPTION
## What

An operator playing smash reported the bow's arrows were wrong three ways on the wire. The arrow-heading fix (#1058) and the per-tick `EntityPositionSync` broadcast (#1062) were verified on **bedwars** but never reached **smash**: smash decorates a game-half projectile it integrates itself and deliberately carries no `Owner`, and `update_projectile_positions` (which owns the #1062 broadcast) requires one. A real-client bow draw confirmed the arrow **spawned at the feet**, **never moved on the wire**, and **left at a fixed speed regardless of draw**.

This is Stage 1 (the operator-visible fix), with the shared primitives shaped so the planned Stage 2 composable-projectile rewrite extends them rather than replaces them.

## Changes

- **`crates/hyperion/.../projectile_motion.rs`**: shared launch geometry both events call once — `muzzle`/`EYE_HEIGHT`/`MUZZLE_OFFSET` and the vanilla `bow_power` charge curve with `MAX_ARROW_SPEED`. bedwars `bow.rs` now calls these instead of transcribing the curve and the 1.62 eye height a third time.
- **`BroadcastProjectile` marker + `broadcast_marked_projectiles`**: the per-tick `EntityPositionSync`, decoupled from `Owner`, so a projectile whose flight a game module integrates itself is still broadcast every tick.
- **smash `draw.rs`**: the drawn entity gets a `Channel` and the marker; `advance_drawn_projectiles` moves its wire position from `Flight` each tick; the render is lifted to the shooter's eye. The `Flight` **simulation is unchanged** — the eye lift is the render only, so the hit model and every smash ability test are untouched.
- **smash `skeleton.rs`**: the bow's speed is `bow_power(charge) * MAX_ARROW_SPEED`, so a tap is slow and a full draw reaches vanilla's 3.0 b/t; Barrage still scales its arrow count with the draw.

## Scope note (Stage 2)

Stage 1 fixes the **wire/visual** origin. The smash `Flight` **hit simulation** stays feet-based, so there is a constant ~1.6-block vertical offset between the rendered arrow and where hits register. Giving the sim its own eye-origin needs a body-aware hit model and a knockback-direction rework (moving the hit point to eye height changes `Knockback::from(at)`), which is the Stage 2 projectile unification (composable flight components + swappable `Visual`, per the operator's design). Deferred so Stage 1 changes no gameplay and keeps every smash mock test green.

## New gate

`tools/smash-bow-check.py` drives a real 776 client through `/kit skeleton`, draws the bow at two lengths, and asserts the arrow's trajectory extrapolates back through the eye, its heading is `look_angles(velocity)`, it is broadcast per tick along a clean arc, and a longer draw is faster. Wired as `smash-bow-e2e` (offset 8700, runner, store-cached `mkCheck`, app).

## Verification (local; aarch64-darwin)

- Live smash server, real client: FAILED 3 checks before, passes all after. Measured: eye trajectory 0.008 off the eye line (vs 1.54 for a feet-origin); 26 per-tick syncs (vs 0), arc off-by 0.012 blocks; full draw 2.983 b/t vs short draw 0.394.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo nextest run -p smash`: 291/291 pass (0 gameplay change).
- Store-cached `checks.smash-bow-e2e` (new) and `checks.bedwars-bow-e2e` (regression): both green.

CI is known-broken on this repo; merged by force per the hyperion workflow after the local checks above.