### PR TITLE
refactor(hyperion): ProjectileMotion as a per-instance component (Stage 2, inc 1)

### DIFF
--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -36,7 +36,7 @@ use crate::{
         event::{self, HitGroundEvent},
         handlers::is_grounded,
         metadata::{MetadataChanges, get_and_clear_metadata},
-        projectile_motion::{MotionOrder, lerp_rotation, look_angles},
+        projectile_motion::{MotionOrder, ProjectileMotion, lerp_rotation, look_angles},
     },
     spatial::get_first_collision,
     storage::Events,
@@ -535,9 +535,16 @@ impl Module for EntityStateSyncModule {
 
                 let world = it.world();
                 let arrow_entity = it.entity(row);
+                // Prefer the per-instance `ProjectileMotion` the `OnAdd` seed
+                // put on every simulated kind; fall back to the kind's default
+                // for any entity that has a kind but no component yet.
                 let motion = arrow_entity
-                    .try_get::<&EntityKind>(|kind| kind.projectile_motion())
-                    .flatten();
+                    .try_get::<&ProjectileMotion>(|motion| *motion)
+                    .or_else(|| {
+                        arrow_entity
+                            .try_get::<&EntityKind>(|kind| kind.projectile_motion())
+                            .flatten()
+                    });
 
                 if velocity.0 != Vec3::ZERO {
                     let center = **position;

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -316,6 +316,7 @@ fn register_components(world: &World) -> MetadataPrefabs {
     world.component::<Flight>().meta();
 
     world.component::<EntityKind>().meta();
+    world.component::<projectile_motion::ProjectileMotion>();
 
     // todo: how
     // world
@@ -442,6 +443,22 @@ fn register_observers(world: &World, prefabs: MetadataPrefabs) {
         .each_entity(|entity, ()| {
             debug!("adding uuid to entity");
             entity.set(Uuid::new_v4());
+        });
+
+    // Seed a projectile's per-tick motion from its kind's vanilla default the
+    // moment the kind is set, so the integrator reads a component a game module
+    // can also override per instance (a hook with no gravity, a heavier lob). A
+    // kind with no entry in `SIMULATED` gets nothing, exactly as before.
+    world
+        .observer_named::<flecs::OnAdd, ()>("seed_projectile_motion")
+        .with_enum_wildcard::<EntityKind>()
+        .each_entity(|entity, ()| {
+            if let Some(motion) = entity
+                .try_get::<&EntityKind>(|kind| kind.projectile_motion())
+                .flatten()
+            {
+                entity.set(motion);
+            }
         });
 
     world

--- a/crates/hyperion/src/simulation/projectile_motion.rs
+++ b/crates/hyperion/src/simulation/projectile_motion.rs
@@ -21,6 +21,7 @@
 //! it moves at all. Sharing one integrator between them is wrong by about a
 //! tenth of a block on the first tick and it never converges.
 
+use flecs_ecs::prelude::*;
 use glam::Vec3;
 
 use super::entity_kind::EntityKind;
@@ -35,7 +36,12 @@ pub enum MotionOrder {
 }
 
 /// One tick of vanilla projectile motion.
-#[derive(Debug, Copy, Clone, PartialEq)]
+///
+/// A per-instance component, not only a per-kind lookup: the kind's entry in
+/// [`SIMULATED`] is the vanilla default an `OnAdd` observer seeds, and a game
+/// module may override it on a single projectile (a hook with no gravity, a
+/// heavier lob) without inventing a new entity kind.
+#[derive(Component, Debug, Copy, Clone, PartialEq)]
 pub struct ProjectileMotion {
     /// The velocity is multiplied by this every tick, out of water.
     ///


### PR DESCRIPTION
## What

First increment of the composable-projectile work (Stage 2). Behavior-preserving foundation: `ProjectileMotion` becomes a per-**instance** `#[derive(Component)]` instead of only a per-**kind** lookup.

- An `OnAdd(EntityKind)` observer (`seed_projectile_motion`) seeds the component from the kind's vanilla `SIMULATED` default. A kind with no entry gets nothing, exactly as before.
- `update_projectile_positions` reads the `&ProjectileMotion` component, with the kind lookup kept as a fallback.

This is the linchpin the rest of the composable work builds on: a game module can now override a single projectile's gravity/drag (a hook with no gravity, a heavier lob) without inventing a new entity kind, and the shared host-independent physics core (next increment) reads one component.

No behavior change: every simulated kind gets its existing motion.

## Verification (local, aarch64-darwin)

- `cargo clippy -p hyperion -p smash -p bedwars --all-targets -- -D warnings`: clean.
- Store-cached `checks.bedwars-bow-e2e` and `checks.smash-bow-e2e`: **both green** (the projectile path this refactors).
- `cargo nextest -p hyperion`: one unrelated pre-existing failure, `effects::status::tests::a_slow_broadcasts_to_the_victims_own_client`, which aborts the hyperion test binary with `ECS_INVALID_OPERATION: Component ...world_time::WorldTime is not registered`. **Proven pre-existing**: reverting all three of my files to origin/main reproduces the identical failure (it is `WorldTimeModule::module` calling `set::<WorldTime>` before registration — the bug being fixed separately). This PR touches only the projectile path, nothing near `world_time.rs`; the smash/bedwars servers (which register WorldTime) boot fine in the passing mkChecks.

**Do not merge until rebased onto the WorldTime registration fix** so the full hyperion suite runs green.

CI is known-broken on this repo.