### PR TITLE
fix(hyperion): register WorldTime as a Singleton so dev boot survives (ENG-11000)

### DIFF
--- a/crates/hyperion/src/lib.rs
+++ b/crates/hyperion/src/lib.rs
@@ -427,6 +427,12 @@ impl HyperionCore {
         // bedwars imported it and smash did not, so the panic was one arrow
         // away the whole time.
         world.import::<SpatialModule>();
+        // The frozen-daylight singleton. Registered here, next to
+        // `SpatialModule`, rather than nested inside `ProtocolModule` so that
+        // it exists for every event before anyone joins: the join path reads
+        // `WorldTime` and a `world.get` of an unregistered singleton panics in
+        // a dev build. See `WorldTimeModule`.
+        world.import::<crate::simulation::WorldTimeModule>();
         // After the simulation, whose components the effects layer writes.
         world.import::<crate::effects::EffectsModule>();
 

--- a/crates/hyperion/src/net/protocol/mod.rs
+++ b/crates/hyperion/src/net/protocol/mod.rs
@@ -152,7 +152,6 @@ pub struct ProtocolModule;
 
 impl Module for ProtocolModule {
     fn module(world: &World) {
-        world.import::<crate::simulation::WorldTimeModule>();
         world.import::<pre_play::PrePlayModule>();
         world.import::<join::JoinModule>();
     }

--- a/crates/hyperion/src/simulation/world_time.rs
+++ b/crates/hyperion/src/simulation/world_time.rs
@@ -41,14 +41,25 @@ impl Default for WorldTime {
     }
 }
 
-/// Installs the default [`WorldTime`] singleton so the join path always finds
-/// one to freeze the sky at. Events that want a different sky call
-/// `world.set(WorldTime { .. })` after importing this.
+/// Registers [`WorldTime`] as a singleton and installs its noon default so the
+/// join path always finds one to freeze the sky at. Events that want a
+/// different sky call `world.set(WorldTime { .. })` after this is imported.
+///
+/// The `add_trait::<flecs::Singleton>()` is load-bearing, not decoration: a
+/// bare `world.set` stores the value but never registers the component, so
+/// `world.get::<&WorldTime>` asserts "component is not registered" the first
+/// time a player joins. A release build compiles that assert out and reads the
+/// value anyway, which is why the miss only surfaced when the smash server was
+/// booted in the dev profile. `HyperionCore` imports this directly, next to
+/// `SpatialModule`, so every event gets it regardless of what else it imports.
 #[derive(Component)]
 pub struct WorldTimeModule;
 
 impl Module for WorldTimeModule {
     fn module(world: &World) {
+        world
+            .component::<WorldTime>()
+            .add_trait::<flecs::Singleton>();
         world.set(WorldTime::default());
     }
 }

--- a/crates/hyperion/tests/world_time.rs
+++ b/crates/hyperion/tests/world_time.rs
@@ -1,0 +1,34 @@
+//! A dev-profile boot regression for the frozen-daylight singleton.
+//!
+//! `WorldTime` is set on join by the join path's `world.get::<&WorldTime>`.
+//! When it was installed with a bare `world.set` and no
+//! `add_trait::<flecs::Singleton>()`, a release build read it fine but a dev
+//! build asserted "component is not registered" the first time a player
+//! joined -- so the smash server crash-looped on boot under `nix run .#smash`
+//! (the dev profile) while every release gate stayed green. This test is that
+//! join-path read in miniature: it boots `HyperionCore` and reads the
+//! singleton, which panics on the unregistered component in exactly the dev
+//! build `cargo test` produces. It fails without the registration and passes
+//! with it.
+
+use flecs_ecs::core::{World, WorldGet};
+use hyperion::simulation::{WorldTime, world_time};
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn world_time_singleton_is_registered_after_core_boot() {
+    let world = World::new();
+    world.import::<hyperion::HyperionCore>();
+
+    // The join path does exactly this. A `world.get` of a singleton that was
+    // never registered with the `Singleton` trait aborts a dev build, which is
+    // the crash the smash operator hit.
+    let day_time = world.get::<&WorldTime>(|world_time| world_time.day_time);
+
+    assert_eq!(
+        day_time,
+        world_time::NOON,
+        "HyperionCore should install the WorldTime singleton at its noon default"
+    );
+}


### PR DESCRIPTION
Fixes the dev-boot crash-loop introduced by #1064 (ENG-11000).

## Regression

`WorldTimeModule` installed the singleton with a bare `world.set(WorldTime::default())` and never registered the component with `add_trait::<flecs::Singleton>()`. A release build auto-registers lazily and reads it fine -- which is why every release gate (including the new `world-time-e2e`) stayed green -- but a **dev build** (the `nix run .#smash` default profile) aborts during module import:

```
ECS_INVALID_OPERATION: Component hyperion::simulation::world_time::WorldTime is not registered with the world before usage
```

so the smash game server crash-looped on boot while the proxy stayed up.

This is the exact class the existing `SpatialIndex` comment in `HyperionCore` calls out: singletons must be registered with the `Singleton` trait, and core singletons are registered in `HyperionCore` rather than nested inside an event's module chain.

## Fix

- `WorldTimeModule` now registers `world.component::<WorldTime>().add_trait::<flecs::Singleton>()` before `world.set(...)`, matching `SpatialModule` and every other singleton.
- `WorldTimeModule` is imported directly from `HyperionCore` (next to `SpatialModule`), not nested inside `ProtocolModule`, so it exists for every event before anyone joins.

## Verification

- `crates/hyperion/tests/world_time.rs`: boots `HyperionCore` in the dev/debug profile `cargo test` produces and reads the singleton -- the join path's `world.get::<&WorldTime>` in miniature. Fail-then-pass confirmed: reverting the registration reproduces the operator's exact `ECS_INVALID_OPERATION` abort; the fix makes it pass. (There is no nix `cargo test` gate in this repo to wire into; this lives alongside `tests/entity.rs` and `tests/differential.rs`, which is where the dev-profile tests run. A release-binary e2e gate structurally cannot catch a dev-only debug assert.)
- Booted the dev-profile smash server + proxy directly: logs `starting hyperion` and `Proxy connection established on 127.0.0.1:51443` with no `ECS_INVALID_OPERATION`.

Generated with Claude Code.
