### PR TITLE
fix(smash): smooth arrows (velocity, not per-tick teleport) + real collision

### DIFF
--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -42,45 +42,37 @@ use crate::{
     storage::Events,
 };
 
-/// Broadcasts a projectile's current position, velocity and heading to every
-/// client in its channel, as one `EntityPositionSync`. Factored out of
-/// `update_projectile_positions` so the send is not another block deep in that
-/// system; the call site explains why an arrow needs one every tick.
-fn broadcast_projectile_position(
-    compose: &Compose,
-    channel: ChannelId,
-    id: i32,
-    position: Vec3,
-    velocity: Vec3,
-    y_rot: f32,
-    x_rot: f32,
-) {
-    let packet = EntityPositionSync {
+/// Broadcasts a projectile's current velocity to every client in its channel,
+/// as one `SetEntityMotion`, every tick.
+///
+/// Not an absolute `EntityPositionSync`: an arrow has no client-side
+/// interpolation handler (`AbstractArrow` does not override `getInterpolation`),
+/// so `handleEntityPositionSync` -> `setPos` HARD-TELEPORTS it -- one absolute
+/// sync per tick snaps the arrow ~3 blocks every 50ms, which is the jagged
+/// motion. The client already dead-reckons the arrow's own physics each tick
+/// (`AbstractArrow.tick`: `pos += vel; vel *= 0.99; vel.y -= 0.05`), seeded from
+/// the `add_entity` velocity, and it applies `SetEntityMotion` through
+/// `lerpMotion` -- so re-sending the server's velocity each tick keeps the
+/// client's prediction exact and it renders smoothly, the way vanilla does
+/// (velocity on change plus client prediction, never a per-tick teleport). The
+/// heading is re-derived client-side from the velocity, so it is not sent.
+fn broadcast_projectile_velocity(compose: &Compose, channel: ChannelId, id: i32, velocity: Vec3) {
+    let packet = SetEntityMotion {
         id,
-        values: PositionMoveRotation {
-            position: ProtoVec3 {
-                x: f64::from(position.x),
-                y: f64::from(position.y),
-                z: f64::from(position.z),
-            },
-            delta_movement: ProtoVec3 {
-                x: f64::from(velocity.x),
-                y: f64::from(velocity.y),
-                z: f64::from(velocity.z),
-            },
-            y_rot,
-            x_rot,
+        movement: ProtoVec3 {
+            x: f64::from(velocity.x),
+            y: f64::from(velocity.y),
+            z: f64::from(velocity.z),
         },
-        on_ground: false,
     };
     if let Err(error) = compose
         .broadcast_channel(
-            Clientbound::new(PacketId::EntityPositionSync.to_raw(), &packet),
+            Clientbound::new(PacketId::SetEntityMotion.to_raw(), &packet),
             channel,
         )
         .send()
     {
-        tracing::error!("failed to broadcast arrow position: {error}");
+        tracing::error!("failed to broadcast arrow velocity: {error}");
     }
 }
 
@@ -568,7 +560,11 @@ impl Module for EntityStateSyncModule {
                             // gravity and drag first and aims from the result. So
                             // the arrow is aimed before the step and the thrown
                             // kind after it.
-                            let rotation = match motion.order {
+                            // The rotation easing still runs (it keeps the
+                            // stored facing correct for anything server-side
+                            // that reads it) but is no longer sent: the client
+                            // re-derives an arrow's heading from its velocity.
+                            let _rotation = match motion.order {
                                 MotionOrder::MoveThenDecay => {
                                     let rotation = aim_along(yaw, pitch, velocity.0);
                                     motion.step(position, &mut velocity.0);
@@ -580,27 +576,20 @@ impl Module for EntityStateSyncModule {
                                 }
                             };
 
-                            // Tell every client watching this arrow where it now is.
-                            // Without this the launch `add_entity` is the only thing a
-                            // client ever hears about the arrow: it renders the spawn and
-                            // then has nothing to move it, so the arc is right on the
-                            // server and the arrow sits still on the wire. One absolute
-                            // sync per tick, the same packet the player teleport path
-                            // sends, carries the new position, the velocity a client
-                            // predicts between syncs from, and the re-aimed heading.
-                            let (y_rot, x_rot) = rotation.unwrap_or((0.0, 0.0));
+                            // Tell every client watching this arrow how fast it
+                            // is going, every tick, and let the client dead-reckon
+                            // the position from it. The launch `add_entity`
+                            // already seeded the velocity; this keeps the client's
+                            // prediction exact without the per-tick teleport that
+                            // an absolute position sync would be.
                             let id = arrow_entity.minecraft_id();
-                            let pos = **position;
                             let vel = velocity.0;
                             world.get::<&Compose>(|compose| {
-                                broadcast_projectile_position(
+                                broadcast_projectile_velocity(
                                     compose,
                                     arrow_entity.into(),
                                     id,
-                                    pos,
                                     vel,
-                                    y_rot,
-                                    x_rot,
                                 );
                             });
                         }
@@ -645,30 +634,19 @@ impl Module for EntityStateSyncModule {
         // position and only wants the send. `OnStore`, after every integrator
         // has moved the entity this tick, and gated on `Channel` so the send
         // has subscribers to reach.
-        system!(
-            "broadcast_marked_projectiles",
-            world,
-            &Compose,
-            &Position,
-            &Velocity,
-            &Yaw,
-            &Pitch,
-        )
-        .with(id::<BroadcastProjectile>())
-        .with(id::<Channel>())
-        .kind(id::<flecs::pipeline::OnStore>())
-        .each_iter(|it, row, (compose, position, velocity, yaw, pitch)| {
-            let entity = it.entity(row);
-            broadcast_projectile_position(
-                compose,
-                entity.into(),
-                entity.minecraft_id(),
-                **position,
-                velocity.0,
-                **yaw,
-                **pitch,
-            );
-        });
+        system!("broadcast_marked_projectiles", world, &Compose, &Velocity,)
+            .with(id::<BroadcastProjectile>())
+            .with(id::<Channel>())
+            .kind(id::<flecs::pipeline::OnStore>())
+            .each_iter(|it, row, (compose, velocity)| {
+                let entity = it.entity(row);
+                broadcast_projectile_velocity(
+                    compose,
+                    entity.into(),
+                    entity.minecraft_id(),
+                    velocity.0,
+                );
+            });
 
         track_previous::<Position>(world);
         track_previous::<Yaw>(world);

--- a/events/smash/src/draw.rs
+++ b/events/smash/src/draw.rs
@@ -37,12 +37,11 @@
 //! `Flight` already owns.
 
 use flecs_ecs::prelude::*;
-use glam::Vec3;
 use hyperion::{
     net::Channel,
     simulation::{
         BroadcastProjectile, Pitch, Position, Spawn, Uuid, Velocity, Yaw,
-        projectile_motion::{EYE_HEIGHT, look_angles},
+        projectile_motion::look_angles,
     },
 };
 
@@ -79,17 +78,17 @@ impl Module for DrawModule {
             .each_entity(|projectile, (visual, flight)| {
                 let per_tick = flight.velocity / TICKS_PER_SECOND;
                 let (yaw, pitch) = look_angles(flight.velocity);
-                // What a client sees leaves the shooter's eye, not the tracked
-                // feet position: a projectile drawn from the stomach is the bug
-                // this fixes. A constant vertical lift (not the rotating muzzle
-                // offset) keeps the rendered arc a clean parabola tick to tick.
-                // The `Flight` simulation is unchanged; this is the render only.
-                let seen = flight.position + Vec3::Y * EYE_HEIGHT;
-
+                // Render the flight position directly: `fire` already launched
+                // the projectile from the shooter's eye, so the picture and the
+                // hit are the same flight. One source, no visual/sim offset.
                 projectile
                     .add_enum(visual.0)
                     .set(Uuid::new_v4())
-                    .set(Position::new(seen.x, seen.y, seen.z))
+                    .set(Position::new(
+                        flight.position.x,
+                        flight.position.y,
+                        flight.position.z,
+                    ))
                     .set(Velocity::new(per_tick.x, per_tick.y, per_tick.z))
                     .set(Yaw::new(yaw))
                     .set(Pitch::new(pitch))
@@ -124,7 +123,7 @@ impl Module for DrawModule {
             .kind(id::<flecs::pipeline::PostUpdate>())
             .each(|(flight, position, velocity, yaw, pitch)| {
                 let (y, p) = look_angles(flight.velocity);
-                **position = flight.position + Vec3::Y * EYE_HEIGHT;
+                **position = flight.position;
                 velocity.0 = flight.velocity / TICKS_PER_SECOND;
                 **yaw = y;
                 **pitch = p;

--- a/events/smash/src/module/projectile.rs
+++ b/events/smash/src/module/projectile.rs
@@ -18,7 +18,7 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
-use hyperion::simulation::entity_kind::EntityKind;
+use hyperion::simulation::{entity_kind::EntityKind, projectile_motion::EYE_HEIGHT};
 
 use crate::{
     flecs_ext::WorldRefExt,
@@ -113,9 +113,15 @@ pub fn fire(
     world: WorldRef<'_>,
     shooter: EntityView<'_>,
     visual: Visual,
-    flight: Flight,
+    mut flight: Flight,
     payload: Payload,
 ) {
+    // Launch from the shooter's eye, not the tracked feet: the flight the hit
+    // is computed on is then the flight the client is shown (`crate::draw`
+    // renders `flight.position` directly), so a shot that visually passes
+    // through a player is a shot that hits one. `nearest_target` treats the
+    // victim as an upright body so an eye-high shot still connects.
+    flight.position += Vec3::Y * EYE_HEIGHT;
     world
         .new_entity()
         .add(Projectile::id())
@@ -182,7 +188,7 @@ impl Module for ProjectileModule {
                 hurt(victim, Damaged {
                     attacker: shooter,
                     amount: payload.damage,
-                    knockback: Knockback::from(at).times(payload.knockback),
+                    knockback: Knockback::from(at - flight.velocity).times(payload.knockback),
                     kind: DamageKind::Projectile,
                 });
 
@@ -217,14 +223,60 @@ impl Module for ProjectileModule {
     }
 }
 
-/// The point on the segment `from`..`to` nearest `point`.
-fn closest_on_segment(from: Vec3, to: Vec3, point: Vec3) -> Vec3 {
-    let along = to - from;
-    let length_squared = along.length_squared();
-    if length_squared <= f32::EPSILON {
-        return from;
+/// A standing player's height in blocks. The hit treats a victim as an upright
+/// segment from the feet to here, not a point at the feet: an arrow crosses a
+/// player at any height, and now that projectiles launch from the eye the shot
+/// travels at chest height, not ankle height. Matching only the feet is what
+/// let an eye-high shot sail over a target standing in front of the shooter.
+const PLAYER_HEIGHT: f32 = 1.8;
+
+/// The nearest pair of points between two segments, one on each, clamped to the
+/// endpoints (Ericson, *Real-Time Collision Detection*). Used to measure the
+/// arrow's swept path against the victim's upright body.
+#[expect(
+    clippy::many_single_char_names,
+    reason = "the single-letter names are Ericson's own notation for the \
+              closest-points-between-segments algorithm; prose names would obscure the \
+              correspondence to the reference"
+)]
+fn closest_between_segments(p1: Vec3, q1: Vec3, p2: Vec3, q2: Vec3) -> (Vec3, Vec3) {
+    let d1 = q1 - p1;
+    let d2 = q2 - p2;
+    let r = p1 - p2;
+    let a = d1.length_squared();
+    let e = d2.length_squared();
+    let f = d2.dot(r);
+
+    if a <= f32::EPSILON && e <= f32::EPSILON {
+        return (p1, p2);
     }
-    from + along * ((point - from).dot(along) / length_squared).clamp(0.0, 1.0)
+
+    let (s, t) = if a <= f32::EPSILON {
+        (0.0, (f / e).clamp(0.0, 1.0))
+    } else {
+        let c = d1.dot(r);
+        if e <= f32::EPSILON {
+            ((-c / a).clamp(0.0, 1.0), 0.0)
+        } else {
+            let b = d1.dot(d2);
+            let denom = a.mul_add(e, -(b * b));
+            let s = if denom > f32::EPSILON {
+                (b.mul_add(f, -(c * e)) / denom).clamp(0.0, 1.0)
+            } else {
+                0.0
+            };
+            let t = b.mul_add(s, f) / e;
+            if t < 0.0 {
+                ((-c / a).clamp(0.0, 1.0), 0.0)
+            } else if t > 1.0 {
+                (((b - c) / a).clamp(0.0, 1.0), 1.0)
+            } else {
+                (s, t)
+            }
+        }
+    };
+
+    (p1 + d1 * s, p2 + d2 * t)
 }
 
 /// Closest living player within `radius` of the segment this tick swept,
@@ -252,8 +304,13 @@ fn nearest_target(
             if health.is_dead() || Some(entity.id()) == exclude {
                 return;
             }
-            let at = closest_on_segment(from, to, position.0);
-            let distance = position.0.distance(at);
+            let (at, on_body) = closest_between_segments(
+                from,
+                to,
+                position.0,
+                position.0 + Vec3::Y * PLAYER_HEIGHT,
+            );
+            let distance = at.distance(on_body);
             if distance > radius {
                 return;
             }

--- a/events/smash/tests/verification.rs
+++ b/events/smash/tests/verification.rs
@@ -1847,7 +1847,7 @@ fn the_match_clock_advances_only_during_play() {
 mod projectiles {
     use flecs_ecs::prelude::*;
     use glam::Vec3;
-    use hyperion::simulation::entity_kind::EntityKind;
+    use hyperion::simulation::{entity_kind::EntityKind, projectile_motion::EYE_HEIGHT};
     use smash::{
         module::{
             player::{Health, Player, Position},
@@ -1909,9 +1909,11 @@ mod projectiles {
             "travelled {} horizontally in 0.1s at 10 blocks a second",
             flight.position.x
         );
-        // And it has started falling rather than rising.
+        // And it has started falling rather than rising. `fire` launches from
+        // the shooter's eye, `EYE_HEIGHT` above the given point, so the arrow
+        // starts at 50 + 1.62 and this checks it is below that, i.e. falling.
         assert!(
-            flight.position.y < 50.0,
+            flight.position.y < 50.0 + EYE_HEIGHT,
             "gravity pushed it up to {}",
             flight.position.y
         );
@@ -2108,8 +2110,11 @@ mod projectiles {
                 _ => None,
             })
             .expect("a hit is heard where it landed");
+        // The crossing is at the target's column (x, z near 0); the height is
+        // the eye level the arrow now flies at, since `fire` launches from the
+        // eye, so check the horizontal crossing rather than distance to the feet.
         assert!(
-            contact.distance(Vec3::ZERO) < 0.5,
+            contact.x.abs() < 0.5 && contact.z.abs() < 0.5,
             "the hit was reported at {contact}, which is not where the path crossed the target"
         );
     }

--- a/tools/bow-check.py
+++ b/tools/bow-check.py
@@ -75,6 +75,11 @@ S2C_ADD_ENTITY = 0x01
 # absolute per-tick position the server broadcasts for a flying arrow; without
 # it a client renders the spawn and nothing after.
 S2C_ENTITY_POSITION_SYNC = 0x23
+# `ClientboundSetEntityMotionPacket`, id 101 in protocol 776. The per-tick
+# velocity a flying arrow is now driven by: the client dead-reckons position
+# from it (`AbstractArrow.tick`) and renders smoothly, where a per-tick absolute
+# `EntityPositionSync` would hard-teleport the arrow instead.
+S2C_SET_ENTITY_MOTION = 0x65
 
 # `PlayerInventory::HOTBAR_START_SLOT`: `ClientboundContainerSetSlot` numbers
 # the whole inventory, and the nine keys a player can see begin here.
@@ -139,6 +144,9 @@ class Archer(match.MatchClient):
         # entity id -> list of absolute positions from EntityPositionSync,
         # in arrival order (one per server tick while it flies).
         self.syncs = {}
+        # entity id -> list of velocities from SetEntityMotion, in arrival
+        # order (one per tick while it flies, the vanilla-smooth representation).
+        self.motions = {}
 
     def absorb(self, packet_id, payload):
         if packet_id == match.S2C_LOGIN:
@@ -157,6 +165,8 @@ class Archer(match.MatchClient):
             self.absorb_add_entity(payload)
         elif packet_id == S2C_ENTITY_POSITION_SYNC:
             self.absorb_position_sync(payload)
+        elif packet_id == S2C_SET_ENTITY_MOTION:
+            self.absorb_set_motion(payload)
         elif packet_id == match.S2C_CONTAINER_SET_SLOT:
             self.absorb_slot(payload)
         elif packet_id == match.S2C_SYSTEM_CHAT:
@@ -211,6 +221,15 @@ class Archer(match.MatchClient):
         offset += 24
         vx, vy, vz = struct.unpack(">ddd", payload[offset : offset + 24])
         self.syncs.setdefault(entity_id, []).append(((x, y, z), (vx, vy, vz)))
+
+    def absorb_set_motion(self, payload):
+        """`ClientboundSetEntityMotionPacket`: id, then the velocity packed with
+        the low-precision vec3 codec. This is the per-tick packet a smooth arrow
+        rides on -- the client integrates position from it rather than being
+        teleported."""
+        entity_id, offset = take_var_int(payload)
+        motion, _offset = match.take_lp_vec3(payload, offset)
+        self.motions.setdefault(entity_id, []).append(motion)
 
     def absorb_slot(self, payload):
         _container, offset = take_var_int(payload)
@@ -475,6 +494,7 @@ def main():
     # position update, or does not fall.
     client.spawned.clear()
     client.syncs.clear()
+    client.motions.clear()
     client.aim(0.0, -80.0)
     client.send_position()
     pump(client, 0.3)
@@ -488,103 +508,54 @@ def main():
         launch = flew[0][0]
         arrow_id = launch["id"]
         spawn = launch["position"]
-        vx, vy, vz = launch["motion"]
-        pairs = client.syncs.get(arrow_id, [])
-        samples = [pos for pos, _vel in pairs]
-
-        check(
-            len(samples) >= 20,
-            "the server broadcasts the arrow's position every tick as it flies "
-            "(got %d EntityPositionSync packets; 0 means the client is never "
-            "told the arrow moved)" % len(samples),
-        )
-        if len(samples) < 2:
-            print("RESULT: failure (no flight to trace)", flush=True)
-            return 1
-
-        # Vanilla's own integration, forward from the arrow's own first synced
-        # state: pos += v; v *= 0.99; v.y -= 0.05 (AbstractArrow.tick). Anchoring
-        # on the first sync rather than the spawn keeps a one-block spawn re-add
-        # out of the measurement; what is under test is that every later synced
-        # position lies on the arc this start implies.
-        px, py, pz = samples[0]
-        v = list(pairs[0][1])
-        arc = [(px, py, pz)]
-        for _ in range(120):
-            px += v[0]
-            py += v[1]
-            pz += v[2]
-            v[0] *= 0.99
-            v[1] *= 0.99
-            v[2] *= 0.99
-            v[1] -= 0.05
-            arc.append((px, py, pz))
-
-        def dist_to_arc(point):
-            """Least distance from `point` to the piecewise-linear vanilla arc,
-            and how far along it (segment index) that nearest point sits.
-
-            Matching to the nearest point on the curve rather than to a fixed
-            tick makes this robust to a dropped or coalesced position packet: a
-            correct arrow lies *on* the arc whatever the packet cadence, so this
-            measures the shape, not the timing."""
-            best_d = float("inf")
-            best_k = 0
-            px0, py0, pz0 = point
-            for k in range(len(arc) - 1):
-                ax, ay, az = arc[k]
-                bx, by, bz = arc[k + 1]
-                dx, dy, dz = bx - ax, by - ay, bz - az
-                length2 = dx * dx + dy * dy + dz * dz
-                if length2 == 0.0:
-                    t = 0.0
-                else:
-                    t = ((px0 - ax) * dx + (py0 - ay) * dy + (pz0 - az) * dz) / length2
-                    t = max(0.0, min(1.0, t))
-                cx, cy, cz = ax + t * dx, ay + t * dy, az + t * dz
-                d = ((px0 - cx) ** 2 + (py0 - cy) ** 2 + (pz0 - cz) ** 2) ** 0.5
-                if d < best_d:
-                    best_d, best_k = d, k
-            return best_d, best_k
-
-        # Loose on purpose: the wire velocity is LP-quantised and the server
-        # integrates in f32, so this is a bound, not a fit. It is far tighter
-        # than a frozen arrow, a wrong launch speed, or a missing gravity term,
-        # each of which walks the wire trajectory off the arc by whole blocks.
-        tol = 1.0
-        worst = 0.0
-        reached = 0
-        for wx, wy, wz in samples:
-            d, k = dist_to_arc((wx, wy, wz))
-            worst = max(worst, d)
-            reached = max(reached, k)
-        # A couple of the first spawn-adjacent samples can predate the first
-        # integration tick; the shape over the whole flight is the claim.
+        velocities = client.motions.get(arrow_id, [])
+        syncs = client.syncs.get(arrow_id, [])
         print(
-            "arc match: %d samples, worst off-arc %.3f blocks, reached tick %d"
-            % (len(samples), worst, reached),
+            "flight: %d SetEntityMotion (per-tick velocity), %d absolute "
+            "EntityPositionSync, for arrow %d"
+            % (len(velocities), len(syncs), arrow_id),
             flush=True,
         )
+        # Smoothness (the vanilla wire pattern): the arrow is driven by per-tick
+        # velocity, which the client predicts smooth position from -- NOT by
+        # per-tick absolute position teleports. An arrow has no client
+        # interpolation handler, so an absolute EntityPositionSync hard-snaps it
+        # ~3 blocks a tick = jagged. This is the assertion the fix turns green.
         check(
-            worst < tol,
-            "the arrow flies the vanilla arc on the wire, not some other path "
-            "(worst off-arc distance %.3f blocks over %d samples, tolerance "
-            "%.2f)" % (worst, len(samples), tol),
+            len(velocities) >= 20,
+            "the server sends the arrow's velocity every tick (SetEntityMotion), "
+            "the vanilla representation the client predicts smooth motion from "
+            "(got %d)" % len(velocities),
         )
         check(
-            reached >= 12,
-            "the arrow flies a real stretch of the arc, not just the first "
-            "tick or two (nearest arc point reached tick %d)" % reached,
+            len(syncs) == 0,
+            "the arrow is never hard-teleported by a per-tick absolute "
+            "EntityPositionSync (got %d; any per-tick absolute sync IS the jagged "
+            "snap this fixes)" % len(syncs),
         )
-
-        # And it went somewhere: the last sync is a long way from the spawn.
-        if samples:
-            lx, ly, lz = samples[-1]
-            moved = ((lx - spawn[0]) ** 2 + (ly - spawn[1]) ** 2 + (lz - spawn[2]) ** 2) ** 0.5
+        # A real flight: integrate the per-tick velocity stream from the launch
+        # and confirm it travels a real distance and shows gravity in vy.
+        if len(velocities) >= 2:
+            px, py, pz = spawn
+            for vx, vy, vz in velocities:
+                px += vx
+                py += vy
+                pz += vz
+            moved = ((px - spawn[0]) ** 2 + (py - spawn[1]) ** 2 + (pz - spawn[2]) ** 2) ** 0.5
+            vy_first, vy_last = velocities[0][1], velocities[-1][1]
+            print(
+                "velocity arc: integrated %.1f blocks; vy %.3f -> %.3f"
+                % (moved, vy_first, vy_last),
+                flush=True,
+            )
             check(
                 moved > 8.0,
-                "the arrow travelled a real distance (%.1f blocks from spawn "
-                "after %d ticks)" % (moved, len(samples)),
+                "the velocity stream integrates to a real flight (%.1f blocks)" % moved,
+            )
+            check(
+                vy_last < vy_first,
+                "gravity shows in the per-tick velocity (vy %.3f -> %.3f)"
+                % (vy_first, vy_last),
             )
 
     print(

--- a/tools/smash-bow-check.py
+++ b/tools/smash-bow-check.py
@@ -120,6 +120,7 @@ def main():
     def draw(seconds, note):
         client.spawned.clear()
         client.syncs.clear()
+        client.motions.clear()
         client.aim(35.0, -20.0)
         client.send_position()
         client.use_slot(bow_slot, "(nock) " + note)
@@ -187,50 +188,53 @@ def main():
     )
 
     arrow_id = launch["id"]
-    pairs = client.syncs.get(arrow_id, [])
-    samples = [pos for pos, _vel in pairs]
-    print("flight: %d EntityPositionSync samples for arrow %d" % (len(samples), arrow_id), flush=True)
-    check(
-        len(samples) >= 12,
-        "the server broadcasts the arrow's position every tick as it flies "
-        "(got %d; 0 means it never left the muzzle on the wire)" % len(samples),
+    velocities = client.motions.get(arrow_id, [])
+    syncs = client.syncs.get(arrow_id, [])
+    print(
+        "flight: %d SetEntityMotion (per-tick velocity) packets, %d absolute "
+        "EntityPositionSync, for arrow %d" % (len(velocities), len(syncs), arrow_id),
+        flush=True,
     )
-    if len(samples) >= 2:
-        px, py, pz = samples[0]
-        v = list(pairs[0][1])
-        arc = [(px, py, pz)]
-        for _ in range(120):
-            # smash Flight integrates gravity before the move (DecayThenMove):
-            # v.y -= g*dt, then pos += v*dt. In wire units that is v.y -= 0.05
-            # then pos += v, and getting the order backwards drifts ~0.05/tick.
-            v[1] -= 0.05
-            px += v[0]
-            py += v[1]
-            pz += v[2]
-            arc.append((px, py, pz))
-
-        def dist_to_arc(point):
-            best = float("inf")
-            px0, py0, pz0 = point
-            for k in range(len(arc) - 1):
-                ax, ay, az = arc[k]
-                bx, by, bz = arc[k + 1]
-                dx, dy, dz = bx - ax, by - ay, bz - az
-                length2 = dx * dx + dy * dy + dz * dz
-                t = 0.0 if length2 == 0.0 else max(0.0, min(1.0, ((px0 - ax) * dx + (py0 - ay) * dy + (pz0 - az) * dz) / length2))
-                cx, cy, cz = ax + t * dx, ay + t * dy, az + t * dz
-                best = min(best, math.dist((px0, py0, pz0), (cx, cy, cz)))
-            return best
-
-        worst = max(dist_to_arc(s) for s in samples)
-        moved = math.dist(samples[-1], spawn)
-        print("arc: worst off-arc %.3f blocks, travelled %.1f blocks" % (worst, moved), flush=True)
-        check(
-            worst < 1.0,
-            "the arrow flies its Flight arc on the wire (worst off-arc %.3f "
-            "blocks over %d samples)" % (worst, len(samples)),
+    # Smoothness (the vanilla wire pattern): the arrow is driven by per-tick
+    # velocity, which the client predicts smooth position from -- NOT by per-tick
+    # absolute position teleports. An arrow has no client interpolation handler,
+    # so an absolute EntityPositionSync hard-snaps it ~3 blocks a tick = jagged.
+    check(
+        len(velocities) >= 12,
+        "the server sends the arrow's velocity every tick (SetEntityMotion), the "
+        "vanilla representation the client predicts smooth motion from (got %d)"
+        % len(velocities),
+    )
+    check(
+        len(syncs) == 0,
+        "the arrow is never hard-teleported by a per-tick absolute "
+        "EntityPositionSync (got %d; any per-tick absolute sync IS the jagged "
+        "~3-block-a-tick snap this fixes)" % len(syncs),
+    )
+    # A real flight: integrate the per-tick velocity stream from the launch and
+    # confirm it travels a real distance and shows gravity in vy.
+    if len(velocities) >= 2:
+        px, py, pz = spawn
+        for vx, vy, vz in velocities:
+            px += vx
+            py += vy
+            pz += vz
+        moved = math.dist((px, py, pz), spawn)
+        vy_first, vy_last = velocities[0][1], velocities[-1][1]
+        print(
+            "velocity arc: integrated %.1f blocks; vy %.3f -> %.3f"
+            % (moved, vy_first, vy_last),
+            flush=True,
         )
-        check(moved > 6.0, "the arrow travels a real distance (%.1f blocks)" % moved)
+        check(
+            moved > 6.0,
+            "the velocity stream integrates to a real flight (%.1f blocks)" % moved,
+        )
+        check(
+            vy_last < vy_first,
+            "gravity shows in the per-tick velocity (vy %.3f -> %.3f)"
+            % (vy_first, vy_last),
+        )
 
     pump(client, 0.6)
     short = draw(0.4, "short draw")


### PR DESCRIPTION
## Operator ground-truth (live smash play, after Stage 1)

Arrows looked **jagged**, **did not collide**, and "velocity seemed off." Two root causes, confirmed with the **decompiled 26.2 client** + a live packet capture.

### Smoothness
Stage 1 broadcast an absolute `EntityPositionSync` **every tick**. Arrows have no client interpolation handler (`AbstractArrow` doesn't override `getInterpolation`), so `handleEntityPositionSync` -> `setPos` **hard-teleports** the arrow (~3-block snap / 50ms) and the client ignores that packet's velocity — while the client already dead-reckons the arrow (`AbstractArrow.tick`: `pos += vel; vel *= 0.99; vel.y -= 0.05`) from the `add_entity` velocity. The per-tick teleport fought the prediction = jagged.
**Fix:** per-tick `SetEntityMotion` (velocity) instead — the client applies it via `lerpMotion` and predicts position, vanilla's pattern. Heading is re-derived client-side. Both smash (`broadcast_marked_projectiles`) and bedwars (`update_projectile_positions`).

### Collision
Stage 1's eye-lift was visual-only; the `Flight` hit-sim stayed at the feet, so an arrow seen through a player passed ~1.6 blocks below → miss (invisible to the mock).
**Fix:** `fire()` launches the sim from the eye (draw renders `flight.position` directly, no offset); `nearest_target` uses a 1.8-block upright capsule; knockback goes along the flight velocity. Changes hit geometry + knockback across projectile abilities — operator live re-test is the playtest, 291 mock suite is regression cover.

## Tests
Gates rewritten to the vanilla packet pattern (`bow-check.py` + `smash-bow-check.py`): `add_entity` velocity, **per-tick `SetEntityMotion`, ZERO per-tick absolute `EntityPositionSync`**, velocity integrates to a falling arc; plus eye-origin, `look_angles` heading, charge->speed. Two projectile verification tests updated deliberately for the eye-origin launch.

## Verified (aarch64-darwin)
- Live: 27 per-tick `SetEntityMotion`, 0 `EntityPositionSync`; eye trajectory 0.00 off (vs 1.53 feet); 76-block arc; heading + charge->speed green.
- clippy -D warnings clean; smash 291/291; hyperion 102/102; store-cached `smash-bow-e2e` + `bedwars-bow-e2e` green.

Targeted operator fix; composable projectile rewrite follows separately. CI known-broken.