### PR TITLE
refactor(hyperion): importable component-registration modules for the simulation base (ENG-11000)

### DIFF
--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -81,8 +81,9 @@ pub mod xp;
 pub use flight::{Flight, FlyingSpeed, MovementTracking};
 pub use lookup::{DeferredMap, IgnMap, PlayerUuidLookup, StreamLookup};
 pub use pose::{
-    ChunkPosition, EntitySize, PLAYER_SPAWN_POSITION, PendingTeleportation, Pitch, Position,
-    Velocity, Yaw, aabb, block_bounds, get_direction_from_rotation,
+    ChunkPosition, EntitySize, KinematicsComponentsModule, PLAYER_SPAWN_POSITION,
+    PendingTeleportation, Pitch, Position, Velocity, Yaw, aabb, block_bounds,
+    get_direction_from_rotation,
 };
 pub use world_time::{WorldTime, WorldTimeModule};
 pub use xp::{Xp, XpVisual};
@@ -253,17 +254,69 @@ pub(crate) fn add_entity(
     }
 }
 
+/// Registration module for the simulation: every component, singleton, prefab,
+/// and reflection the game world owns, and nothing that behaves.
+///
+/// The behavior (observers, systems) lives in [`SimModule`], which imports this
+/// first. Keeping the two apart is the repo-wide flecs convention (see the
+/// root `CLAUDE.md`): a consumer that wants the simulation's *types* without its
+/// *behavior* -- the smash mock, a physics-only rebuild -- imports this module
+/// directly and gets a world where `Velocity`, `Position`, `EntityKind` and the
+/// rest are registered, with none of the spawn/metadata observers attached.
+#[derive(Component)]
+pub struct SimComponentsModule;
+
+impl Module for SimComponentsModule {
+    // The order is load-bearing: a relation has to be a registered entity
+    // before anything points at it, and reflection has to precede the
+    // components it annotates.
+    fn module(world: &World) {
+        // The base of the registration DAG: `KinematicsComponentsModule`
+        // imports `ReflectionComponentsModule` (glam/valence meta) and registers
+        // the `Position`/`Velocity` kinematics base, so both exist before
+        // `register_components` annotates the rest.
+        world.import::<pose::KinematicsComponentsModule>();
+        // Registers every remaining simulation component and sets the
+        // `MetadataPrefabs` singleton, which `SimModule`'s observers read back
+        // to pick a prefab base per entity kind.
+        register_components(world);
+    }
+}
+
+/// Behavior module for the simulation: the observers that react to the
+/// components changing. It imports [`SimComponentsModule`] for the types it
+/// watches, so flecs's import DAG registers every component before an observer
+/// is declared -- an observer that comes before the component it watches is the
+/// ordering the DAG now forbids.
 #[derive(Component)]
 pub struct SimModule;
 
 impl Module for SimModule {
-    // Read as a table of contents. Each step runs in the order flecs needs:
-    // a relation has to be a registered entity before anything points at it,
-    // and an observer has to come after the components it watches.
+    fn module(world: &World) {
+        world.import::<SimComponentsModule>();
+        // `SimComponentsModule` set this; `MetadataPrefabs` is `Copy`, so read a
+        // value out for the observers rather than holding the singleton borrow
+        // across their setup.
+        let prefabs = world.get::<&MetadataPrefabs>(|prefabs| *prefabs);
+        register_observers(world, prefabs);
+    }
+}
+
+/// Registration module for the reflection metadata flecs cannot derive on its
+/// own: the glam and valence types (`Vec3`, `IVec3`, `Quat`, `VarInt`,
+/// `BlockState`) plus [`EntitySize`] as an opaque.
+///
+/// The root of the simulation's registration DAG. Everything whose
+/// `#[flecs(meta)]` reaches a glam type -- [`Position`], [`Velocity`] and the
+/// rest -- imports this (directly or through
+/// [`KinematicsComponentsModule`](pose::KinematicsComponentsModule)) so the
+/// base types exist before their meta is registered. Registration only.
+#[derive(Component)]
+pub struct ReflectionComponentsModule;
+
+impl Module for ReflectionComponentsModule {
     fn module(world: &World) {
         register_reflection(world);
-        let prefabs = register_components(world);
-        register_observers(world, prefabs);
     }
 }
 
@@ -276,6 +329,13 @@ impl Module for SimModule {
 fn register_reflection(world: &World) {
     component!(world, VarInt).member(id::<i32>(), "x");
 
+    // `EntitySize` registers as an opaque, which needs the component to exist
+    // first. In a full boot `HyperionCore` happens to register it before
+    // importing the simulation, but a standalone import of this module (the
+    // smash mock, projectile physics) has no such luck -- so register it here
+    // and keep the module self-sufficient. Plain, not `.meta()`: a meta-struct
+    // plus an opaque on one type aborts.
+    world.component::<EntitySize>();
     component!(world, EntitySize).opaque_func(meta_ser_stringify_type_display::<EntitySize>);
 
     component!(world, IVec3 {
@@ -304,7 +364,8 @@ fn register_reflection(world: &World) {
 /// pick a base for each entity kind it spawns. They used to reach it as a
 /// closure capture over one long function body; threading it through says so.
 fn register_components(world: &World) -> MetadataPrefabs {
-    world.component::<Velocity>().meta();
+    // `Position` and `Velocity` are registered by
+    // `KinematicsComponentsModule`, imported before this runs.
     world.component::<Player>();
     world.component::<Visible>();
     world.component::<Spawn>();
@@ -348,8 +409,6 @@ fn register_components(world: &World) -> MetadataPrefabs {
     world.component::<command::FixedSuggestions>();
 
     component!(world, IgnMap);
-
-    world.component::<Position>().meta();
 
     world.component::<Name>();
     component!(world, Name).opaque_func(meta_ser_stringify_type_display::<Name>);

--- a/crates/hyperion/src/simulation/pose.rs
+++ b/crates/hyperion/src/simulation/pose.rs
@@ -248,6 +248,35 @@ pub fn get_direction_from_rotation(yaw: f32, pitch: f32) -> Vec3 {
     )
 }
 
+/// Registration module for the core kinematics base: where an entity is
+/// ([`Position`]) and how it is moving ([`Velocity`]).
+///
+/// This is the "settled base" of the flecs module convention (see the root
+/// `CLAUDE.md`): the two components nearly every system reads, registered in
+/// one importable place so nothing re-registers them ad hoc. Both the
+/// simulation ([`super::SimComponentsModule`]) and the projectile physics
+/// import this rather than each calling `world.component::<Position>()`
+/// themselves, and a use-before-register of the kinematics base becomes an
+/// import edge the DAG supplies rather than an ordering a contributor can miss
+/// (ENG-11000's class).
+///
+/// It imports [`super::ReflectionComponentsModule`] because `Position` and
+/// `Velocity` register their reflection through the glam `Vec3` meta that module
+/// installs, so a standalone `world.import::<KinematicsComponentsModule>()` into
+/// a bare world is self-sufficient. Registration only, no behavior.
+#[derive(Component)]
+pub struct KinematicsComponentsModule;
+
+impl Module for KinematicsComponentsModule {
+    fn module(world: &World) {
+        // `Position`/`Velocity` carry `#[flecs(meta)]` over a `Vec3`, so the
+        // glam reflection has to exist before their meta is registered.
+        world.import::<super::ReflectionComponentsModule>();
+        world.component::<Position>().meta();
+        world.component::<Velocity>().meta();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/hyperion/tests/kinematics_base.rs
+++ b/crates/hyperion/tests/kinematics_base.rs
@@ -1,0 +1,45 @@
+//! Dev-profile guard for the kinematics registration base (ENG-11000's class).
+//!
+//! The flecs module convention (root `CLAUDE.md`) says a consumer can import a
+//! registration module on its own and get its components registered, with no
+//! behavior and no need to boot the whole engine. The projectile physics relies
+//! on exactly this: it imports [`KinematicsComponentsModule`] to get `Position`
+//! and `Velocity` without pulling in the simulation's observers.
+//!
+//! `Position`/`Velocity` register their reflection through the glam `Vec3` meta,
+//! so a naive standalone registration would abort a dev build with
+//! `ECS_INVALID_OPERATION` the first time the meta is registered without `Vec3`
+//! present. `KinematicsComponentsModule` imports `ReflectionComponentsModule`
+//! to close that gap; this test is the proof, in the dev build `cargo test`
+//! produces. It fails (aborts) if the reflection import is dropped.
+
+use flecs_ecs::{
+    core::{World, WorldGet},
+    prelude::*,
+};
+use hyperion::simulation::{KinematicsComponentsModule, Position, Velocity};
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn kinematics_base_is_usable_after_standalone_import() {
+    // A bare world: no HyperionCore, no SimModule, nothing but the kinematics
+    // registration module. This is the smash mock / projectile-physics shape.
+    let world = World::new();
+    world.import::<KinematicsComponentsModule>();
+
+    // Using the components in a dev build is the guard: a `set`/`get` of an
+    // unregistered component aborts under `flecs_manual_registration`, and the
+    // `.meta()` over `Vec3` would abort at import time without the reflection
+    // base. Both are exercised here.
+    let entity = world.entity();
+    entity.set(Position::new(1.0, 2.0, 3.0));
+    entity.set(Velocity::new(0.0, -1.0, 0.0));
+
+    let (px, vy) = entity.get::<(&Position, &Velocity)>(|(p, v)| (p.x, v.0.y));
+    assert_eq!(px, 1.0, "Position should round-trip through the bare world");
+    assert_eq!(
+        vy, -1.0,
+        "Velocity should round-trip through the bare world"
+    );
+}


### PR DESCRIPTION
Applies the flecs module convention (root `CLAUDE.md`, #1069) to the core
simulation: splits component registration out of the behavior module so a
consumer can import the **types** without the **systems**. This is the settled
base the projectile Stage-2 rewrite and the smash mock need.

## The registration DAG

```
ReflectionComponentsModule   glam/valence meta: Vec3, IVec3, Quat, VarInt,
      ^                      BlockState, EntitySize opaque
KinematicsComponentsModule   the core Position + Velocity base
      ^
SimComponentsModule          every remaining simulation component + prefabs
      ^
SimModule                    behavior: the spawn/metadata observers
```

`SimModule` now imports `SimComponentsModule` and reads the `MetadataPrefabs`
singleton back for its observers, so registration provably runs before any
observer is declared. `HyperionCore` still imports `SimModule` unchanged, so the
full boot is behavior-preserving.

## Why (ENG-11000)

The workspace builds flecs with `flecs_manual_registration`, whose guard is a
debug-only `ecs_assert`. A use-before-register aborts a dev build and passes
every release gate. Making registration an importable module that behavior
imports turns "register before use" into an import edge the DAG supplies rather
than an ordering a contributor can miss.

## A latent instance of the same class, found and fixed

Extracting the reflection module surfaced one: `register_reflection`'s
`EntitySize` opaque registration depended on `EntitySize` already being plainly
registered, which only happened by luck in `HyperionCore` before the simulation
import. A standalone import of the base aborted with

```
ECS_INVALID_OPERATION: Component hyperion::simulation::pose::EntitySize is not registered with the world before usage
```

`register_reflection` now registers it itself, so the module is self-sufficient
in a bare world.

## Verification

- `crates/hyperion/tests/kinematics_base.rs` (new): imports **only**
  `KinematicsComponentsModule` into a bare world and uses `Position`/`Velocity`
  -- the projectile-physics shape -- which aborts a dev build if the reflection
  base is missing. Watched it fail (it caught the `EntitySize` gap above), then
  pass.
- `cargo test -p hyperion --test kinematics_base --test world_time` green in the
  dev profile after rebase onto f3d280a.
- `cargo check -p hyperion -p smash -p bedwars` green.
- `checks.smash-dev-boot-e2e` (the new dev-profile boot gate, which is exactly
  this change's class).

## Not in this PR

Deliberately scoped to the importable core base. The behavior modules that still
mix registration and behavior are enumerated as follow-up increments. smash's
`PlayerModule` `Position`/`Velocity` are the adapter's **mirror** types, distinct
from hyperion's `pose` types, and are intentionally left alone. No projectile
components touched.

Generated with Claude Code.