### PR TITLE
fix(hyperion): make tests/kinematics_base.rs pass clippy so main is green

### DIFF
--- a/crates/hyperion/tests/kinematics_base.rs
+++ b/crates/hyperion/tests/kinematics_base.rs
@@ -13,15 +13,18 @@
 //! to close that gap; this test is the proof, in the dev build `cargo test`
 //! produces. It fails (aborts) if the reflection import is dropped.
 
-use flecs_ecs::{
-    core::{World, WorldGet},
-    prelude::*,
-};
+use flecs_ecs::{core::World, prelude::*};
 use hyperion::simulation::{KinematicsComponentsModule, Position, Velocity};
 use serial_test::serial;
 
 #[test]
 #[serial]
+#[expect(
+    clippy::float_cmp,
+    reason = "the assertions round-trip the exact literals just set through the bare world; an \
+              epsilon would weaken the claim, which is that the component stored and returned the \
+              same bits rather than that it stored something close"
+)]
 fn kinematics_base_is_usable_after_standalone_import() {
     // A bare world: no HyperionCore, no SimModule, nothing but the kinematics
     // registration module. This is the smash mock / projectile-physics shape.


### PR DESCRIPTION
## What

`cargo clippy -p hyperion --all-targets -- -D warnings` fails on **main** with three errors, all in `crates/hyperion/tests/kinematics_base.rs`:

- unused `WorldGet` import (the prelude already provides it)
- two `clippy::float_cmp` pedantic errors on the `assert_eq!` round-trips

The exact comparison is the *point* of those assertions — they check the component gave back the same bits that were just set, not something close — so they keep exact equality under an `#[expect]` naming that reason, rather than being loosened to an epsilon.

## Why it reached main

This is the masked-exit-code class. A check run as `cargo clippy ... | tail -N` reports **`tail`'s** status, not clippy's, so a red clippy reads as green; with CI known-broken there was nothing else to catch it. The repo convention (root `CLAUDE.md`) is to redirect to a file and check the exit code before reading it, never to pipe when the exit code matters. Recording it here so the fix and the cause are both on the record.

## Why it's standalone

A red main hides the next real failure and blocks clippy verification for anyone working in this crate, so it is split out of the feature branch that found it.

## Verified (aarch64-darwin, real exit codes, not piped)

- `cargo clippy -p hyperion --test kinematics_base -- -D warnings` → exit 0 (was 101 with 3 errors).
- `cargo nextest run -p hyperion -E 'binary(kinematics_base)'` → 1 test passed. The guard still guards: it is a dev-profile abort check for the kinematics registration base, and it still exercises the standalone `KinematicsComponentsModule` import.

CI is known-broken on this repo; merged by force per the workflow after the local checks above.