### PR TITLE
style(hyperion): format net/protocol/join.rs so main passes cargo fmt --check

### DIFF
--- a/crates/hyperion/src/net/protocol/join.rs
+++ b/crates/hyperion/src/net/protocol/join.rs
@@ -12,8 +12,8 @@ use hyperion_minecraft_proto::{
     generated::packet_id::play::clientbound::PacketId,
     packets::play_login::{
         BlockPos, ClockNetworkState, CommonPlayerSpawnInfo, GameEvent, GameType, GlobalPos, Login,
-        PlayerPosition, PositionMoveRotation, Relative, SetChunkCacheCenter, SetDefaultSpawnPosition,
-        SetTime, Vec3,
+        PlayerPosition, PositionMoveRotation, Relative, SetChunkCacheCenter,
+        SetDefaultSpawnPosition, SetTime, Vec3,
     },
 };
 use hyperion_utils::EntityExt;
@@ -224,10 +224,7 @@ pub fn enter_world(
         PacketId::SetTime.to_raw(),
         &SetTime {
             game_time: compose.global().tick,
-            clock_updates: vec![(
-                overworld_clock,
-                ClockNetworkState::frozen(day_time),
-            )],
+            clock_updates: vec![(overworld_clock, ClockNetworkState::frozen(day_time))],
         },
     )?;
 


### PR DESCRIPTION
## What

`cargo fmt --all -- --check` **fails on main**, on `crates/hyperion/src/net/protocol/join.rs` (the import list at line 12 and the `SetTime` clock-updates literal at line 224). Running `cargo fmt` produces exactly this diff — the change is rustfmt's own output and nothing else.

## Why it matters

Same class as the clippy breakage fixed in #1074: a merged change whose format check was never actually run green, on a repo whose CI is known-broken. A tree that does not pass its own formatter means every later branch silently picks up an unrelated reformat the moment its author runs `cargo fmt` — which is how this surfaced, by reappearing in a feature branch's diff twice.

Split out on its own so the formatting is not buried inside a feature change.

## Verified (aarch64-darwin, real exit codes)

- `cargo fmt --all -- --check` on main's version of the file → exit **1** (`Diff in ...join.rs:12`, `:224`).
- Same command with this change → exit **0**.

Formatting only; no behavior change. CI known-broken; force-merged per the workflow.