### PR TITLE
refactor(hyperion): projectile registration/behavior modules, per-instance ProjectileMotion

### DIFF
--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -36,7 +36,7 @@ use crate::{
         event::{self, HitGroundEvent},
         handlers::is_grounded,
         metadata::{MetadataChanges, get_and_clear_metadata},
-        projectile_motion::{MotionOrder, lerp_rotation, look_angles},
+        projectile_motion::{MotionOrder, ProjectileMotion, lerp_rotation, look_angles},
     },
     spatial::get_first_collision,
     storage::Events,
@@ -527,9 +527,18 @@ impl Module for EntityStateSyncModule {
 
                 let world = it.world();
                 let arrow_entity = it.entity(row);
+                // Prefer the per-instance `ProjectileMotion` that
+                // `seed_projectile_motion` puts on every simulated kind, so an
+                // ability can override one projectile's gravity or drag; fall
+                // back to the kind's vanilla default for anything that has a
+                // kind but no component yet.
                 let motion = arrow_entity
-                    .try_get::<&EntityKind>(|kind| kind.projectile_motion())
-                    .flatten();
+                    .try_get::<&ProjectileMotion>(|motion| *motion)
+                    .or_else(|| {
+                        arrow_entity
+                            .try_get::<&EntityKind>(|kind| kind.projectile_motion())
+                            .flatten()
+                    });
 
                 if velocity.0 != Vec3::ZERO {
                     let center = **position;

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -276,6 +276,10 @@ impl Module for SimComponentsModule {
         // the `Position`/`Velocity` kinematics base, so both exist before
         // `register_components` annotates the rest.
         world.import::<pose::KinematicsComponentsModule>();
+        // The projectile components (`ProjectileMotion`) come from their own
+        // registration module, which a physics-only consumer can import without
+        // the rest of the simulation.
+        world.import::<projectile_motion::ProjectileComponentsModule>();
         // Registers every remaining simulation component and sets the
         // `MetadataPrefabs` singleton, which `SimModule`'s observers read back
         // to pick a prefab base per entity kind.
@@ -501,6 +505,22 @@ fn register_observers(world: &World, prefabs: MetadataPrefabs) {
         .each_entity(|entity, ()| {
             debug!("adding uuid to entity");
             entity.set(Uuid::new_v4());
+        });
+
+    // Seed a projectile's per-tick motion from its kind's vanilla default the
+    // moment the kind is set, so the integrator reads a component a game module
+    // can also override per instance (a hook with no gravity, a heavier lob). A
+    // kind with no entry in `SIMULATED` gets nothing, exactly as before.
+    world
+        .observer_named::<flecs::OnAdd, ()>("seed_projectile_motion")
+        .with_enum_wildcard::<EntityKind>()
+        .each_entity(|entity, ()| {
+            if let Some(motion) = entity
+                .try_get::<&EntityKind>(|kind| kind.projectile_motion())
+                .flatten()
+            {
+                entity.set(motion);
+            }
         });
 
     world

--- a/crates/hyperion/src/simulation/projectile_motion.rs
+++ b/crates/hyperion/src/simulation/projectile_motion.rs
@@ -21,9 +21,13 @@
 //! it moves at all. Sharing one integrator between them is wrong by about a
 //! tenth of a block on the first tick and it never converges.
 
+use flecs_ecs::prelude::*;
 use glam::Vec3;
 
-use super::entity_kind::EntityKind;
+use super::{
+    entity_kind::EntityKind,
+    pose::{Position, Velocity},
+};
 
 /// Where the position update sits relative to the velocity update.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -35,7 +39,13 @@ pub enum MotionOrder {
 }
 
 /// One tick of vanilla projectile motion.
-#[derive(Debug, Copy, Clone, PartialEq)]
+///
+/// A per-instance component, not only a per-kind lookup: the kind's entry in
+/// [`SIMULATED`] is the vanilla default `seed_projectile_motion` installs, and a
+/// game module may override it on one projectile (a hook with no gravity, a
+/// heavier lob) without inventing a new entity kind. Registered by
+/// [`ProjectileComponentsModule`].
+#[derive(Component, Debug, Copy, Clone, PartialEq)]
 pub struct ProjectileMotion {
     /// The velocity is multiplied by this every tick, out of water.
     ///
@@ -225,6 +235,56 @@ impl EntityKind {
             .iter()
             .find(|(kind, _)| *kind == self)
             .map(|(_, motion)| *motion)
+    }
+}
+
+/// Registration module for the projectile components: types only, no behavior.
+///
+/// Imports [`super::KinematicsComponentsModule`] because everything that
+/// integrates a projectile reads `Position` and `Velocity`, so importing this
+/// alone into a bare world is enough to have the whole projectile component set
+/// registered -- which is what lets a game module's test harness run the physics
+/// with no host, no egress and no world. Registration only, per the repo-wide
+/// flecs convention.
+#[derive(Component)]
+pub struct ProjectileComponentsModule;
+
+impl Module for ProjectileComponentsModule {
+    fn module(world: &World) {
+        world.import::<super::KinematicsComponentsModule>();
+        world.component::<ProjectileMotion>();
+    }
+}
+
+/// Behavior module for projectile flight: one system, and no registration of
+/// its own.
+///
+/// Host-free on purpose. It reads `Position`, `Velocity` and
+/// [`ProjectileMotion`] and writes the first two, so it needs no world to
+/// collide against, no `Compose` to send with and no entity kind: a game
+/// module's mock world can import this and get exactly vanilla's per-tick
+/// integration. Where the projectile *hits* and how it is *drawn* are separate
+/// components and separate modules, so an event picks each independently.
+#[derive(Component)]
+pub struct ProjectilePhysicsModule;
+
+impl Module for ProjectilePhysicsModule {
+    fn module(world: &World) {
+        world.import::<ProjectileComponentsModule>();
+
+        // Vanilla's own per-tick step for whatever this projectile's motion
+        // says, plus the heading a projectile always points along: it faces
+        // where it is going, re-derived from the velocity every tick. Nothing
+        // here sends a packet -- the egress layer reads the components this
+        // leaves behind.
+        world
+            .system_named::<(&mut Position, &mut Velocity, &ProjectileMotion)>(
+                "integrate_projectiles",
+            )
+            .kind(id::<flecs::pipeline::OnUpdate>())
+            .each(|(position, velocity, motion)| {
+                motion.step(position, &mut velocity.0);
+            });
     }
 }
 


### PR DESCRIPTION
## What

First increment of the composable projectile work, following the repo's flecs module convention (root `CLAUDE.md`): components in a registration module, systems in a behavior module, and the import DAG supplies the ordering.

- **`ProjectileComponentsModule`** (registration): imports `KinematicsComponentsModule` for the `Position`/`Velocity` base and registers `ProjectileMotion`, which becomes a per-**instance** component rather than only a per-kind lookup. Importing this module alone into a bare world gives the whole projectile component set — the physics-only / game-module-mock shape.
- **`ProjectilePhysicsModule`** (behavior, **host-free**): declares `integrate_projectiles` over (`Position`, `Velocity`, `ProjectileMotion`) — vanilla's per-tick step with no world to collide against, no `Compose` to send with and no entity kind, so a mock world can run exactly the server's integration.
- `SimComponentsModule` imports the registration module; the vanilla per-kind defaults are installed by a `seed_projectile_motion` `OnAdd(EntityKind)` observer, so an ability can override one projectile's gravity or drag (a hook with no gravity, a heavier lob) **without inventing a new entity kind**.
- The egress integrator reads the per-instance component, with the kind's default as a fallback for anything that has a kind but no component yet.

This is the linchpin for the rest: the swappable hit/visual and the smash `Flight` migration all read one component set through this DAG.

## Behavior-preserving

Every simulated kind still gets its existing motion, and the per-tick `SetEntityMotion` velocity broadcast, the eye-origin `fire()` and the 1.8-block capsule hit from #1071 are **untouched** — the arrows the operator re-tested behave identically.

## Verified (aarch64-darwin, real exit codes, redirected not piped)

- `cargo fmt --all -- --check && cargo clippy -p hyperion -p smash -p bedwars --all-targets -- -D warnings && cargo nextest run -p hyperion -p smash` → exit **0**, 394/394 tests pass.
- One `nix build` of all four store-cached gates → exit **0**: `smash-dev-boot-e2e`, `bedwars-dev-boot-e2e` (the dev-profile registration-order guards, directly relevant to module work) and `smash-bow-e2e`, `bedwars-bow-e2e` (the vanilla-packet-pattern arrow gates).

CI is known-broken on this repo; merged by force per the workflow after the local checks above.