### PR TITLE
refactor(hyperion): registration modules for spatial, decode, chunk sync, inventory, ingress (ENG-11053)

### DIFF
--- a/crates/hyperion/src/egress/sync_chunks.rs
+++ b/crates/hyperion/src/egress/sync_chunks.rs
@@ -36,12 +36,32 @@ pub struct ChunkSendQueue {
     changes: Vec<I16Vec2>,
 }
 
+/// Registration module for chunk streaming: the per-player
+/// [`ChunkSendQueue`].
+///
+/// Registration only, per the flecs convention in the root `CLAUDE.md`. The two
+/// systems that fill and drain the queue live in [`SyncChunksModule`], which
+/// imports this.
+#[derive(Component)]
+pub struct SyncChunksComponentsModule;
+
+impl Module for SyncChunksComponentsModule {
+    fn module(world: &World) {
+        world.component::<ChunkSendQueue>();
+    }
+}
+
+/// Behavior module for chunk streaming: one system turns a change of chunk into
+/// a queue of columns to send, the other drains that queue at a fixed rate.
 #[derive(Component)]
 pub struct SyncChunksModule;
 
 impl Module for SyncChunksModule {
     fn module(world: &World) {
-        world.component::<ChunkSendQueue>();
+        world.import::<SyncChunksComponentsModule>();
+        // Both systems read `Position` and the `ChunkPosition` derived from it,
+        // so the kinematics registration base is imported rather than assumed.
+        world.import::<crate::simulation::KinematicsComponentsModule>();
 
         let radius = world.get::<&Config>(|config| config.view_distance);
         let liberal_radius = radius + 2;

--- a/crates/hyperion/src/ingress/decode.rs
+++ b/crates/hyperion/src/ingress/decode.rs
@@ -146,17 +146,40 @@ fn register_play(world: &World) {
     );
 }
 
+/// Registration module for the play-decode path: the per-connection frame
+/// [`Receiver`](packet_channel::Receiver) and the shared [`Decompressor`].
+///
+/// Registration only, per the flecs convention in the root `CLAUDE.md`. The
+/// systems that read them live in [`DecodeModule`], which imports this.
+#[derive(Component)]
+pub struct DecodeComponentsModule;
+
+impl Module for DecodeComponentsModule {
+    fn module(world: &World) {
+        world.component::<packet_channel::Receiver>();
+
+        // Registered as a singleton before it is set. A bare `set` stores the
+        // value without registering the type, and that is the dev-only
+        // ECS_INVALID_OPERATION abort of ENG-11000.
+        world
+            .component::<Decompressor>()
+            .add_trait::<flecs::Singleton>();
+        world.set(Decompressor::default());
+    }
+}
+
+/// Behavior module for the play-decode path: the `recv_data` system that drains
+/// every queued frame and dispatches it through [`packet_switch`].
 #[derive(Component)]
 pub struct DecodeModule;
 
 impl Module for DecodeModule {
     fn module(world: &World) {
-        world.component::<packet_channel::Receiver>();
-
-        world
-            .component::<Decompressor>()
-            .add_trait::<flecs::Singleton>();
-        world.set(Decompressor::default());
+        world.import::<DecodeComponentsModule>();
+        // `recv_data` reads `Position`, `Yaw`, `Pitch` and `EntitySize` off the
+        // player it is decoding for, so the module registering the kinematics
+        // base is imported rather than assumed.
+        world.import::<crate::simulation::KinematicsComponentsModule>();
 
         register_play(world);
     }

--- a/crates/hyperion/src/ingress/mod.rs
+++ b/crates/hyperion/src/ingress/mod.rs
@@ -76,16 +76,35 @@ fn remove_player_from_visibility(world: &World) {
         });
 }
 
+/// Registration module for the inbound edge: the [`PendingRemove`] tag a
+/// disconnect leaves behind and the [`ServerPingResponse`] singleton the status
+/// path answers from.
+///
+/// Registration only, per the flecs convention in the root `CLAUDE.md`. The
+/// systems live in [`IngressModule`], which imports this.
+#[derive(Component)]
+pub struct IngressComponentsModule;
+
+impl Module for IngressComponentsModule {
+    fn module(world: &World) {
+        world.component::<PendingRemove>();
+        // Registered as a singleton before it is set: a bare `set` leaves the
+        // type unregistered, which aborts a dev build (ENG-11000).
+        world
+            .component::<ServerPingResponse>()
+            .add_trait::<flecs::Singleton>();
+        world.set(ServerPingResponse::default());
+    }
+}
+
+/// Behavior module for the inbound edge: shutdown, the IGN map refresh, play
+/// decoding, and reaping the entities a disconnect marked [`PendingRemove`].
 #[derive(Component)]
 pub struct IngressModule;
 
 impl Module for IngressModule {
     fn module(world: &World) {
-        world.component::<PendingRemove>();
-        world
-            .component::<ServerPingResponse>()
-            .add_trait::<flecs::Singleton>();
-        world.set(ServerPingResponse::default());
+        world.import::<IngressComponentsModule>();
 
         world.import::<DecodeModule>();
 

--- a/crates/hyperion/src/simulation/inventory.rs
+++ b/crates/hyperion/src/simulation/inventory.rs
@@ -55,23 +55,44 @@ use valence_protocol::{
 };
 use valence_server::ItemStack;
 
-use super::{Player, event, handlers::PacketSwitchQuery};
+use super::{event, handlers::PacketSwitchQuery};
 use crate::net::{
     Compose, ConnectionId, DataBundle,
     protocol::{Clientbound, send},
 };
 
+/// Registration module for the inventory types: the player's own
+/// [`PlayerInventory`] and [`CursorItem`], the [`InventoryState`] tracking what
+/// the client has been told, and the [`OpenInventory`] that points at a
+/// container being viewed.
+///
+/// Registration only, per the flecs convention in the root `CLAUDE.md`, and it
+/// imports nothing: a consumer wanting an entity to *have* an inventory (a mock,
+/// a test, a kit builder) gets the types from here without the packet systems in
+/// [`InventoryModule`]. The `Player`-implies-inventory traits live with `Player`
+/// in [`SimComponentsModule`](crate::simulation::SimComponentsModule), which
+/// imports this, so the trait and the component it points at cannot be
+/// registered out of order.
+#[derive(Component)]
+pub struct InventoryComponentsModule;
+
+impl Module for InventoryComponentsModule {
+    fn module(world: &World) {
+        world.component::<PlayerInventory>();
+        world.component::<CursorItem>();
+        world.component::<InventoryState>();
+        world.component::<OpenInventory>();
+    }
+}
+
+/// Behavior module for inventories: the observers and systems that keep a
+/// client's copy of a container in step with the server's.
 #[derive(Component)]
 pub struct InventoryModule;
 
 impl Module for InventoryModule {
     fn module(world: &World) {
-        world.component::<OpenInventory>();
-        world.component::<InventoryState>();
-
-        world
-            .component::<Player>()
-            .add_trait::<(flecs::With, InventoryState)>();
+        world.import::<InventoryComponentsModule>();
 
         observer!(
             world,

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -280,6 +280,10 @@ impl Module for SimComponentsModule {
         // registration module, which a physics-only consumer can import without
         // the rest of the simulation.
         world.import::<projectile_motion::ProjectileComponentsModule>();
+        // The inventory types, so the `Player`-implies-`CursorItem` and
+        // `Player`-implies-`InventoryState` traits below have a registered
+        // component to point at.
+        world.import::<inventory::InventoryComponentsModule>();
         // Registers every remaining simulation component and sets the
         // `MetadataPrefabs` singleton, which `SimModule`'s observers read back
         // to pick a prefab base per entity kind.
@@ -438,12 +442,16 @@ fn register_components(world: &World) -> MetadataPrefabs {
     world.component::<ConfirmBlockSequences>();
     world.component::<animation::ActiveAnimation>();
 
-    world.component::<hyperion_inventory::PlayerInventory>();
-    world.component::<hyperion_inventory::CursorItem>();
-
+    // `PlayerInventory`, `CursorItem` and `InventoryState` are registered by
+    // `inventory::InventoryComponentsModule`, imported above. What belongs here
+    // is the other half: a `Player` carries all three, and that trait is a
+    // statement about `Player`, which this module owns.
     world
         .component::<Player>()
         .add_trait::<(flecs::With, hyperion_inventory::CursorItem)>();
+    world
+        .component::<Player>()
+        .add_trait::<(flecs::With, hyperion_inventory::InventoryState)>();
 
     prefabs
 }

--- a/crates/hyperion/src/spatial/mod.rs
+++ b/crates/hyperion/src/spatial/mod.rs
@@ -19,6 +19,31 @@ use super::{
     },
 };
 
+/// Registration module for the spatial index: the [`Spatial`] opt-in tag and
+/// the [`SpatialIndex`] singleton it feeds.
+///
+/// Registration only, per the flecs convention in the root `CLAUDE.md`. A
+/// consumer that wants to mark entities [`Spatial`] and read the index without
+/// the per-tick rebuild attached imports this; the rebuild lives in
+/// [`SpatialModule`].
+#[derive(Component)]
+pub struct SpatialComponentsModule;
+
+impl Module for SpatialComponentsModule {
+    fn module(world: &World) {
+        world.component::<Spatial>();
+        // `add_trait::<flecs::Singleton>()` before the `set`: a bare `set`
+        // stores the value without registering the type, which is the
+        // ENG-11000 abort in a dev build.
+        world
+            .component::<SpatialIndex>()
+            .add_trait::<flecs::Singleton>();
+        world.set(SpatialIndex::default());
+    }
+}
+
+/// Behavior module for the spatial index: the `OnStore` pass that rebuilds the
+/// BVH from what moved this tick.
 #[derive(Component)]
 pub struct SpatialModule;
 
@@ -145,11 +170,12 @@ fn all_indexed_entities(world: &World) -> Vec<Entity> {
 //
 impl Module for SpatialModule {
     fn module(world: &World) {
-        world.component::<Spatial>();
-        world
-            .component::<SpatialIndex>()
-            .add_trait::<flecs::Singleton>();
-        world.set(SpatialIndex::default());
+        world.import::<SpatialComponentsModule>();
+        // The rebuild reads `Position` and `EntitySize` off every `Spatial`
+        // entity, so the module that registers them is imported here rather
+        // than assumed: a full boot happens to register them first, a
+        // standalone import of this module would not.
+        world.import::<crate::simulation::KinematicsComponentsModule>();
 
         system!("recalculate_spatial_index", world, &mut SpatialIndex,)
             .kind(id::<flecs::pipeline::OnStore>())

--- a/crates/hyperion/tests/registration_modules.rs
+++ b/crates/hyperion/tests/registration_modules.rs
@@ -1,0 +1,108 @@
+//! Dev-profile guard: every registration module stands on its own.
+//!
+//! The flecs convention (root `CLAUDE.md`) says a registration module can be
+//! imported into a bare world and leave every component it owns registered,
+//! with no systems and no engine boot. That is what makes "give me the types,
+//! not the behavior" expressible, and it is the property ENG-11000's class
+//! breaks: a component used before it is registered aborts a dev build with
+//! `ECS_INVALID_OPERATION` and compiles clean in release, so only a
+//! debug-assertions test like this one sees it.
+//!
+//! Each test imports exactly one registration module into an otherwise empty
+//! world and asks flecs which components exist. `get_component_id` answers
+//! without registering anything itself, so a dropped `world.component::<T>()`
+//! shows up as a failed assertion naming the type rather than as an abort with
+//! no attribution.
+
+use flecs_ecs::core::{ComponentId, World, WorldGet};
+use hyperion::{
+    egress::sync_chunks::{ChunkSendQueue, SyncChunksComponentsModule},
+    ingress::{
+        IngressComponentsModule, PendingRemove, ServerPingResponse,
+        decode::{DecodeComponentsModule, Decompressor},
+    },
+    simulation::inventory::InventoryComponentsModule,
+    spatial::{Spatial, SpatialComponentsModule, SpatialIndex},
+};
+use hyperion_inventory::{CursorItem, InventoryState, OpenInventory, PlayerInventory};
+use serial_test::serial;
+
+/// Asserts `T` is registered in `world` without registering it as a side
+/// effect, which a plain `id::<T>()` or `set` would do.
+fn assert_registered<T: ComponentId>(world: &World) {
+    assert!(
+        world.get_component_id::<T>().is_some(),
+        "{} should be registered by its registration module alone",
+        core::any::type_name::<T>()
+    );
+}
+
+#[test]
+#[serial]
+fn spatial_components_module_registers_the_index_standalone() {
+    let world = World::new();
+    world.import::<SpatialComponentsModule>();
+
+    assert_registered::<Spatial>(&world);
+    assert_registered::<SpatialIndex>(&world);
+    // The singleton default has to be installed by the same module that
+    // registers the type. A `get` of an unset or unregistered singleton is the
+    // dev-build abort, so reaching it at all is the assertion.
+    world.get::<&SpatialIndex>(|_| ());
+
+    // The other half of the convention: registration carries no behavior, so
+    // the rebuild system that `SpatialModule` installs must not be here.
+    assert!(
+        world.try_lookup("recalculate_spatial_index").is_none(),
+        "a registration module must install no systems"
+    );
+}
+
+#[test]
+#[serial]
+fn decode_components_module_registers_the_frame_path_standalone() {
+    let world = World::new();
+    world.import::<DecodeComponentsModule>();
+
+    assert_registered::<packet_channel::Receiver>(&world);
+    assert_registered::<Decompressor>(&world);
+    world.get::<&Decompressor>(|_| ());
+}
+
+#[test]
+#[serial]
+fn sync_chunks_components_module_registers_the_queue_standalone() {
+    let world = World::new();
+    world.import::<SyncChunksComponentsModule>();
+
+    assert_registered::<ChunkSendQueue>(&world);
+    world.entity().set(ChunkSendQueue::default());
+}
+
+#[test]
+#[serial]
+fn inventory_components_module_registers_every_inventory_type_standalone() {
+    let world = World::new();
+    world.import::<InventoryComponentsModule>();
+
+    // All four, because `SimComponentsModule` declares `Player`-implies-
+    // `CursorItem` and `Player`-implies-`InventoryState` traits that point at
+    // two of them: a relation target has to be a registered entity first.
+    assert_registered::<PlayerInventory>(&world);
+    assert_registered::<CursorItem>(&world);
+    assert_registered::<InventoryState>(&world);
+    assert_registered::<OpenInventory>(&world);
+
+    world.entity().set(PlayerInventory::default());
+}
+
+#[test]
+#[serial]
+fn ingress_components_module_registers_the_inbound_edge_standalone() {
+    let world = World::new();
+    world.import::<IngressComponentsModule>();
+
+    assert_registered::<PendingRemove>(&world);
+    assert_registered::<ServerPingResponse>(&world);
+    world.get::<&ServerPingResponse>(|_| ());
+}


### PR DESCRIPTION
Part of ENG-11053, the remainder of the flecs registration/behavior split the
convention in the root `CLAUDE.md` describes (ENG-11000, #1069, #1073).

Five modules that mixed component registration with behavior are now two modules
each. The behavior half imports the registration half, so flecs's import DAG runs
every `world.component::<T>()` before any system that reads `T` is declared.

New registration modules and what each owns:

- `SpatialComponentsModule`: `Spatial`, `SpatialIndex` singleton + default
- `DecodeComponentsModule`: `packet_channel::Receiver`, `Decompressor` singleton
- `SyncChunksComponentsModule`: `ChunkSendQueue`
- `InventoryComponentsModule`: `PlayerInventory`, `CursorItem`, `InventoryState`, `OpenInventory`
- `IngressComponentsModule`: `PendingRemove`, `ServerPingResponse` singleton

The inventory split moves ownership rather than relabelling it. `PlayerInventory`
and `CursorItem` were registered in `simulation/mod.rs`, `InventoryState` by the
behavior module, so nobody could import "the inventory types" without the packet
systems. All four now live in `InventoryComponentsModule`, which imports nothing.
The two `Player`-implies-inventory traits stay with `Player` in
`SimComponentsModule`, which imports it: a trait and the component it points at
can no longer be registered out of order.

The behavior modules also import `KinematicsComponentsModule` where their systems
read `Position`, `Yaw`, `Pitch` or `EntitySize`. A full boot happens to register
those first; a standalone import of one behavior module did not, which is the
same latent shape ENG-11000 shipped.

## The guard, watched failing

`crates/hyperion/tests/registration_modules.rs` imports one registration module
per test into a bare world and asks flecs which components exist through
`get_component_id`, which answers without registering anything itself.

I deleted a single line, `world.component::<InventoryState>()`, and watched both
halves of the gate go red:

```
$ cargo test -p hyperion --test registration_modules
thread 'inventory_components_module_registers_every_inventory_type_standalone' panicked at
  crates/hyperion/tests/registration_modules.rs:33:5:
hyperion_inventory::InventoryState should be registered by its registration module alone
test result: FAILED. 4 passed; 1 failed

$ nix build .#checks.aarch64-darwin.smash-dev-boot-e2e
hyperion-smash-dev-boot-e2e> ECS_INVALID_OPERATION: Component hyperion_inventory::InventoryState is not registered with the world before usage
error: Cannot build '/nix/store/l3ds5k1bwkrc4g70ma41ng7y65jbakph-hyperion-smash-dev-boot-e2e.drv'.
```

Then restored the line and confirmed green.

## Verification

- `checks.smash-dev-boot-e2e`, `checks.bedwars-dev-boot-e2e`: green
- `checks.smash-bow-e2e`, `checks.bedwars-bow-e2e`: green
- `cargo clippy -p hyperion --all-targets -- -D warnings`: clean (on top of #1074)
- `cargo test -p smash -p bedwars`: 291 passed
- `cargo test -p hyperion` registration_modules, kinematics_base, spatial, collision, entity: green

The differential vanilla comparison was not run: no physics changed.

## Not in scope

The projectile components and the files a concurrent rewrite owns are untouched;
that rewrite adopts the convention natively. smash's `PlayerModule` mirror
`Position`/`Velocity` stay distinct from hyperion's pose types, as ENG-11053 says.

Remaining after this: 14 of the 19 modules ENG-11053 lists.
