### PR TITLE
fix: proxy could never resolve its game server

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1518,7 +1518,7 @@
           self.nixosModules.game-server
           self.nixosModules.proxy
           (
-            { lib, ... }:
+            { config, lib, ... }:
             {
               boot.loader.grub.enable = false;
               fileSystems."/" = {
@@ -1543,7 +1543,12 @@
 
               services.hyperion-proxy = {
                 enable = true;
-                gameServer = "hyperion-game.ix.internal:35565";
+                gameServer = {
+                  host = "hyperion-game.ix.internal";
+                  # Read off the game server rather than restated, so this
+                  # smoke test cannot pass while the two disagree.
+                  port = config.services.hyperion-game-server.port;
+                };
                 pki = {
                   rootCaCert = "/var/lib/hyperion-pki/root_ca.crt";
                   cert = "/var/lib/hyperion-pki/proxy.crt";

--- a/flake.nix
+++ b/flake.nix
@@ -1421,7 +1421,7 @@
                 }
 
                 expect "/bin/bedwars --ip :: --port 35565"
-                expect "/bin/hyperion-proxy '[::]:25565' --server hyperion-game.internal:35565"
+                expect "/bin/hyperion-proxy '[::]:25565' --server hyperion-game.ix.internal:35565"
                 expect "--root-ca-cert /var/lib/hyperion-pki/root_ca.crt --cert /var/lib/hyperion-pki/game.crt --private-key /var/lib/hyperion-pki/game_private_key.pem"
                 expect "--root-ca-cert /var/lib/hyperion-pki/root_ca.crt --cert /var/lib/hyperion-pki/proxy.crt --private-key /var/lib/hyperion-pki/proxy_private_key.pem"
 
@@ -1543,7 +1543,7 @@
 
               services.hyperion-proxy = {
                 enable = true;
-                gameServer = "hyperion-game.internal:35565";
+                gameServer = "hyperion-game.ix.internal:35565";
                 pki = {
                   rootCaCert = "/var/lib/hyperion-pki/root_ca.crt";
                   cert = "/var/lib/hyperion-pki/proxy.crt";

--- a/nix/modules/proxy.nix
+++ b/nix/modules/proxy.nix
@@ -33,18 +33,39 @@ in
       '';
     };
 
-    gameServer = mkOption {
-      type = types.str;
-      example = "hyperion-game.ix.internal:35565";
-      description = ''
-        The game server, as `host:port`.
+    # Two typed fields rather than one `host:port` string. The string form
+    # made the port a second copy of `services.hyperion-game-server.port`,
+    # free to drift from it, and nothing rendered the pair in one place.
+    gameServer = {
+      host = mkOption {
+        type = types.str;
+        example = "hyperion-game.ix.internal";
+        description = ''
+          The game server's name.
 
-        This must be a name, not an address. The host part becomes the TLS
-        server name the proxy expects on the game server's certificate, so an
-        address here fails the handshake against a certificate issued for a
-        name, and the failure reads as a connection problem rather than a
-        naming one.
-      '';
+          This must be a name, not an address: it becomes the TLS server name
+          the proxy expects on the game server's certificate, so an address
+          here fails the handshake against a certificate issued for a name,
+          and the failure reads as a connection problem rather than a naming
+          one.
+
+          It must also be a name the guest can resolve. On ix that is the
+          `ix.internal` zone; a bare `.internal` is not a zone ix serves, so
+          it is forwarded upstream and returns NXDOMAIN.
+        '';
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 35565;
+        description = ''
+          The port the game server listens on.
+
+          Where both services evaluate together, set this from
+          `config.services.hyperion-game-server.port` rather than repeating
+          the number, so the two cannot disagree.
+        '';
+      };
     };
 
     openFirewall = mkOption {
@@ -74,7 +95,7 @@ in
         ExecStart = escapeShellArgs ([
           "${cfg.package}/bin/${cfg.package.meta.mainProgram}"
           cfg.listen
-          "--server" cfg.gameServer
+          "--server" "${cfg.gameServer.host}:${toString cfg.gameServer.port}"
           "--root-ca-cert" (toString cfg.pki.rootCaCert)
           "--cert" (toString cfg.pki.cert)
           "--private-key" (toString cfg.pki.privateKey)

--- a/nix/modules/proxy.nix
+++ b/nix/modules/proxy.nix
@@ -35,7 +35,7 @@ in
 
     gameServer = mkOption {
       type = types.str;
-      example = "hyperion-game.internal:35565";
+      example = "hyperion-game.ix.internal:35565";
       description = ''
         The game server, as `host:port`.
 


### PR DESCRIPTION
The proxy has never been able to resolve its upstream. Two commits: the
one-word fix, then the removal of the duplication that let it go stale.

## The bug

`services.hyperion-proxy.gameServer` was `hyperion-game.internal:35565`.
`.internal` is not a zone ix serves — the guest-facing zone is
`ix.internal` — so the name is forwarded upstream and returns NXDOMAIN.
Observed on `hyperion-proxy-0`, restart counter **33**:

```
hyperion-proxy[1618555]: Error: Custom { kind: Uncategorized,
  error: "failed to lookup address information: Name or service not known" }
systemd[1]: hyperion-proxy.service: Main process exited, code=exited, status=1/FAILURE
```

The deployed unit already carried the correct `hyperion-game.ix.internal:35565`.
The repo was the stale side, not the running VM.

Authoritative in three independent places in the ix repo:
`crates/ix/sdk-core/src/overlay.rs:57`,
`crates/net/overlay-client/src/dns.rs:14` (`const ZONE = "ix.internal."`),
and `docs/dns/common.md:110`.

## Why the second commit exists

Fixing the string alone would have replaced the same literal in three
places and left the reason it drifted. `gameServer` was a hand-assembled
`host:port` string whose port was a second copy of
`services.hyperion-game-server.port`, free to diverge from it, with no
single place rendering the pair.

It is now two typed fields — `host` (`types.str`) and `port`
(`types.port`) — and the module is the only thing that renders
`"${host}:${toString port}"`. The smoke test reads the port off
`config.services.hyperion-game-server.port` instead of restating it.

## Verification, with the control

The obvious eval does not distinguish the two cases: 35565 is the
default on both sides, so that output is equally consistent with the
value being derived and with it being hardcoded.

```
$ nix eval ... module-smoke-test ... hyperion-proxy ... ExecStart
  --server hyperion-game.ix.internal:35565

$ ... extendModules { services.hyperion-game-server.port = 44444; }
  --server hyperion-game.ix.internal:44444
```

The second line is the claim.

## What this does not fix

**The zone is still unreachable, for a different reason.** `ix-dns`
fails to bind its group gateway listener because the systemd
`SocketBindAllow` list omits `ipv6:udp:53`, so TCP/53 is refused and
UDP/53 times out on every host. ENG-11131, fix in ix#9095. This change
is necessary and not sufficient.

**Cross-host east-west is separately broken.** The group overlay's
forwarding database has no remote peers, so multicast neighbour
discovery never leaves the host and a cross-host ULA connect returns
`EHOSTUNREACH`. Measured just now from `hyperion-proxy-0`
(hil-compute-1) to `hyperion-game` (hil-compute-3): cross-host fails
with the neighbour entry in `FAILED`, same-host succeeds with a resolved
`lladdr`. ix#9073.

**`flake.nix:1424` still asserts the argv by copying the string from the
config it checks.** It pins flag spelling and argument order, which is
its stated purpose, but it cannot catch a wrong value — it passed with
the wrong zone. It is stronger than it was, because the value it
compares against is now derived rather than hand-typed on both sides,
but the structural gap remains and a reviewer should know it.

(sent by an AI agent via Claude Code)
