### PR TITLE
test(tools): a wire assertion must be its own wait

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,17 @@
           # a `nix flake check` can afford.
           kitSkinPython = pkgs.python3.withPackages (python: [ python.cryptography ]);
 
+          # The client scripts, plus the rule they are held to. Narrow on
+          # purpose: a check whose input is the whole tree reruns on every
+          # commit and stops being cheap.
+          wireAssertionSource = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              ./nix/verify-wire-assertions.py
+              ./tools
+            ];
+          };
+
           # The files the skin check reads: the payloads, Mojang's keys, and the
           # kit sources that declare which payload is whose. Narrow on purpose,
           # so editing an unrelated Rust file does not rebuild the check.
@@ -1338,6 +1349,21 @@
             smash-hotbar-e2e-app = scripts.smash-hotbar-e2e;
             smash-hud-e2e-app = scripts.smash-hud-e2e;
             oob-move-e2e-app = scripts.oob-move-e2e;
+
+            # A gate script may not wait on one packet and assert on the next.
+            # The failure that shipped read as a server bug for an afternoon:
+            # `smash-selector-e2e` reported an action bar the server had sent
+            # 0.2 ms earlier, because the wait was keyed on the chat line in
+            # front of it. See nix/verify-wire-assertions.py.
+            wire-assertions-are-their-own-wait =
+              pkgs.runCommand "hyperion-wire-assertions-are-their-own-wait"
+                {
+                  nativeBuildInputs = [ pkgs.python3 ];
+                }
+                ''
+                  python3 ${wireAssertionSource}/nix/verify-wire-assertions.py \
+                    ${wireAssertionSource} | tee "$out"
+                '';
 
             # Every kit's skin, checked offline against Mojang's committed
             # public keys. A derivation rather than only an app, because the

--- a/nix/verify-wire-assertions.py
+++ b/nix/verify-wire-assertions.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""A wire assertion must be its own wait.
+
+The class of bug this refuses is the one that shipped as
+`smash-selector-e2e` failing with "the action bar never said so: []" while
+the server had sent the line 0.2 ms earlier (CI run 30500640846). The check
+waited on `client.kit`, which is set from the chat packet, and then asserted
+on `client.action_bar`, which is the packet after it. `drain` takes one
+`recv` per pump, so a burst split across two reads satisfies the wait with
+the asserted-on packet still in flight.
+
+That reads exactly like a server defect and sends somebody into the wrong
+code for an afternoon, which is what makes it worth a check of its own
+rather than a note in review. The rule:
+
+    an assertion about a field the packet handler fills must be preceded,
+    in the same function, by a wait whose predicate reads that same field.
+
+A field this file has never heard of is ignored, and a field is only under
+the rule when a packet handler is what fills it, because those are exactly
+the fields with a "has not arrived yet" state.
+
+The escape hatch is a comment on the failing line or the line above:
+
+    # not-a-wire-assertion: <why this is not about a packet>
+
+with the reason required. A bare marker is a mute button, so the reason is
+part of the syntax and an empty one is itself an error.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+import sys
+
+# Methods that take a predicate and poll it. The predicate is the first
+# argument; nothing here cares about the timeout.
+WAITERS = frozenset({"wait_until", "must_become", "must_not_become"})
+
+# Where packets are decoded. A field is "observed" if one of these fills it,
+# which is derived rather than listed: a new packet handler brings its field
+# under the rule the day it lands, and a renamed field cannot leave a stale
+# entry behind.
+HANDLERS = frozenset({"handle", "on_chat", "dispatch", "consume"})
+
+MUTATORS = frozenset({"append", "extend", "update", "add", "setdefault", "clear"})
+
+MARKER = re.compile(r"#\s*not-a-wire-assertion:(?P<reason>.*)$")
+
+
+def attribute_names(node):
+    """Every `<anything>.name` read anywhere under `node`."""
+    return {n.attr for n in ast.walk(node) if isinstance(n, ast.Attribute)}
+
+
+def self_calls(node):
+    """Every `self.method(...)` called under `node`."""
+    out = set()
+    for call in ast.walk(node):
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        if (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "self"
+        ):
+            out.add(func.attr)
+    return out
+
+
+def observed_fields(tree):
+    """The fields a packet handler in this file fills."""
+    found = set()
+    for fn in ast.walk(tree):
+        if not isinstance(fn, ast.FunctionDef) or fn.name not in HANDLERS:
+            continue
+        for node in ast.walk(fn):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in MUTATORS
+                and isinstance(node.func.value, ast.Attribute)
+            ):
+                found.add(node.func.value.attr)
+            if isinstance(node, (ast.Assign, ast.AugAssign)):
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                for target in targets:
+                    if isinstance(target, ast.Attribute):
+                        found.add(target.attr)
+                    elif isinstance(target, ast.Subscript) and isinstance(
+                        target.value, ast.Attribute
+                    ):
+                        found.add(target.value.attr)
+    return found
+
+def waits_of(fn, observed):
+    """Observed fields the waits written inside `fn` poll on."""
+    waited = set()
+    for call in ast.walk(fn):
+        if (
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr in WAITERS
+            and call.args
+        ):
+            waited |= attribute_names(call.args[0]) & observed
+    return waited
+
+
+def summarise(tree, observed):
+    """For each method, the fields its own waits cover, to a fixpoint.
+
+    Waits propagate through `self` calls and reads deliberately do not. A
+    helper that waits, like `ask_podiums`, has to credit its caller, or every
+    function that reads an answer somebody else waited for is a false report.
+    Reads travelling the same edges is what makes the analysis useless: every
+    wait reaches `pump` reaches `handle`, which reads every field there is, so
+    propagating reads would make every assertion depend on everything.
+
+    The cost of not propagating reads is real and worth naming: an assertion
+    whose field is reached only through a helper is not seen by this rule. It
+    catches the shape where the field is in front of you, which is the shape
+    that shipped.
+    """
+    methods = {
+        fn.name: fn for fn in ast.walk(tree) if isinstance(fn, ast.FunctionDef)
+    }
+    direct = {name: waits_of(fn, observed) for name, fn in methods.items()}
+    calls = {name: self_calls(fn) & set(methods) for name, fn in methods.items()}
+
+    waits = {name: set(value) for name, value in direct.items()}
+    changed = True
+    while changed:
+        changed = False
+        for name in methods:
+            grown = set(direct[name])
+            for callee in calls[name]:
+                if callee != name:
+                    grown |= waits[callee]
+            if grown != waits[name]:
+                waits[name] = grown
+                changed = True
+    return waits, methods
+
+
+def is_failure(call):
+    """`self.fail(...)`, or an append onto something named for failures."""
+    if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Attribute):
+        return False
+    if call.func.attr == "fail":
+        return True
+    if call.func.attr != "append":
+        return False
+    target = call.func.value
+    name = target.id if isinstance(target, ast.Name) else getattr(target, "attr", "")
+    return "failure" in name
+
+
+def enclosing_test(fn, call):
+    """The condition that leads to `call`, or None if it is unconditional."""
+    best = None
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.If):
+            continue
+        for branch in (node.body, node.orelse):
+            for stmt in branch:
+                for inner in ast.walk(stmt):
+                    if inner is call:
+                        if best is None or node.lineno > best.lineno:
+                            best = node
+    return best.test if best is not None else None
+
+def local_assignments(fn):
+    """`name = <expr>` inside `fn`, latest assignment wins per line order."""
+    out = {}
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name):
+                out.setdefault(target.id, []).append(node.value)
+    return out
+
+
+def fields_of(expr, observed, assignments, seen=None):
+    """Which observed fields `expr` reads directly.
+
+    Local names are followed into what they were assigned, because the shape
+    this rule is about hides the field behind exactly one: the assertion reads
+    `told`, and `told` is a comprehension over `client.action_bar`.
+    """
+    if seen is None:
+        seen = set()
+    fields = attribute_names(expr) & observed
+    for name in {n.id for n in ast.walk(expr) if isinstance(n, ast.Name)}:
+        if name in seen or name not in assignments:
+            continue
+        seen.add(name)
+        for value in assignments[name]:
+            fields |= fields_of(value, observed, assignments, seen)
+    return fields
+
+
+def waited_before(fn, line, observed, waits):
+    """Observed fields some wait earlier in `fn` has already covered."""
+    covered = set()
+    for call in ast.walk(fn):
+        if not isinstance(call, ast.Call) or call.lineno >= line:
+            continue
+        func = call.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        if func.attr in WAITERS and call.args:
+            covered |= attribute_names(call.args[0]) & observed
+        elif (
+            isinstance(func.value, ast.Name)
+            and func.value.id == "self"
+            and func.attr in waits
+        ):
+            # A helper that waits counts for its caller: `ask_podiums` polls
+            # `client.podiums` itself, and the caller that reads the answer
+            # never writes a wait of its own.
+            covered |= waits[func.attr]
+    return covered
+
+
+def marker_reason(lines, line):
+    """The escape hatch's reason, `None` if unmarked, `""` if left blank.
+
+    Searched on the failing line and up through the comment block directly
+    above it, so a reason too long for one line can be written as a paragraph
+    like every other comment here rather than crammed onto one.
+    """
+    candidate = line
+    while 1 <= candidate <= len(lines):
+        found = MARKER.search(lines[candidate - 1])
+        if found:
+            return found.group("reason").strip()
+        candidate -= 1
+        if candidate < 1 or not lines[candidate - 1].lstrip().startswith("#"):
+            break
+    return None
+
+
+def check(path):
+    text = path.read_text()
+    lines = text.splitlines()
+    tree = ast.parse(text)
+    observed = observed_fields(tree)
+    if not observed:
+        return []
+
+    waits, methods = summarise(tree, observed)
+    problems = []
+    for name, fn in methods.items():
+        # Only a function that waits at all. One that does not is reading a
+        # fact somebody else established, and the bug this refuses is not
+        # "forgot to wait", it is "waited, and for the wrong packet". Flagging
+        # the rest is how a check becomes noise and the escape hatch becomes a
+        # mute button.
+        if not waits_of(fn, observed):
+            continue
+        assignments = local_assignments(fn)
+        for call in ast.walk(fn):
+            if not is_failure(call):
+                continue
+            test = enclosing_test(fn, call)
+            subject = test if test is not None else ast.Tuple(elts=list(call.args))
+            fields = fields_of(subject, observed, assignments)
+            missing = fields - waited_before(fn, call.lineno, observed, waits)
+            reason = marker_reason(lines, call.lineno)
+            if reason == "":
+                problems.append(
+                    "%s:%d: `not-a-wire-assertion` with no reason after the colon. "
+                    "The reason is the point: say which non-wire thing this asserts."
+                    % (path.name, call.lineno)
+                )
+                continue
+            if reason is not None:
+                continue
+            if missing:
+                problems.append(
+                    "%s:%d: in `%s`, this fails on %s, which the packet handler "
+                    "fills, and no wait before it reads %s. Wait on the field you "
+                    "assert on (`must_become`), or mark the line "
+                    "`# not-a-wire-assertion: <why>`."
+                    % (
+                        path.name,
+                        call.lineno,
+                        name,
+                        ", ".join("`%s`" % f for f in sorted(missing)),
+                        "it" if len(missing) == 1 else "them",
+                    )
+                )
+    return problems
+
+
+def main():
+    root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else ".")
+    tools = sorted((root / "tools").glob("*.py"))
+    if not tools:
+        print("no client scripts under %s/tools" % root)
+        return 1
+
+    problems = []
+    for path in tools:
+        try:
+            problems.extend(check(path))
+        except SyntaxError as error:
+            problems.append("%s: does not parse: %s" % (path.name, error))
+
+    for problem in problems:
+        print(problem)
+    print("")
+    print("%d client scripts checked, %d problems" % (len(tools), len(problems)))
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/smash-selector.py
+++ b/tools/smash-selector.py
@@ -561,6 +561,31 @@ class Run:
             self.fail("timed out after %.0fs waiting for %s" % (seconds, why))
         return False
 
+    def must_become(self, predicate, seconds, message):
+        """Wait for `predicate`, and fail with `message` if it never holds.
+
+        The predicate is the assertion, which is the whole point: waiting on
+        one packet and asserting on another is how `smash-selector-e2e` came
+        to report an action bar the server had already sent. See
+        nix/verify-wire-assertions.py, which refuses that shape.
+        """
+        if self.wait_until(predicate, seconds):
+            return True
+        self.fail(message() if callable(message) else message)
+        return False
+
+    def must_not_become(self, predicate, seconds, message):
+        """Fail if `predicate` ever holds inside the window.
+
+        The other polarity, and it is not `settle` then look: this fails the
+        instant the bad thing happens rather than only if it is still true at
+        the end, and it still waits the full window before passing.
+        """
+        if self.wait_until(predicate, seconds):
+            self.fail(message() if callable(message) else message)
+            return False
+        return True
+
     def settle(self, seconds):
         deadline = time.time() + seconds
         while time.time() < deadline:
@@ -1158,20 +1183,17 @@ class Run:
         # across two reads satisfies the wait above while the action bar is
         # still on its way. Run 30500640846 recorded the failure at
         # 00:21:41.7509285 and logged the line it was waiting for at
-        # 00:21:41.7511018. Waiting on the packet the claim is about, rather
-        # than on the one that happens to precede it, is the whole fix: the
-        # bytes had not reached the client, so no amount of draining harder
-        # would have found them.
-        self.wait_until(
-            lambda: any(entry["kit"] in line for line in client.action_bar), 10.0
-        )
-        told = [line for line in client.action_bar if entry["kit"] in line]
-        if not told:
-            self.fail(
-                "%s picked the %s and the action bar never said so: %r"
-                % (client.name, entry["kit"], client.action_bar)
-            )
+        # 00:21:41.7511018. The bytes had not reached the client, so no amount
+        # of draining harder would have found them; the only fix is to wait on
+        # the packet the claim is about.
+        if not self.must_become(
+            lambda: any(entry["kit"] in line for line in client.action_bar),
+            10.0,
+            lambda: "%s picked the %s and the action bar never said so: %r"
+            % (client.name, entry["kit"], client.action_bar),
+        ):
             return entry
+        told = [line for line in client.action_bar if entry["kit"] in line]
         self.prove(
             "a right-click on a podium picks that mob",
             "%s right-clicked %s and the server answered %r"
@@ -1323,6 +1345,9 @@ class Run:
         podiums = self.ask_podiums(self.live()[0])
         free = [entry for entry in podiums if entry["held_by"] is None]
         if len(free) < len(waiting):
+            # not-a-wire-assertion: this counts the lobby against the ring.
+            # `kit` is only how "has not picked yet" is spelled here, and no
+            # packet arriving a moment later can make the count wrong.
             self.fail(
                 "a lobby of %d has only %d free mobs left"
                 % (len(self.live()), len(free))
@@ -1415,20 +1440,27 @@ class Run:
         # about the phase rule rather than about reach, so the click is sent
         # from wherever the scatter put the player.
         client.right_click(self.click_at(other), "(%s, mid-match)" % other["kit"])
-        self.settle(1.0)
-        if client.kit != held:
-            self.fail(
-                "%s clicked a podium mid-match and changed from %s to %s"
-                % (client.name, held, client.kit)
-            )
+        # Both halves waited for rather than slept on. `settle(1.0)` guessed a
+        # second, and a second was generous enough that this never failed; the
+        # same guess at zero is what made the selection announcement flaky.
+        # The kit one is the negative polarity, which is not "sleep and look":
+        # it fails the instant the kit changes and still waits the full second
+        # before believing it did not.
+        if not self.must_not_become(
+            lambda: client.kit != held,
+            1.0,
+            lambda: "%s clicked a podium mid-match and changed from %s to %s"
+            % (client.name, held, client.kit),
+        ):
+            return
+        if not self.must_become(
+            lambda: any("cannot change kit" in line for line in client.action_bar),
+            10.0,
+            lambda: "a mid-match click was ignored rather than refused: %r"
+            % client.action_bar,
+        ):
             return
         told = [line for line in client.action_bar if "cannot change kit" in line]
-        if not told:
-            self.fail(
-                "a mid-match click was ignored rather than refused: %r"
-                % client.action_bar
-            )
-            return
         self.prove(
             "a click after the match commits is refused",
             "%s clicked the %s while playing the %s and was told %r"


### PR DESCRIPTION
`smash-selector-e2e` failed in CI with exactly one assertion:

    FAILED S1 picked the Skeleton and the action bar never said so: []

The server had sent that line. Run 30500640846 recorded the failure at
`00:21:41.7509285` and logged the line it was waiting for at
`00:21:41.7511018`:

```
00:21:41.7508758  15.94s [S1 ] <- chat: Kit set to Skeleton.
00:21:41.7509285  15.94s      FAILED S1 picked the Skeleton and the action bar never said so: []
00:21:41.7511018  15.94s [S1 ] <- action bar: You are the Skeleton.
```

The check waited on `client.kit`, which is set from the chat packet
`lobby::choose` sends one ahead of the action bar, and `drain` takes a single
`recv` per pump, so a burst split across two reads satisfies the wait with the
asserted-on packet still in flight. Production code was not at fault.

That fix landed on its own in #1083. This is the rule that stops it recurring.

## What this adds

`nix/verify-wire-assertions.py`, wired in as a flake check so the subtractive
gate in `nix/ci/flake-gate.nix` picks it up without anybody adding it anywhere.
The rule: an assertion about a field the packet handler fills must be preceded,
in the same function, by a wait whose predicate reads that same field.
`must_become` and `must_not_become` make the predicate the assertion, so waiting
on one thing and asserting on another is not expressible through them.

The rule is deliberately narrow. It only looks at functions that wait at all,
because the bug is not "forgot to wait", it is "waited, and for the wrong
packet". The observed field set is derived from what the packet handlers fill
rather than listed, so a new handler brings its field under the rule the day it
lands. Two limits are documented in the script: it does not follow a field
through a helper call, and it says nothing about functions that never wait.

## What it flags today, and what I did with it

Three sites, which is what the rule reports on this tree rather than a set I
picked. I deliberately did not hand-convert the other 64 assertions: that diff
is mechanical, and a conversion with a subtly wrong predicate turns a real
assertion into one that cannot fail while the gate stays green.

| site | verdict |
| --- | --- |
| `a_click_picks_the_mob` | the shipped bug, now `must_become` |
| the mid-match refusal | real: slept `settle(1.0)` where a second happened to be generous. Now `must_not_become` for the kit and `must_become` for the refusal |
| the lobby-count assertion | false positive. Takes the escape hatch, with a reason |

The escape hatch is `# not-a-wire-assertion: <why>` and the reason is part of
the syntax: a marker with nothing after the colon is itself an error, because a
bare marker is a mute button.

## Break-it results

The lint was broken three ways and watched, through the real flake check. Three
cases and not one, because a rule that rejects everything passes the
reject-the-bad-thing test perfectly: the first version of this script flagged 67
of 67 assertion sites.

- rejects the shape that shipped: `smash-selector.py:1191: in a_click_picks_the_mob, this fails on action_bar, which the packet handler fills, and no wait before it reads it.`
- accepts a correct `must_become`: `14 client scripts checked, 0 problems`
- rejects a marker with no reason: `smash-selector.py:1349: not-a-wire-assertion with no reason after the colon. The reason is the point: say which non-wire thing this asserts.`

Because two live assertions changed, the gate they live in was re-run rather
than trusted: `nix build .#checks.x86_64-linux.smash-selector-e2e`, rc=0, with
both converted claims passing.

## Enforcement, stated plainly

The check runs in CI automatically via the `Flake` job and nobody has to
remember it. It does not *block* a merge: ruleset 566717 on `main` carries no
`required_status_checks` rule, so no check in this repository is a required
context and a red gate is enforced by somebody noticing. ENG-10827.
