### PR TITLE
test(smash): the selector check waits for the packet it asserts on

### DIFF
--- a/tools/smash-selector.py
+++ b/tools/smash-selector.py
@@ -1152,16 +1152,30 @@ class Run:
             "%s to be playing the %s" % (client.name, entry["kit"]),
         ):
             return None
+        # And then for the announcement, separately. `client.kit` is read off
+        # the chat line, which `lobby::choose` sends one packet ahead of the
+        # action bar, and `drain` takes a single `recv` per pump: a burst split
+        # across two reads satisfies the wait above while the action bar is
+        # still on its way. Run 30500640846 recorded the failure at
+        # 00:21:41.7509285 and logged the line it was waiting for at
+        # 00:21:41.7511018. Waiting on the packet the claim is about, rather
+        # than on the one that happens to precede it, is the whole fix: the
+        # bytes had not reached the client, so no amount of draining harder
+        # would have found them.
+        self.wait_until(
+            lambda: any(entry["kit"] in line for line in client.action_bar), 10.0
+        )
         told = [line for line in client.action_bar if entry["kit"] in line]
         if not told:
             self.fail(
                 "%s picked the %s and the action bar never said so: %r"
                 % (client.name, entry["kit"], client.action_bar)
             )
+            return entry
         self.prove(
             "a right-click on a podium picks that mob",
             "%s right-clicked %s and the server answered %r"
-            % (client.name, self.click_at(entry), told or client.action_bar),
+            % (client.name, self.click_at(entry), told),
         )
         return entry
 


### PR DESCRIPTION
`smash-selector-e2e` fails intermittently with

    FAILED S1 picked the Skeleton and the action bar never said so: []

and the line it says never arrived is in the same log **0.2 ms later**.

The server is not at fault. `lobby::choose` sends two packets, a chat line
and then a separate `Channel::ActionBar` line. The check waited on
`client.kit`, which `on_chat` sets from the *first* of the two, then read
the action bar with no further wait. The harness reads one packet per pump,
so a burst split across two reads leaves the second packet still on the wire
when the assertion runs. Draining harder would not help; the bytes had
genuinely not arrived.

Every other action bar assertion in the suite either settles first or waits
on the action bar itself. This was the only one keying its wait on a
different packet that merely precedes the one it asserts on.

Proved in **both** directions on a Linux builder, because the unfixed tree
also passes on a good run and one green run here proves nothing:

  fixed      PASS ... the server answered ['You are the Skeleton.']
  negative   with the `Channel::ActionBar` send deleted from `lobby::choose`,
             rc=1, failing after the full 10 s wait rather than passing
             vacuously

That the negative control was necessary rather than merely thorough is now
measured: `smash-hud-e2e` and `smash-selector-e2e` each failed one CI run
and passed the next on effectively the same tree. Two of five failures in
that suite are coin flips.

Split out of #1082 deliberately. That PR carries this fix plus a 322 line
static analyzer that stops the whole class being written again, and the
analyzer deserves an unhurried review. This half is costing a 35 to 90
minute CI run every time it fires and reads as a server bug to whoever sees
it next, so it should not wait on the discretionary half.

Diagnosed, fixed and controlled by a subagent; the negative control was its
own idea. Split and landed by me.

(sent by an AI agent via Claude Code)