### PR TITLE
perf(ci): flake gate realises every check in one concurrent nix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,12 @@ jobs:
   flake:
     name: Flake
     runs-on: ubuntu-latest
-    # A runner-level guard, not a target. The gate builds every check serially
-    # from a cold hosted store; the bedwars binary alone measured 620 to 670
-    # seconds across four runs on 2026-07-28 and everything else is minutes.
+    # A runner-level guard, not a target. The gate realises every check from a
+    # cold hosted store in one `nix build --keep-going`, so nix schedules them
+    # up to `max-jobs` (auto, four here) rather than one at a time. The floor is
+    # the release compile plus the longest single gate behind it: on run
+    # 30500640846 that was roughly 500 seconds of crate graph and then
+    # `smash-e2e` at 639.
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4

--- a/nix/ci/flake-gate.nix
+++ b/nix/ci/flake-gate.nix
@@ -101,9 +101,75 @@ let
           ${reasonArms}esac
       }
 
-      build() {
-        nix build --accept-flake-config --no-link --print-build-logs \
-          "$flake#checks.${system}.$1"
+      # One `nix build` for the whole set, rather than one per name.
+      #
+      # The checks ran strictly one after another and nothing about a check
+      # needs the machine to itself, so all the serialisation bought was wall
+      # clock. Measured on GitHub Actions run 30500640846: 67 checks, 2102
+      # seconds, of which `smash-e2e` was 639 and `bedwars-bow-e2e` was 546.
+      # The other 65 queued behind those two, and 55 of the 67 were under 20
+      # seconds each.
+      #
+      # Concurrency is nix's own `max-jobs` and is deliberately not pinned
+      # here. `nix-installer-action` writes `max-jobs = auto`, so on the hosted
+      # runner it is the core count -- four, which the hud gate reads back off
+      # the same machine as `CPU 2% of 400%`. A number written into this script
+      # would be that machine's number on everybody else's. It also does not
+      # raise the ceiling: one `nix build` of one e2e check already scheduled
+      # its crate units four wide, so four is what the compile phase ran at
+      # before this. What changes is that whole checks overlap, and an e2e gate
+      # spends its time waiting on a server to boot rather than on a core.
+      #
+      # `--keep-going` is load bearing. Without it the first failed check
+      # abandons the rest, and every name after it would report as failed
+      # having never been attempted -- the opposite of the complete report the
+      # loops below exist to produce.
+      #
+      # The cost, named: an evaluation error in any one check now aborts the
+      # command before anything builds, so every name reports FAILED where only
+      # the broken one used to. nix prints the eval error with the offending
+      # attribute in it immediately above the report, which is where to look
+      # when every name goes red at once.
+      installables=()
+      for name in "''${enforced[@]}" "''${excluded[@]}"; do
+        installables+=("$flake#checks.${system}.$name")
+      done
+
+      # `--print-build-logs` prefixes every line with the derivation that
+      # emitted it, which is what keeps interleaved logs attributable. The
+      # prefix is the derivation name and not the check name, so `smash-e2e`
+      # reads as `hyperion-smash-e2e`.
+      #
+      # The exit status is discarded on purpose: it says only that something
+      # failed, and which checks failed is the question the loops below answer
+      # per name. It is also the expected status whenever `excluded` is
+      # non-empty.
+      nix build --accept-flake-config --no-link --print-build-logs --keep-going \
+        "''${installables[@]}" || true
+
+      # Did this check pass? Asked of the store, never by building it again.
+      #
+      # `--max-jobs 0` forbids starting a local build, so this exits 0 exactly
+      # when the output is already realised and fails otherwise; `--builders ""`
+      # closes the same door for a contributor whose nix.conf names a remote
+      # builder. A plain `nix build` per name would instead rebuild every check
+      # that just failed, because a failed derivation is not in the store, and
+      # the slowest thing in the job would be paid for twice.
+      #
+      # Asked of nix rather than by comparing `.outPath` against the store,
+      # because cargoUnit content-addresses every crate unit and a derivation
+      # downstream of a content-addressed one has a deferred output path.
+      # `nix eval .#checks.${system}.smash-e2e.outPath` answers with a
+      # placeholder rather than a store path for 14 of the 67 checks, and those
+      # 14 are exactly the e2e gates.
+      #
+      # Output is dropped because the only thing on the failing path is nix
+      # explaining that it will not build with max-jobs 0, which is the answer
+      # rather than a problem. The build above is where a check says why it
+      # failed.
+      realised() {
+        nix build --accept-flake-config --no-link --max-jobs 0 --builders "" \
+          "$flake#checks.${system}.$1" > /dev/null 2>&1
       }
 
       status=0
@@ -112,7 +178,7 @@ let
       # Every failure is reported rather than the first one only, so a single
       # push can fix all of them.
       for name in "''${enforced[@]}"; do
-        if build "$name"; then
+        if realised "$name"; then
           echo "ok        $name"
         else
           echo "FAILED    $name"
@@ -122,7 +188,7 @@ let
       done
 
       for name in "''${excluded[@]}"; do
-        if build "$name"; then
+        if realised "$name"; then
           echo "STALE     $name"
           {
             echo "checks.${system}.$name is excluded from CI but now builds."


### PR DESCRIPTION
## The problem, measured

`Flake` is the slowest job in the repository. Per-check wall time computed from
the log timestamps of run
[30500640846](https://github.com/hyperion-mc/hyperion/actions/runs/30500640846):
**67 checks, 2102 seconds**.

| check | seconds | share |
| --- | --- | --- |
| smash-e2e | 639 | 30% |
| bedwars-bow-e2e | 546 | 26% |
| bedwars-dev-boot-e2e | 162 | |
| differential-traces | 149 | |
| smash-hud-e2e | 62 | |
| bedwars | 60 | |
| smash-selector-e2e | 48 | |
| 60 more | 436 | |

55 of the 67 were under 20 seconds each and every one of them waited its turn
behind the two that were not. The gate ran one `nix build` per name in two
`for` loops, so 67 flake evaluations and no overlap at all.

## What changed

One `nix build --keep-going` over all 67 installables. Nix schedules them
itself up to `max-jobs`, from one evaluation. `-L` prefixes every log line with
the derivation that emitted it, so concurrent logs stay attributable.

Per-check status then comes from `nix build --max-jobs 0 --builders ""`, which
exits 0 exactly when the output is already realised and refuses to start a
build otherwise. Two reasons it is written that way:

- A second per-name `nix build` would rebuild every check that just failed, so
  the slowest thing in the job would be paid for twice.
- It cannot be done by comparing `.outPath` against the store. cargoUnit
  content-addresses every crate unit, and a derivation downstream of a CA
  derivation has a *deferred* output path.
  `nix eval --json .#checks.x86_64-linux --apply 'cs: builtins.mapAttrs (_: c: c.outPath) cs'`
  answers with a placeholder for 14 of the 67, and those 14 are exactly the e2e
  gates. Verified: `--max-jobs 0` returns 1 before a deferred-output derivation
  is built and 0 after, without ever building it.

## Concurrency safety

The precondition was verified, not assumed.

- **The e2e checks do not use `e2eOffsets` at all.** `mkCheck` in `nix/e2e.nix`
  leaves `HYPERION_PLAYER_PORT` and `HYPERION_SERVER_PORT` unset, so the driver
  picks a free pair with `bind(('127.0.0.1', 0))`, holding both sockets open
  until both numbers are read. The offsets and `e2e-ports-distinct` govern the
  `nix run .#<name>-e2e` app wrappers, which the gate never runs.
- **On Linux each build has its own network namespace**, so two e2e gates
  cannot see each other's loopback whatever port they pick. `sandbox` is at its
  default and no check sets `__noChroot`.
- **No shared filesystem state.** Every path an e2e touches is under
  `$NIX_BUILD_TOP`: `HOME`, `XDG_CACHE_HOME`, `HYPERION_E2E_LOG`, and the
  `mktemp -t` client log via the sandbox's private `TMPDIR`.

**`max-jobs` is deliberately not pinned in the script.**
`nix-installer-action` writes `max-jobs = auto`, which on this runner is 4:
`smash-hud-e2e`'s own `/serverload` output in the run above reads
`CPU 2% of 400%` and `MEM 1.89 GiB of 15.6 GiB`. A number written into the
script would be that machine's number on everybody else's.

This does not raise the peak concurrency of the compile phase, which is where
the memory goes: a single `nix build` of one e2e check already scheduled its
crate units four wide. What is new is up to four e2e gates at once, and an e2e
gate is wall-clock bound rather than CPU bound (2% of one machine, most of it
waiting for a server to boot). 16 GiB across four game servers, four proxies
and their clients is comfortable; the compile and e2e phases barely overlap
anyway, because every e2e depends on a binary the compile produces.

## Predicted and measured

**Predicted before running anything: about 1150 s (19 min), range 1050 to
1300.** The floor is structural rather than a scheduling artifact. The release
crate graph must finish before `smash-e2e` can start, and on run 30500640846
that graph was the ~500 s inside `bedwars-bow-e2e`'s window (401+ derivations,
starting with `cargo-git-sources.toml`). `smash-e2e` itself built exactly one
derivation and spent all 639 s running it. 500 + 639 = 1139 s is the shortest
this DAG can be, and no amount of concurrency removes it.

**Measured: this PR's own `Flake` job.** See the comment below.

## Behaviour that did not change

Verified by running the gate over six real checks with the change in place
(aarch64-darwin, `names` trimmed to keep it cheap):

- All six pass: six `ok` lines, exit 0.
- One check deliberately broken (two gates given the same `e2eOffsets` value,
  which is what `e2e-ports-distinct` exists to catch), placed **first** in the
  list: `FAILED e2e-ports-distinct`, the five after it still `ok` (this is what
  `--keep-going` buys), `enforced checks that failed: e2e-ports-distinct` and
  the `reproduce one with:` hint unchanged, exit 1. The check's own diagnostic
  is in the log as `hyperion-e2e-ports-distinct> FAIL: these gates claim the
  same port offset: smash-bow-e2e, smash-skin-e2e`.
- Both `excluded` arms: a still-failing entry reports
  `excluded  <name> (still failing, on the evidence recorded for it)` with its
  reason and does not set the exit status; a passing entry reports
  `STALE <name>` with the delete-it message and exits 1.

The base of this branch has five genuinely failing enforced checks, so the CI
run on this PR is itself the multi-failure case rather than a synthetic one.

## The cost, stated

An evaluation error in any single check now aborts the one command before
anything builds, so every name reports FAILED where only the broken one used
to. nix prints the eval error naming the offending attribute immediately above
the report. This is written down in the file next to the code that causes it.
