### PR TITLE
test(hud): stop measuring the builder CPU jitter (ENG-11404)

### DIFF
--- a/crates/hyperion/src/egress/boss_bar.rs
+++ b/crates/hyperion/src/egress/boss_bar.rs
@@ -488,6 +488,89 @@ mod tests {
         ]);
     }
 
+    /// The whole of [`operation`]'s truth table: one field moved is that
+    /// field's own operation, two or more is a fresh `Add`, and nothing moved
+    /// is silence.
+    ///
+    /// A table here rather than only on the wire, because a gate cannot always
+    /// arrange to see a given transition. `smash-hud-e2e` used to read the
+    /// title-only case off the server's own CPU bar, which produces one only
+    /// when the host's load crosses a whole percent of a core, so on a quiet
+    /// 128-core builder that transition never happened inside the gate's
+    /// window and the check went red for the machine being idle. What the
+    /// table gives up is the wire itself, which is why `diff_check` in
+    /// `tools/hud-check.py` still reads every packet of a real run.
+    #[test]
+    fn one_field_moving_costs_that_field_and_two_cost_the_whole_bar() {
+        fn name(operation: Option<&BossEventOperation<'_>>) -> &'static str {
+            match operation {
+                None => "nothing",
+                Some(BossEventOperation::Add { .. }) => "add",
+                Some(BossEventOperation::Remove) => "remove",
+                Some(BossEventOperation::UpdateProgress(_)) => "update_progress",
+                Some(BossEventOperation::UpdateName(_)) => "update_name",
+                Some(BossEventOperation::UpdateStyle { .. }) => "update_style",
+                Some(BossEventOperation::UpdateProperties(_)) => "update_properties",
+            }
+        }
+
+        let before = Sent {
+            title: Text::text("before"),
+            progress: 0.25,
+            style: Style::default(),
+            effects: Effects::default(),
+        };
+        let after = Sent {
+            title: Text::text("after"),
+            progress: 0.5,
+            style: Style {
+                colour: BossBarColor::Red,
+                overlay: BossBarOverlay::Notched6,
+            },
+            effects: Effects(BossBarProperties::ALL),
+        };
+
+        // One bit per field, so every subset of the four is visited and not
+        // only the five the code spells out.
+        for moved in 0..16_u8 {
+            let mut now = before.clone();
+            if moved & 1 != 0 {
+                now.title = after.title.clone();
+            }
+            if moved & 2 != 0 {
+                now.progress = after.progress;
+            }
+            if moved & 4 != 0 {
+                now.style = after.style;
+            }
+            if moved & 8 != 0 {
+                now.effects = after.effects;
+            }
+            let expected = match moved {
+                0 => "nothing",
+                1 => "update_name",
+                2 => "update_progress",
+                4 => "update_style",
+                8 => "update_properties",
+                _ => "add",
+            };
+            assert_eq!(
+                name(operation(&before, &now).as_ref()),
+                expected,
+                "fields {moved:#06b}"
+            );
+        }
+
+        // And a narrow operation carries the new value and not the old, which
+        // the names above cannot tell apart.
+        let mut retitled = before.clone();
+        retitled.title = after.title.clone();
+        assert!(matches!(
+            operation(&before, &retitled),
+            Some(BossEventOperation::UpdateName(title)) if title == after.title
+        ));
+    }
+
     /// Deleting a viewer takes away what that viewer was told and leaves
     /// everybody else's bar alone.
     ///

--- a/tools/hud-check.py
+++ b/tools/hud-check.py
@@ -587,6 +587,10 @@ class Run:
                 % sorted({bar["colour"] for bar in counting_bars}),
             )
 
+        # Where the countdown's own packets begin, so the retitle claim below
+        # counts seconds passing and not the lobby's player count moving.
+        first_countdown_op = len(narrator.bar_ops)
+
         # The last three seconds, then the word that starts the match.
         started = self.until(lambda: "GO!" in narrator.titles, 120.0, "the match to start")
         if not self.check(started, "the start of the match is a title: %s" % narrator.titles):
@@ -606,6 +610,47 @@ class Run:
             len(drained) > 4 and drained == sorted(drained, reverse=True) and drained[-1] < 0.3,
             "the countdown bar drains towards the start rather than filling: %s"
             % [round(value, 3) for value in drained],
+        )
+
+        # An update sends only the update, read off the one bar in the game
+        # whose label moves to a clock the server owns. `whole_seconds` is a
+        # `ceil`, so the title changes on the tick the timer crosses a whole
+        # second, while the fill is quantised to sixty-fourths of the span and
+        # steps at its own rate: most of those seconds move the title and
+        # nothing else, and each has to cost one `UpdateName` carrying one
+        # field. The seconds where a fill step lands on the same tick are a
+        # two-field change and are allowed to be an `Add`, which is why this
+        # counts the label-only ones rather than requiring every second to be
+        # one.
+        #
+        # This claim used to be read off the CPU bar, where it needed the
+        # *host* to move a whole percent of a core inside twenty seconds. See
+        # `load_check` for why that made the gate a measurement of the builder.
+        #
+        # Not redundant with `diff_check`, though the two overlap on one
+        # failure and it is worth saying why before somebody deletes this as a
+        # duplicate. `diff_check` is four rules of the form "no packet did X",
+        # so it can only judge packets that exist; a packet that was never sent
+        # is invisible to every one of them. Measured, by making `operation`
+        # return `None` for a title-only change: every countdown froze on every
+        # screen, and `diff_check` passed all four rules over 780 packets
+        # (0 empty, 0 wasteful, 0 orphaned) while this check was the only thing
+        # in the suite that went red. The two claims are opposites -- that one
+        # says no packet carried a field that did not move, this one says a
+        # field that moved did get a packet -- and each is blind exactly where
+        # the other looks.
+        countdown = {bar["uuid"] for bar in counting_bars}
+        retitles = [
+            moved
+            for uuid, operation, moved, _ in narrator.bar_ops[first_countdown_op:]
+            if uuid in countdown and operation == "update_name"
+        ]
+        label_only = [moved for moved in retitles if moved == {"title"}]
+        self.check(
+            len(label_only) >= 3 and len(label_only) == len(retitles),
+            "a second passing that moves only the countdown's label costs one "
+            "packet carrying only the label: %d of %d retitle(s) carried the "
+            "title and nothing else" % (len(label_only), len(retitles)),
         )
 
         digits = [text for text in narrator.titles if text in COUNTDOWN_DIGITS]
@@ -790,15 +835,8 @@ class Run:
             "against %.2f/%.1f" % (admin.bar_state[memory]["progress"], resident, total),
         )
 
-        # An update sends only the update. The CPU label is rewritten every
-        # second while its fill, quantised against every core the machine has,
-        # usually does not move at all, so a label-only second is an
-        # `UpdateName` on its own and nothing else. The colour and the effects
-        # never move, and after the `Add` that carried them they are never on
-        # the wire again.
-        self.until(
-            lambda: admin.ops_for(cpu).count("update_name") >= 3, 20.0, "three CPU readings"
-        )
+        # The colour and the effects never move, so after the `Add` that
+        # carried them they are never on the wire again.
         for name, uuid in (("CPU", cpu), ("memory", memory)):
             operations = admin.ops_for(uuid)
             self.check(
@@ -812,17 +850,21 @@ class Run:
                 "and its colour and effects, which never move, are never on "
                 "the wire again after it: %s" % operations,
             )
-        self.check(
-            admin.ops_for(cpu).count("update_name") >= 2,
-            "a new CPU reading that moves only the label costs one packet "
-            "carrying only the label: %s" % admin.ops_for(cpu),
-        )
-        # And the memory bar, whose reading did not move far enough to change
-        # either the two decimals on its label or a sixty-fourth of the
-        # machine, says nothing at all. There is no assertion on how many
-        # packets that is, because it depends on how much memory the box has:
-        # what is checked is that whatever it sent obeyed the rule, which
-        # `diff_check` does over every packet of the whole run.
+        # Neither bar is asserted on for how many packets it sent, because
+        # neither count is a property of the software. The CPU label is a whole
+        # percent of one core, so whether this second's reading differs from
+        # the last one is a fact about the host: this check used to wait twenty
+        # seconds for two of them and went red on a 128-core builder that idled
+        # at `CPU 1% of 12800%` and held that label the whole time, which is
+        # the gate measuring the machine. The memory bar is the same shape
+        # against how much memory the box has. What is checked instead is that
+        # whatever they sent obeyed the rule, which `diff_check` does over
+        # every packet of the whole run, and that a label-only change costs one
+        # `UpdateName`, which `match_check` reads off the countdown bar because
+        # the server's own clock moves that label rather than the host's load.
+        # What that gives up is a wire-level witness for these two bars
+        # specifically; `egress::boss_bar`'s own truth-table test covers the
+        # transition itself.
         self.log(
             "the memory bar sent %d packet(s) against the CPU bar's %d"
             % (len(admin.ops_for(memory)), len(admin.ops_for(cpu)))
@@ -891,17 +933,61 @@ class Run:
         self.until(lambda: cpu in leaver.bar_state, 20.0, "the leaver's own load bars")
         leaver.sock.close()
         leaver.alive = False
+        # Carrying on is proved by a change this check causes rather than by
+        # one it waits for. Waiting was what this did -- two more CPU readings
+        # inside twenty seconds -- and a reading only reaches the wire when the
+        # host's load crosses a whole percent of a core, so on a quiet builder
+        # the survivor's screen was correct and silent and the gate read that
+        # as the server having stopped. Toggling the audience puts the same
+        # drive system through the same work on demand.
+        #
+        # What that gives up is the unprompted case: this no longer notices a
+        # server that draws only when asked. Nothing else here can, without
+        # asking the machine to be busy.
+        #
+        # STATUS: UNPROVEN. Read this before deleting it as redundant, and
+        # before trusting it. It is deterministic and it is green, which is
+        # more than the assertion it replaced could say, but nobody has yet
+        # shown it catches anything the three earlier toggle checks do not.
+        # Two attempts to break the game so that only this check notices:
+        #
+        #  1. Breaking `/serverload`'s re-add. The gate died at the *first*
+        #     `/serverload` and `load_check` returned before reaching here, so
+        #     this check never ran. Too blunt.
+        #  2. `add_if_new` matching `(Sent, Wildcard)` instead of
+        #     `(Sent, viewer)`, so a bar anybody holds is never sent to anyone
+        #     else. Two neighbouring checks went red and this one PASSED: the
+        #     admin already held the bars, so their toggle still worked.
+        #
+        # The defect only this could catch is one that needs a stale
+        # `(Sent, dead_viewer)` pair to exist before it shows, because this is
+        # the only bar check that runs after a socket has died -- the earlier
+        # toggle checks all run while every viewer is still connected. That is
+        # an argument, not evidence, and it is labelled as one deliberately.
+        # If you want to finish the job, that is the defect to build.
         admin.bar_ops.clear()
-        survived = self.until(
-            lambda: admin.ops_for(cpu).count("update_name") >= 2,
+        admin.command("serverload")
+        off = self.until(
+            lambda: cpu not in admin.bar_state and memory not in admin.bar_state,
             20.0,
-            "the load bars to keep updating after a viewer vanished",
+            "the surviving viewer's bars to come off",
         )
+        admin.command("serverload")
+        on = self.until(
+            lambda: cpu in admin.bar_state and memory in admin.bar_state,
+            20.0,
+            "and to come back",
+        )
+        # Only the lifecycle operations, because a CPU reading that did happen
+        # to move in between is a packet this check has no opinion about.
+        lifecycle = {
+            name: [op for op in admin.ops_for(uuid) if op in ("remove", "add")]
+            for name, uuid in (("CPU", cpu), ("memory", memory))
+        }
         self.check(
-            survived,
+            off and on and all(ops == ["remove", "add"] for ops in lifecycle.values()),
             "a viewer disconnecting with a bar on their screen leaves the "
-            "server drawing everybody else's: %d further packet(s)"
-            % len(admin.bar_ops),
+            "server drawing everybody else's: %s" % lifecycle,
         )
 
     # --- a player who arrives after the match started --------------------


### PR DESCRIPTION
Fixes the enforced `smash-hud-e2e` failure. ENG-11404.

## What was failing

```
FAIL a new CPU reading that moves only the label costs one packet carrying only the label: ['add']
```

`['add']` was the entire packet history for that bar: the Add, then twenty seconds of nothing. Nothing sent a wrong action; **nothing was sent at all**, and the message could not tell those two apart. The replacement distinguishes them in its own text: the same break now reads `0 of 0 retitle(s)`.

## The mechanism, which is the inverse of the obvious one

The builder was not too busy. It was **too quiet and too large**.

The CPU label is a whole percent of ONE core (`crates/hyperion/src/egress/server_load.rs`, `percent()` rounds `cores * 100.0` into a `u32`). The game server idles at about 0.01 cores and `vc1-nix` has 128 of them, so the label sat at `CPU 1% of 12800%` and consecutive one-second windows rounded to the same integer. `operation()` correctly sent nothing, and the check timed out waiting for a packet that was right not to exist:

```
33.59s [H1 ] <- boss bar add 'CPU 1% of 12800%' 0.000 full, blue
53.67s       TIMED OUT waiting for three CPU readings
53.67s FAIL a new CPU reading that moves only the label ... : ['add']
54.49s [H1 ] <- boss bar update_name 'CPU 2% of 12800%' 0.000 full, blue
```

It moved 0.8 s after the deadline. Hunting for contention would have found nothing and read as the hypothesis being wrong.

**The defect was in the check, not the game.**

## There were two coin flips, not one

`load_check`'s disconnect liveness claim waited on the same `count("update_name") >= 2` and had been passing on the same jitter. Removing the first assertion shifted the phase and turned the second red on the very next run:

```
54.64s FAIL a viewer disconnecting with a bar on their screen leaves the server drawing everybody else's: 0 further packet(s)
```

Fixing only the reported one would have left a landmine that fires after the fix lands.

## What replaces them

- The "an update carries only the update" claim now reads off the lobby countdown bar, whose label moves on the server's own tick clock (`whole_seconds` is a `ceil`) rather than the host's load.
- The liveness claim causes the change it observes: the surviving viewer toggles `/serverload`, and the Remove then Add have to come back.
- The CPU and memory packet counts are logged, not asserted, for the reason the memory bar already carried.
- `egress::boss_bar` gains a truth-table test over `operation()`, all 16 subsets of the four fields.

## Why it should stay green: the margin, not the run count

Six green runs would say little. The assertion needs 3 label-only retitles out of the ~9 second-flips in a countdown, and measured **7, 7, 7, 7, 7, 8, 8** across seven runs. It is nowhere near its threshold, which is the thing that predicts tomorrow. Do not tighten the threshold without re-measuring that spread.

**Residual:** the countdown timer advances by wall-clock `dt`, so a server crawling below roughly 7 tps for a whole countdown would collide every second-flip with a fill step and turn them all into Adds. Several other assertions here fail first at that tick rate, but it is not zero.

## Negative controls

Breaking `operation()`'s title-only branch to send a whole-bar Add turns it red for the right reason:

```
30.07s FAIL a second passing that moves only the countdown's label ... : 0 of 0 retitle(s) carried the title and nothing else
34.76s FAIL and a whole bar was only ever resent where two or more fields moved at once: 48 of 828 [('H3', '6879705f', ['title']), ...]
```

Two controls aimed at the *disconnect* assertion both failed to reach it. The first broke `/serverload`'s re-add and killed the gate at the first `/serverload`, before the assertion ran. The second used a realistic bug shape (`add_if_new` matching `(Sent, Wildcard)` instead of `(Sent, viewer)`); two neighbouring checks went red and **this one passed**, because the admin already held the bars.

So that assertion is deterministic and green but its incremental value over the three earlier toggle checks is **unproven**, and it is labelled `STATUS: UNPROVEN` in the source next to itself, with both failed attempts written out and a description of the defect that would actually distinguish it (one needing a stale `(Sent, dead_viewer)` pair, since this is the only bar check that runs after a socket has died). Anyone later deciding whether to delete it as redundant gets the evidence rather than a guess.

**Honest tally: 6 green runs of the fixed gate, 1 red baseline, 3 induced reds from deliberate breaks, and 1 control that would not fire.**

## Not redundant with `diff_check`, and this was measured

Making `operation()` return `None` for a title-only change freezes every countdown on every screen:

```
30.36s FAIL a second passing that moves only the countdown's label ... : 0 of 0 retitle(s)
35.00s PASS 780 boss bar packet(s) went out this run ...
35.00s PASS no boss bar packet said anything the client already knew: 0 of 780 []
35.00s PASS and a whole bar was only ever resent where two or more fields moved at once: 0 of 780 []
35.00s PASS and nothing arrived for a bar the client had never been given: 0 of 780 []
```

`diff_check` passes all four rules; this check is the only one in the suite that goes red. Its rules are all "no packet did X", so they can only judge packets that exist, and the volume guard does not help because progress updates dominate the count. The two claims are opposites and each is blind exactly where the other looks. That reasoning is written next to the assertion so it is not resolved the wrong way later.

## bedwars / shared engine

`boss_bar.rs` is engine code every mode shares, so worth stating: **a bedwars client sees nothing different, because no runtime code changed.** The whole Rust diff is one insertion hunk, `@@ -490,0 +491,83 @@ mod tests`, and `#[cfg(test)]` starts at line 410. `operation()` is untouched.

Who reads the path: `crates/hyperion/src/egress/mod.rs:50-51` imports `BossBarModule` and `ServerLoadModule` unconditionally, so every event including bedwars gets the drive system and the `/serverload` bars (an engine command, `crates/hyperion-clap/src/lib.rs:621`). `events/smash/src/adapter.rs:520-578` is the only game-mode consumer. `events/bedwars/src/` has no boss bar reference at all.

**Caveat:** because bedwars draws no bars of its own, no bedwars gate exercises this path, and the new wire-level coverage is smash-only. The truth-table unit test is the mode-independent part.

## Verification

- `nix build .#checks.x86_64-linux.smash-hud-e2e -L` on `vc1-nix`: 50 PASS, 0 FAIL, `rc=0`. Seven green runs total against a 1-for-1 red baseline.
- `cargo test -p hyperion --lib egress::boss_bar`: 5 passed. Watched the new test fail under the induced break (`left: "add"  right: "update_name"`).
- `cargo fmt --check -p hyperion` and `cargo clippy -p hyperion --lib --tests`: clean.
- Gate is also 20 s shorter (56.5 s to 35.0 s of client time).

## Unrelated, filed separately

- ENG-11405: `checks.*.{fmt,lint,test,ci,deny}` are `writeShellApplication` derivations that build the script rather than run it, so `nix flake check` cannot fail on them. This briefly made me report a clean lint that was not.
- Pre-existing clippy errors at HEAD in `events/smash/src/module/visuals.rs:418` and `:525`, owned by another change in flight.
