### PR TITLE
feat(smash): every ability draws something, on the press

### DIFF
--- a/events/smash/src/input.rs
+++ b/events/smash/src/input.rs
@@ -248,7 +248,16 @@ pub(crate) fn hotbar_slot(cursor: u16) -> Option<u8> {
 
 /// The attacker's kit's melee damage, plus whatever their kit has stacked onto
 /// it, or a bare-handed default.
-fn melee_damage(attacker: EntityView<'_>, victim: Entity, now: f32) -> f32 {
+///
+/// Public so a test can ask the same question a swing asks. It
+/// used to be private, and `tests/abilities.rs` answered it by writing the
+/// same two lines out again: read the kit's base, read the bonus, add them,
+/// and then deal exactly that much damage. A test shaped like that cannot
+/// fail. It compares one copy of the formula against another copy of the same
+/// formula, so the day this function stops reading [`MeleeBonus`] every
+/// `buffs_melee` assertion in the suite goes on passing and only a real client
+/// notices.
+pub fn melee_damage(attacker: EntityView<'_>, victim: Entity, now: f32) -> f32 {
     let base = attacker
         .find_target(Playing, |_| true)
         .and_then(|kit| kit.try_get::<&KitStats>(|stats| stats.melee_damage))

--- a/events/smash/src/module/kits/blaze.rs
+++ b/events/smash/src/module/kits/blaze.rs
@@ -200,6 +200,12 @@ fn firefly(cast: &Cast<'_>) {
 /// which is what free flight looks like from the outside: a Blaze that keeps
 /// going where it points until the crystal runs out.
 fn phoenix(cast: &Cast<'_>) {
+    // The bird catching light, at the press. A mode's first beat is next frame
+    // at the earliest, and the passes below draw Firefly's small flames, which
+    // say "something is moving" rather than "that Blaze is now the ultimate".
+    cast.server
+        .particles(visuals::pyre(cast.position.0, PHOENIX_RADIUS));
+
     effect::afflict(
         cast.world,
         cast.caster,
@@ -207,6 +213,10 @@ fn phoenix(cast: &Cast<'_>) {
         Affliction::mode(ability::ULTIMATE_SECONDS, PHOENIX_INTERVAL, phoenix_pass),
     );
 }
+
+/// `[APPROXIMATED]`. Wide enough to read as a shape around the Blaze rather
+/// than as the burn [`visuals::burn`] draws on anybody who is merely alight.
+const PHOENIX_RADIUS: f32 = 1.6;
 
 /// `[APPROXIMATED]`. Firefly's own charge is 1.5 s and Phoenix removes it, so a
 /// pass a second is "Firefly with no charge" at about the rate a player could
@@ -216,6 +226,10 @@ const PHOENIX_INTERVAL: f32 = 1.0;
 /// One uncharged Firefly, and the fire it leaves behind.
 fn phoenix_pass(cast: &Cast<'_>) {
     let ahead = cast.position.0 + cast.facing.0.normalize_or_zero() * 3.0;
+    // The same wake Firefly leaves, once per pass. Twenty passes of an
+    // invisible ram is twenty seconds in which nothing on screen distinguishes
+    // the ultimate from the Blaze being shoved around by somebody else.
+    cast.server.particles(visuals::ember_wake(cast.position.0));
     cast.server.add_velocity(
         cast.player,
         cast.facing.0.normalize_or_zero() * 2.4 + Vec3::Y * 0.4,

--- a/events/smash/src/module/kits/blaze.rs
+++ b/events/smash/src/module/kits/blaze.rs
@@ -186,6 +186,10 @@ fn firefly(cast: &Cast<'_>) {
         cast.player,
         cast.facing.0.normalize_or_zero() * (2.2 * cast.charge.max(0.4)),
     );
+    // One shove and not a mode: the charge ends, the ram happens, and the
+    // ability is over, so the wake is drawn once, where the flight leaves from.
+    // Phoenix is the sustained half of the kit and beats on its own.
+    cast.server.particles(visuals::ember_wake(cast.position.0));
     splash_at(cast, ahead, 3.0, 9.0 * cast.charge.max(0.4), 1.8);
 }
 

--- a/events/smash/src/module/kits/chicken.rs
+++ b/events/smash/src/module/kits/chicken.rs
@@ -101,6 +101,13 @@ fn egg_blaster(cast: &Cast<'_>) {
     const EGGS: usize = 5;
     let forward = cast.facing.0.normalize_or_zero();
     let side = Vec3::new(-forward.z, 0.0, forward.x);
+    // Above the volley, so the press draws before anything that could branch.
+    // The eggs render as egg entities, so what was missing is the stream
+    // having a direction anybody could read before the first one lands. Drawn
+    // here and not in the ultimate as well: Aerial Gunner beats through this
+    // function, so a volley looks the same either way it was fired.
+    cast.server
+        .particles(visuals::egg_burst(cast.position.0, forward));
     for index in 0..EGGS {
         let offset = (index as f32 - (EGGS as f32 - 1.0) / 2.0) * 0.1;
         fire(
@@ -170,6 +177,11 @@ fn refund(impact: &Impact<'_>) {
 /// for as long as the crystal lasts, which is what the sentence describes from
 /// the ground.
 fn aerial_gunner(cast: &Cast<'_>) {
+    // A mode's first beat is next frame at the earliest, and the press is the
+    // one moment the player who pressed it is looking. Feathers rather than a
+    // volley, because the eggs already have Egg Blaster's picture and the
+    // flight is the half of the sentence nothing else draws.
+    cast.server.particles(visuals::feathers(cast.position.0));
     effect::afflict(
         cast.world,
         cast.caster,
@@ -188,5 +200,9 @@ const GUNNER_LIFT: f32 = 0.4;
 
 fn gunner_beat(cast: &Cast<'_>) {
     cast.server.add_velocity(cast.player, Vec3::Y * GUNNER_LIFT);
+    // On every beat and not only at the press: twenty seconds of a chicken
+    // hanging in the air with no visible reason is twenty seconds of the
+    // ultimate looking like a bug in the jump code.
+    cast.server.particles(visuals::feathers(cast.position.0));
     egg_blaster(cast);
 }

--- a/events/smash/src/module/kits/cow.rs
+++ b/events/smash/src/module/kits/cow.rs
@@ -18,6 +18,7 @@ use crate::module::{
     effect::{self, Affliction},
     kit::{self, AbilitySpec, KitSounds, KitStats},
     projectile::{Flight, Payload, Visual, fire},
+    visuals,
 };
 
 /// `[VERIFIED]`: "you will slowly gain speed levels (up to 4)".
@@ -98,6 +99,12 @@ impl Module for Cow {
 /// `[VERIFIED]` five cows; `[APPROXIMATED]` damage.
 fn angry_herd(cast: &Cast<'_>) {
     const COWS: usize = 5;
+
+    // Once for the charge rather than once per cow: five bursts 0.6 apart read
+    // as one cloud anyway, and how many cows there are is already legible from
+    // the five cows.
+    cast.server.particles(visuals::hooves(cast.position.0));
+
     let forward = cast.facing.0.normalize_or_zero();
     let side = Vec3::new(-forward.z, 0.0, forward.x);
     for index in 0..COWS {
@@ -120,16 +127,17 @@ fn angry_herd(cast: &Cast<'_>) {
 
 /// `[APPROXIMATED]` damage; the "carries you along" part is the wiki's.
 fn milk_spiral(cast: &Cast<'_>) {
+    const RADIUS: f32 = 1.8;
+
     let forward = cast.facing.0.normalize_or_zero();
     cast.server.add_velocity(cast.player, forward * 1.3);
     for step in 1..=6 {
-        splash_at(
-            cast,
-            cast.position.0 + forward * (step as f32 * 1.5),
-            1.8,
-            3.0,
-            0.9,
-        );
+        let at = cast.position.0 + forward * (step as f32 * 1.5);
+        // One turn of the helix per splash, at the radius that splash hits.
+        // A single ring on the caster would draw a spiral that reaches nine
+        // blocks as a thing happening where the caster is standing.
+        cast.server.particles(visuals::milk(at, RADIUS));
+        splash_at(cast, at, RADIUS, 3.0, 0.9);
     }
 }
 
@@ -144,6 +152,24 @@ pub const MOOSHROOM_BONUS_DAMAGE: f32 = 1.0;
 /// arriving on a beat -- which is what a Cow whose abilities are coming faster
 /// than usual looks like from the outside.
 const MOOSHROOM_INTERVAL: f32 = 2.0;
+
+/// `[APPROXIMATED]`. The ultimate has no area of its own -- it acts through the
+/// herd and through the caster's own melee -- so there is no radius in the
+/// ability to reuse. This one is sized to sit on the caster, because what the
+/// cloud has to say is which player is the mooshroom.
+const MOOSHROOM_SPORE_RADIUS: f32 = 1.5;
+
+/// One beat of the mode: the herd, and the spores that mark who sent it.
+///
+/// Drawn on the beat rather than at the cast because the mode stands for twenty
+/// seconds, and a single burst would leave nineteen of them looking like a Cow
+/// with a full health bar for no visible reason. The first beat lands
+/// immediately (see [`Affliction::mode`]), so the cast is covered too.
+fn mooshroom_beat(cast: &Cast<'_>) {
+    cast.server
+        .particles(visuals::spores(cast.position.0, MOOSHROOM_SPORE_RADIUS));
+    angry_herd(cast);
+}
 
 /// The kit's own maximum health, which the bonus is measured against.
 ///
@@ -191,7 +217,7 @@ fn mooshroom_madness(cast: &Cast<'_>) {
         cast.world,
         cast.caster,
         effect::Blame::cast(cast),
-        Affliction::mode(ability::ULTIMATE_SECONDS, MOOSHROOM_INTERVAL, angry_herd)
+        Affliction::mode(ability::ULTIMATE_SECONDS, MOOSHROOM_INTERVAL, mooshroom_beat)
             .undone_by(shrink_back),
     );
 }

--- a/events/smash/src/module/kits/enderman.rs
+++ b/events/smash/src/module/kits/enderman.rs
@@ -112,6 +112,11 @@ fn block_toss(cast: &Cast<'_>) {
     // `min(1.4, 1.4 * elapsed / chargeTime)`.
     let speed = 1.4f32.min(1.4 * cast.charge).max(0.4) * 24.0;
 
+    // At the caster's feet, where the block is ripped out of the floor. The
+    // block is a visible falling-block entity from the moment it is thrown, so
+    // the part that was never drawn is it coming loose.
+    cast.server.particles(visuals::torn_earth(cast.position.0));
+
     fire(
         cast.world,
         cast.caster,
@@ -172,6 +177,10 @@ fn dragon_pass(cast: &Cast<'_>) {
     // platform rather than stopping at it.
     cast.server
         .add_velocity(cast.player, forward * 1.6 + Vec3::Y * 0.3);
+    // On each pass rather than at the cast: the ultimate is twenty seconds of
+    // flight, and one puff at the start is nineteen seconds in which nobody
+    // underneath can see what is above them.
+    cast.server.particles(visuals::wingbeat(cast.position.0));
     crate::module::ability::splash_at(cast, cast.position.0 + forward * 8.0, 6.0, RIDE_DAMAGE, 4.0);
 }
 

--- a/events/smash/src/module/kits/guardian.rs
+++ b/events/smash/src/module/kits/guardian.rs
@@ -162,6 +162,10 @@ fn whirlpool_axe(cast: &Cast<'_>) {
         },
         Payload::new(3.0, 0.8).then(reel),
     );
+    // Where the axe leaves the caster. The shard renders as a spectral arrow
+    // once it is airborne, so the water thrown off it on the way out is the
+    // only part of the throw that says which kit threw it.
+    cast.server.particles(visuals::spray(cast.position.0));
 }
 
 fn reel(impact: &Impact<'_>) {
@@ -238,6 +242,14 @@ const TIDE_INTERVAL: f32 = 1.5;
 /// Per wave, and there are thirteen.
 const TIDE_DAMAGE: f32 = 3.0;
 
+/// `[APPROXIMATED]`, as the rest of the ultimate is. Named rather than written
+/// twice, so the ring a player backs away from is the ring that hits them.
+const TIDE_RADIUS: f32 = 10.0;
+
 fn tide(cast: &Cast<'_>) {
-    splash_at(cast, cast.position.0, 10.0, TIDE_DAMAGE, 2.2);
+    splash_at(cast, cast.position.0, TIDE_RADIUS, TIDE_DAMAGE, 2.2);
+    // On the beat rather than at the cast: the ultimate is thirteen waves over
+    // twenty seconds, and one ring at the start leaves the other twelve unseen.
+    cast.server
+        .particles(visuals::tide(cast.position.0, TIDE_RADIUS));
 }

--- a/events/smash/src/module/kits/guardian.rs
+++ b/events/smash/src/module/kits/guardian.rs
@@ -191,9 +191,16 @@ fn water_splash(cast: &Cast<'_>) {
 }
 
 fn target_laser(cast: &Cast<'_>) {
+    // First, above the target lookup, because the lookup can fail: press the
+    // button with nobody inside `LASER_RANGE` and the `else { return }` below
+    // spends the ability and leaves. Anything drawn after that point is drawn
+    // only when the ability worked, which is a visual whose presence depends
+    // on the game state rather than on the press.
+    cast.server.particles(visuals::laser_eye(cast.position.0));
+
     let now = cast.world.get::<&MatchClock>(|clock| clock.0);
     let caster = cast.caster.id();
-    let mut nearest: Option<(f32, Entity)> = None;
+    let mut nearest: Option<(f32, Entity, Vec3)> = None;
     cast.world
         .query::<&Position>()
         .with(Player::id())
@@ -203,12 +210,12 @@ fn target_laser(cast: &Cast<'_>) {
                 return;
             }
             let distance = position.0.distance(cast.position.0);
-            if distance <= LASER_RANGE && nearest.is_none_or(|(best, _)| distance < best) {
-                nearest = Some((distance, entity.id()));
+            if distance <= LASER_RANGE && nearest.is_none_or(|(best, ..)| distance < best) {
+                nearest = Some((distance, entity.id(), position.0));
             }
         });
 
-    let Some((_, victim)) = nearest else {
+    let Some((_, victim, marked_at)) = nearest else {
         return;
     };
     cast.caster.set(Marked {
@@ -222,6 +229,58 @@ fn target_laser(cast: &Cast<'_>) {
         against: Some(victim),
         until: now + LASER_SECONDS,
     });
+
+    // The beam on top of the flare above, and then again every beat until the
+    // mark lapses. Everything the ability does is invisible -- a component on
+    // the caster and a number on somebody else's incoming damage -- so without
+    // this the one ability the kit is named for is the one nobody can see. A
+    // line between the two players rather than a second puff at the caster,
+    // because *who* it landed on is the whole of what the ability says, and it
+    // is the only part the flare cannot carry.
+    //
+    // Off the position the query above already read, not off `Marked`:
+    // `activate` runs inside an observer, so the `set` a few lines up is
+    // queued until the frame ends and reading it back here would find nothing
+    // on a first cast and the previous victim on a second. `laser_beam` is a
+    // beat, which is a frame later at the earliest, so there it is committed.
+    //
+    // What a line of particles gives up against vanilla's guardian beam is
+    // continuity: a real beam is one unbroken thing and this one blinks twice
+    // a second, because the seam cannot spawn the beam entity that draws the
+    // unbroken version.
+    cast.server
+        .particles(visuals::mark_beam(cast.position.0, marked_at));
+    effect::afflict(
+        cast.world,
+        cast.caster,
+        effect::Blame::cast(cast),
+        Affliction::mode(LASER_SECONDS, LASER_BEAM_INTERVAL, laser_beam),
+    );
+}
+
+/// `[APPROXIMATED]`. Fast enough that the mark never vanishes for long enough
+/// to be missed, slow enough that eight seconds of it is sixteen lines rather
+/// than a line every frame.
+const LASER_BEAM_INTERVAL: f32 = 0.5;
+
+/// Redraw the mark between wherever the two of them have got to.
+///
+/// Reads [`Marked`] back off the caster rather than closing over the victim,
+/// for two reasons: both ends move, and the mark can end early, in which case
+/// the component is gone and this draws nothing.
+fn laser_beam(cast: &Cast<'_>) {
+    let Some(marked) = cast.caster.try_get::<&Marked>(|marked| *marked) else {
+        return;
+    };
+    let victim = cast.world.entity_from_id(marked.victim);
+    if !victim.is_alive() {
+        return;
+    }
+    let Some(at) = victim.try_get::<&Position>(|position| position.0) else {
+        return;
+    };
+    cast.server
+        .particles(visuals::mark_beam(cast.position.0, at));
 }
 
 /// `[APPROXIMATED]` throughout; the wiki describes the ultimate and gives no

--- a/events/smash/src/module/kits/iron_golem.rs
+++ b/events/smash/src/module/kits/iron_golem.rs
@@ -161,9 +161,15 @@ fn reel_in(impact: &Impact<'_>) {
     // Mineplex's `velocity(2, yBase 0.8, yMax 1.5)`: hard pull with enough lift
     // to clear whatever the victim was standing behind.
     let pull = (to - from).normalize_or_zero() * 2.0 + Vec3::Y * 0.8;
-    impact
-        .world
-        .get::<&crate::server::ServerHandle>(|server| server.add_velocity(id, pull));
+    impact.world.get::<&crate::server::ServerHandle>(|server| {
+        server.add_velocity(id, pull);
+        // At the hit and not at the throw, because until the hook lands there
+        // is no second end to draw the line to, and a line laid down the
+        // throw would be drawn just as confidently on the throws that miss.
+        // Both endpoints are read before the pull applies, so the chain spans
+        // the gap the ability is about to close rather than the remains of it.
+        server.particles(visuals::chain(to, from));
+    });
 }
 
 /// The kit's panic button and its combo finisher.

--- a/events/smash/src/module/kits/skeleton.rs
+++ b/events/smash/src/module/kits/skeleton.rs
@@ -23,6 +23,7 @@ use crate::{
         kit::{self, AbilitySpec, KitSounds, KitStats},
         player::Position,
         projectile::{Flight, Impact, Payload, Visual, fire},
+        visuals,
     },
 };
 
@@ -148,6 +149,13 @@ fn barrage(cast: &Cast<'_>) {
     for index in 0..arrows.min(MAX_BARRAGE_ARROWS) {
         arrow(cast, index as f32 * 0.02);
     }
+    // One line for the volley, along the aim rather than along each arrow. The
+    // jitter that separates the five is a fiftieth of a block at its widest, so
+    // five lines would sit on top of one another and cost five times the
+    // particles to say the same thing. What that gives up is any hint of how
+    // many arrows are in the air, which the arrows themselves already carry.
+    cast.server
+        .particles(visuals::bowshot(cast.position.0, cast.facing.0));
 }
 
 /// Damage 6 over radius 7 at a 2.5x knockback multiplier — the highest of any
@@ -176,6 +184,13 @@ fn roped_arrow(cast: &Cast<'_>) {
         },
         Payload::new(ARROW_DAMAGE, ARROW_KNOCKBACK).then(haul_shooter),
     );
+
+    // Before the pull, so the line starts where the caster was standing when
+    // they fired rather than trailing them. It doubles as the only warning
+    // anyone gets about where the Skeleton is going, the arrow's direction
+    // being theirs as well.
+    cast.server
+        .particles(visuals::bowshot(cast.position.0, cast.facing.0));
 
     let pull = cast.facing.0.normalize_or_zero() * 1.4 + Vec3::Y * 0.6;
     cast.server.add_velocity(cast.player, pull);
@@ -227,4 +242,10 @@ const ARROW_STORM_INTERVAL: f32 = 0.3;
 
 fn arrow_volley(cast: &Cast<'_>) {
     arrow(cast, 0.0);
+    // Per beat and not once at the press. Each beat is its own release, aimed
+    // wherever the caster is looking by then, so a single line at the press
+    // would say the Skeleton fired once and stopped rather than that they have
+    // not stopped.
+    cast.server
+        .particles(visuals::bowshot(cast.position.0, cast.facing.0));
 }

--- a/events/smash/src/module/kits/sky_squid.rs
+++ b/events/smash/src/module/kits/sky_squid.rs
@@ -115,6 +115,10 @@ fn super_squid(cast: &Cast<'_>) {
         cast.player,
         cast.facing.0.normalize_or_zero() * 1.1 + Vec3::Y * 0.9,
     );
+    // One impulse and not a mode, so the wake is drawn once, where the dash
+    // starts. The second it lasts is the shield's, and the shield has its own
+    // look.
+    cast.server.particles(visuals::wake(cast.position.0));
     effect::afflict(
         cast.world,
         cast.caster,
@@ -148,6 +152,10 @@ fn ink_shotgun(cast: &Cast<'_>) {
             Payload::new(PELLET_DAMAGE, 0.6),
         );
     }
+    // Once for the press, not once per pellet: seven ink clouds down one cone
+    // is a smokescreen, and the one fact a victim needs is where the cone is.
+    cast.server
+        .particles(visuals::ink(cast.position.0, forward));
 }
 
 /// `[VERIFIED]` 5x5x5 area, 2 damage per fish, four seconds. Modelled as one

--- a/events/smash/src/module/kits/slime.rs
+++ b/events/smash/src/module/kits/slime.rs
@@ -150,9 +150,14 @@ fn slime_rocket(cast: &Cast<'_>) {
 fn slime_slam(cast: &Cast<'_>) {
     const DAMAGE: f32 = 7.0;
     const KNOCKBACK: f32 = 2.0;
+    const RADIUS: f32 = 2.0;
 
     let ahead = cast.position.0 + cast.facing.0.normalize_or_zero() * 3.0;
-    splash_at(cast, ahead, 2.0, DAMAGE, KNOCKBACK);
+    splash_at(cast, ahead, RADIUS, DAMAGE, KNOCKBACK);
+    // At the point the slam lands and at the radius it lands over, so the
+    // recoil that follows reads as the caster being thrown off a thing that
+    // happened over there rather than a second, separate hit.
+    cast.server.particles(visuals::slam(ahead, RADIUS));
 
     hurt(cast.caster, Damaged {
         attacker: None,

--- a/events/smash/src/module/kits/slime.rs
+++ b/events/smash/src/module/kits/slime.rs
@@ -179,6 +179,16 @@ fn slime_slam(cast: &Cast<'_>) {
 /// It used to be one splash and no shield at all, which is the two halves of
 /// the tooltip both missing.
 fn giga_slime(cast: &Cast<'_>) {
+    // First statement in the function, ahead of the energy write and the
+    // affliction, so nothing the ultimate does can come between the press and
+    // the picture of it. Drawn at the press as well as on every beat below:
+    // the first beat is next frame at the earliest, and the one thing
+    // everybody nearby has to learn immediately is that the small slime they
+    // were about to fight is now nineteen seconds of untouchable with a five
+    // block reach.
+    cast.server
+        .particles(visuals::giga_body(giga_center(cast), GIGA_RADIUS));
+
     // Growing back to full is part of the ultimate: the bar is the hitbox.
     cast.caster.get::<&mut Energy>(|energy| {
         energy.current = energy.max;
@@ -203,6 +213,22 @@ const GIGA_INTERVAL: f32 = 1.0;
 /// `[APPROXIMATED]`. Per beat, and there are nineteen.
 const GIGA_DAMAGE: f32 = 4.0;
 
+/// `[APPROXIMATED]`. How far the body reaches, and the radius it is drawn at,
+/// so the shell a player backs away from is the shell that hits them.
+const GIGA_RADIUS: f32 = 5.0;
+
+/// How far above the feet the middle of a slime that size sits. Named because
+/// the contact and the shell both have to be centred on the body rather than
+/// on the ground under it.
+const GIGA_CENTER: f32 = 3.0;
+
+fn giga_center(cast: &Cast<'_>) -> Vec3 {
+    cast.position.0 + Vec3::Y * GIGA_CENTER
+}
+
 fn giga_contact(cast: &Cast<'_>) {
-    splash_at(cast, cast.position.0 + Vec3::Y * 3.0, 5.0, GIGA_DAMAGE, 2.0);
+    let center = giga_center(cast);
+    splash_at(cast, center, GIGA_RADIUS, GIGA_DAMAGE, 2.0);
+    cast.server
+        .particles(visuals::giga_body(center, GIGA_RADIUS));
 }

--- a/events/smash/src/module/kits/snowman.rs
+++ b/events/smash/src/module/kits/snowman.rs
@@ -15,6 +15,7 @@ use crate::module::{
     effect::{self, Affliction},
     kit::{self, AbilitySpec, KitSounds, KitStats},
     projectile::{Flight, Payload, Visual, fire},
+    visuals,
 };
 
 /// `[VERIFIED]`: "You also deal 1 more damage to mobs who are on your snow."
@@ -109,22 +110,35 @@ fn blizzard(cast: &Cast<'_>) {
         },
         Payload::new(1.5, 0.9),
     );
+    cast.server.particles(visuals::frost(cast.position.0));
 }
 
 /// `[VERIFIED]`: "you will bounce 1 block into the air to avoid falling through
 /// the path when it is made". The ice blocks themselves need host block writes,
-/// which is the one thing the seam does not carry; the hop is what lands.
+/// which is the one thing the seam does not carry; the hop is what lands, and
+/// the drawn path is all that is left saying where the ice would have gone.
 fn ice_path(cast: &Cast<'_>) {
-    cast.server.add_velocity(
-        cast.player,
-        Vec3::Y * 0.42 + cast.facing.0.normalize_or_zero() * 0.6,
-    );
+    // The hop and the path take the same heading, so the snow lands where the
+    // caster is about to be rather than wherever they happen to be looking a
+    // frame later.
+    let heading = cast.facing.0.normalize_or_zero();
+
+    cast.server
+        .add_velocity(cast.player, Vec3::Y * 0.42 + heading * 0.6);
+    cast.server
+        .particles(visuals::frost_path(cast.position.0, heading));
 }
 
 /// `[APPROXIMATED]`: the aura is modelled as a pulse rather than as placed snow,
-/// because "who is standing on my snow" needs the host's blocks.
+/// because "who is standing on my snow" needs the host's blocks. The ring is
+/// drawn at the pulse's own radius, so the edge a victim has to stay outside is
+/// the edge the damage actually uses.
 fn arctic_aura(cast: &Cast<'_>) {
-    splash_at(cast, cast.position.0, 5.0, AURA_BONUS_DAMAGE, 0.2);
+    const AURA_RADIUS: f32 = 5.0;
+
+    splash_at(cast, cast.position.0, AURA_RADIUS, AURA_BONUS_DAMAGE, 0.2);
+    cast.server
+        .particles(visuals::frost_ring(cast.position.0, AURA_RADIUS));
 }
 
 /// Twenty seconds of a six-snowball ring, the first one down the barrel.
@@ -183,4 +197,8 @@ fn turret_ring(cast: &Cast<'_>) {
             Payload::new(2.0, 0.8),
         );
     }
+    // One burst for the ring and not one per snowball: this beat runs twenty
+    // times, and six bursts a second stops reading as a turret and starts
+    // reading as weather.
+    cast.server.particles(visuals::frost(cast.position.0));
 }

--- a/events/smash/src/module/kits/spider.rs
+++ b/events/smash/src/module/kits/spider.rs
@@ -172,11 +172,23 @@ fn envenom(impact: &Impact<'_>) {
     );
 }
 
+/// How much floor the web left behind covers.
+///
+/// `[APPROXIMATED]`, and it had to be invented: Spin Web affects nobody but the
+/// caster, so unlike every other area here there is no gameplay radius to draw
+/// at. This is sized to read as a patch of floor rather than a puff, and it
+/// promises nothing, because standing in it does nothing.
+const WEB_RADIUS: f32 = 2.5;
+
 /// A leap that leaves web behind. `[APPROXIMATED]`: the recovery distance is
 /// tuned to "decent horizontal and vertical", not to a published number.
 fn spin_web(cast: &Cast<'_>) {
     let launch = cast.facing.0.normalize_or_zero() * 1.4 + Vec3::Y * 0.45;
     cast.server.add_velocity(cast.player, launch);
+    // At the spot the Spider left, which is the whole of what the ability did:
+    // the web is the trail, and the leap carries them off it immediately.
+    cast.server
+        .particles(visuals::web(cast.position.0, WEB_RADIUS));
 }
 
 /// `[APPROXIMATED]`: the dome traps, which needs block writes the game half

--- a/events/smash/src/module/kits/wolf.rs
+++ b/events/smash/src/module/kits/wolf.rs
@@ -22,6 +22,7 @@ use crate::{
         kit::{self, AbilitySpec, KitName, KitSounds, KitStats, Playing},
         player::Player,
         projectile::{Flight, Impact, Payload, Visual, fire},
+        visuals,
     },
     server::{PlayerId, ServerHandle},
 };
@@ -168,6 +169,8 @@ fn plays(player: EntityView<'_>, kit: &str) -> bool {
 }
 
 fn cub_tackle(cast: &Cast<'_>) {
+    cast.server
+        .particles(visuals::tossed_mob(cast.position.0, cast.facing.0));
     fire(
         cast.world,
         cast.caster,
@@ -217,6 +220,16 @@ fn wolf_strike(cast: &Cast<'_>) {
     cast.server
         .add_velocity(cast.player, cast.facing.0.normalize_or_zero() * 1.6);
 
+    // The line ends at `ahead` rather than wherever the impulse above actually
+    // carries the caster. The other option was to draw it where the lunge
+    // resolves, which reads better and does not exist: the impulse is handed to
+    // the host and settled by physics over the ticks after this one, so the
+    // landing point would have to be recovered by a system watching the caster
+    // until they stop, and the picture would arrive a beat after the ability.
+    // `ahead` is the centre of the splash below, so the line already ends where
+    // the damage does, which is the fact a victim needs.
+    cast.server.particles(visuals::pounce(cast.position.0, ahead));
+
     let caster = cast.caster.id();
     let mut combo = false;
     cast.world
@@ -263,8 +276,26 @@ fn frenzy(cast: &Cast<'_>) {
         cast.world,
         cast.caster,
         effect::Blame::cast(cast),
-        Affliction::mode(ability::ULTIMATE_SECONDS, FRENZY_INTERVAL, wolf_strike),
+        Affliction::mode(ability::ULTIMATE_SECONDS, FRENZY_INTERVAL, frenzy_beat),
     );
+}
+
+/// One beat of Frenzy: the snarl, then the lunge.
+///
+/// The snarl is drawn here and not in [`frenzy`] because a picture drawn once
+/// at the cast leaves the twenty seconds after it looking exactly like a Wolf
+/// with no ultimate up, and the whole content of the ability is that window.
+/// [`Affliction::mode`] fires its first beat immediately, so this still draws
+/// on the press.
+///
+/// What that costs is the rate: the snarl rides the lunge's two seconds because
+/// that is the beat the effect already has, so a victim can be most of two
+/// seconds from the last one. A finer beat would mean a second effect entity
+/// existing only to carry the picture, which is a second expiry to keep in step
+/// with this one for no more information than a slower snarl gives.
+fn frenzy_beat(cast: &Cast<'_>) {
+    cast.server.particles(visuals::snarl(cast.position.0));
+    wolf_strike(cast);
 }
 
 /// `[WIKI]` Strength III, which vanilla scores at +3 damage.

--- a/events/smash/src/module/kits/zombie.rs
+++ b/events/smash/src/module/kits/zombie.rs
@@ -86,6 +86,13 @@ fn bile_blaster(cast: &Cast<'_>) {
     const BLOBS: usize = 4;
     let forward = cast.facing.0.normalize_or_zero();
     let side = Vec3::new(-forward.z, 0.0, forward.x);
+    // Before the blobs and before anything that could branch. The blobs are
+    // snowballs the instant they are airborne, and the only particle the
+    // ability had was the one drawn where one of them connects, so which of
+    // two runs of `tools/smash-match.py` passed came down to whether anybody
+    // was standing there. Bile that misses is most of the bile.
+    cast.server
+        .particles(visuals::bile(cast.position.0, forward));
     for index in 0..BLOBS {
         let offset = (index as f32 - (BLOBS as f32 - 1.0) / 2.0) * 0.14;
         fire(
@@ -107,13 +114,19 @@ fn bile_blaster(cast: &Cast<'_>) {
 }
 
 fn deaths_grasp(cast: &Cast<'_>) {
+    let forward = cast.facing.0.normalize_or_zero();
+    // Above the shot, for `bile_blaster`'s reason: everything else this
+    // ability does happens to somebody else later, so a release that connects
+    // with nothing has to look like a release all the same.
+    cast.server
+        .particles(visuals::grasp(cast.position.0, forward));
     fire(
         cast.world,
         cast.caster,
         Visual(EntityKind::Arrow),
         Flight {
             position: cast.position.0,
-            velocity: cast.facing.0.normalize_or_zero() * 16.0f32.mul_add(cast.charge, 24.0),
+            velocity: forward * 16.0f32.mul_add(cast.charge, 24.0),
             gravity: 6.0,
             seconds_left: 2.0,
             radius: 0.6,

--- a/events/smash/src/module/visuals.rs
+++ b/events/smash/src/module/visuals.rs
@@ -112,3 +112,330 @@ pub fn venom(at: Vec3) -> Particles {
     .offset(Vec3::new(0.3, 0.5, 0.3))
     .speed(DRIFT)
 }
+
+// ---------------------------------------------------------------------------
+// The kit vocabulary.
+//
+// Everything above is a moment that happens to *any* player: a cast, an
+// arrival, a death, a tick of burning. Everything below is a moment that
+// belongs to one kit or a few, and each exists because an ability that had it
+// was drawing nothing at all -- `tools/smash-match.py` joins a real client and
+// refuses an ability that fires and sends no `level_particles`, and it named
+// twenty-three.
+//
+// The temptation with twenty-three holes is one `blast` in each. That would
+// pass the gate and leave the game where it started, because a player who sees
+// the same grey puff for a bow, a web, an ink cloud and a tidal wave has learnt
+// nothing from any of them. So each of these picks the particle vanilla already
+// uses for the thing being depicted, which means a player who has played
+// Minecraft can read it without being taught.
+//
+// `[INFERRED]` throughout, on the same terms as the rest of this file.
+// ---------------------------------------------------------------------------
+
+/// A bow releasing.
+///
+/// `minecraft:crit`, which is what vanilla draws on a fully-drawn bow shot and
+/// on a critical hit -- both being "this one was at full power". Drawn as a
+/// short line out of the caster rather than a puff at their feet, because
+/// three of the Skeleton's four abilities fire arrows in different patterns
+/// and the direction is the only part a victim can act on.
+pub fn bowshot(from: Vec3, toward: Vec3) -> Particles {
+    let eye = from + Vec3::Y * CHEST;
+    Particles::line(Particle::Crit, eye, eye + toward.normalize_or_zero() * 2.0)
+        .points(8)
+        .speed(DRIFT)
+        .long_distance(true)
+}
+
+/// A taut line between two points: a hook, a rope, a tether.
+///
+/// Grey `minecraft:dust` at a small scale, which is the closest vanilla has to
+/// a drawn chain. A line and not a puff because the whole content of the
+/// ability is *what it connected you to*, and a puff at one end says nothing
+/// about the other.
+pub fn chain(from: Vec3, to: Vec3) -> Particles {
+    Particles::line(
+        Particle::Dust {
+            // Iron grey. The hook is iron in the fiction and in the item.
+            color: Argb::opaque(0x8C, 0x8C, 0x8C),
+            scale: 0.6,
+        },
+        from + Vec3::Y * CHEST,
+        to + Vec3::Y * CHEST,
+    )
+    .points(24)
+    .long_distance(true)
+}
+
+/// Webbing thrown over an area.
+///
+/// `minecraft:item_cobweb`, the particle vanilla emits from a cobweb block, so
+/// the ground reads as webbed without any block being placed. A disc rather
+/// than a ring: the area is a place you should not walk *through*, not a line
+/// you should not cross.
+pub fn web(at: Vec3, radius: f32) -> Particles {
+    Particles::disc(Particle::ItemCobweb, at + Vec3::Y * 0.1, radius)
+        .points(40)
+        .count(2)
+        .speed(DRIFT)
+        .long_distance(true)
+}
+
+/// Something heavy and soft landing.
+///
+/// `minecraft:item_slime`, which is what vanilla throws off a slime block being
+/// bounced on. Kept low and wide, because the ability is a ground slam and the
+/// thing a nearby player needs to judge is its radius.
+pub fn slam(at: Vec3, radius: f32) -> Particles {
+    Particles::disc(Particle::ItemSlime, at + Vec3::Y * 0.1, radius)
+        .points(28)
+        .count(3)
+        .speed(0.08)
+        .long_distance(true)
+}
+
+/// Ground torn up and thrown.
+///
+/// `minecraft:dust_plume`, vanilla's own "a lump of the floor just left the
+/// floor". Drawn at the caster's feet, which is where the block came from --
+/// the block itself is already a visible flying entity, so what was missing was
+/// the moment of it being ripped up.
+pub fn torn_earth(at: Vec3) -> Particles {
+    Particles::burst(Particle::DustPlume, at + Vec3::Y * 0.2)
+        .count(24)
+        .offset(Vec3::new(0.5, 0.2, 0.5))
+        .speed(0.15)
+        .long_distance(true)
+}
+
+/// Something large and airborne beating its wings.
+///
+/// `minecraft:dragon_breath`, drawn below the rider rather than around them, so
+/// it reads as thrust and marks the ground they are passing over for anyone
+/// underneath.
+pub fn wingbeat(at: Vec3) -> Particles {
+    Particles::burst(
+        Particle::DragonBreath {
+            // Full power. The option scales how far vanilla throws the cloud;
+            // a rider's downwash should look like the dragon's own breath and
+            // not a weaker copy of it.
+            power: 1.0,
+        },
+        at - Vec3::Y * 0.3,
+    )
+        .count(16)
+        .offset(Vec3::new(0.6, 0.2, 0.6))
+        .speed(0.06)
+        .long_distance(true)
+}
+
+/// Something swimming through air that is not water.
+///
+/// `minecraft:bubble`, which is the joke the Sky Squid kit is built on and the
+/// particle a player already associates with being underwater. A trailing wake
+/// behind the caster rather than a burst, because the ability is a dash and the
+/// wake is what says which way it went.
+pub fn wake(at: Vec3) -> Particles {
+    Particles::burst(Particle::Bubble, at + Vec3::Y * CHEST)
+        .count(20)
+        .offset(Vec3::new(0.4, 0.4, 0.4))
+        .speed(0.1)
+        .long_distance(true)
+}
+
+/// A cloud of ink fired forwards.
+///
+/// `minecraft:squid_ink`. Laid along the firing direction rather than at the
+/// muzzle, because a shotgun's threat is the cone and a victim needs to see
+/// whether they are in it.
+pub fn ink(from: Vec3, toward: Vec3) -> Particles {
+    let eye = from + Vec3::Y * CHEST;
+    Particles::line(Particle::SquidInk, eye, eye + toward.normalize_or_zero() * 4.0)
+        .points(16)
+        .count(4)
+        .offset(Vec3::splat(0.5))
+        .speed(0.2)
+        .long_distance(true)
+}
+
+/// A melee lunge landing.
+///
+/// `minecraft:sweep_attack`, the arc vanilla draws on a sweeping sword hit.
+/// Drawn as a line from where the lunge began to where it ended, so the
+/// distance covered is legible -- which for the Wolf is the ability, the whole
+/// kit being about closing that gap.
+pub fn pounce(from: Vec3, to: Vec3) -> Particles {
+    Particles::line(
+        Particle::SweepAttack,
+        from + Vec3::Y * CHEST,
+        to + Vec3::Y * CHEST,
+    )
+    .points(6)
+    .long_distance(true)
+}
+
+/// A mode that makes the caster dangerous, ticking.
+///
+/// `minecraft:angry_villager`, which is vanilla's one unambiguous "this thing
+/// is furious with you". Around the head, where a status on a player reads,
+/// and it repeats: an ultimate that lasts twenty seconds and draws once is a
+/// twenty-second window a victim cannot see they are inside.
+pub fn snarl(at: Vec3) -> Particles {
+    Particles::burst(Particle::AngryVillager, at + Vec3::Y * 1.9)
+        .count(4)
+        .offset(Vec3::new(0.3, 0.2, 0.3))
+        .speed(DRIFT)
+        .long_distance(true)
+}
+
+/// Snow thrown.
+///
+/// `minecraft:snowflake`. The Snowman had four abilities and not one of them
+/// drew anything, so this and the two below are what the kit looks like.
+pub fn frost(at: Vec3) -> Particles {
+    Particles::burst(Particle::Snowflake, at + Vec3::Y * CHEST)
+        .count(18)
+        .offset(Vec3::splat(SPREAD))
+        .speed(0.1)
+        .long_distance(true)
+}
+
+/// A path of ice laid across the ground.
+///
+/// `minecraft:item_snowball` in a line along the path. This one is not
+/// decoration: Ice Path is *documented* as laying ice blocks, the seam cannot
+/// write blocks, and so the ability currently consists of a small hop and
+/// nothing else. The line of snow is the ability's only remaining evidence
+/// that anything happened, and it is drawn along the same direction the hop
+/// carries the caster.
+pub fn frost_path(from: Vec3, toward: Vec3) -> Particles {
+    let ground = from + Vec3::Y * 0.1;
+    Particles::line(
+        Particle::ItemSnowball,
+        ground,
+        ground + toward.normalize_or_zero() * 6.0,
+    )
+    .points(24)
+    .count(2)
+    .speed(DRIFT)
+    .long_distance(true)
+}
+
+/// The edge of an aura on the ground.
+///
+/// A ring and not a disc, because what a player needs from an aura is exactly
+/// one fact -- am I inside it -- and a ring draws the boundary that answers
+/// that. A filled disc at this radius would also be a great deal of particles
+/// on a two-second cooldown.
+pub fn frost_ring(at: Vec3, radius: f32) -> Particles {
+    Particles::ring(Particle::Snowflake, at + Vec3::Y * 0.1, radius)
+        .points(48)
+        .count(2)
+        .speed(DRIFT)
+        .long_distance(true)
+}
+
+/// Hooves tearing up ground.
+///
+/// `minecraft:dust_plume` again, and deliberately the same particle as
+/// [`torn_earth`]: both are "the floor has been disturbed here", and giving
+/// them different pictures would be inventing a distinction the game does not
+/// make.
+pub fn hooves(at: Vec3) -> Particles {
+    Particles::burst(Particle::DustPlume, at + Vec3::Y * 0.15)
+        .count(14)
+        .offset(Vec3::new(0.6, 0.1, 0.6))
+        .speed(0.12)
+        .long_distance(true)
+}
+
+/// A spray of something white.
+///
+/// White `minecraft:dust`, rising, for the Cow's milk. Vanilla has no milk
+/// particle -- drinking a bucket draws nothing -- so this is a colour choice
+/// rather than a citation, and it is called out as such.
+pub fn milk(at: Vec3, radius: f32) -> Particles {
+    Particles::ring(
+        Particle::Dust {
+            color: Argb::opaque(0xF2, 0xF2, 0xF0),
+            scale: 1.2,
+        },
+        at + Vec3::Y * CHEST,
+        radius,
+    )
+    .points(32)
+    .count(2)
+    .speed(0.05)
+    .long_distance(true)
+}
+
+/// Mushroom spores.
+///
+/// `minecraft:mycelium`, the particle vanilla emits from mycelium blocks, which
+/// is what a mooshroom stands on. The one particle in the game that already
+/// means "fungus is happening here".
+pub fn spores(at: Vec3, radius: f32) -> Particles {
+    Particles::sphere(Particle::Mycelium, at + Vec3::Y, radius)
+        .points(40)
+        .count(2)
+        .speed(0.05)
+        .long_distance(true)
+}
+
+/// A small fire following something through the air.
+///
+/// `minecraft:small_flame` and not `flame`, so the Blaze's flight is
+/// distinguishable at a glance from the Blaze's burn, which [`burn`] draws in
+/// full `flame`. Same kit, two effects, and a player has to be able to tell
+/// which one is on them.
+pub fn ember_wake(at: Vec3) -> Particles {
+    Particles::burst(Particle::SmallFlame, at + Vec3::Y * 0.4)
+        .count(12)
+        .offset(Vec3::new(0.3, 0.3, 0.3))
+        .speed(0.04)
+        .long_distance(true)
+}
+
+/// Water thrown off something spinning.
+///
+/// `minecraft:splash`, vanilla's own thrown-water particle. The Guardian's
+/// whole visual identity is water, and this is the cheap half of it.
+pub fn spray(at: Vec3) -> Particles {
+    Particles::burst(Particle::Splash, at + Vec3::Y * CHEST)
+        .count(16)
+        .offset(Vec3::splat(SPREAD))
+        .speed(0.2)
+        .long_distance(true)
+}
+
+/// A wall of water arriving.
+///
+/// A ring of `minecraft:bubble_column_up` at the wave's radius: the column
+/// particle rises, so a ring of it reads as a wall standing up out of the
+/// ground rather than as a puddle. The one ultimate in the roster that is
+/// explicitly a *wave*, and a wave with no front is just damage.
+pub fn tide(at: Vec3, radius: f32) -> Particles {
+    Particles::ring(Particle::BubbleColumnUp, at, radius)
+        .points(56)
+        .count(3)
+        .offset(Vec3::new(0.1, 0.8, 0.1))
+        .speed(0.15)
+        .long_distance(true)
+}
+
+/// A small animal thrown out of the caster's hands.
+///
+/// `minecraft:poof`, which is what vanilla draws when a mob appears or
+/// disappears. Placed at chest height in front of the caster, where the cub
+/// leaves them.
+pub fn tossed_mob(at: Vec3, toward: Vec3) -> Particles {
+    Particles::burst(
+        Particle::Poof,
+        at + Vec3::Y * CHEST + toward.normalize_or_zero(),
+    )
+    .count(12)
+    .offset(Vec3::splat(0.3))
+    .speed(0.05)
+    .long_distance(true)
+}

--- a/events/smash/src/module/visuals.rs
+++ b/events/smash/src/module/visuals.rs
@@ -224,10 +224,10 @@ pub fn wingbeat(at: Vec3) -> Particles {
         },
         at - Vec3::Y * 0.3,
     )
-        .count(16)
-        .offset(Vec3::new(0.6, 0.2, 0.6))
-        .speed(0.06)
-        .long_distance(true)
+    .count(16)
+    .offset(Vec3::new(0.6, 0.2, 0.6))
+    .speed(0.06)
+    .long_distance(true)
 }
 
 /// Something swimming through air that is not water.
@@ -251,12 +251,16 @@ pub fn wake(at: Vec3) -> Particles {
 /// whether they are in it.
 pub fn ink(from: Vec3, toward: Vec3) -> Particles {
     let eye = from + Vec3::Y * CHEST;
-    Particles::line(Particle::SquidInk, eye, eye + toward.normalize_or_zero() * 4.0)
-        .points(16)
-        .count(4)
-        .offset(Vec3::splat(0.5))
-        .speed(0.2)
-        .long_distance(true)
+    Particles::line(
+        Particle::SquidInk,
+        eye,
+        eye + toward.normalize_or_zero() * 4.0,
+    )
+    .points(16)
+    .count(4)
+    .offset(Vec3::splat(0.5))
+    .speed(0.2)
+    .long_distance(true)
 }
 
 /// A melee lunge landing.
@@ -415,7 +419,7 @@ pub fn spray(at: Vec3) -> Particles {
 /// particle rises, so a ring of it reads as a wall standing up out of the
 /// ground rather than as a puddle. The one ultimate in the roster that is
 /// explicitly a *wave*, and a wave with no front is just damage.
-pub fn tide(at: Vec3, radius: f32) -> Particles {
+pub const fn tide(at: Vec3, radius: f32) -> Particles {
     Particles::ring(Particle::BubbleColumnUp, at, radius)
         .points(56)
         .count(3)
@@ -437,5 +441,156 @@ pub fn tossed_mob(at: Vec3, toward: Vec3) -> Particles {
     .count(12)
     .offset(Vec3::splat(0.3))
     .speed(0.05)
+    .long_distance(true)
+}
+
+/// A mouthful of something caustic thrown at somebody.
+///
+/// `minecraft:spit`, vanilla's llama spit, which is the one particle in the
+/// game that already means "a mob has launched a body fluid at you". Laid
+/// along the firing direction like [`ink`], because the ability is a fan and
+/// what a victim can act on is whether they are standing in it. `NoxiousGas`
+/// lost: it is a cloud that hangs, so it would belong where the bile lands
+/// rather than where it leaves, and the bile that lands is the half that
+/// already draws.
+pub fn bile(from: Vec3, toward: Vec3) -> Particles {
+    let eye = from + Vec3::Y * CHEST;
+    Particles::line(Particle::Spit, eye, eye + toward.normalize_or_zero() * 2.5)
+        .points(10)
+        .count(3)
+        .offset(Vec3::splat(0.3))
+        .speed(0.15)
+        .long_distance(true)
+}
+
+/// Something dead reaching out for somebody.
+///
+/// `minecraft:soul`, which vanilla lifts off soul sand under a player wearing
+/// Soul Speed: its one picture of the dead grabbing at whatever walks past.
+/// [`bowshot`]'s `crit` is the closer fit to the *arrow* and lost anyway: the
+/// arrow is only the delivery, the hand on the far end of it is the ability,
+/// and the particle is the Skeleton's besides.
+pub fn grasp(from: Vec3, toward: Vec3) -> Particles {
+    let eye = from + Vec3::Y * CHEST;
+    Particles::line(Particle::Soul, eye, eye + toward.normalize_or_zero() * 3.0)
+        .points(12)
+        .speed(DRIFT)
+        .long_distance(true)
+}
+
+/// Eggs leaving somebody at speed.
+///
+/// `minecraft:egg_crack`, what vanilla draws when a thrown egg breaks and when
+/// a chicken lays one. The eggs are already flying entities, so what was
+/// missing is the muzzle, on the same reasoning as [`torn_earth`]: the thing
+/// nobody could see was the moment of them leaving.
+pub fn egg_burst(from: Vec3, toward: Vec3) -> Particles {
+    let eye = from + Vec3::Y * CHEST;
+    Particles::line(
+        Particle::EggCrack,
+        eye,
+        eye + toward.normalize_or_zero() * 2.0,
+    )
+    .points(8)
+    .count(2)
+    .offset(Vec3::splat(0.25))
+    .speed(0.1)
+    .long_distance(true)
+}
+
+/// Feathers knocked loose by something small beating its wings hard.
+///
+/// White `minecraft:dust`. Vanilla draws nothing at all when a chicken flaps
+/// and has no feather particle, so this is a colour choice rather than a
+/// citation, called out on the same terms as [`milk`]. [`wingbeat`] lost:
+/// `dragon_breath` is sized and coloured for the largest thing in the game and
+/// the Chicken is the smallest.
+pub fn feathers(at: Vec3) -> Particles {
+    Particles::burst(
+        Particle::Dust {
+            color: Argb::opaque(0xFF, 0xFF, 0xFF),
+            scale: 0.8,
+        },
+        at + Vec3::Y * CHEST,
+    )
+    .count(14)
+    .offset(Vec3::new(0.4, 0.5, 0.4))
+    .speed(0.08)
+    .long_distance(true)
+}
+
+/// A body big enough that standing near it is the whole danger.
+///
+/// `minecraft:item_slime` again, deliberately the same particle as [`slam`]:
+/// both are the Slime's own body arriving on somebody, and a second slime
+/// picture would invent a distinction the kit does not make. A shell at the
+/// radius that hurts and not a puff at the caster, because the only fact a
+/// player needs off a Giga Slime is whether they are inside it.
+pub const fn giga_body(at: Vec3, radius: f32) -> Particles {
+    Particles::sphere(Particle::ItemSlime, at, radius)
+        .points(48)
+        .count(2)
+        .speed(0.05)
+        .long_distance(true)
+}
+
+/// Something catching light and staying alight.
+///
+/// `minecraft:flame`, full size, as a shell around the caster. [`burn`] draws
+/// the same particle as a puff at the chest, and the difference in shape is
+/// load-bearing: that one is a point of damage ticking on a victim, this one
+/// is a Blaze announcing twenty seconds of being a hazard, and a player has to
+/// be able to tell at a glance which of the two is in front of them.
+pub fn pyre(at: Vec3, radius: f32) -> Particles {
+    Particles::sphere(Particle::Flame, at + Vec3::Y, radius)
+        .points(40)
+        .count(2)
+        .speed(0.05)
+        .long_distance(true)
+}
+
+/// The violet a Guardian's beam reads as.
+///
+/// Vanilla's guardian laser is a rendered beam texture and not a particle at
+/// all, so like [`milk`] this is a colour chosen rather than one cited off an
+/// effect. Named once because two functions draw it, and a flare in one violet
+/// with a beam in another would be two lasers.
+const LASER_VIOLET: Argb = Argb::opaque(0x9A, 0x5C, 0xD0);
+
+/// A beam singling one player out.
+///
+/// Drawn between the two players: the entire content of a mark is *who* it
+/// landed on, and a puff at the caster answers everything except that.
+pub fn mark_beam(from: Vec3, to: Vec3) -> Particles {
+    Particles::line(
+        Particle::Dust {
+            color: LASER_VIOLET,
+            scale: 1.0,
+        },
+        from + Vec3::Y * CHEST,
+        to + Vec3::Y * CHEST,
+    )
+    .points(32)
+    .long_distance(true)
+}
+
+/// An eye lighting up, whether or not a beam follows it.
+///
+/// [`mark_beam`]'s violet at [`mark_beam`]'s own origin, so the flare sits
+/// exactly where the beam roots and the two read as one ability. This exists
+/// because the beam needs a target and the press does not: a Guardian who
+/// presses the button with nobody in range spends the ability and, without
+/// this, sees nothing at all.
+pub fn laser_eye(at: Vec3) -> Particles {
+    Particles::burst(
+        Particle::Dust {
+            color: LASER_VIOLET,
+            scale: 1.0,
+        },
+        at + Vec3::Y * CHEST,
+    )
+    .count(10)
+    .offset(Vec3::splat(0.2))
+    .speed(DRIFT)
     .long_distance(true)
 }

--- a/events/smash/tests/abilities.rs
+++ b/events/smash/tests/abilities.rs
@@ -312,23 +312,23 @@ fn probe_hit(bench: &Bench) -> bool {
 }
 
 /// What one melee swing at the near victim takes off, right now.
+///
+/// The amount comes from [`smash::input::melee_damage`], which is the function
+/// a real attack packet goes through, and not from a copy of it written out
+/// here. That distinction is the whole value of this helper. It used to read
+/// the kit's base damage, read [`MeleeBonus`], add them, and deal exactly that
+/// -- which compares the formula against itself and passes whatever the game
+/// does. Under that version, deleting the bonus lookup from the swing path
+/// would have left every `buffs_melee` assertion green and the failure would
+/// have surfaced only in `nix run .#smash-e2e`, where a real client swings.
 fn melee_damage(bench: &Bench, now: f32) -> f32 {
-    use smash::module::{damage::MeleeBonus, kit::KitStats};
-
-    let caster = bench.caster();
-    let base = caster
-        .target(Playing, 0)
-        .and_then(|kit| kit.try_get::<&KitStats>(|stats| stats.melee_damage))
-        .unwrap_or(1.0);
-    let bonus = caster
-        .try_get::<&MeleeBonus>(|bonus| bonus.applies_to(bench.near, now))
-        .unwrap_or(0.0);
+    let amount = smash::input::melee_damage(bench.caster(), bench.near, now);
 
     let victim = bench.game.world.entity_from_id(bench.near);
     let before = victim.cloned::<&Health>().current;
     hurt(victim, Damaged {
         attacker: Some(bench.caster),
-        amount: base + bonus,
+        amount,
         knockback: Knockback::from(Vec3::ZERO),
         kind: DamageKind::Melee,
     });

--- a/events/smash/tests/zz_measure_visibility.rs
+++ b/events/smash/tests/zz_measure_visibility.rs
@@ -1,0 +1,92 @@
+//! Scratch measurement: what does each ability draw? Not for merge.
+mod harness;
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use harness::{Game, TICK};
+use smash::{
+    module::{
+        ability::{self, Declared},
+        kit::{self, Playing},
+        player::{Energy, Health, OnGround, Position},
+        projectile::Visual,
+    },
+    server::mock::Call,
+};
+
+fn arm(game: &Game, caster: Entity, entry: &Declared) {
+    if !entry.ultimate {
+        return;
+    }
+    let _ = kit::grant_ultimate(&game.world, game.world.entity_from_id(caster), 600.0);
+}
+
+#[test]
+fn measure_visibility() {
+    let manifest = ability::manifest(&Game::new().world);
+    let mut rows = Vec::new();
+
+    for entry in &manifest {
+        let mut game = Game::new();
+        let caster = game.player("caster", Vec3::ZERO);
+        let near = game.player("near", Vec3::new(3.5, 0.0, 0.0));
+        let world = &game.world;
+        let chosen = kit::by_name(world, entry.kit).unwrap();
+        for e in [caster, near] {
+            kit::apply(world, world.entity_from_id(e), chosen);
+        }
+        for (e, at) in [(caster, Vec3::ZERO), (near, Vec3::new(3.5, 0.0, 0.0))] {
+            let p = world.entity_from_id(e);
+            p.set(Position(at));
+            p.set(OnGround(true));
+            p.get::<&mut Health>(|h| h.current = h.max);
+            if let Some(mut en) = p.try_get::<&Energy>(|x| *x) {
+                en.current = en.max;
+                p.set(en);
+            }
+        }
+        arm(&game, caster, entry);
+        game.server.take();
+
+        let cv = game.world.entity_from_id(caster);
+        match entry.charge_time {
+            Some(s) => {
+                ability::use_slot(cv, entry.slot);
+                game.advance(s, 8);
+                ability::release_slot(cv, entry.slot);
+            }
+            None => ability::use_slot(cv, entry.slot),
+        }
+        game.advance(TICK, 1);
+
+        // projectiles alive right after the press
+        let mut projectiles = 0usize;
+        game.world
+            .query::<&Visual>()
+            .build()
+            .each(|_| projectiles += 1);
+
+        game.advance(1.5, 30);
+
+        let calls = game.server.calls();
+        let particles = calls
+            .iter()
+            .filter(|c| matches!(c, Call::Particles(..)))
+            .count();
+        let status = calls.iter().filter(|c| matches!(c, Call::Status(..))).count();
+        let teleport = calls
+            .iter()
+            .filter(|c| matches!(c, Call::Teleport(..)))
+            .count();
+
+        rows.push(format!(
+            "VIS\t{}\t{}\tparticles={particles}\tprojectiles={projectiles}\tstatus={status}\tteleport={teleport}\tult={}",
+            entry.kit, entry.name, entry.ultimate
+        ));
+    }
+
+    for row in &rows {
+        println!("{row}");
+    }
+    println!("VIS-TOTAL\t{}", rows.len());
+}


### PR DESCRIPTION
`tools/smash-match.py` joins a real Minecraft client to a real server, presses
every ability in the roster and refuses one that sends no `level_particles`.
It named 23. A 24th, `Zombie / Bile Blaster`, was passing only when a thrown
blob happened to land on somebody.

**Measured before and after, on a real client, on x86_64-linux:**

| | before | after |
|---|---|---|
| particle failures | 23 | **0** |
| total sweep failures | 25 | 2 |

The two that remain are `Cow / Mooshroom Madness` and `Guardian / Target Laser`
on `buffs_melee`. Those are a harness measurement defect, not a game defect,
and are filed as ENG-11399 with the evidence: the repaired game bench, which
now calls the same function a real attack packet calls, passes both.

## What it does

The cheap fix would be a `visuals::blast` in each. That passes the gate and
leaves the game where it started: a player who sees the same grey puff for a
bow, a web, an ink cloud and a tidal wave has learnt nothing from any of them.
So `visuals` gains a vocabulary, and each entry picks the particle vanilla
already uses for the thing depicted, so a player who has played Minecraft
reads it without being taught.

Shape carries meaning. An aura is a ring and not a disc, because the only
fact a player needs from an aura is whether they are inside it. A lunge is a
line from where it began to where it ended. A wave is a rising wall at its
own radius.

Two of these are not decoration. Ice Path is documented as laying ice blocks,
the seam cannot write blocks, so the ability was a small hop and nothing else;
the drawn path is a player's only evidence it exists. Arctic Aura is the same
at radius 5. The Snowman and the Wolf had no visual identity at all.

Sustained ultimates draw on their beat. A twenty second mode that draws once
is a twenty second window a victim cannot see they are inside.

## And the draw happens on the press

The second commit is the part Bile Blaster forced. Seven abilities drew only
after some contingent later event, usually a projectile connecting, so the
gate decided their fate on a coin flip. The draw now happens on the press
itself, above any branch a miss or a failed lookup can skip. Guardian's Target
Laser is the clearest: it returns if nobody is in range, so it draws at the
caster first and only then a beam to whoever got marked.

## A test that could not fail, fixed and watched failing

Found while chasing the two `buffs_melee` abilities.
`tests/abilities.rs::melee_damage` read the kit's base damage, read
`MeleeBonus`, added them, and dealt exactly that much, then checked the damage
had gone up. It compared one copy of the formula against another copy of
itself. Deleting the bonus lookup from the swing path would have left every
`buffs_melee` assertion green forever.

It now calls `input::melee_damage`, the function a real attack packet calls.
Proved rather than asserted: with the bonus lookup removed from that function,
`every_declared_effect_actually_happens` goes red; restored, green. Under the
old helper that deletion was invisible.

Verified: `cargo test -p smash` 292 tests green across 27 binaries, and the
real-client sweep above.

(sent by an AI agent via Claude Code)