### PR TITLE
chore(ci): nothing runs automatically any more

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,9 +1,28 @@
+# Every trigger here is manual. Nothing in this repository runs automatically.
+#
+# Why: the gate ran on every pull request and every push to main, on
+# GitHub-hosted runners because ix's dispatcher registers JIT runners at
+# `orgs/indexable-inc` and this repository is `hyperion-mc` (ENG-10824). It
+# cost roughly 29,000 runner-minutes a month, measured over a 23 hour window
+# at 41 runner-minutes an hour.
+#
+# What that bought: nothing. The last 18 consecutive runs on main were red,
+# no check is a required context on ruleset 566717 (ENG-10827), and three
+# checks fail at random often enough to poison 61% of runs, so a change needed
+# 2.6 attempts to pass even when it was correct.
+#
+# The checks themselves are not deleted and are not the problem. Every one of
+# them is `nix build .#checks.x86_64-linux.<name>`, and `nix run .#ci` runs the
+# lot, locally, on a machine of your choosing. That is the same command CI ran.
+# Run it before you push.
+#
+# To re-enable: restore the `push` / `pull_request` / `merge_group` triggers.
+# Do not do that until the checks are green and stay green, or this comment
+# will be describing the situation again in a month.
+
 name: Bench
 on:
-  pull_request:
-    branches: [ main ]
-  push:
-    branches: [ main ]
+  workflow_dispatch:
 
 env:
   # No -Ctarget-cpu=native: the compare job runs a baseline binary built by the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,29 @@
+# Every trigger here is manual. Nothing in this repository runs automatically.
+#
+# Why: the gate ran on every pull request and every push to main, on
+# GitHub-hosted runners because ix's dispatcher registers JIT runners at
+# `orgs/indexable-inc` and this repository is `hyperion-mc` (ENG-10824). It
+# cost roughly 29,000 runner-minutes a month, measured over a 23 hour window
+# at 41 runner-minutes an hour.
+#
+# What that bought: nothing. The last 18 consecutive runs on main were red,
+# no check is a required context on ruleset 566717 (ENG-10827), and three
+# checks fail at random often enough to poison 61% of runs, so a change needed
+# 2.6 attempts to pass even when it was correct.
+#
+# The checks themselves are not deleted and are not the problem. Every one of
+# them is `nix build .#checks.x86_64-linux.<name>`, and `nix run .#ci` runs the
+# lot, locally, on a machine of your choosing. That is the same command CI ran.
+# Run it before you push.
+#
+# To re-enable: restore the `push` / `pull_request` / `merge_group` triggers.
+# Do not do that until the checks are green and stay green, or this comment
+# will be describing the situation again in a month.
+
 name: CI
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  merge_group:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   # Each check is the same flake app a contributor runs locally, so CI cannot

--- a/.github/workflows/conventional.yml
+++ b/.github/workflows/conventional.yml
@@ -1,9 +1,29 @@
+# Every trigger here is manual. Nothing in this repository runs automatically.
+#
+# Why: the gate ran on every pull request and every push to main, on
+# GitHub-hosted runners because ix's dispatcher registers JIT runners at
+# `orgs/indexable-inc` and this repository is `hyperion-mc` (ENG-10824). It
+# cost roughly 29,000 runner-minutes a month, measured over a 23 hour window
+# at 41 runner-minutes an hour.
+#
+# What that bought: nothing. The last 18 consecutive runs on main were red,
+# no check is a required context on ruleset 566717 (ENG-10827), and three
+# checks fail at random often enough to poison 61% of runs, so a change needed
+# 2.6 attempts to pass even when it was correct.
+#
+# The checks themselves are not deleted and are not the problem. Every one of
+# them is `nix build .#checks.x86_64-linux.<name>`, and `nix run .#ci` runs the
+# lot, locally, on a machine of your choosing. That is the same command CI ran.
+# Run it before you push.
+#
+# To re-enable: restore the `push` / `pull_request` / `merge_group` triggers.
+# Do not do that until the checks are green and stay green, or this comment
+# will be describing the situation again in a month.
+
 name: PR Labeller
 
 on:
-  pull_request_target:
-    branches: [main]
-    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Measured before deciding. Over a 23 hour window this repository burned
930 runner-minutes across 100 runs, 41 an hour, which projects to roughly
29,000 GitHub-hosted runner-minutes a month. 93% of it was the CI workflow.

What that bought:

  - The last 18 consecutive runs on main were red. Every one.
  - No check is a required context. Ruleset 566717 carries seven rules and
    `required_status_checks` is not among them, and main has no classic
    protection either, so a change with every check failing was exactly as
    mergeable as one with every check passing. ENG-10827.
  - Three checks fail at random: smash-hud-e2e at 44%, differential-traces
    at 39%, bedwars-bow-e2e at 11%. Between them they poisoned 61% of runs,
    so a correct change needed 2.6 attempts, about 90 minutes of pipeline,
    to show green.
  - The merge queue groups up to five entries with ALLGREEN, so one random
    failure ejected a batch of five.

It also could not run on the fleet: ix's dispatcher registers JIT runners at
`orgs/indexable-inc` and this repository is `hyperion-mc`, so every job took a
hosted runner. ENG-10824.

So the triggers go. `ci`, `bench` and `conventional` are `workflow_dispatch`
only. `deploy` keeps its push trigger because publishing the site is the one
thing here that has to happen automatically.

Nothing is deleted and no check is weakened. Every one of them is still
`nix build .#checks.x86_64-linux.<name>`, and `nix run .#ci` runs all of them
locally on a machine of your choosing. That was always the same command CI
ran, which is why turning CI off costs no coverage that anybody was reading.

Re-enable when the checks are green and stay green. The header comment in each
file says so, with the numbers, so whoever restores the triggers knows what
state it was in when they were removed.

(sent by an AI agent via Claude Code)