### PR TITLE
chore(ci): correct why the triggers were removed

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,12 +1,12 @@
 # Every trigger here is manual. Nothing in this repository runs automatically.
 #
-# Why: the gate ran on every pull request and every push to main, on
-# GitHub-hosted runners because ix's dispatcher registers JIT runners at
-# `orgs/indexable-inc` and this repository is `hyperion-mc` (ENG-10824). It
-# cost roughly 29,000 runner-minutes a month, measured over a 23 hour window
-# at 41 runner-minutes an hour.
+# Why, and NOT for the reason the first version of this comment gave. It said
+# the gate cost roughly 29,000 runner-minutes a month, which is true and was
+# wrong to lead with: this repository is public and runs on `ubuntu-latest`,
+# and GitHub bills nothing for standard hosted runners on a public repository.
+# The pipeline was free. The reason is signal, not money.
 #
-# What that bought: nothing. The last 18 consecutive runs on main were red,
+# The last 18 consecutive runs on main were red,
 # no check is a required context on ruleset 566717 (ENG-10827), and three
 # checks fail at random often enough to poison 61% of runs, so a change needed
 # 2.6 attempts to pass even when it was correct.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 # Every trigger here is manual. Nothing in this repository runs automatically.
 #
-# Why: the gate ran on every pull request and every push to main, on
-# GitHub-hosted runners because ix's dispatcher registers JIT runners at
-# `orgs/indexable-inc` and this repository is `hyperion-mc` (ENG-10824). It
-# cost roughly 29,000 runner-minutes a month, measured over a 23 hour window
-# at 41 runner-minutes an hour.
+# Why, and NOT for the reason the first version of this comment gave. It said
+# the gate cost roughly 29,000 runner-minutes a month, which is true and was
+# wrong to lead with: this repository is public and runs on `ubuntu-latest`,
+# and GitHub bills nothing for standard hosted runners on a public repository.
+# The pipeline was free. The reason is signal, not money.
 #
-# What that bought: nothing. The last 18 consecutive runs on main were red,
+# The last 18 consecutive runs on main were red,
 # no check is a required context on ruleset 566717 (ENG-10827), and three
 # checks fail at random often enough to poison 61% of runs, so a change needed
 # 2.6 attempts to pass even when it was correct.

--- a/.github/workflows/conventional.yml
+++ b/.github/workflows/conventional.yml
@@ -1,12 +1,12 @@
 # Every trigger here is manual. Nothing in this repository runs automatically.
 #
-# Why: the gate ran on every pull request and every push to main, on
-# GitHub-hosted runners because ix's dispatcher registers JIT runners at
-# `orgs/indexable-inc` and this repository is `hyperion-mc` (ENG-10824). It
-# cost roughly 29,000 runner-minutes a month, measured over a 23 hour window
-# at 41 runner-minutes an hour.
+# Why, and NOT for the reason the first version of this comment gave. It said
+# the gate cost roughly 29,000 runner-minutes a month, which is true and was
+# wrong to lead with: this repository is public and runs on `ubuntu-latest`,
+# and GitHub bills nothing for standard hosted runners on a public repository.
+# The pipeline was free. The reason is signal, not money.
 #
-# What that bought: nothing. The last 18 consecutive runs on main were red,
+# The last 18 consecutive runs on main were red,
 # no check is a required context on ruleset 566717 (ENG-10827), and three
 # checks fail at random often enough to poison 61% of runs, so a change needed
 # 2.6 attempts to pass even when it was correct.


### PR DESCRIPTION
The header comment #1088 added leads with a cost figure, roughly 29,000
GitHub-hosted runner-minutes a month. The figure is real and leading with it
was wrong, because it reads as an expense and there was none: this repository
is public and the `flake` job runs on `ubuntu-latest`, which is a standard
runner, and GitHub's billing documentation says use of standard hosted runners
is free and unlimited on public repositories.

So the pipeline cost nothing. The reasons that actually justify removing the
triggers are the other three, and they stand on their own:

  - the last 18 consecutive runs on main were red, every one
  - no check is a required context, so a change with everything failing was as
    mergeable as one with everything passing (ENG-10827)
  - three checks fail at random, 44%, 39% and 11%, poisoning 61% of runs, so a
    correct change needed 2.6 attempts to show green

A decision reached for a stated reason that turns out to be false is a trap for
whoever reads it next, because they inherit the reason rather than the
evidence. The decision was re-confirmed against the corrected reasoning before
this commit was written.

Found by the agent measuring runner sizing, which turned up that the org is on
the Free plan and sent me to check the billing rules.

(sent by an AI agent via Claude Code)