### PR TITLE
ci: judge pull requests on the delta from main, not on absolute green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,26 @@
 name: CI
 
 on:
+  # LEFT DELIBERATELY MANUAL. #1088 and #1089 removed every automatic trigger,
+  # and the header above has the reasoning: 18 consecutive red runs on main, no
+  # required status context, and three checks failing at random often enough to
+  # poison 61% of runs.
+  #
+  # This change answers two of those three and restores none of the triggers. A
+  # differential verdict makes a red base survivable and stops the three coin
+  # flips being blamed on anybody, but it does not make the checks green, and
+  # green-and-stays-green is the bar #1089 set. Restoring the triggers is a
+  # decision for whoever set that bar, not a side effect of landing the
+  # machinery that changes what the bar is worth.
+  #
+  # Until then `workflow_dispatch` exercises the whole path, and it is what
+  # produces the first baseline and the first instability samples.
+  #
+  # WHEN THE TRIGGERS COME BACK, ADD `schedule` WITH THEM. Running an unchanged
+  # tree again is the cleanest probe for nondeterminism there is, because the
+  # derivations are identical and any disagreement is therefore a proof. That
+  # record is what decides which checks are coin flips, and without it the gate
+  # only learns from the pushes people happen to make.
   workflow_dispatch:
 
 jobs:
@@ -96,15 +116,34 @@ jobs:
   flake:
     name: Flake
     runs-on: ubuntu-latest
+    # Reading the baseline and the instability record is two artifact API calls.
+    # Nothing here needs write access to anything.
+    permissions:
+      contents: read
+      actions: read
     # A runner-level guard, not a target. The gate realises every check from a
     # cold hosted store in one `nix build --keep-going`, so nix schedules them
     # up to `max-jobs` (auto, four here) rather than one at a time. The floor is
     # the release compile plus the longest single gate behind it: on run
     # 30500640846 that was roughly 500 seconds of crate graph and then
     # `smash-e2e` at 639.
+    #
+    # THIS NUMBER MUST DROP BELOW 60 BEFORE THE VERDICT BECOMES A REQUIRED
+    # CONTEXT. Ruleset 566717's merge_queue rule sets
+    # `check_response_timeout_minutes: 60`, so a job permitted to take 90 can be
+    # abandoned by the queue at 60, and the failure presents as a mysterious
+    # queue timeout rather than as two numbers that disagree. It is invisible
+    # today only because nothing is required. The invariant is `timeout-minutes`
+    # strictly below the queue timeout; either may move, they must not cross.
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The differential verdict forfeits derivation-identity immunity for a
+          # pull request that changes what the derivation does not capture but
+          # the run depends on, and answering that needs the diff against the
+          # base rather than one commit.
+          fetch-depth: 0
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           # The DAEMON is what decides whether a content-addressed derivation
@@ -115,7 +154,14 @@ jobs:
           # succeeds. The gate re-checks this itself and says so if it is lost.
           extra-conf: |
             extra-experimental-features = ca-derivations
-      - run: nix run --accept-flake-config .#flake-gate
+      - name: Flake gate
+        env:
+          HYPERION_GATE_OUT_DIR: ${{ runner.temp }}/gate/out
+          HYPERION_GATE_BASELINE: ${{ runner.temp }}/gate/baseline.json
+          HYPERION_GATE_INSTABILITY: ${{ runner.temp }}/gate/instability.json
+          HYPERION_GATE_CHANGED_FILES: ${{ runner.temp }}/gate/changed-files.txt
+        run: nix run --accept-flake-config .#flake-gate
+
       # One json line per check: attr, outcome, drvPath. Uploaded even when the
       # gate is red, because a red gate is the case a consumer differencing two
       # runs is there for. `if: always()` and not `if: failure()`: the run this
@@ -124,8 +170,112 @@ jobs:
         if: always()
         with:
           name: flake-gate-results
-          path: flake-gate-results.jsonl
+          path: ${{ runner.temp }}/gate/out/results.jsonl
           if-no-files-found: error
+
+      # Read before building, because a rejected baseline is a normal outcome
+      # that has to reach the summary rather than fail the job. Both scripts
+      # exit 0 whatever happens and print one line saying what they found.
+      - name: Read the baseline and the instability record
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/gate"
+          bash nix/ci/gate-artifacts.sh baseline "$RUNNER_TEMP/gate/baseline.json"
+          bash nix/ci/gate-artifacts.sh instability "$RUNNER_TEMP/gate/instability.json"
+
+      # What the pull request touches, for the immunity-forfeiture guard. An
+      # empty file (a push, a schedule) forfeits nothing, which is right: main
+      # is the reference and has no base to be judged against.
+      - name: List the files this pull request changes
+        if: github.event_name == 'pull_request'
+        run: |
+          git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}...HEAD" \
+            >"$RUNNER_TEMP/gate/changed-files.txt"
+
+      - name: Flake gate
+        env:
+          HYPERION_GATE_OUT_DIR: ${{ runner.temp }}/gate/out
+          HYPERION_GATE_BASELINE: ${{ runner.temp }}/gate/baseline.json
+          HYPERION_GATE_INSTABILITY: ${{ runner.temp }}/gate/instability.json
+          HYPERION_GATE_CHANGED_FILES: ${{ runner.temp }}/gate/changed-files.txt
+        run: nix run --accept-flake-config .#flake-gate
+
+      # Publish on GREEN as well as red, and this is not an optimisation to
+      # skip. A pull request takes the NEWEST baseline, so the moment main goes
+      # green the newest baseline names no failures and every standing excuse
+      # disappears in the same instant. Publishing only on red would leave the
+      # last red baseline excusing failures that main has already repaired.
+      - name: Publish the baseline
+        if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-check-failures
+          path: ${{ runner.temp }}/gate/out/results.json
+          retention-days: 14
+
+      # Only main and the nightly fold the record. A pull request reads it and
+      # does not write it: two pull requests finishing at once would each fold
+      # from the same parent and one set of samples would be lost, and the
+      # measured flake rate is defined over main runs anyway. The cost is that
+      # samples seen only on a pull request are not kept.
+      - name: Publish the instability record
+        if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: gate-instability
+          path: |
+            ${{ runner.temp }}/gate/out/instability.json
+            ${{ runner.temp }}/gate/out/flake-rate.json
+          retention-days: 30
+
+      # The verdict rides along on every run, green or red, so the decision and
+      # its evidence stay available after the log scrolls away.
+      - name: Publish the verdict
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gate-verdict
+          path: |
+            ${{ runner.temp }}/gate/out/verdict.json
+            ${{ runner.temp }}/gate/out/results.json
+            ${{ runner.temp }}/gate/out/summary.md
+          retention-days: 14
+
+  # The pressure mechanism, and the only part of this that asks a person for
+  # anything. See nix/ci/standing-issue.sh for why it is one issue rewritten in
+  # place rather than a notification per red run.
+  #
+  # Its own job so that `issues: write` stays off the job that builds the tree.
+  # DRY RUN until someone sets GATE_ISSUE_APPLY=1: a script that files issues
+  # should be watched rendering its output before it is allowed to file
+  # anything, and the render is the whole of what it does.
+  standing-issue:
+    name: Standing issue
+    runs-on: ubuntu-latest
+    needs: flake
+    if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: gate-verdict
+          path: gate
+      - uses: actions/download-artifact@v4
+        with:
+          name: gate-instability
+          path: gate
+        continue-on-error: true
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          # Flip to "1" to let it write. One line, deliberately.
+          GATE_ISSUE_APPLY: "0"
+        run: bash nix/ci/standing-issue.sh gate/results.json gate/instability.json
 
   coverage:
     name: Code Coverage

--- a/flake.nix
+++ b/flake.nix
@@ -1463,9 +1463,34 @@
           checks = baseChecks // {
             flake-gate = import ./nix/ci/flake-gate.nix {
               inherit lib system;
-              inherit (pkgs) writeShellApplication;
+              inherit (pkgs) writeShellApplication bash jq;
               names = builtins.attrNames checks;
             };
+
+            # The differential verdict, exercised against fixtures rather than
+            # against a real run: no network, no nix, no clock. Every row of the
+            # table in nix/ci/delta-gate.sh gets a case, and so does the inverse
+            # of every guard, because the failure mode of a test like this is
+            # passing for the wrong reason. Six deliberate mutations of the
+            # verdict logic were each caught by a named case before this landed.
+            delta-gate = pkgs.runCommand "check-delta-gate"
+              {
+                nativeBuildInputs = [
+                  pkgs.bash
+                  pkgs.jq
+                  pkgs.coreutils
+                  pkgs.gnugrep
+                  pkgs.gnused
+                ];
+              }
+              ''
+                install -m 0755 ${./nix/ci/delta-gate.sh} delta-gate.sh
+                install -m 0755 ${./nix/ci/delta-gate-tests.sh} delta-gate-tests.sh
+                # The suite locates the library beside itself, so both have to
+                # sit in one directory rather than being read from the store.
+                bash ./delta-gate-tests.sh
+                touch $out
+              '';
           };
 
         in

--- a/nix/ci/delta-gate-tests.sh
+++ b/nix/ci/delta-gate-tests.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# Fixture tests for nix/ci/delta-gate.sh. No network, no nix, no clock beyond
+# `date`, so `nix build .#checks.<system>.delta-gate` runs the whole table.
+#
+# Every row of the verdict table gets a case, and so does every guard. A guard
+# nobody has watched fail is not a guard: the cases below deliberately include
+# the inverse of each one (immunity granted AND immunity forfeited, cap blocks
+# AND cap yields to a shrinking set), because the failure mode of this file is
+# a test that passes for the wrong reason.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Invoked through `bash` rather than executed: a nix build sandbox has no
+# /usr/bin/env, so the shebang would exit 126 and every case would fail for
+# a reason that has nothing to do with the verdict.
+dg() { bash "${here}/delta-gate.sh" "$@"; }
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+pass=0
+fail=0
+
+# `check <name> <expected> <actual>`
+check() {
+  if [[ "$2" == "$3" ]]; then
+    printf 'ok    %s\n' "$1"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL  %s\n        expected: %s\n        actual:   %s\n' "$1" "$2" "$3"
+    fail=$((fail + 1))
+  fi
+}
+
+# The library must PARSE before anything else is asserted. Twice now an
+# apostrophe inside a jq program has ended the enclosing shell string, and the
+# symptom was sixty failing cases rather than one syntax error. One line here
+# turns that back into one line of output.
+if ! bash -n "${here}/delta-gate.sh" 2>"${work}/parse.err"; then
+  printf 'FAIL  delta-gate.sh does not parse\n'
+  cat "${work}/parse.err"
+  printf '\nhint: an apostrophe inside a single-quoted jq program ends the string.\n'
+  exit 1
+fi
+printf 'ok    delta-gate.sh parses\n'
+
+now="$(date +%s)"
+
+# results <file> <runId> <evalFailed> <attr:outcome:drv> ...
+# `outcome` is flake-gate.nix's own vocabulary: pass or fail.
+results() {
+  local out=$1 run=$2 evalFailed=$3
+  shift 3
+  local checks="[]" entry
+  for entry in "$@"; do
+    IFS=: read -r a o d <<<"${entry}"
+    checks="$(jq -c --arg a "$a" --arg o "$o" --arg d "$d" \
+      '. + [{attr: $a, outcome: $o, drvPath: (if $d == "" then null else $d end)}]' <<<"${checks}")"
+  done
+  jq -n --arg run "${run}" --argjson ef "${evalFailed}" --argjson checks "${checks}" \
+    --argjson epoch "${now}" \
+    '{schemaVersion: 1, system: "x86_64-linux", commit: "deadbeef", runId: $run,
+      recordedAt: "2026-07-29T00:00:00Z", recordedAtEpoch: $epoch,
+      evalFailed: $ef, checks: $checks}' >"${out}"
+}
+
+verdict_field() { jq -r "$2" "$1"; }
+
+# --- row 1: fails here, fails on the base -> excused, gate passes -------------
+results "${work}/pr.json"   pr   false "smash-e2e:fail:/nix/store/A.drv" "ok-check:pass:/nix/store/B.drv"
+results "${work}/base.json" base false "smash-e2e:fail:/nix/store/A.drv" "ok-check:pass:/nix/store/B.drv"
+dg verdict "${work}/pr.json" "${work}/base.json" "" "" "" >"${work}/v.json"
+check "row1 fails-both: gate passes"   true    "$(verdict_field "${work}/v.json" .gatePasses)"
+check "row1 fails-both: excused names it" "smash-e2e" "$(verdict_field "${work}/v.json" '.excused[0].attr')"
+check "row1 fails-both: identical drv recorded" "identical-drv" "$(verdict_field "${work}/v.json" '.excused[0].evidence')"
+check "row1 fails-both: nothing blocked" 0 "$(verdict_field "${work}/v.json" '.blocked | length')"
+
+# --- row 2: fails here, passes on the base, DIFFERENT drv -> BLOCK ------------
+# The regression case. `minecraft-literals` on 2026-07-29 was exactly this: the
+# derivation moved and the outcome flipped, and it must not be excused.
+results "${work}/pr.json"   pr   false "minecraft-literals:fail:/nix/store/NEW.drv"
+results "${work}/base.json" base false "minecraft-literals:pass:/nix/store/OLD.drv"
+dg verdict "${work}/pr.json" "${work}/base.json" "" "" "" >"${work}/v.json"
+check "row2 new-failure: gate BLOCKS" false "$(verdict_field "${work}/v.json" .gatePasses)"
+check "row2 new-failure: names the check" "minecraft-literals" "$(verdict_field "${work}/v.json" '.blocked[0].attr')"
+check "row2 new-failure: verdict is block" "block" "$(verdict_field "${work}/v.json" .verdict)"
+check "row2 new-failure: not excused as unstable" 0 "$(verdict_field "${work}/v.json" '.unstable | length')"
+
+# --- row 2b: same, but the drv is IDENTICAL -> nondeterminism, not a block ----
+# `differential-traces` on 2026-07-29: byte-identical derivation, opposite
+# outcomes, eighteen minutes apart.
+results "${work}/pr.json"   pr   false "differential-traces:fail:/nix/store/SAME.drv"
+results "${work}/base.json" base false "differential-traces:pass:/nix/store/SAME.drv"
+dg verdict "${work}/pr.json" "${work}/base.json" "" "" "" >"${work}/v.json"
+check "row2b same-drv flip: gate passes" true "$(verdict_field "${work}/v.json" .gatePasses)"
+check "row2b same-drv flip: reported unstable" "differential-traces" "$(verdict_field "${work}/v.json" '.unstable[0].attr')"
+check "row2b same-drv flip: evidence names the proof" "identical-drv-passed-on-base" \
+  "$(verdict_field "${work}/v.json" '.unstable[0].evidence')"
+check "row2b same-drv flip: nothing blocked" 0 "$(verdict_field "${work}/v.json" '.blocked | length')"
+
+# --- guard: immunity forfeited -> the SAME input now blocks -------------------
+# The inverse of row2b, on byte-identical fixtures. If this does not flip, the
+# forfeiture is decorative.
+dg verdict "${work}/pr.json" "${work}/base.json" "" "" "touches nix/ci/flake-gate.nix" >"${work}/v.json"
+check "forfeit: same-drv flip now BLOCKS" false "$(verdict_field "${work}/v.json" .gatePasses)"
+check "forfeit: reason is carried" "touches nix/ci/flake-gate.nix" \
+  "$(verdict_field "${work}/v.json" .forfeitReason)"
+check "forfeit: no longer excused as unstable" 0 "$(verdict_field "${work}/v.json" '.unstable | length')"
+
+# --- a changed check set withdraws the identical-derivation excuse ------------
+# The gap this closes: a pull request that ADDS a check adds contention under a
+# concurrent gate, which can time out an e2e check whose own derivation did not
+# move. Without this, that reads as a coin flip and is waved through.
+results "${work}/pr.json"   pr   false "proxy:fail:/nix/store/P.drv" "brand-new-check:pass:/nix/store/X.drv"
+results "${work}/base.json" base false "proxy:pass:/nix/store/P.drv"
+dg verdict "${work}/pr.json" "${work}/base.json" "" "" "" >"${work}/v.json"
+check "check-set: adding a check withdraws same-drv immunity" false "$(verdict_field "${work}/v.json" .gatePasses)"
+check "check-set: the change is reported" true "$(verdict_field "${work}/v.json" .checkSetChanged)"
+check "check-set: the new failure is named" "proxy" "$(verdict_field "${work}/v.json" '.blocked[0].attr')"
+
+# ... and with the check set UNCHANGED the identical fixtures are excused, or
+# the check-set test above is passing for some other reason.
+results "${work}/pr.json"   pr   false "proxy:fail:/nix/store/P.drv"
+dg verdict "${work}/pr.json" "${work}/base.json" "" "" "" >"${work}/v.json"
+check "check-set: unchanged set still grants same-drv immunity" true "$(verdict_field "${work}/v.json" .gatePasses)"
+
+# A check PROVEN nondeterministic keeps its excuse even when the set changed:
+# that is a claim about the check, not about this run.
+results "${work}/f-ok.json"  f1 false "flaky:pass:/nix/store/F.drv"
+results "${work}/f-bad.json" f2 false "flaky:fail:/nix/store/F.drv"
+dg fold ""                 "${work}/f-ok.json"  >"${work}/k1.json"
+dg fold "${work}/k1.json"  "${work}/f-bad.json" >"${work}/krec.json"
+results "${work}/pr.json"   pr   false "flaky:fail:/nix/store/G.drv" "brand-new-check:pass:/nix/store/X.drv"
+results "${work}/base.json" base false "flaky:pass:/nix/store/G.drv"
+dg verdict "${work}/pr.json" "${work}/base.json" "${work}/krec.json" "" "" >"${work}/v.json"
+check "check-set: a proven coin flip keeps its excuse" true "$(verdict_field "${work}/v.json" .gatePasses)"
+check "check-set: and the evidence is the record, not the drv" "proven-nondeterministic" \
+  "$(verdict_field "${work}/v.json" '.unstable[0].evidence')"
+
+# --- row 3: passes here, fails on the base -> fixed, and it is CREDITED -------
+results "${work}/pr.json"   pr   false "completions-e2e:pass:/nix/store/N.drv" "other:pass:/nix/store/B.drv"
+results "${work}/base.json" base false "completions-e2e:fail:/nix/store/O.drv" "other:pass:/nix/store/B.drv"
+dg verdict "${work}/pr.json" "${work}/base.json" "" "" "" >"${work}/v.json"
+check "row3 repaired: gate passes" true "$(verdict_field "${work}/v.json" .gatePasses)"
+check "row3 repaired: named in fixed" "completions-e2e" "$(verdict_field "${work}/v.json" '.fixed[0].attr')"
+check "row3 repaired: not called removed" 0 "$(verdict_field "${work}/v.json" '.removed | length')"
+
+# --- a DELETED check is not a repaired check ---------------------------------
+# The check set moved between 60 and 67 entries over eighteen runs, so a base
+# failure that is simply absent here is a real case and must not read as repair.
+results "${work}/pr.json"   pr   false "other:pass:/nix/store/B.drv"
+results "${work}/base.json" base false "deleted-check:fail:/nix/store/O.drv" "other:pass:/nix/store/B.drv"
+dg verdict "${work}/pr.json" "${work}/base.json" "" "" "" >"${work}/v.json"
+check "removed: not credited as a repair" 0 "$(verdict_field "${work}/v.json" '.fixed | length')"
+check "removed: reported as removed" "deleted-check" "$(verdict_field "${work}/v.json" '.removed[0].attr')"
+check "removed: gate passes" true "$(verdict_field "${work}/v.json" .gatePasses)"
+
+# --- row 4: nothing fails anywhere -> absolute green -------------------------
+results "${work}/pr.json"   pr   false "a:pass:/nix/store/A.drv"
+results "${work}/base.json" base false "a:pass:/nix/store/A.drv"
+dg verdict "${work}/pr.json" "${work}/base.json" "" "" "" >"${work}/v.json"
+check "row4 all-green: gate passes" true "$(verdict_field "${work}/v.json" .gatePasses)"
+check "row4 all-green: verdict is pass" "pass" "$(verdict_field "${work}/v.json" .verdict)"
+
+# --- history-proven instability, when the pull request MOVED the drv ---------
+# The case the within-verdict proof cannot reach: a pull request touching a core
+# crate moves every downstream hash, so the base and PR derivations differ and
+# only the record can speak.
+results "${work}/r-ok.json"   r1 false "smash-hud-e2e:pass:/nix/store/H.drv"
+results "${work}/r-bad.json"  r2 false "smash-hud-e2e:fail:/nix/store/H.drv"
+dg fold ""                  "${work}/r-ok.json"  >"${work}/i1.json"
+dg fold "${work}/i1.json"   "${work}/r-bad.json" >"${work}/inst.json"
+check "fold: the check is proven unstable" "smash-hud-e2e" "$(dg unstable "${work}/inst.json")"
+
+results "${work}/pr.json"   pr   false "smash-hud-e2e:fail:/nix/store/MOVED.drv"
+results "${work}/base.json" base false "smash-hud-e2e:pass:/nix/store/OTHER.drv"
+dg verdict "${work}/pr.json" "${work}/base.json" "${work}/inst.json" "" "" >"${work}/v.json"
+check "history: moved drv, still not blamed" true "$(verdict_field "${work}/v.json" .gatePasses)"
+check "history: evidence is the record" "proven-nondeterministic" \
+  "$(verdict_field "${work}/v.json" '.unstable[0].evidence')"
+
+# ... and the same fixtures with NO record must block, or the record is not
+# what is doing the work.
+dg verdict "${work}/pr.json" "${work}/base.json" "" "" "" >"${work}/v.json"
+check "history: without the record it BLOCKS" false "$(verdict_field "${work}/v.json" .gatePasses)"
+
+# --- a deterministic check is never promoted by the fold ---------------------
+# Two runs, two different derivations, one ok and one fail. That is a
+# regression, not a coin flip, and the record must not confuse them.
+results "${work}/d-ok.json"  d1 false "deterministic:pass:/nix/store/D1.drv"
+results "${work}/d-bad.json" d2 false "deterministic:fail:/nix/store/D2.drv"
+dg fold ""                   "${work}/d-ok.json"  >"${work}/j1.json"
+dg fold "${work}/j1.json"    "${work}/d-bad.json" >"${work}/j2.json"
+check "fold: different drvs prove nothing" "" "$(dg unstable "${work}/j2.json")"
+
+# --- the cap -----------------------------------------------------------------
+seven=(); for n in 1 2 3 4 5 6 7; do seven+=("c${n}:fail:/nix/store/C${n}.drv"); done
+results "${work}/base.json" base false "${seven[@]}"
+results "${work}/pr.json"   pr   false "${seven[@]}"
+dg verdict "${work}/pr.json" "${work}/base.json" "" "" "" >"${work}/v.json"
+check "cap: seven on the base BLOCKS a no-op PR" false "$(verdict_field "${work}/v.json" .gatePasses)"
+check "cap: verdict says cap" "cap" "$(verdict_field "${work}/v.json" .verdict)"
+
+# The escape hatch. Without it, tripping the cap would block the fixes that are
+# the only way to untrip it.
+results "${work}/pr.json" pr false "c1:pass:/nix/store/C1.drv" "c2:fail:/nix/store/C2.drv" \
+  "c3:fail:/nix/store/C3.drv" "c4:fail:/nix/store/C4.drv" "c5:fail:/nix/store/C5.drv" \
+  "c6:fail:/nix/store/C6.drv" "c7:fail:/nix/store/C7.drv"
+dg verdict "${work}/pr.json" "${work}/base.json" "" "" "" >"${work}/v.json"
+check "cap: a PR that shrinks the set still lands" true "$(verdict_field "${work}/v.json" .gatePasses)"
+check "cap: the shrink is recorded" true "$(verdict_field "${work}/v.json" .shrinksFailingSet)"
+
+# --- an evaluation failure is never excused ----------------------------------
+results "${work}/pr.json"   pr   true  "a:fail:"
+results "${work}/base.json" base false "a:fail:/nix/store/A.drv"
+dg verdict "${work}/pr.json" "${work}/base.json" "" "" "" >"${work}/v.json"
+check "eval failure: BLOCKS even though the base fails too" false "$(verdict_field "${work}/v.json" .gatePasses)"
+check "eval failure: verdict says so" "eval-failed" "$(verdict_field "${work}/v.json" .verdict)"
+
+# --- no baseline: fail closed, exactly the old behaviour ---------------------
+results "${work}/pr.json" pr false "a:fail:/nix/store/A.drv"
+dg verdict "${work}/pr.json" "" "" "no baseline has been published yet" "" >"${work}/v.json"
+check "no baseline: nothing is excused" false "$(verdict_field "${work}/v.json" .gatePasses)"
+check "no baseline: the reason is carried to the reader" "no baseline has been published yet" \
+  "$(verdict_field "${work}/v.json" .baseline.rejectedBecause)"
+
+# --- baseline admission fails closed on every malformed shape ----------------
+good="$(jq -n --argjson e "${now}" '{schemaVersion:1, system:"x86_64-linux", evalFailed:false,
+  recordedAtEpoch:$e, checks:[{attr:"a",outcome:"ok",drvPath:"/nix/store/A.drv"}]}')"
+admit() { printf '%s' "$1" >"${work}/b.json"; dg admissible "${work}/b.json" x86_64-linux 48 2>/dev/null; }
+
+admit "${good}"; check "admit: a good baseline is admitted" 0 "$?"
+admit "$(jq '.schemaVersion = 99' <<<"${good}")"; check "admit: wrong schema refused" 1 "$?"
+admit "$(jq '.system = "aarch64-darwin"' <<<"${good}")"; check "admit: wrong system refused" 1 "$?"
+admit "$(jq '.evalFailed = true' <<<"${good}")"; check "admit: eval-failed baseline refused" 1 "$?"
+admit "$(jq '.checks = []' <<<"${good}")"; check "admit: empty check set refused" 1 "$?"
+admit "$(jq --argjson e "$((now - 60 * 3600))" '.recordedAtEpoch = $e' <<<"${good}")"
+check "admit: a 60h baseline refused at a 48h limit" 1 "$?"
+admit "not json at all"; check "admit: garbage refused" 1 "$?"
+admit ""; check "admit: an empty document refused" 1 "$?"
+
+# --- the forfeiture path recognises what it claims to --------------------
+printf 'crates/hyperion/src/lib.rs\n' >"${work}/files.txt"
+check "forfeit-reason: an ordinary source change forfeits nothing" "" \
+  "$(dg forfeit-reason "${work}/files.txt")"
+printf 'crates/hyperion/src/lib.rs\n.github/workflows/ci.yml\n' >"${work}/files.txt"
+check "forfeit-reason: a workflow change forfeits, naming the path" ".github/workflows/ci.yml" \
+  "$(dg forfeit-reason "${work}/files.txt" | grep -o '\.github/workflows/ci\.yml')"
+printf 'nix/ci/flake-gate.nix\n' >"${work}/files.txt"
+check "forfeit-reason: a gate change forfeits" "nix/ci/flake-gate.nix" \
+  "$(dg forfeit-reason "${work}/files.txt" | grep -o 'nix/ci/flake-gate.nix')"
+
+# --- the summary renders for every verdict, and says which meaning is in force
+for v in pass block cap excused; do
+  case "${v}" in
+  pass)    results "${work}/pr.json" pr false "a:pass:/nix/store/A.drv"
+           results "${work}/base.json" base false "a:pass:/nix/store/A.drv" ;;
+  block)   results "${work}/pr.json" pr false "a:fail:/nix/store/N.drv"
+           results "${work}/base.json" base false "a:pass:/nix/store/O.drv" ;;
+  cap)     results "${work}/base.json" base false "${seven[@]}"
+           results "${work}/pr.json" pr false "${seven[@]}" ;;
+  excused) results "${work}/pr.json" pr false "a:fail:/nix/store/A.drv"
+           results "${work}/base.json" base false "a:fail:/nix/store/A.drv" ;;
+  esac
+  dg verdict "${work}/pr.json" "${work}/base.json" "" "" "" >"${work}/v.json"
+  dg summary "${work}/v.json" >"${work}/s.md" 2>"${work}/s.err"
+  rc=$?
+  check "summary(${v}): renders" 0 "${rc}"
+  check "summary(${v}): is not empty" true "$([[ -s ${work}/s.md ]] && echo true || echo false)"
+  check "summary(${v}): states the enforcement status" true \
+    "$(grep -q 'not a required status check' "${work}/s.md" && echo true || echo false)"
+done
+
+printf '\n%d passed, %d failed\n' "${pass}" "${fail}"
+[[ ${fail} -eq 0 ]]

--- a/nix/ci/delta-gate.sh
+++ b/nix/ci/delta-gate.sh
@@ -1,0 +1,649 @@
+#!/usr/bin/env bash
+# Differential CI gating: judge a pull request on the DELTA against the base
+# rather than on absolute green.
+#
+# | check fails on the PR | fails on the base too | verdict                   |
+# | --------------------- | --------------------- | ------------------------- |
+# | yes                   | yes                   | pass, not this PR's fault |
+# | yes                   | no                    | BLOCK, this PR's fault    |
+# | no                    | yes                   | pass, this PR fixed it    |
+# | no                    | no                    | pass                      |
+#
+# WHY THIS EXISTS. On 2026-07-29 two correct pull requests each displayed
+# exactly the failures the other one fixes. 1080 fixed `completions-e2e` and
+# `minecraft-literals` and its CI reported `bedwars-dev-boot-e2e`,
+# `smash-dev-boot-e2e` and `smash-e2e`; 1081 fixed the two boot gates and its CI
+# reported the other three. Neither could ever be green on its own, so neither
+# could land, so the failures accumulated. An absolute verdict cannot express
+# "better than before", which is the only question a reviewer actually has.
+#
+# The design is ix's, from `Differential CI verdict (ix#9053)`. It is vendored
+# rather than imported because indexable-inc/ix is INTERNAL and this repository
+# is PUBLIC, so a flake input pointing at it would break every outside
+# contributor. This is a second copy and it will drift; when it does, ix's
+# scripts/ci/delta-gate.sh is the elder.
+#
+# Two things here are NOT from ix, because ix does not have them.
+#
+#   The whole flakiness half. ix's gate calls a coin flip a regression and
+#   blocks. That is survivable there and is not survivable here: three checks in
+#   this suite are measured coin flips, 61% of runs hit at least one, and a
+#   differential gate that falsely accuses is dead within a week.
+#
+#   Reporting `removed` apart from `fixed`. A check a pull request DELETED is
+#   absent from its failing set for a reason that is not repair, and calling it
+#   repaired credits the wrong thing. The check set here moved between 60 and 67
+#   entries over eighteen consecutive runs, so this is not hypothetical.
+#
+# THE IDENTITY IS THE CHECK ATTRIBUTE, NOT THE DERIVATION HASH. A pull request
+# that touches a shared crate moves every downstream drv hash, so a hash
+# comparison would call all of them new and block on failures the PR did not
+# cause. The hash answers a different and narrower question, below.
+set -euo pipefail
+
+readonly DG_SCHEMA_VERSION=1
+
+# The results vocabulary is nix/ci/flake-gate.nix's: `outcome` is "pass" or
+# "fail". Everything here tests for "fail" and treats anything else as passing,
+# so a third spelling arriving one day reads as a pass rather than silently
+# turning every check red.
+
+# The most failing checks a base may carry before this gate refuses a pull
+# request regardless of its delta.
+#
+# A differential gate makes red survivable, and survivable is comfortable. This
+# is the number that stops "no worse than before" from being a licence for
+# "before" to grow without limit. Six was chosen against a measured base of four
+# deterministic failures, so there is room for a genuine two-cause day and not
+# room for a habit.
+#
+# EDIT THIS DOWNWARD ONLY, and never from an observed count. A suite carrying
+# proven coin flips will eventually have a lucky night, and a cap that lowered
+# itself onto that night's number would freeze the repository on the next
+# ordinary day. That is the failure mode this whole file exists to prevent, and
+# self-inflicting it would be worse than not having a cap.
+#
+# A pull request that STRICTLY SHRINKS the failing set is exempt. Without that,
+# tripping the cap would block the fixes that are the only way to untrip it,
+# which is the original deadlock wearing a cap.
+readonly DG_BASELINE_CAP=6
+
+# How long an observation stays evidence about a check's determinism.
+readonly DG_INSTABILITY_WINDOW_DAYS=30
+
+# Bound on the per-derivation recency map, oldest dropped first.
+readonly DG_INSTABILITY_MAX_ENTRIES=5000
+
+# How many recent runs the measured flake rate is taken over. Exit criterion 1
+# for making this verdict a required status context asks for 20.
+readonly DG_FLAKE_RATE_RUNS=20
+
+# Diagnostic sink. Defaults to stderr so a local run says what it is doing.
+dg_log() { printf 'delta-gate: %s\n' "$*" >>"${DG_LOG_SINK:-/dev/stderr}"; }
+
+# --- what the derivation hash is for ----------------------------------------
+#
+# A derivation is the complete specification of a build, and its path is a
+# Merkle root over every input derivation. So an unchanged drvPath means an
+# unchanged build closure, and:
+#
+#     SAME DERIVATION, DIFFERENT OUTCOME, IS A PROOF OF NONDETERMINISM.
+#
+# Not evidence, not a heuristic. If a check's drvPath is identical on the base
+# and on the pull request, and it passed there and fails here, then the diff did
+# not cause the failure. Something outside the derivation did: a timeout against
+# a slower runner, an OOM, a sandbox leak. Which one does not matter for the
+# verdict. The verdict-relevant claim is "this pull request did not cause it",
+# and that claim is airtight.
+#
+# This is worth having because a retry cannot do the job. For a check that fails
+# 30% of the time, two failures in a row happen 9% of the time, so a retry can
+# acquit and can never convict. Any gate whose flake answer is a retry blocks
+# honest work 9% of the time. A proof has no such rate.
+#
+# Measured here, on this repository, on 2026-07-29:
+#
+#   run 30428441399 (34eb46c, 06:31Z)  differential-traces  ok
+#   run 30429463435 (dd8311f, 06:49Z)  differential-traces  FAILED
+#   both on /nix/store/fczpzka3v7c9npf4a3i730ahkncla3f5-check-hyperion-differential-traces.drv
+#
+# Byte-identical derivation, opposite outcomes, eighteen minutes apart. The
+# failure was `IllegalStateException: chunks were still not entity ticking after
+# 600 ticks`, a wall-clock timeout inside the sandbox. Nothing in the derivation
+# moved; the runner was slower.
+#
+# And the counter-example that fixes the resolution. `minecraft-literals`
+# transitioned contiguously from ok to FAILED across runs 30417510835 and
+# 30418671535, and each run builds two derivations sharing the name
+# `check-minecraft-literals`:
+#
+#   ok    d48rbprp0l1q7ndhz0klp5qws89wbbg1 , 9md01i6lzfz65fxjk4ql9jkaykk9krsr
+#   fail  d48rbprp0l1q7ndhz0klp5qws89wbbg1 , 3rwh12gki71qk23xczyjzdp8jcyjgjdf
+#
+# `d48rbprp` is common to both. Comparing "a derivation named after the check"
+# and happening to pick that one would have excused a genuine regression as a
+# flake. The one nix named in `Cannot build` is `3rwh12gk`, which is new.
+#
+# The resolution is to compare THE CHECK ATTRIBUTE'S OWN drvPath, from
+# `nix eval`, and nothing else. Because a drv path is a Merkle root, the
+# attribute's own path moves whenever anything it depends on moves, so it is
+# both the coarsest comparison that is sound and the only one worth making.
+# `d48rbprp` staying fixed while `3rwh12gk` moved is itself the proof that
+# `d48rbprp` is not an ancestor of the failing derivation.
+
+# --- guard: when the derivation does not describe the run --------------------
+
+# Paths whose contents the derivation does not capture but the run depends on.
+# A pull request touching any of them FORFEITS drv-identity immunity, because
+# for such a change "identical derivation" no longer implies "this PR is not the
+# cause".
+#
+# Three known members, and the general form matters more than the list because
+# the list will grow:
+#
+#   ENVIRONMENT. `.github/workflows/**` picks the runner and the timeouts;
+#   flake.nix's `nixConfig` picks the substituters. Same derivation, different
+#   world, and the pull request is why.
+#
+#   SCHEDULING and CONCURRENCY. These e2e checks start real servers on real
+#   ports. `nix/ci/flake-gate.nix` decides whether checks run one at a time or
+#   all at once, and the e2e port offsets decide whether two of them collide.
+#   A change there can break a check whose derivation is byte identical, and the
+#   cause genuinely is the change. The branch that makes this gate concurrent is
+#   exactly such a pull request and is the first one this will meet.
+#
+# The general form, for whoever adds the fourth: a pull request forfeits
+# immunity when it changes anything the derivation does not capture but the run
+# depends on.
+dg_immunity_forfeit_reason() {
+  local changed_files=$1
+  [[ -s ${changed_files} ]] || return 0
+  local hit
+  hit="$(grep -aE '^(\.github/workflows/|nix/ci/flake-gate\.nix$|nix/ci/delta-gate\.sh$)' \
+    "${changed_files}" || true)"
+  if [[ -z ${hit} ]]; then
+    hit="$(grep -aE 'e2e[Oo]ffsets|ports-distinct' "${changed_files}" || true)"
+  fi
+  [[ -z ${hit} ]] && return 0
+  printf 'this pull request changes %s, which the derivation does not capture but the run depends on' \
+    "$(tr '\n' ' ' <<<"${hit}" | sed 's/ $//')"
+}
+
+# --- instability: which checks are proven nondeterministic -------------------
+
+# Fold one run's results into the instability record, and promote any check
+# attribute whose derivation has now been seen both passing and failing.
+#
+#   $1 the existing record, or "" on the first run
+#   $2 this run's results document
+#
+# Keyed on drvPath for the PROOF and promoted onto the ATTRIBUTE for the
+# CONCLUSION, and those are two different things on purpose. The proof has to be
+# per-derivation, because that is the only comparison that means anything. The
+# conclusion has to be per-attribute, because nondeterminism is a property of
+# how a check is written and it survives a change to that check's inputs.
+# Without the promotion the record would go silent for exactly the pull requests
+# that move a drv hash, which is most of them.
+#
+# The cost of the promotion, stated plainly: one infrastructure failure (an OOM,
+# a bad NAR) against an otherwise deterministic check marks that check unstable
+# for the length of the window, and the gate stops enforcing it. That is a real
+# hole. The mitigations are visibility rather than cleverness: the window
+# expires, every grant of immunity prints the two run ids that bought it, and
+# the standing issue names every unstable check with the date it was proven.
+dg_merge_instability() {
+  local record=${1:-} results=$2
+  local record_arg=/dev/null
+  [[ -n ${record} && -s ${record} ]] && record_arg=${record}
+
+  jq -n \
+    --slurpfile old "${record_arg}" \
+    --slurpfile run "${results}" \
+    --argjson windowDays "${DG_INSTABILITY_WINDOW_DAYS}" \
+    --argjson maxEntries "${DG_INSTABILITY_MAX_ENTRIES}" \
+    --argjson rateRuns "${DG_FLAKE_RATE_RUNS}" \
+    --argjson nowEpoch "$(date +%s)" '
+    ($old[0] // {}) as $o
+    | ($run[0] // {}) as $r
+    | ($nowEpoch - ($windowDays * 86400)) as $cutoff
+    | ($r.runId // "unknown") as $runId
+    | (($o.seen // {}) | with_entries(select(.value.lastEpoch >= $cutoff))) as $aged
+    | reduce (($r.checks // [])[] | select(.drvPath != null and .drvPath != "")) as $c
+        ($aged;
+          .[$c.drvPath] as $p
+          | .[$c.drvPath] = {
+              attr: $c.attr,
+              ok:   (($p.ok   // false) or ($c.outcome != "fail")),
+              fail: (($p.fail // false) or ($c.outcome == "fail")),
+              okRunId:   (if $c.outcome != "fail" then $runId else ($p.okRunId   // null) end),
+              failRunId: (if $c.outcome == "fail" then $runId else ($p.failRunId // null) end),
+              lastEpoch: $nowEpoch
+            })
+    # Oldest-first eviction, so reaching the bound on a busy day cannot silently
+    # discard the disagreement that matters.
+    | ([to_entries[]] | sort_by(-.value.lastEpoch) | .[0:$maxEntries] | from_entries) as $seen
+    | [$seen | to_entries[] | select(.value.ok and .value.fail)
+       | {attr: .value.attr, drvPath: .key, okRunId: .value.okRunId,
+          failRunId: .value.failRunId, provenAtEpoch: .value.lastEpoch}] as $fresh
+    # One row per run, so the flake rate is measured rather than assumed. Which
+    # attrs failed is recorded raw; which of them count as unstable is decided
+    # at read time against the CURRENT proof set, so a check proven flaky
+    # tomorrow is credited in the runs already recorded.
+    | ([{runId: $runId, epoch: $nowEpoch,
+         failed: [($r.checks // [])[] | select(.outcome == "fail") | .attr] | sort}]
+       + [($o.runs // [])[] | select(.epoch >= $cutoff)]
+       | sort_by(-.epoch) | .[0:($rateRuns * 3)]) as $runs
+    | {
+        schemaVersion: '"${DG_SCHEMA_VERSION}"',
+        windowDays: $windowDays,
+        updatedAt: ($r.recordedAt // "unknown"),
+        updatedAtEpoch: $nowEpoch,
+        runsFolded: (($o.runsFolded // 0) + 1),
+        seen: $seen,
+        runs: $runs,
+        # A proof keeps its ORIGINAL date through later folds, so the standing
+        # issue can show how long a check has gone unenforced rather than
+        # resetting the clock every night.
+        proven: ([($o.proven // [])[] | select(.provenAtEpoch >= $cutoff)] + $fresh
+                 | group_by(.attr) | map(sort_by(.provenAtEpoch) | .[0]) | sort_by(.attr))
+      }
+  '
+}
+
+# The check attributes proven nondeterministic, one per line.
+dg_unstable_attrs() {
+  local record=${1:-}
+  [[ -n ${record} && -s ${record} ]] || return 0
+  jq -r '(.proven // [])[] | .attr' "${record}" 2>/dev/null | sort -u
+}
+
+# The measured share of recent runs in which at least one PROVEN-UNSTABLE check
+# failed, plus the sample size. This is exit criterion 1 for turning the verdict
+# into a required status context: 0.61 measured over the 18 main runs of
+# 2026-07-28/29, and the criterion is 0.05.
+#
+# Reported as a document rather than a bare number because a rate without its
+# sample size is not a measurement, and because the criterion needs both.
+dg_flake_rate() {
+  local record=${1:-}
+  local arg=/dev/null
+  [[ -n ${record} && -s ${record} ]] && arg=${record}
+  jq -n --slurpfile r "${arg}" --argjson rateRuns "${DG_FLAKE_RATE_RUNS}" '
+    ($r[0] // {}) as $rec
+    | [($rec.proven // [])[] | .attr] as $unstable
+    | ([($rec.runs // [])[]] | sort_by(-.epoch) | .[0:$rateRuns]) as $runs
+    | ($runs | length) as $n
+    | ([$runs[] | select([.failed[] | select(IN($unstable[]))] | length > 0)] | length) as $hit
+    | {
+        runs: $n,
+        runsWithAFlake: $hit,
+        rate: (if $n == 0 then null else (($hit / $n) * 1000 | round) / 1000 end),
+        unstableChecks: ($unstable | sort),
+        criterion: 0.05,
+        meetsCriterion: (if $n < $rateRuns then false
+                         else (($hit / $n) <= 0.05) end),
+        why: (if $n < $rateRuns
+              then "only \($n) of the \($rateRuns) runs the criterion asks for have been folded"
+              else "measured over the last \($n) runs" end)
+      }
+  '
+}
+
+# --- baseline admission ------------------------------------------------------
+
+# Structural admission of a published baseline: schema, system, freshness.
+# ANCESTRY IS NOT CHECKED HERE, because it needs the API; the caller does it.
+# Every path fails closed. A baseline nobody can read must excuse nothing, which
+# is exactly how this gate behaved before the feature existed.
+dg_baseline_admissible() {
+  local baseline=$1 system=$2 max_age_hours=${3:-48}
+  local schema doc_system recorded_at age_hours
+
+  if [[ ! -s ${baseline} ]]; then
+    dg_log "baseline ${baseline} is missing or empty"
+    return 1
+  fi
+  if ! jq -e 'type == "object"' "${baseline}" >/dev/null 2>&1; then
+    dg_log "baseline ${baseline} is not a JSON object"
+    return 1
+  fi
+  schema="$(jq -r '.schemaVersion // "missing"' "${baseline}")"
+  if [[ ${schema} != "${DG_SCHEMA_VERSION}" ]]; then
+    dg_log "baseline schemaVersion is ${schema}, this gate speaks ${DG_SCHEMA_VERSION}"
+    return 1
+  fi
+  doc_system="$(jq -r '.system // ""' "${baseline}")"
+  if [[ ${doc_system} != "${system}" ]]; then
+    dg_log "baseline is for system '${doc_system}', this run is '${system}'"
+    return 1
+  fi
+  # A run whose evaluation failed produced no per-check identity at all, so it
+  # says nothing about which checks fail and must never excuse anything.
+  if [[ "$(jq -r '.evalFailed // false' "${baseline}")" == "true" ]]; then
+    dg_log "the baseline run could not evaluate the flake, so it names no checks"
+    return 1
+  fi
+  if [[ "$(jq -r '(.checks // []) | length' "${baseline}")" == "0" ]]; then
+    dg_log "the baseline names no checks at all"
+    return 1
+  fi
+  recorded_at="$(jq -r '.recordedAtEpoch // empty' "${baseline}")"
+  if [[ -z ${recorded_at} || ! ${recorded_at} =~ ^[0-9]+$ ]]; then
+    dg_log "baseline carries no usable recordedAtEpoch"
+    return 1
+  fi
+  age_hours=$((($(date +%s) - recorded_at) / 3600))
+  if ((age_hours > max_age_hours)); then
+    # Not pedantry. The ancestry check cannot catch a check that main FIXED
+    # after the baseline was taken; only freshness can. Without a limit this
+    # gate would excuse a pull request for re-breaking something main repaired.
+    dg_log "baseline is ${age_hours}h old (limit ${max_age_hours}h), too stale to describe the base"
+    return 1
+  fi
+  return 0
+}
+
+# --- the verdict -------------------------------------------------------------
+
+#   $1 this run's results document
+#   $2 the baseline document, or "" for "no usable baseline"
+#   $3 the instability record, or "" for "nothing is proven unstable yet"
+#   $4 why the baseline was rejected, rendered when $2 is absent
+#   $5 why drv-identity immunity is forfeited, or "" when it is not
+#
+# `gatePasses` is the single field the gate keys off.
+dg_verdict() {
+  local pr_doc=$1 baseline_doc=${2:-} instability=${3:-} reject=${4:-} forfeit=${5:-}
+  local base_arg=/dev/null inst_arg=/dev/null have_baseline=false
+  if [[ -n ${baseline_doc} && -s ${baseline_doc} ]]; then
+    base_arg=${baseline_doc}
+    have_baseline=true
+  fi
+  [[ -n ${instability} && -s ${instability} ]] && inst_arg=${instability}
+
+  jq -n \
+    --slurpfile pr "${pr_doc}" \
+    --slurpfile base "${base_arg}" \
+    --slurpfile inst "${inst_arg}" \
+    --argjson haveBaseline "${have_baseline}" \
+    --argjson cap "${DG_BASELINE_CAP}" \
+    --arg reject "${reject}" \
+    --arg forfeit "${forfeit}" '
+    ($pr[0] // {}) as $p
+    | (if $haveBaseline then ($base[0] // {}) else null end) as $b
+    | ($inst[0] // {}) as $i
+    | ($forfeit | length > 0) as $forfeited
+    | (($p.checks // [])) as $prAll
+    | (if $b == null then [] else ($b.checks // []) end) as $baseAll
+    | [$prAll[]   | select(.outcome == "fail")] as $prFail
+    | [$baseAll[] | select(.outcome == "fail")] as $baseFail
+    | ($prAll   | map(.attr)) as $prAttrs
+    | ($prFail  | map(.attr)) as $prFailAttrs
+    | ($baseFail | map(.attr)) as $baseFailAttrs
+    | [($i.proven // [])[] | .attr] as $unstableAttrs
+    | ($i.proven // []) as $proofs
+
+    | [$prFail[] | select(.attr | IN($baseFailAttrs[]))] as $excusedRaw
+    | [$prFail[] | select((.attr | IN($baseFailAttrs[])) | not)] as $newFail
+
+    # A failure the base does not have is this pull request s to answer for,
+    # UNLESS the derivation proves it could not be. Two proofs, both exact.
+    # A pull request that ADDS OR REMOVES a check changes what else is running
+    # beside every other check, and the derivation of those others does not
+    # record that. Under a concurrent gate that is contention, and contention is
+    # how an e2e check that starts a real server on a real port times out
+    # without anything it depends on having moved. So a changed check set
+    # withdraws the same-derivation excuse.
+    #
+    # Detected from the two documents rather than from a path list, which is
+    # both more general and impossible to forget: any edit that changes the set
+    # shows up here whatever file it lived in.
+    #
+    # It withdraws the SAME-DRV excuse only, not the proven-nondeterministic
+    # one. Those claim different things. Same-drv claims "everything else about
+    # this run is equal", which a changed check set contradicts outright.
+    # Proven-nondeterministic claims "this check is a coin flip", which stays
+    # true under contention: blocking on it would accuse falsely at the base rate
+    # that check already has, which is the thing this gate exists not to do.
+    #
+    # NOTE, and this has now cost two debugging rounds: an apostrophe anywhere in
+    # a jq program below ENDS THE SHELL STRING. Keep these comments free of them.
+    | (($prAttrs | sort) != ($baseAll | map(.attr) | sort)) as $checkSetChanged
+    | [$newFail[]
+       | . as $c
+       | ($baseAll[] | select(.attr == $c.attr)) as $m
+       | (($c.drvPath != null) and ($c.drvPath != "")
+          and ($m.drvPath == $c.drvPath) and ($checkSetChanged | not)) as $sameDrv
+       | ($c.attr | IN($unstableAttrs[])) as $proven
+       | select(($forfeited | not) and ($sameDrv or $proven))
+       | {attr: $c.attr, drvPath: $c.drvPath,
+          evidence: (if $sameDrv then "identical-drv-passed-on-base" else "proven-nondeterministic" end),
+          proof: (if $sameDrv
+                  then {baseRunId: ($b.runId // null), prRunId: ($p.runId // null), drvPath: $c.drvPath}
+                  else (($proofs[] | select(.attr == $c.attr))
+                        | {okRunId, failRunId, drvPath, provenAtEpoch}) end)}]
+      as $unstable
+    | ($unstable | map(.attr)) as $unstableHere
+    | [$newFail[] | select((.attr | IN($unstableHere[])) | not)] as $blocked
+
+    # A check the pull request DELETED is not a check it repaired.
+    | [$baseFail[] | select((.attr | IN($prFailAttrs[])) | not)
+                   | select(.attr | IN($prAttrs[]))] as $fixed
+    | [$baseFail[] | select((.attr | IN($prAttrs[])) | not)] as $removed
+
+    | ($baseFail | length) as $baseCount
+    | ($prFail | length) as $prCount
+    | ($prCount < $baseCount) as $shrinks
+    | (($baseCount > $cap) and ($shrinks | not)) as $capBlocks
+    | ($p.evalFailed == true) as $evalFailed
+
+    | {
+        schemaVersion: '"${DG_SCHEMA_VERSION}"',
+        system: ($p.system // null),
+        prCommit: ($p.commit // null),
+        prRunId: ($p.runId // null),
+        evalFailed: $evalFailed,
+        immunityForfeited: $forfeited,
+        forfeitReason: (if $forfeited then $forfeit else null end),
+        cap: $cap,
+        checkSetChanged: $checkSetChanged,
+        baselineFailingCount: $baseCount,
+        prFailingCount: $prCount,
+        shrinksFailingSet: $shrinks,
+        capExceeded: ($baseCount > $cap),
+        capBlocks: $capBlocks,
+        baseline: (if $b == null
+                   then {accepted: false, rejectedBecause: $reject}
+                   else {accepted: true, commit: ($b.commit // null), runId: ($b.runId // null),
+                         recordedAt: ($b.recordedAt // null), failingCount: $baseCount}
+                   end),
+        instability: {runsFolded: ($i.runsFolded // 0), provenUnstable: ($unstableAttrs | sort)},
+        excused: [$excusedRaw[] | . as $e | ($baseFail[] | select(.attr == $e.attr)) as $m
+                  | {attr: $e.attr, prDrvPath: ($e.drvPath // null), baseDrvPath: ($m.drvPath // null),
+                     evidence: (if ($e.drvPath != null) and ($e.drvPath == $m.drvPath)
+                                then "identical-drv" else "same-attr" end)}] | sort_by(.attr),
+        unstable: ($unstable | sort_by(.attr)),
+        blocked: [$blocked[] | {attr, drvPath: (.drvPath // null)}] | sort_by(.attr),
+        fixed:   [$fixed[]   | {attr, baseDrvPath: (.drvPath // null)}] | sort_by(.attr),
+        removed: [$removed[] | {attr}] | sort_by(.attr)
+      }
+    | .gatePasses = (((.blocked | length) == 0) and (.capBlocks | not) and (.evalFailed | not))
+    | .verdict = (if .evalFailed then "eval-failed"
+                  elif (.blocked | length) > 0 then "block"
+                  elif .capBlocks then "cap"
+                  elif (.excused | length) > 0 or (.unstable | length) > 0 then "excused"
+                  else "pass" end)
+    | .reason = (if .evalFailed
+                 then "the flake did not evaluate, so no check has an identity and nothing can be compared"
+                 elif (.blocked | length) > 0
+                 then "this pull request introduces \(.blocked | length) failure(s) that do not fail on the base"
+                 elif .capBlocks
+                 then "the base carries \(.baselineFailingCount) failing checks, over the cap of \(.cap), and this pull request does not shrink the set"
+                 elif (.unstable | length) > 0 and (.excused | length) > 0
+                 then "\(.excused | length) failure(s) also fail on the base and \(.unstable | length) are proven nondeterministic, so this pull request makes nothing worse"
+                 elif (.unstable | length) > 0
+                 then "\(.unstable | length) failure(s) are proven nondeterministic and not attributable to this pull request"
+                 elif (.excused | length) > 0
+                 then "\(.excused | length) failure(s) also fail on the base, so this pull request makes nothing worse"
+                 elif (.fixed | length) > 0
+                 then "no failures here, and this pull request repairs \(.fixed | length) check(s) that fail on the base"
+                 else "no failures" end)
+  '
+}
+
+# --- the summary -------------------------------------------------------------
+
+# Render the verdict as markdown for $GITHUB_STEP_SUMMARY and the job log.
+#
+# This is not decoration. Differential gating changes what a green tick MEANS,
+# from "this is shippable" to "this is no worse than the base", and a reader of
+# a tick cannot be expected to know which one is in force. So the first line
+# always states it, on every run, including the boring ones.
+dg_render_summary() {
+  local verdict_doc=$1
+  jq -r '
+    def drv($d): if $d == null then "-" else "`\($d)`" end;
+    ["## Flake gate: differential verdict", ""]
+    + (if .verdict == "eval-failed" then
+         ["**BLOCKED: the flake did not evaluate.**", "",
+          "No check has an identity when evaluation fails, so there is nothing to compare",
+          "and nothing can be excused. The evaluation error is above this summary in the",
+          "job log; it names the offending attribute.", ""]
+       elif .verdict == "block" then
+         ["**BLOCKED:** \(.reason).", "",
+          "A failure that is not present on the base belongs to this pull request, red base",
+          "or not. Excusing it is how one red cause becomes six, which is the state this",
+          "gate was written to end, so a red base is not a licence to add to it.", ""]
+       elif .verdict == "cap" then
+         ["**BLOCKED by the cap:** \(.reason).", "",
+          "This is not about your change. The base has accumulated more failures than the",
+          "cap allows, and the only pull requests that can land until it is back under the",
+          "cap are ones that shrink it. Differential gating makes red survivable; the cap is",
+          "what stops survivable becoming permanent.", ""]
+       elif .verdict == "excused" then
+         ["**Green here means \"no worse than the base\", NOT absolutely green.**",
+          "\(.reason).", ""]
+       elif (.fixed | length) > 0 then
+         ["**Green, and better than the base:** \(.reason).", ""]
+       else
+         ["**Green means absolutely green:** \(.reason).", ""]
+       end)
+    + ["- failing checks: base \(.baselineFailingCount), here \(.prFailingCount), net \(if .prFailingCount > .baselineFailingCount then "+" else "" end)\(.prFailingCount - .baselineFailingCount)  (cap \(.cap))"]
+    + (if .baseline.accepted then
+         ["- baseline: `\(.baseline.commit // "?")` (run \(.baseline.runId // "?"), recorded \(.baseline.recordedAt // "?"))"]
+       else
+         ["- baseline: **none accepted**, so nothing was excused against a base and this gate behaved exactly as it did before the differential verdict existed. Reason: \(.baseline.rejectedBecause // "not published")"]
+       end)
+    + ["- instability record: \(.instability.runsFolded) run(s) folded, proven nondeterministic: \(if (.instability.provenUnstable | length) == 0 then "none" else (.instability.provenUnstable | join(", ")) end)"]
+    + (if .checkSetChanged and (.baseline.accepted) then
+         ["- **the check set changed**, so the identical-derivation excuse is withdrawn: adding or removing a check changes what runs beside every other check, and their derivations do not record that. A check proven nondeterministic is still excused, because that is a claim about the check rather than about this run."]
+       else [] end)
+    + (if .immunityForfeited then
+         ["- **drv-identity immunity forfeited**: \(.forfeitReason). A pull request that changes what the derivation does not capture but the run depends on (environment, scheduling, concurrency) is judged strictly, because for such a change an identical derivation no longer means an unrelated failure."]
+       else [] end)
+    + (if (.blocked | length) > 0 then
+         ["", "### Blocking: \(.blocked | length) failure(s) not present on the base", "",
+          "| check | derivation |", "| --- | --- |"]
+         + [.blocked[] | "| `\(.attr)` | \(drv(.drvPath)) |"]
+         + ["", "Reproduce one with `nix build .#checks.\(.system // "x86_64-linux").<name> -L`."]
+       else [] end)
+    + (if (.unstable | length) > 0 then
+         ["", "### Not attributable to this pull request: \(.unstable | length) nondeterministic failure(s)", "",
+          "`identical-drv-passed-on-base` means the base and this run built the BYTE-IDENTICAL",
+          "derivation and disagreed about the result, which is a proof that the diff did not",
+          "cause it. `proven-nondeterministic` means some derivation of this check has been",
+          "recorded both passing and failing, so the check is a coin flip whatever it is",
+          "built from.", "",
+          "**These checks are not gating anything.** That is the deliberate trade, and it is",
+          "not free: a real break in one of them would also pass here. They are named in the",
+          "standing issue with the date they were proven, and the point of the record is that",
+          "the list should be getting shorter.", "",
+          "| check | evidence | proof |", "| --- | --- | --- |"]
+         + [.unstable[] | "| `\(.attr)` | \(.evidence) | ok in run \(.proof.okRunId // .proof.baseRunId // "?"), failed in run \(.proof.failRunId // .proof.prRunId // "?") |"]
+       else [] end)
+    + (if (.excused | length) > 0 then
+         ["", "### Excused: \(.excused | length) failure(s) that already fail on the base", "",
+          "Not this pull request'"'"'s fault. `identical-drv` means the base and this run failed",
+          "on the byte-identical derivation, so it is literally the same build; `same-attr`",
+          "means the hash moved because this pull request touches something the check depends",
+          "on, and the CHECK ATTRIBUTE is the identity.", "",
+          "| check | evidence | derivation |", "| --- | --- | --- |"]
+         + [.excused[] | "| `\(.attr)` | \(.evidence) | \(drv(.prDrvPath)) |"]
+       else [] end)
+    + (if (.fixed | length) > 0 then
+         ["", "### Repaired by this pull request: \(.fixed | length) check(s)", "",
+          "These fail on the base and pass here.", "",
+          "| check | derivation on the base |", "| --- | --- |"]
+         + [.fixed[] | "| `\(.attr)` | \(drv(.baseDrvPath)) |"]
+       else [] end)
+    + (if (.removed | length) > 0 then
+         ["", "### Removed by this pull request: \(.removed | length) check(s)", "",
+          "These fail on the base and no longer exist here. Deleting a check is not repairing",
+          "it, so they are reported apart from the repairs above.", "",
+          "| check |", "| --- |"]
+         + [.removed[] | "| `\(.attr)` |"]
+       else [] end)
+    + ["",
+       "---",
+       "",
+       "This verdict is **not a required status check**. Ruleset 566717 on `main` carries no",
+       "`required_status_checks` rule at all, so nothing here blocks a merge; one approving",
+       "review is the only gate. Making it binding is one `required_status_checks` entry",
+       "naming this job, and it should not be added until: the flake rate is at or under 5%",
+       "over 20 consecutive runs (measured 61% on 2026-07-29), the instability record holds",
+       "at least 30 runs, at most 1 in 20 pull request runs is blocked by a verdict a re-run",
+       "then clears, and the p95 gate wall time is under 40 minutes against the merge queue'"'"'s",
+       "60 minute `check_response_timeout_minutes`."]
+    | .[]
+  ' "${verdict_doc}"
+}
+
+# --- CLI ---------------------------------------------------------------------
+
+dg_usage() {
+  cat >&2 <<'EOF'
+usage:
+  delta-gate.sh admissible <baseline.json> <system> [max-age-hours]
+  delta-gate.sh verdict <results.json> [baseline.json] [instability.json] [reject-reason] [forfeit-reason]
+  delta-gate.sh summary <verdict.json>
+  delta-gate.sh fold <instability.json|""> <results.json>
+  delta-gate.sh unstable <instability.json>
+  delta-gate.sh flake-rate <instability.json>
+  delta-gate.sh forfeit-reason <changed-files.txt>
+EOF
+  exit 64
+}
+
+if [[ ${BASH_SOURCE[0]} == "${0}" ]]; then
+  case "${1:-}" in
+  admissible)
+    [[ $# -ge 3 ]] || dg_usage
+    dg_baseline_admissible "$2" "$3" "${4:-48}"
+    ;;
+  verdict)
+    [[ $# -ge 2 ]] || dg_usage
+    dg_verdict "$2" "${3:-}" "${4:-}" "${5:-}" "${6:-}"
+    ;;
+  summary)
+    [[ $# -eq 2 ]] || dg_usage
+    dg_render_summary "$2"
+    ;;
+  fold)
+    [[ $# -eq 3 ]] || dg_usage
+    dg_merge_instability "$2" "$3"
+    ;;
+  unstable)
+    [[ $# -eq 2 ]] || dg_usage
+    dg_unstable_attrs "$2"
+    ;;
+  flake-rate)
+    [[ $# -eq 2 ]] || dg_usage
+    dg_flake_rate "$2"
+    ;;
+  forfeit-reason)
+    [[ $# -eq 2 ]] || dg_usage
+    dg_immunity_forfeit_reason "$2"
+    ;;
+  *) dg_usage ;;
+  esac
+fi

--- a/nix/ci/flake-gate.nix
+++ b/nix/ci/flake-gate.nix
@@ -1,53 +1,45 @@
-# Which flake checks CI enforces, and the named exceptions.
+# Which flake checks CI enforces, and how a pull request is judged against them.
 #
 # Enforcement is subtractive: every attribute of `checks` is built and must
-# pass, except the names listed in `excluded`. A check added tomorrow is
-# enforced the day it lands rather than the day someone remembers to add it
-# here, which is the failure this file exists to prevent. See ENG-10817: the
-# job that would have built these sat behind `continue-on-error: true`, so
-# every gate landed in that window was believed to be running when it was not.
+# pass. A check added tomorrow is enforced the day it lands rather than the day
+# someone remembers to add it here, which is the failure this file exists to
+# prevent. See ENG-10817: the job that would have built these sat behind
+# `continue-on-error: true`, so every gate landed in that window was believed to
+# be running when it was not.
 #
-# An exclusion is not a comment. `nix run .#flake-gate` builds each excluded
-# check as well and requires it to STILL FAIL. The day one starts passing, the
-# gate goes red and names the entry to delete, so an exception cannot outlive
-# the defect it was written for.
+# THERE IS NO EXCLUSION LIST ANY MORE, and that is deliberate. This file used to
+# carry an `excluded` attrset of known-broken checks with a recorded reason, and
+# rebuilt each one to require that it STILL FAIL. The idea was right and the
+# storage was wrong: a list in the repository is refreshed by human attention,
+# so it goes stale on a schedule nobody sets, and every repair is a merge
+# conflict against every other repair in flight.
+#
+# "This check is known broken" now lives in the baseline, which main publishes
+# on every run and which therefore cannot go stale, and a reason belongs in the
+# standing issue where a reader will actually meet it. If you find yourself
+# wanting an exception list back, what you want is either the baseline or, for a
+# check that genuinely cannot run in CI on this system, leaving the attribute
+# out of `checks` in flake.nix. That is a truer home for "this cannot run here"
+# than a CI-side exception.
+#
+# The verdict is DIFFERENTIAL: a pull request is judged on whether it makes the
+# failing set worse, not on whether the set is empty. Two correct pull requests
+# on 2026-07-29 each displayed exactly the failures the other one repairs, so
+# neither could be green and neither could land. The rule, the soundness
+# conditions and the reason the check attribute rather than the derivation hash
+# is the identity all live in nix/ci/delta-gate.sh, whose pure half
+# nix/ci/delta-gate-tests.sh exercises without a network or a nix store.
 {
   lib,
   writeShellApplication,
   system,
+  bash,
+  jq,
   # Every name in `checks`, rather than the derivations: the gate shells out to
   # `nix build .#checks.<system>.<name>` and needs no more than the name.
   names,
 }:
 let
-  # Empty, and that is the interesting part. ENG-10817 exempted the whole set
-  # on the belief that most of it could not pass. Measured per check on
-  # ubuntu-latest instead of as one all-or-nothing job (run 30341722090, 41
-  # checks), 38 passed and the 3 that failed were the sandboxed e2e gates,
-  # failing on a missing trust store rather than on the runner. nix/e2e.nix
-  # names the CA bundle now, so nothing is left to exempt.
-  #
-  # `differential-traces` is the one worth remembering: it failed on run
-  # 30341066882 and then passed four times (30341722090, plus three
-  # independent repeats in 30342250503). The only difference was whether the
-  # daemon could realise a content-addressed derivation, so it was the store
-  # and not the check, and it is enforced.
-  #
-  # An entry here is `name = <the evidence>`, never a justification. The gate
-  # prints that text, builds the check anyway, and fails if it passes, so an
-  # exception cannot outlive the defect it was written for. Anything you cannot
-  # write as an observation carrying a date and a run id does not belong here.
-  # Fix the check or delete it instead.
-  excluded = { };
-
-  excludedNames = lib.attrNames excluded;
-
-  # A renamed or deleted check must not leave a dead exclusion behind, reading
-  # as though it exempts something while exempting nothing.
-  stale = lib.subtractLists names excludedNames;
-
-  enforced = lib.subtractLists excludedNames names;
-
   # The results file is JSON assembled with printf rather than jq, so a name
   # has to be a string that survives being dropped between two quotes. Every
   # attribute in `checks` is a plain identifier today, and this is what stops
@@ -57,17 +49,14 @@ let
 
   quote = xs: lib.concatMapStringsSep " " lib.escapeShellArg xs;
 
-  # The recorded evidence is printed by the gate, not left in this file for
-  # someone to go and read. An exception nobody sees is an exception nobody
-  # revisits.
-  reasonArms = lib.concatStrings (
-    lib.mapAttrsToList (
-      name: why: "${lib.escapeShellArg name}) printf '%s' ${lib.escapeShellArg why} ;;\n    "
-    ) excluded
-  );
+  deltaGate = ./delta-gate.sh;
 
   gate = writeShellApplication {
     name = "flake-gate";
+    runtimeInputs = [
+      bash
+      jq
+    ];
     text = ''
       flake="''${1:-.}"
 
@@ -100,13 +89,7 @@ let
         exit 1
       fi
 
-      enforced=(${quote enforced})
-      excluded=(${quote excludedNames})
-
-      reason() {
-        case "$1" in
-          ${reasonArms}esac
-      }
+      enforced=(${quote names})
 
       # Every check's derivation path, in one flake load.
       #
@@ -144,7 +127,7 @@ let
       # otherwise report as a failed check, which is a true statement about
       # nothing. Say which name instead.
       unevaluated=()
-      for name in "''${enforced[@]}" "''${excluded[@]}"; do
+      for name in "''${enforced[@]}"; do
         [ -n "''${drv_path[$name]:-}" ] || unevaluated+=("$name")
       done
       if [ "''${#unevaluated[@]}" -gt 0 ]; then
@@ -185,7 +168,7 @@ let
       # other 66. The report is not printed at all in that case, which is the
       # honest answer: nothing was measured.
       installables=()
-      for name in "''${enforced[@]}" "''${excluded[@]}"; do
+      for name in "''${enforced[@]}"; do
         installables+=("$flake#checks.${system}.$name")
       done
 
@@ -196,8 +179,7 @@ let
       #
       # The exit status is discarded on purpose: it says only that something
       # failed, and which checks failed is the question the loops below answer
-      # per name. It is also the expected status whenever `excluded` is
-      # non-empty.
+      # per name.
       nix build --accept-flake-config --no-link --print-build-logs --keep-going \
         "''${installables[@]}" || true
 
@@ -250,7 +232,13 @@ let
       # Built with printf rather than jq: an attribute name is checked at
       # evaluation time (see `unquotable`) to need no JSON escaping, and a
       # store path cannot contain a quote or a backslash.
-      results="''${FLAKE_GATE_RESULTS:-flake-gate-results.jsonl}"
+      # Where this run's documents land. CI points HYPERION_GATE_OUT_DIR at a
+      # directory it uploads; a local run gets a temporary one and the same
+      # files. FLAKE_GATE_RESULTS still overrides the results path alone, so
+      # anything already pointing at it keeps working.
+      out="''${HYPERION_GATE_OUT_DIR:-$(mktemp -d -t flake-gate.XXXXXX)}"
+      mkdir -p "$out"
+      results="''${FLAKE_GATE_RESULTS:-$out/results.jsonl}"
       : > "$results"
       record() {
         printf '{"attr":"%s","outcome":"%s","drvPath":"%s","seconds":null}\n' \
@@ -274,53 +262,95 @@ let
         fi
       done
 
-      # An excluded check is recorded by what it did, not by how the gate
-      # treats it. A consumer differencing two runs wants the outcome; whether
-      # this file forgives it is this file's business and changes under them.
-      for name in "''${excluded[@]}"; do
-        if realised "''${drv_path[$name]}"; then
-          echo "STALE     $name"
-          record "$name" pass "''${drv_path[$name]}"
-          {
-            echo "checks.${system}.$name is excluded from CI but now builds."
-            echo "nix/ci/flake-gate.nix excluded it on this evidence:"
-            reason "$name"
-            echo "Delete the entry; CI enforces the check from then on."
-          } >&2
-          status=1
-        else
-          echo "excluded  $name (still failing, on the evidence recorded for it)"
-          record "$name" fail "''${drv_path[$name]}"
-          reason "$name"
-        fi
-      done
-
       echo ""
       echo "$results holds one json line per check: attr, outcome, drvPath."
       # The gate's own wall clock, so a run says what it cost without anyone
       # having to subtract two timestamps out of the job log. This is the
       # number the change to one concurrent build was made to move.
-      echo "gate: ''${#enforced[@]} enforced and ''${#excluded[@]} excluded checks in ''${SECONDS}s"
+      echo "gate: ''${#enforced[@]} checks in ''${SECONDS}s"
 
       if [ "''${#failed[@]}" -gt 0 ]; then
         {
           echo ""
-          echo "enforced checks that failed: ''${failed[*]}"
+          echo "checks that failed: ''${failed[*]}"
           echo "reproduce one with: nix build .#checks.${system}.<name> -L"
         } >&2
       fi
 
+      # ---- the differential verdict -------------------------------------
+      #
+      # Everything below reads the results file and nothing else, so how the
+      # checks were built is not its business. That is the seam: the loop above
+      # went from one `nix build` per name to one concurrent build for the whole
+      # set without any of this noticing.
+
+      jq -s \
+        --arg system "${system}" \
+        --arg commit "''${GITHUB_SHA:-$(git -C "$flake" rev-parse HEAD 2>/dev/null || echo unknown)}" \
+        --arg runId "''${GITHUB_RUN_ID:-local}" \
+        --arg event "''${GITHUB_EVENT_NAME:-local}" \
+        --arg recordedAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+        --argjson recordedAtEpoch "$(date +%s)" \
+        '{schemaVersion: 1, system: $system, commit: $commit, runId: $runId,
+          event: $event, recordedAt: $recordedAt, recordedAtEpoch: $recordedAtEpoch,
+          evalFailed: false, checks: (. | sort_by(.attr))}' \
+        "$results" >"$out/results.json"
+
+      # Folded on every run including a green one. A run that agrees with the
+      # last is not a wasted sample: the record needs agreements for the
+      # eventual disagreement to mean anything.
+      ${bash}/bin/bash ${deltaGate} fold \
+        "''${HYPERION_GATE_INSTABILITY:-}" "$out/results.json" >"$out/instability.json"
+      ${bash}/bin/bash ${deltaGate} flake-rate "$out/instability.json" >"$out/flake-rate.json"
+
+      # A baseline is admitted or it is not, and there is no middle. When it is
+      # not, nothing is excused and the gate behaves exactly as it did before
+      # any of this existed, which is the fail-closed direction.
+      baseline=""
+      reject="no baseline was supplied to this run"
+      if [ -n "''${HYPERION_GATE_BASELINE:-}" ] && [ -s "''${HYPERION_GATE_BASELINE}" ]; then
+        if ${bash}/bin/bash ${deltaGate} admissible "''${HYPERION_GATE_BASELINE}" \
+          "${system}" "''${HYPERION_GATE_BASELINE_MAX_AGE_HOURS:-48}"; then
+          baseline="''${HYPERION_GATE_BASELINE}"
+          reject=""
+        else
+          reject="the published baseline was not admissible; see the delta-gate lines above"
+        fi
+      fi
+
+      forfeit=""
+      if [ -n "''${HYPERION_GATE_CHANGED_FILES:-}" ] && [ -s "''${HYPERION_GATE_CHANGED_FILES}" ]; then
+        forfeit="$(${bash}/bin/bash ${deltaGate} forfeit-reason "''${HYPERION_GATE_CHANGED_FILES}")"
+      fi
+
+      ${bash}/bin/bash ${deltaGate} verdict \
+        "$out/results.json" "$baseline" "$out/instability.json" "$reject" "$forfeit" \
+        >"$out/verdict.json"
+      ${bash}/bin/bash ${deltaGate} summary "$out/verdict.json" >"$out/summary.md"
+
+      printf '::group::Differential CI verdict\n'
+      cat "$out/summary.md"
+      printf '::endgroup::\n'
+      if [ -n "''${GITHUB_STEP_SUMMARY:-}" ]; then
+        printf '\n' >>"$GITHUB_STEP_SUMMARY"
+        cat "$out/summary.md" >>"$GITHUB_STEP_SUMMARY"
+      fi
+
+      # The verdict decides, not the raw status. A run whose every failure also
+      # fails on the base has made nothing worse, and saying otherwise is the
+      # deadlock this exists to end. With no baseline the two agree, so a local
+      # `nix run .#flake-gate` behaves exactly as it always has.
+      if [ "$(jq -r '.gatePasses' "$out/verdict.json")" = "true" ]; then
+        exit 0
+      fi
+      [ "$status" -eq 0 ] && status=1
       exit "$status"
     '';
   };
 in
-lib.throwIf (stale != [ ]) ''
-  nix/ci/flake-gate.nix excludes checks that do not exist: ${lib.concatStringsSep ", " stale}
-  Delete them, or spell them the way `checks.${system}` does.
-''
-  (lib.throwIf (unquotable != [ ]) ''
-    nix/ci/flake-gate.nix writes each check's verdict into a json results file
-    with printf, which holds only for names that need no json escaping. These
-    do: ${lib.concatStringsSep ", " unquotable}
-    Rename them, or teach the gate to escape a name before it writes one.
-  '' gate)
+lib.throwIf (unquotable != [ ]) ''
+  nix/ci/flake-gate.nix writes each check's verdict into a json results file
+  with printf, which holds only for names that need no json escaping. These
+  do: ${lib.concatStringsSep ", " unquotable}
+  Rename them, or teach the gate to escape a name before it writes one.
+'' gate

--- a/nix/ci/gate-artifacts.sh
+++ b/nix/ci/gate-artifacts.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Read the two documents this gate carries between runs: the BASELINE (main's
+# failing set, which a pull request is judged against) and the INSTABILITY
+# RECORD (which checks have been proven nondeterministic). Both are Actions
+# artifacts.
+#
+# THE IMPURE HALF ONLY. Every decision that can be made from files alone lives
+# in nix/ci/delta-gate.sh, where the fixture suite can reach it. What is here is
+# what needs the API: which artifact is newest, and whether its commit is
+# actually an ancestor of this pull request's base.
+#
+# Artifacts rather than a second evaluation of the base tree. `main` already
+# computes its failing set in order to build at all, so publishing that set
+# makes a pull request's comparison ONE API read instead of a full rebuild of
+# the base. Rebuilding the base per pull request would double a job measured at
+# 31 to 41 minutes over the eighteen main runs of 2026-07-28/29, and there is no
+# cache to make the second copy cheap: the flake names cache.ix.dev as a
+# substituter but nothing in this repository pushes to it.
+#
+# Every path exits 0 and prints a reason. "No baseline" is a normal outcome that
+# degrades the gate to absolute green, which is the fail-closed direction and is
+# exactly how the gate behaved before any of this existed. It is not an error
+# that should fail the job.
+set -uo pipefail
+
+say() { printf '%s\n' "$*"; }
+
+# Download the newest unexpired artifact named $1 and extract member $2 to $3.
+# Prints a reason and returns 1 when it cannot.
+newest_artifact() {
+  local name=$1 member=$2 dest=$3 artifacts id created zip
+  for tool in gh jq unzip; do
+    command -v "${tool}" >/dev/null 2>&1 || { say "${tool} is not on PATH"; return 1; }
+  done
+  [[ -n ${GH_TOKEN:-} && -n ${GITHUB_REPOSITORY:-} ]] || {
+    say "GH_TOKEN or GITHUB_REPOSITORY is unset, so ${name} cannot be read"
+    return 1
+  }
+  # ONE read of the artifact index, filtered server-side by name. Newest by
+  # created_at taken explicitly rather than by trusting the endpoint order:
+  # "newest wins" is what makes a main that has gone GREEN revoke every excuse,
+  # because the newest baseline is then an empty failing set. Publishing on
+  # green is not an optimisation to skip, it is the revocation mechanism.
+  artifacts="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${name}&per_page=50" 2>/dev/null)" || {
+    say "the artifacts API read failed"
+    return 1
+  }
+  read -r id created <<<"$(jq -r '
+    [.artifacts[]? | select(.expired != true)] | max_by(.created_at)
+    | if . == null then "" else "\(.id) \(.created_at)" end' <<<"${artifacts}")"
+  [[ -n ${id:-} ]] || { say "no unexpired '${name}' artifact has been published yet"; return 1; }
+
+  zip="${dest}.zip"
+  gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}/zip" >"${zip}" 2>/dev/null || {
+    say "artifact ${id} could not be downloaded"
+    return 1
+  }
+  unzip -p "${zip}" "${member}" >"${dest}" 2>/dev/null || {
+    rm -f "${zip}"
+    say "artifact ${id} contains no ${member}"
+    return 1
+  }
+  rm -f "${zip}"
+  printf '%s %s' "${id}" "${created}"
+  return 0
+}
+
+cmd_baseline() {
+  local dest=${1:?usage: gate-artifacts.sh baseline <dest.json>}
+  local meta id created commit status
+
+  [[ ${GITHUB_EVENT_NAME:-} == "pull_request" ]] || {
+    say "event '${GITHUB_EVENT_NAME:-local}' is not a pull request, so there is no base to be no-worse-than"
+    return 0
+  }
+  # Without the base sha the ancestry check cannot run, and a baseline that
+  # cannot be placed in this pull request's history must be refused rather than
+  # trusted.
+  [[ -n ${PR_BASE_SHA:-} ]] || {
+    say "PR_BASE_SHA is unset, so the baseline cannot be placed in this pull request's history"
+    return 0
+  }
+  meta="$(newest_artifact "${BASELINE_ARTIFACT:-main-check-failures}" results.json "${dest}")" || {
+    say "${meta}"
+    return 0
+  }
+  read -r id created <<<"${meta}"
+
+  # ANCESTRY. A baseline describes this pull request's base only when its commit
+  # is an ancestor of, or equal to, that base. `compare/A...B` answers `ahead`
+  # when B is ahead of A, which is to say A is an ancestor of B, and `identical`
+  # when they are the same commit. `behind` or `diverged` means the baseline
+  # describes a main this pull request is not built on, and excusing against it
+  # would excuse failures that may already have been repaired.
+  commit="$(jq -r '.commit // ""' "${dest}" 2>/dev/null)"
+  [[ -n ${commit} ]] || { rm -f "${dest}"; say "the baseline names no commit"; return 0; }
+  status="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${commit}...${PR_BASE_SHA}" --jq '.status' 2>/dev/null || true)"
+  case "${status}" in
+  identical | ahead) ;;
+  *)
+    rm -f "${dest}"
+    say "baseline commit ${commit} is '${status:-unresolvable}' relative to this base ${PR_BASE_SHA}, so it does not describe this base"
+    return 0
+    ;;
+  esac
+
+  say "baseline accepted: ${commit} (artifact ${id}, created ${created}, $(
+    jq -r '[(.checks // [])[] | select(.outcome == "fail")] | length' "${dest}"
+  ) failing check(s))"
+}
+
+# The instability record is not about any particular commit, so it needs no
+# ancestry check: a proof that some derivation of a check both passed and failed
+# stays a proof whatever the tree has done since.
+cmd_instability() {
+  local dest=${1:?usage: gate-artifacts.sh instability <dest.json>}
+  local meta
+  meta="$(newest_artifact "${INSTABILITY_ARTIFACT:-gate-instability}" instability.json "${dest}")" || {
+    say "${meta}; starting a fresh record"
+    return 0
+  }
+  say "instability record loaded ($(jq -r '.runsFolded // 0' "${dest}") run(s) folded, $(
+    jq -r '(.proven // []) | length' "${dest}"
+  ) check(s) proven nondeterministic)"
+}
+
+case "${1:-}" in
+baseline) shift; cmd_baseline "$@" ;;
+instability) shift; cmd_instability "$@" ;;
+*)
+  cat >&2 <<'EOF'
+usage:
+  gate-artifacts.sh baseline <dest.json>
+  gate-artifacts.sh instability <dest.json>
+EOF
+  exit 64
+  ;;
+esac

--- a/nix/ci/standing-issue.sh
+++ b/nix/ci/standing-issue.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# The standing issue: one issue in this repository, rewritten in place on every
+# main run, that names what is currently failing and how long it has been.
+#
+# WHY A STANDING ISSUE AND NOT A NOTIFICATION. Differential gating makes red
+# survivable, and survivable is comfortable. Three things push back, and this is
+# the weakest of the three, deliberately:
+#
+#   The RATCHET, which is automatic and needs nobody. A pull request takes the
+#   newest baseline, so the instant a check passes on main it can never be
+#   excused again. Repairs are one-way and there is no list to forget.
+#
+#   The CAP in nix/ci/delta-gate.sh, which refuses everything but repairs once
+#   the base carries more than six failures.
+#
+#   This issue, which is the only part that asks a person for anything.
+#
+# One issue rewritten in place, never one per red run, and it closes itself when
+# main goes green. A stream of notifications is a stream people mute; a single
+# document with a date on it is a thing somebody can be asked about.
+#
+# It lives in hyperion-mc/hyperion rather than in Linear because the repository
+# is public and so is the failing set. An outside contributor who meets a red
+# gate needs to be able to read why without an internal account. Reference the
+# Linear issue from the body for internal tracking, not the other way round.
+#
+# DRY RUN IS THE DEFAULT. Set GATE_ISSUE_APPLY=1 to actually write. A script
+# that files issues should be watched rendering its output before it is allowed
+# to file anything, and the render is the whole of what it does.
+set -euo pipefail
+
+title=${GATE_ISSUE_TITLE:-"Flake gate: main is red"}
+repo=${GITHUB_REPOSITORY:-hyperion-mc/hyperion}
+results=${1:?usage: standing-issue.sh <results.json> [instability.json]}
+record=${2:-}
+apply=${GATE_ISSUE_APPLY:-0}
+
+body="$(mktemp)"
+trap 'rm -f "${body}"' EXIT
+
+failing="$(jq -r '[(.checks // [])[] | select(.outcome == "fail")] | length' "${results}")"
+
+# The existing issue, matched on an EXACT title. Search is fuzzy, and a near
+# miss would open a second standing issue on every run, which is the notification
+# stream this exists to avoid.
+existing=""
+if command -v gh >/dev/null 2>&1 && [[ -n ${GH_TOKEN:-} ]]; then
+  existing="$(gh issue list --repo "${repo}" --state open --limit 100 \
+    --search "\"${title}\" in:title" --json number,title \
+    --jq "[.[] | select(.title == \"${title}\")] | first | .number // empty" 2>/dev/null || true)"
+fi
+
+if [[ ${failing} -eq 0 ]]; then
+  if [[ -n ${existing} ]]; then
+    printf 'main is green; closing #%s\n' "${existing}"
+    [[ ${apply} == 1 ]] && gh issue close "${existing}" --repo "${repo}" \
+      --comment "Every flake check passes on main as of \`$(jq -r '.commit // "?"' "${results}")\` (run $(jq -r '.runId // "?"' "${results}")). Closed by nix/ci/standing-issue.sh."
+  else
+    printf 'main is green and no standing issue is open\n'
+  fi
+  exit 0
+fi
+
+{
+  printf '%s check(s) are failing on `main` as of `%s` ([run %s](https://github.com/%s/actions/runs/%s)).\n\n' \
+    "${failing}" "$(jq -r '.commit // "?"' "${results}")" "$(jq -r '.runId // "?"' "${results}")" \
+    "${repo}" "$(jq -r '.runId // "?"' "${results}")"
+  printf 'Pull requests are judged on the DELTA against this set, so a red `main` does\n'
+  printf 'not block anybody: a pull request passes when it makes the set no larger. That\n'
+  printf 'is what stops one red cause becoming six, and it is also why this issue exists,\n'
+  printf 'because nothing else here is inconvenienced by the set staying red.\n\n'
+  printf 'Two things do push back. The set is a RATCHET: the moment a check passes on\n'
+  printf '`main` it can never be excused again, so a repair cannot be undone by\n'
+  printf 'inattention. And there is a CAP of 6 in `nix/ci/delta-gate.sh`: past it, the\n'
+  printf 'only pull requests that can land are ones that shrink this list.\n\n'
+  printf '### Failing\n\n| check |\n| --- |\n'
+  jq -r '(.checks // [])[] | select(.outcome == "fail") | "| `\(.attr)` |"' "${results}"
+
+  if [[ -n ${record} && -s ${record} ]]; then
+    unstable="$(jq -r '(.proven // []) | length' "${record}")"
+    if [[ ${unstable} -gt 0 ]]; then
+      printf '\n### Proven nondeterministic, and therefore NOT GATING ANYTHING\n\n'
+      printf 'Some derivation of each of these has been recorded both passing and failing,\n'
+      printf 'which is a proof that the check is a coin flip rather than a suspicion. The\n'
+      printf 'gate does not blame a pull request for them, which is the only way a\n'
+      printf 'differential verdict can be trusted, and the cost is that a real break in one\n'
+      printf 'of them would also go unnoticed. **This list should be getting shorter.**\n\n'
+      printf '| check | proof |\n| --- | --- |\n'
+      jq -r '(.proven // [])[] | "| `\(.attr)` | passed in run \(.okRunId // "?"), failed in run \(.failRunId // "?"), same derivation |"' "${record}"
+      printf '\nMeasured flake rate: '
+      jq -r 'if .rate == null then "not enough runs yet" else "\(.rate * 100 | round)% of the last \(.runs) runs hit at least one of these (criterion for making the verdict a required check: 5%)" end' \
+        <(bash "$(dirname "${BASH_SOURCE[0]}")/delta-gate.sh" flake-rate "${record}")
+      printf '\n'
+    fi
+  fi
+
+  printf '\n---\n\nRewritten in place by every `main` run of `nix/ci/standing-issue.sh`, and closed\n'
+  printf 'automatically when every check passes. There is deliberately no comment and no\n'
+  printf 'new issue per failure: this is a status document, not a notification stream.\n'
+} >"${body}"
+
+if [[ ${apply} != 1 ]]; then
+  printf '=== DRY RUN (set GATE_ISSUE_APPLY=1 to write) ===\n'
+  printf 'would %s issue in %s titled: %s\n\n' \
+    "$([[ -n ${existing} ]] && echo "update #${existing}" || echo "create an")" "${repo}" "${title}"
+  cat "${body}"
+  exit 0
+fi
+
+if [[ -n ${existing} ]]; then
+  gh issue edit "${existing}" --repo "${repo}" --body-file "${body}"
+  printf 'updated #%s\n' "${existing}"
+else
+  gh issue create --repo "${repo}" --title "${title}" --body-file "${body}"
+fi


### PR DESCRIPTION
## The problem, with the evidence

On 2026-07-29 two correct pull requests each displayed exactly the failures the other one fixes.

- **#1080** repairs `completions-e2e` and `minecraft-literals`. Its CI reported `bedwars-dev-boot-e2e`, `smash-dev-boot-e2e`, `smash-e2e`.
- **#1081** repairs the two dev-boot gates. Its CI reported `completions-e2e`, `minecraft-literals`, `smash-e2e`.

Neither could ever be green on its own, so neither could land, so the failures accumulated. Both were correct. Both looked broken. A gate that can only say "green" cannot say "better than before", and when main is already red that is the only question a reviewer has.

## What this does

The gate compares this run's failing set against a baseline that main publishes on every push. A pull request that leaves the set no larger passes. One that adds a name blocks, and the summary names it.

Replayed against the real 1080/1081 sets, using this implementation:

| scenario | verdict | detail |
| --- | --- | --- |
| PR 1080 | **pass** | `fixed = [completions-e2e, minecraft-literals]`, three excused |
| PR 1081 | **pass** | `fixed = [bedwars-dev-boot-e2e, smash-dev-boot-e2e]`, three excused |
| breaks a check (derivation moved) | **block** | `blocked = [proxy]` |
| same derivation, unchanged check set | pass | reported nondeterministic, not blamed |
| same derivation, but the check set changed | **block** | `blocked = [proxy]` |

## Flakiness is answered with a proof, not a statistic

A retry cannot do this job. For a check failing 30% of the time, two failures in a row happen 9% of the time, so a retry can acquit and never convict. Any gate whose flake answer is a retry blocks honest work 9% of the time.

A derivation path is a Merkle root over every input derivation, so an unchanged path means an unchanged build closure. Therefore:

> **Same derivation, different outcome, is a proof of nondeterminism.**

Not evidence, not a heuristic. If a check passed on the base and fails here on the byte-identical derivation, the diff did not cause it. Measured here:

```
run 30428441399 (34eb46c, 06:31Z)  differential-traces  ok
run 30429463435 (dd8311f, 06:49Z)  differential-traces  FAILED
both on /nix/store/fczpzka3v7c9npf4a3i730ahkncla3f5-check-hyperion-differential-traces.drv

java.lang.IllegalStateException: chunks were still not entity ticking after 600 ticks
        at VanillaTrace.tickServer(VanillaTrace.java:514)
```

A wall-clock timeout inside the sandbox. Nothing in the derivation moved; the runner was slower.

Applied at two scopes: within a verdict when the derivation is unchanged, and across a rolling record for the common case where a pull request moves the hash. The record keys on the derivation for the **proof** and promotes onto the attribute for the **conclusion**, because nondeterminism is a property of how a check is written and survives a change to its inputs.

## What the 18 main runs of 2026-07-28/29 actually say

Every one of the 18 was red. Extracted from the `Flake` job logs; `.` = ok, `X` = FAILED, `-` = check did not exist yet, oldest leftmost.

```
smash-e2e                XXXXXXXXXXXXXXXXXX   18/18   deterministic
completions-e2e          XXXXXXXXXXXXXXXXXX   18/18   deterministic
smash-dev-boot-e2e       -----------XXXXXXX     7/7   deterministic
bedwars-dev-boot-e2e     -----------XXXXXXX     7/7   deterministic
minecraft-literals       ......XXXXXXXXXXXX   12/18   REGRESSION, see below
smash-hud-e2e            X....X.XX.X..X..XX    8/18   44% nondeterministic
differential-traces      .....XXXXX..X....X    7/18   39% nondeterministic
bedwars-bow-e2e          ........XX........    2/18   11% nondeterministic
smash-selector-e2e       ..................    0/18   clean
```

**61% of runs hit at least one flake**, 2.57 gate runs expected per clean pass. That is measured, not assumed, and the implementation reproduces it: `dg flake-rate` on the folded real history returns `0.611` over the same 18 runs.

Three things here were not previously known. `differential-traces` and `bedwars-bow-e2e` are flaky and nobody had noticed. `smash-selector-e2e` is no longer flaky. And **`minecraft-literals` is not one of the standing five, it is a regression that landed mid-window and stuck** while the gate was already red, which is consequence 2 of a permanently red gate caught in the act.

### Why the identity has to be the derivation, demonstrated on that data

Folding the real 18-run history two ways:

```
A. every check given a constant derivation
   proven nondeterministic: bedwars-bow-e2e, differential-traces, minecraft-literals, smash-hud-e2e

B. modelling the one real derivation change verified from the logs
   (minecraft-literals 9md01i6l -> 3rwh12gk at run 30418671535)
   proven nondeterministic: bedwars-bow-e2e, differential-traces, smash-hud-e2e
```

A excuses a genuine regression as a coin flip. B does not. The derivation keying is the whole difference, on real data.

## Guards, and each was watched failing

Immunity is withdrawn when the derivation does not describe the run. The general form, because the list will grow: **a pull request forfeits immunity when it changes anything the derivation does not capture but the run depends on.** Three known members: environment (`.github/workflows/**`, `nixConfig`), scheduling and concurrency (`nix/ci/flake-gate.nix`, e2e port offsets), and a **changed check set** (detected from the two documents rather than a path list, because adding a check adds contention under a concurrent gate and no path list would catch every way of doing that).

`nix/ci/delta-gate-tests.sh` is 65 cases with no network, no nix and no clock, wired as `checks.<system>.delta-gate`. It contains the inverse of every guard, because the failure mode of a suite like this is passing for the wrong reason. Six deliberate mutations of the verdict logic were each caught by a named case:

```
immunity ignores forfeiture          CAUGHT  forfeit: same-drv flip now BLOCKS
every drv counts as identical        CAUGHT  row2 new-failure: gate BLOCKS
cap ignores the shrink exemption     CAUGHT  cap: a PR that shrinks the set still lands
deleted check counts as repaired     CAUGHT  removed: not credited as a repair
eval failure no longer blocks        CAUGHT  eval failure: BLOCKS even though the base fails too
instability keyed on attr not drv    CAUGHT  fold: the check is proven unstable
```

## What keeps the failing set from becoming permanent

- **The ratchet**, automatic and needing nobody: a pull request takes the newest baseline, so the instant a check passes on main it can never be excused again. Publishing on green is the revocation mechanism, not an optimisation.
- **A cap of 6** in `nix/ci/delta-gate.sh`. Past it nothing lands except pull requests that shrink the set. It is a committed constant, editable downward only and deliberately never derived from an observed count: a suite with proven coin flips will eventually have a lucky night, and a self-lowering cap would latch onto it and freeze the repository the next ordinary day.
- **A standing issue**, one rewritten in place and closed automatically on green. In this repository rather than Linear, because the repository is public and an outside contributor meeting a red gate needs to read why without an internal account. **Dry-run by default**; `GATE_ISSUE_APPLY: "1"` is one line in the workflow.

## The exclusion list is deleted

Same idea at lower fidelity, stored where only human attention could refresh it, and every fix was a merge conflict against every other fix in flight. The header of `nix/ci/flake-gate.nix` now says where "known broken" lives so nobody reinvents it. A check that genuinely cannot run in CI belongs out of `checks` in `flake.nix`, which is a truer home for "this cannot run here" than a CI-side exception.

## This is NOT a required status context, and this PR does not make it one

`gh api repos/hyperion-mc/hyperion/rulesets/566717 --jq '.rules[].type'` returns seven rules and no `required_status_checks`; it is the only ruleset and `branches/main/protection` returns 404. So one approving review is the only thing between any pull request and main today, red pipeline or no pipeline. Making the verdict binding is one `required_status_checks` entry naming this job. **Four criteria should hold first, none of which does:**

1. **Flake rate at or under 5%** over 20 consecutive runs. Measured 61%.
2. **At least 30 runs in the instability record.** At n=18 an 11% flake like `bedwars-bow-e2e` is still 12% likely to be unproven; n=30 puts anything at or above 10% over 97% likely to be proven.
3. **At most 1 in 20 pull request runs** blocked by a verdict a re-run then clears, over 20 runs. Only measurable in this report-only phase, which is why it is its own step.
4. **p95 wall time under 40 minutes.** Measured 31 to 41 over the 18 runs, all red; no green run of this gate has ever been observed, so the green cost is unknown. The merge queue's `check_response_timeout_minutes` is 60 while this job is allowed 90, so those two must stop disagreeing before anything is required.

Criterion 4 makes #1084 (concurrent gate) a prerequisite. The gate is two long checks and a tail with a 4-second median, so the concurrency floor is about 11 minutes.

Also worth naming: the queue's `grouping_strategy` is `ALLGREEN` with `max_entries_to_build: 5`, so once checks are required one flake ejects a batch of five rather than costing one author a re-run.

## Composing with #1087, which landed while this was being written

#1087 gave the gate a `results.jsonl` of `{attr, outcome, drvPath}` per check, and wrote the same rationale I had arrived at separately: "the same derivation with two different outcomes is proof the change did not cause the failure." So this rebases onto their file rather than replacing it. Their concurrent build, their `drv_map`, their `realised()` store oracle and their `unquotable` guard are all untouched. What this adds is `excluded` deleted, and a verdict stage at the end that reads `results.jsonl` and nothing else.

That seam is load-bearing and now demonstrated: the build loop changed from one `nix build` per name to one concurrent `--keep-going` build for the whole set, and no part of the verdict noticed.

I adopted their vocabulary (`pass`/`fail`, not `ok`/`fail`), and the library tests for `fail` and treats anything else as passing, so a third spelling arriving later reads as a pass rather than silently turning every check red.

## This does NOT restore the CI triggers

#1088 and #1089 removed every automatic trigger while this was in flight. Three of the reasons given are measurements from this same investigation: 18 consecutive red runs, no required status context, and three checks poisoning 61% of runs so a correct change needed 2.6 attempts.

**This change answers two of those three and restores none of the triggers.** A differential verdict makes a red base survivable and stops the coin flips being blamed on anybody, but it does not make the checks green, and green-and-stays-green is the bar #1089 set. Restoring triggers is a decision for whoever set that bar, not a side effect of landing machinery that changes what the bar is worth.

The consequence, stated plainly: **on `workflow_dispatch` alone this machinery is mostly inert.** No push means no published baseline, so the first pull request to run under it will find none and be judged exactly as it is today. A manual dispatch on `main` does produce a baseline and does fold the first instability samples, and the publish conditions are written as `github.ref == 'refs/heads/main' && github.event_name != 'pull_request'` so they keep working unchanged whenever the triggers come back.

## Verification

- `nix build .#checks.aarch64-darwin.delta-gate` passes in the sandbox: 65 of 65.
- `nix build .#checks.aarch64-darwin.flake-gate` builds, so shellcheck passes on the gate.
- `nix run .#fmt` makes no changes.
- Workflow YAML parses; job and permission structure checked with `yq`.
- Replayed against the real 1080/1081 sets and against the real 18-run history; `dg flake-rate` on the folded history returns `0.611`, matching the hand measurement.

**Not verified, and worth knowing before approving:**

- No full `nix run .#flake-gate` on x86_64-linux. The verdict stage is exercised only through fixtures and replays.
- **No live CI run of any of this.** With triggers manual, this PR does not run its own CI, so the baseline fetch, the artifact publishing, the standing issue job and the permission set have never executed. The first `workflow_dispatch` on `main` after this merges is where they are first exercised. That is the largest untested surface here and I am not going to describe it as working.
- The standing issue writes nothing until `GATE_ISSUE_APPLY` is `"1"`. Its body has been rendered locally against the real folded record; it has never posted.
