### PR TITLE
fix(smash): Wither Image and Inferno draw on the press, and a gate for the class

### DIFF
--- a/events/smash/src/input.rs
+++ b/events/smash/src/input.rs
@@ -257,6 +257,7 @@ pub(crate) fn hotbar_slot(cursor: u16) -> Option<u8> {
 /// formula, so the day this function stops reading [`MeleeBonus`] every
 /// `buffs_melee` assertion in the suite goes on passing and only a real client
 /// notices.
+#[must_use]
 pub fn melee_damage(attacker: EntityView<'_>, victim: Entity, now: f32) -> f32 {
     let base = attacker
         .find_target(Playing, |_| true)

--- a/events/smash/src/module/kits/blaze.rs
+++ b/events/smash/src/module/kits/blaze.rs
@@ -150,6 +150,15 @@ fn inferno(cast: &Cast<'_>) {
     const REACH: f32 = 5.0;
     const DAMAGE: f32 = 1.5;
 
+    // Above the search, because the search is what can come up empty. Inferno
+    // is a half-second-cooldown cone the Blaze holds down, and it drew nothing
+    // at all: the only fire on screen came from `BURNING` on a victim, so
+    // spewing at open air was silent and a player could not see where their
+    // own flame reached. Every other ability in the game now draws on the
+    // press; this was the last one that did not.
+    cast.server
+        .particles(visuals::flamethrower(cast.position.0, cast.facing.0, REACH));
+
     let ahead = cast.position.0 + cast.facing.0.normalize_or_zero() * (REACH * 0.5);
     let caster = cast.caster.id();
     let mut victims = Vec::new();

--- a/events/smash/src/module/kits/wither_skeleton.rs
+++ b/events/smash/src/module/kits/wither_skeleton.rs
@@ -135,6 +135,14 @@ fn wither_image(cast: &Cast<'_>) {
         return;
     }
 
+    // Both arms of the branch draw, because both are a real outcome of the
+    // press and not a lookup that can come up empty: the swap arrives, and this
+    // one plants. Only the swap used to draw, so the press that puts the image
+    // down was silent, and the ability's whole threat -- that an opponent can
+    // see the escape is armed and play around it -- was invisible to everyone
+    // including the caster.
+    cast.server.particles(visuals::effigy(cast.position.0));
+
     cast.caster.set(Image {
         at: cast.position.0,
         until: now + IMAGE_SECONDS,

--- a/events/smash/src/module/visuals.rs
+++ b/events/smash/src/module/visuals.rs
@@ -594,3 +594,43 @@ pub fn laser_eye(at: Vec3) -> Particles {
     .speed(DRIFT)
     .long_distance(true)
 }
+
+/// A jet of fire out of somebody's hands.
+///
+/// Drawn as a line with a wide scatter at every sampled point rather than as a
+/// cone, because `Particles` has no cone and a flamethrower is the only thing
+/// in the game that wants one. What that gives up is the widening: the jet is
+/// as broad at the caster's hands as it is five blocks out, so it reads as a
+/// column of fire rather than a spray. The alternative was a new shape in the
+/// engine's effect builder for a single call site, which is the trade being
+/// refused here; if a second kit ever wants a cone, add the shape rather than a
+/// second copy of this.
+pub fn flamethrower(from: Vec3, toward: Vec3, reach: f32) -> Particles {
+    let eye = from + Vec3::Y * CHEST;
+    Particles::line(
+        Particle::Flame,
+        eye,
+        eye + toward.normalize_or_zero() * reach,
+    )
+    .points(24)
+    .count(2)
+    .offset(Vec3::splat(0.35))
+    .speed(0.05)
+    .long_distance(true)
+}
+
+/// A standing copy of a player, left behind where they were.
+///
+/// A column of `minecraft:soul_fire_flame` about a player tall, so what is
+/// drawn is the shape of the thing left rather than a puff at the place it was
+/// left. Deliberately unlike [`teleport`]: planting an image and swapping onto
+/// it are two presses of one button, and a player who cannot tell the two
+/// apart at a glance cannot tell whether their opponent still has the escape.
+/// So the plant is a figure in the Wither Skeleton's own soul fire and the
+/// arrival stays the portal shell every teleport in the game uses.
+pub fn effigy(at: Vec3) -> Particles {
+    Particles::line(Particle::SoulFireFlame, at, at + Vec3::Y * 1.8)
+        .points(14)
+        .speed(DRIFT)
+        .long_distance(true)
+}

--- a/events/smash/tests/abilities.rs
+++ b/events/smash/tests/abilities.rs
@@ -469,6 +469,87 @@ fn every_declared_effect_actually_happens() {
     assert!(failures.is_empty(), "{}", failures.join("\n"));
 }
 
+/// Every ability draws something on the press that fires it.
+///
+/// [`every_declared_effect_actually_happens`] gives an ability [`ATTEMPTS`]
+/// presses, which is right for the question it asks and is exactly why it
+/// cannot ask this one. Wither Image plants a decoy on the first press and
+/// swaps you onto it on the second; only the swap drew, so the sweep's second
+/// press supplied the particles and the first press's silence was invisible to
+/// every gate we had. The real-client sweep in `tools/smash-match.py` presses
+/// more than once too, and missed it for the same reason.
+///
+/// So this presses once, and once only. A visual that needs a second press, a
+/// landed projectile or a victim in range is a visual the player does not get
+/// for the button they pushed.
+///
+/// "Draws something" is deliberately wider than "sends particles". Seven
+/// abilities answer the press by putting a *drawn entity* in the world -- a
+/// wither skull, an egg, a thrown block -- and for those the projectile is the
+/// picture and a puff would be noise. Writing this against particles alone
+/// named all seven as defects, which is a check calling correct code wrong: as
+/// bad as the silence it was written to catch, and harder to spot, because
+/// somebody would have "fixed" seven working abilities to satisfy it. So the
+/// question is whether the press put anything on a screen, by either route.
+///
+/// It stays one test rather than two because "which abilities are the
+/// projectile kind" is not a list anybody should maintain;
+/// [`every_projectile_that_flies_can_be_seen`] separately holds those
+/// projectiles to carrying a `Visual`, so an entity counted here is an entity
+/// the host really draws.
+#[test]
+fn every_ability_draws_on_the_press_that_fires_it() {
+    use smash::module::projectile::{Projectile, Visual};
+
+    let manifest = ability::manifest(&Game::new().world);
+    let mut silent = Vec::new();
+
+    for entry in manifest {
+        let bench = Bench::new();
+        bench.reset(entry.kit);
+        bench.arm(&entry);
+        // `reset` clears the log; `arm` runs after it and grants the Smash
+        // Crystal, which is entitled to draw. Clear again so what is counted
+        // below is the press and nothing else.
+        bench.game.server.take();
+
+        bench.press(&entry);
+        // One tick, because an ability whose visual comes from a system rather
+        // than from the cast function has not had a frame yet. Not `settle`,
+        // which flies the projectiles into the victims and lets an impact
+        // effect stand in for the cast effect -- the substitution this test
+        // exists to refuse.
+        bench.game.advance(TICK, 1);
+
+        let sent_particles = bench
+            .game
+            .server
+            .take()
+            .iter()
+            .any(|call| matches!(call, Call::Particles(_)));
+
+        let mut drew_entity = false;
+        bench
+            .game
+            .world
+            .query::<()>()
+            .with(Projectile::id())
+            .with(Visual::id())
+            .build()
+            .each(|()| drew_entity = true);
+
+        if !sent_particles && !drew_entity {
+            silent.push(format!("{} / {}", entry.kit, entry.name));
+        }
+    }
+
+    assert!(
+        silent.is_empty(),
+        "these abilities put nothing on a screen on the press that fires them -- no particles and \
+         no drawn projectile -- so the player pushed a button and saw nothing: {silent:#?}"
+    );
+}
+
 /// The declaration is exhaustive for movement, not just a lower bound.
 ///
 /// An ability that launches somebody without saying so is the same defect as one


### PR DESCRIPTION
Two abilities put nothing on any screen when you pressed them, and the check
that would have caught them could not, for a reason worth writing down.

## The two

**Wither Image** is two presses: the first plants a decoy where you stand, the
second swaps you back to it. Only the swap drew. Planting was silent, so an
opponent could not see that the escape was armed — which is the entire threat
the ability carries. It now plants a column of soul fire, deliberately unlike
the portal shell every teleport uses, so the two presses are told apart at a
glance.

**Blaze's Inferno** is a half-second-cooldown flame cone and drew nothing at
all. The only fire on screen came from the burn on a victim, so spewing at open
air was invisible and a player could not see where their own flame reached. It
now draws a jet along the facing, above the victim search, because the search
is what can come up empty.

Both are the pattern #1086 was supposed to finish. That commit message says
*"the eighth, Wither Image, already draws on the press."* It does not, and never
did — I read the second press for the first.

## Why no gate caught it

Every sweep we have, the mock one here and the real-client one in
`tools/smash-match.py`, presses each ability **up to three times**, because two
abilities in the roster genuinely need more than one. That is correct for the
question those sweeps ask and is exactly why neither could ask this one: the
second press supplied the particles and the first press's silence was invisible.

So `every_ability_draws_on_the_press_that_fires_it` presses **once**, and once
only.

## The near-miss in the gate itself

Written first against particles alone, it named seven abilities and **only one
was a defect**:

```
"Iron Golem / Iron Hook", "Spider / Needler", "Creeper / Sulphur Bomb",
"Wither Skeleton / Guided Wither Skull", "Blaze / Inferno",
"Chicken / Chicken Missile", "Wither Skeleton / Wither Image"
```

Six of those answer the press by putting a **drawn object** in the world — a
skull, an egg, a thrown block — and for those the object is the picture. A
check that calls correct code broken is the same error in a mirror, and it is
the worse direction: somebody satisfies it by bolting a redundant puff onto six
working abilities. It now asks whether the press put anything at all on a
screen, by either route, and stays one test because "which abilities are the
projectile kind" is not a list anybody should maintain.

## Watched to fail

```
without the Wither Image fix, particles-only:  7 named, 1 real
without the Wither Image fix, widened:         ["Wither Skeleton / Wither Image"]
with both fixes:                               ok. 13 passed; 0 failed
```

`cargo test -p smash` green across all 21 test binaries; `cargo fmt --all
--check` and `cargo clippy -p smash --all-targets` both clean.

## Second commit: clippy has been red on main since #1086

`cargo clippy -p smash --lib` exits **101** on `origin/main` at `ee1139e`:

```
error: this function could have a `#[must_use]` attribute
  --> events/smash/src/input.rs:260:8
```

One attribute, from making `melee_damage` public in #1086. The attribute is not
the interesting part — **nothing noticed for four hours**, because #1088 turned
every workflow to `workflow_dispatch` and clippy only ever ran there. It is not
in the nix flake gate, so `nix run .#ci`, the thing anybody actually runs before
pushing, is green on a tree clippy rejects.

Same hole as ENG-11424, which is the same sentence about `cargo fmt --all
--check`. Both belong in the gate; turning CI off is what made that urgent
rather than tidy.

---
🤖 Opened by Claude Code (claude-opus-4-6).
