### PR TITLE
ci: make the flake gate run clippy and cargo fmt --check (ENG-11424)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,28 @@ jobs:
   # branch has no classic protection either, so today nothing here is a
   # required context and a red job does not block a merge on its own. Renaming
   # a job is therefore safe and enforcement is weaker than it reads. ENG-10827.
+  #
+  # THE Clippy AND Formatting ENTRIES BELOW DUPLICATE `checks.clippy` AND
+  # `checks.rustfmt` IN THE `flake` JOB, AND THAT IS THE INTENDED STATE. Do not
+  # delete them to save the duplicated run.
+  #
+  # They answer different questions. This matrix answers "is this branch
+  # lint-clean" -- fast, standalone, and legible as its own line in the pull
+  # request's checks list. The gate's entry answers "does `results.jsonl` tell
+  # the truth about lint", which is what the differential verdict, the
+  # published baseline and the instability record all consume. Collapsing the
+  # two would leave the fast answer depending on the slow one: a red clippy
+  # would surface at minute thirty instead of minute two, and loop length is
+  # the thing this repository keeps paying for.
+  #
+  # The duplication is execution, not definition. Both paths invoke the same
+  # `checkScripts.lint` / `checkScripts.fmt` derivation, so there is already
+  # exactly one source of truth for the command and the flags, and merging the
+  # jobs would collapse nothing that is currently split.
+  #
+  # Until ENG-11424 the gate ran neither. `checks = scripts // { ... }`, so
+  # `checks.lint` was the SCRIPT: building it ran shellcheck over the text of a
+  # cargo command and never ran cargo, while the gate reported `ok lint`.
   check:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest

--- a/flake.nix
+++ b/flake.nix
@@ -1259,7 +1259,20 @@
             # `runCommandCC`, not `runCommand`: the latter is `stdenvNoCC` and
             # several build scripts in the graph are C. Without it the check
             # fails at `linker `cc` not found` rather than at a lint.
-            clippy = pkgs.runCommandCC "hyperion-clippy" { inherit nativeBuildInputs; } ''
+            clippy = pkgs.runCommandCC "hyperion-clippy" {
+              inherit nativeBuildInputs;
+              # Clippy builds the dev profile, so every C build script in the
+              # graph compiles at `-O0`, and glibc answers `_FORTIFY_SOURCE`
+              # with a `#warning` whenever optimisation is off. An autoconf
+              # probe that reads stderr then misreads its own test as a
+              # compile failure: on run 30514788219 tikv-jemalloc-sys died at
+              # `configure: error: cannot determine return type of strerror_r`,
+              # nowhere near the real cause. The release build never meets this
+              # because it compiles at -O3. Darwin never meets it either, which
+              # is why this check was green on aarch64-darwin and red on the
+              # first x86_64-linux run.
+              hardeningDisable = [ "fortify" ];
+            } ''
               cp -r ${./.}/. .
               chmod -R u+w .
               # Points CARGO_HOME at the vendored crates cargoUnit already

--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,26 @@
             ];
           };
 
+          # Every Rust source, every manifest, and the formatting rules. Narrow
+          # on purpose: `cargo fmt` reads nothing else, so a change to a world,
+          # a document or a nix file must not rerun it.
+          rustfmtSource =
+            let
+              formatted =
+                dir:
+                lib.fileset.fileFilter (file: file.hasExt "rs" || file.name == "Cargo.toml") dir;
+            in
+            lib.fileset.toSource {
+              root = ./.;
+              fileset = lib.fileset.unions [
+                (formatted ./crates)
+                (formatted ./events)
+                (formatted ./tools)
+                ./Cargo.toml
+                ./rustfmt.toml
+              ];
+            };
+
           # Every kit's skin image, fetched from the url its signed payload names
           # and pinned by hash in textures.lock.json. Fixed-output so the image
           # gate stays offline and store-cached: the fetch happens once, here,
@@ -1191,10 +1211,71 @@
                   --set HYPERION_BUILD_DIRTY ${lib.escapeShellArg buildStamp.dirty}
               '';
 
+          # `nix run .#fmt -- --check` and `nix run .#lint`, as derivations the
+          # gate realises. ENG-11424.
+          #
+          # `checks` is `scripts // ...`, so `checks.fmt` and `checks.lint`
+          # already existed -- as the SCRIPTS. Building one runs shellcheck over
+          # the text of a cargo command and never runs cargo, so the gate was
+          # green on a tree that both reject. `cargo clippy -p smash --lib`
+          # exited 101 on main at ee1139e for about four hours and nothing said
+          # so: #1088 left every workflow `workflow_dispatch`, and clippy only
+          # ever ran there.
+          #
+          # Each check runs the script rather than restating its command, so the
+          # gate and what a contributor runs by hand cannot say different things
+          # about the same tree. Flags, lints and their configuration stay where
+          # they already are: `clippyArgs` above, `[workspace.lints]` in
+          # Cargo.toml, `clippy.toml` and `rustfmt.toml`.
+          lintChecks = {
+            rustfmt = pkgs.runCommand "hyperion-rustfmt" { } ''
+              cp -r ${rustfmtSource}/. .
+              chmod -R u+w .
+              # cargo-fmt finds the members with `cargo metadata --no-deps`,
+              # which resolves nothing, so this needs neither the vendor dir nor
+              # a network -- but cargo still insists on a writable CARGO_HOME.
+              export CARGO_HOME="$PWD/.cargo-home"
+              ${lib.getExe checkScripts.fmt} --check
+              touch $out
+            '';
+
+            # Whole workspace, `--all-targets --all-features`, which is what
+            # `clippyArgs` says and therefore covers `crates/*` and `tools/*` as
+            # well as the two events.
+            #
+            # Source is the whole tree rather than a fileset, because clippy
+            # compiles: a kit's arena is `include_str!`, so narrowing the input
+            # would be narrowing what compiles. Reusing `workspaceArgs.src`
+            # keeps it one store copy shared with the release build.
+            #
+            # Cost, measured cold with an empty CARGO_TARGET_DIR on an M-series
+            # mac: 63 s wall, 429 s CPU. It shares nothing with the release
+            # build and cannot -- clippy reads dev-profile metadata produced by
+            # `clippy-driver`, not release rlibs produced by `rustc` -- but at
+            # 429 CPU-seconds against the gate's ~8400 (2102 s over four cores,
+            # run 30500640846) it is about 5% more work, overlapped by
+            # `--keep-going` with e2e gates that are waiting on a server to boot
+            # rather than on a core.
+            # `runCommandCC`, not `runCommand`: the latter is `stdenvNoCC` and
+            # several build scripts in the graph are C. Without it the check
+            # fails at `linker `cc` not found` rather than at a lint.
+            clippy = pkgs.runCommandCC "hyperion-clippy" { inherit nativeBuildInputs; } ''
+              cp -r ${./.}/. .
+              chmod -R u+w .
+              # Points CARGO_HOME at the vendored crates cargoUnit already
+              # fetched for the release build, so this resolves the same lock
+              # from the same sources with no second set of hashes to drift.
+              ${workspace.cargoConfigScript}
+              ${lib.getExe checkScripts.lint}
+              touch $out
+            '';
+          };
+
           # `nix flake check` builds every app, which is what proves each one
           # passes shellcheck and that its tools resolve. What CI enforces of
           # this set, and the named exceptions, live in nix/ci/flake-gate.nix.
-          baseChecks = scripts // {
+          baseChecks = scripts // lintChecks // {
+
             # The two gates that read the wire the way a player does, as
             # derivations: nix builds the binaries, the sandbox boots them on
             # loopback, and the scripted client's verdict is the build result.

--- a/flake.nix
+++ b/flake.nix
@@ -1243,10 +1243,17 @@
             # `clippyArgs` says and therefore covers `crates/*` and `tools/*` as
             # well as the two events.
             #
-            # Source is the whole tree rather than a fileset, because clippy
-            # compiles: a kit's arena is `include_str!`, so narrowing the input
-            # would be narrowing what compiles. Reusing `workspaceArgs.src`
-            # keeps it one store copy shared with the release build.
+            # Source is `workspaceArgs.src`, so clippy reads exactly the tree
+            # the release build compiles and there is one store copy rather
+            # than two. Written as the binding rather than as `./.` a second
+            # time: the two are the same path today (checked in one evaluation
+            # -- both `/nix/store/4p2rn13...-source`), but that is a coincidence
+            # of two identical literals, and narrowing the release build's
+            # source later would silently leave clippy on the whole tree.
+            #
+            # Whole tree is the right input anyway, and not an oversight:
+            # clippy compiles, and a kit's arena is `include_str!`, so
+            # narrowing it is narrowing what compiles.
             #
             # Cost, measured cold with an empty CARGO_TARGET_DIR on an M-series
             # mac: 63 s wall, 429 s CPU. It shares nothing with the release
@@ -1273,7 +1280,7 @@
               # first x86_64-linux run.
               hardeningDisable = [ "fortify" ];
             } ''
-              cp -r ${./.}/. .
+              cp -r ${workspaceArgs.src}/. .
               chmod -R u+w .
               # Points CARGO_HOME at the vendored crates cargoUnit already
               # fetched for the release build, so this resolves the same lock


### PR DESCRIPTION
`checks = scripts // ...`, so `checks.lint` and `checks.fmt` already existed — **as the scripts**. Building one runs shellcheck over the text of a cargo command and never runs cargo. `nix run .#flake-gate` has been printing `ok lint` and `ok fmt` about tools it has never invoked.

**That matters beyond wall clock: the gate is the only thing that writes `results.jsonl`.** The published baseline and the instability record have therefore carried two checks recorded as passing that were never run, and every consumer of the differential verdict has been reading that.

`cargo clippy -p smash --lib` exited 101 on `main` at `ee1139e` for about four hours. Fixed in #1093; this is the hole that let it sit.

## What this adds

- `checks.rustfmt` — `cargo fmt --all --check`
- `checks.clippy` — `cargo clippy --all-targets --all-features -- -D warnings`, whole workspace

Each **invokes the existing script** (`${lib.getExe checkScripts.fmt} --check`, `${lib.getExe checkScripts.lint}`) rather than restating its command, so the gate and what a contributor runs by hand cannot say different things about the same tree. No lint configuration is invented: flags stay in `clippyArgs`, lints stay in `[workspace.lints]`, `clippy.toml` and `rustfmt.toml`.

`checks.clippy` reuses `workspace.cargoConfigScript`, pointing `CARGO_HOME` at the vendor dir cargoUnit already built for the release build — one set of `outputHashes`, nothing to drift.

## The Clippy matrix job stays, deliberately

`ci.yml` has had a `Clippy` job and a `Formatting` job in its `check` matrix all along, so clippy now runs twice on a dispatched run. The obvious cleanup is to delete the matrix entries, and it is the wrong one. Third commit writes the reasoning next to the matrix so nobody re-proposes it from the diff alone:

The two answer different questions. The matrix answers "is this branch lint-clean" — fast, standalone, legible as its own line in the checks list. The gate's entry answers "does `results.jsonl` tell the truth about lint". Merging them would make the fast answer wait on the slow one: a red clippy at minute thirty instead of minute two. And the duplication is execution, not definition — both paths invoke the same `checkScripts` derivation, so merging would collapse nothing that is currently split.

## Watched both go red

`mod   cached_save;` in `crates/hyperion-utils/src/lib.rs`:

```
hyperion-rustfmt> Diff in .../crates/hyperion-utils/src/lib.rs:4:
hyperion-rustfmt> -mod   cached_save;
hyperion-rustfmt> +mod cached_save;
error: Cannot build '/nix/store/rvf7q8...-hyperion-rustfmt.drv'. Reason: builder failed with exit code 1.
```

Separately broke `events/smash/src/lib.rs` and `tools/rust-mc-bot/src/lib.rs` together, because a fileset that silently misses a workspace member is exactly the failure this check would hide:

```
hyperion-rustfmt> Diff in .../events/smash/src/lib.rs:19:
hyperion-rustfmt> Diff in .../tools/rust-mc-bot/src/lib.rs:5:
```

A `pub fn` returning a value — the same lint `main` was red on:

```
hyperion-clippy> error: this function could have a `#[must_use]` attribute
hyperion-clippy>   --> crates/hyperion-utils/src/lib.rs:12:8
hyperion-clippy>    = note: `-D clippy::must-use-candidate` implied by `-D clippy::pedantic`
hyperion-clippy> error: this could be a `const fn`
hyperion-clippy>    = note: `-D clippy::missing-const-for-fn` implied by `-D clippy::nursery`
hyperion-clippy> error: could not compile `hyperion-utils` (lib) due to 2 previous errors
```

All reverted.

## The first linux run caught something darwin could not

`checks.clippy` was green on aarch64-darwin and red on the first `x86_64-linux` gate run (30514788219), inside `tikv-jemalloc-sys`:

```
configure: error: cannot determine return type of strerror_r
```

Clippy builds the dev profile, so every C build script in the graph compiles at `-O0`, and glibc answers `_FORTIFY_SOURCE` with a `#warning` whenever optimisation is off. An autoconf probe reading stderr then reads its own test as a compile failure. The release build never meets this because it compiles at `-O3`; darwin never meets it at all. Second commit adds `hardeningDisable = [ "fortify" ]`, and the check is green on both systems.

## Cost, measured on ubuntu-latest

Two gate runs on hosted four-core runners, same night, cold store, same base:

| run | ref | checks | gate seconds |
| --- | --- | --- | --- |
| [30514860323](https://github.com/hyperion-mc/hyperion/actions/runs/30514860323) | `main` d8df46f | 69 | **1977** |
| [30516652866](https://github.com/hyperion-mc/hyperion/actions/runs/30516652866) | this branch | 71 | **2282** |

**+305 s, +15.4%**, and in that run the gate printed `ok clippy` and `ok rustfmt`. One sample each, so read it against the spread: this gate has been observed between 31 and 41 minutes, and a five-minute delta is not cleanly separable from that. The floor is firmer — clippy costs 429 CPU-seconds cold (measured `user 328.30 sys 100.87`), which is 107 s of a four-core runner under perfect overlap. It does not overlap perfectly, and 305 s is what imperfect overlap looks like.

Clippy cannot share the release build's artifacts, and this is structural: clippy reads dev-profile metadata produced by `clippy-driver`, the release build produces optimised rlibs from `rustc`. Nothing is reusable in either direction.

## Known cost: `checks.clippy` reruns on any tracked file

Its source is the whole tree, because clippy compiles and a kit's arena is `include_str!` — narrowing the input would be narrowing what compiles. So a change to a document or to `.github/` reruns 429 CPU-seconds of clippy. Demonstrated by this PR's own third commit, which touches only `ci.yml`:

```
checks.x86_64-linux.clippy    1k2686w5pk7313gq8bfwlimk5xhaq1qs -> 93a35bbg18b4i71n4w7ilkxl0zpz535p
checks.x86_64-linux.rustfmt   ywv83av7xy1dnhf1hj57b0111d1bxgz8 -> ywv83av7xy1dnhf1hj57b0111d1bxgz8
```

`checks.rustfmt` is unaffected because it reads a fileset of Rust sources, manifests and `rustfmt.toml` alone. Narrowing clippy the same way is possible but has a real failure mode — miss one `include_str!` and the check compiles a different tree than the release build does — so it is deliberately left as a follow-up rather than done half-way here.

## What this still does not cover

The pipeline is manual. Every workflow is `workflow_dispatch:` since #1088, `main` carries no required status checks, and `branches/main/protection` 404s — so somebody has to dispatch the `Flake` job, or run `nix run .#flake-gate` locally. This makes the gate *correct*; it does not make it *run*.

The cheapest thing that would make skipping harder is a pre-commit hook running `cargo fmt --all --check` alone; clippy is too slow for one. The repo has no hook machinery today, so that is a separate change.

The one remaining failure on the after-run is `smash-e2e`, which fails identically on `main` (run 30514860323, `checks that failed: smash-e2e`). The verdict reads it as blocking only because no baseline artifact was admitted, which is the fail-closed direction working as designed.

ENG-11424.