### PR TITLE
feat(smash): put the build on the player's screen (ENG-11446)

### DIFF
--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -53,7 +53,7 @@ use valence_nbt::{Compound, List, Value};
 use crate::{
     module::kit::{self, Playing},
     server::{
-        BarColour, BossBar, Channel, Experience, HotbarItem, Particles, PlayerId, Server,
+        BarColour, BarSlot, BossBar, Channel, Experience, HotbarItem, Particles, PlayerId, Server,
         SidebarLine, Sound, SoundCategory, Status, Text, Title,
     },
 };
@@ -117,6 +117,7 @@ enum Op {
     },
     SetBossBar {
         player: Entity,
+        slot: BarSlot,
         bar: BossBar,
     },
     ShowTitle {
@@ -243,9 +244,10 @@ impl Server for HyperionServer {
         });
     }
 
-    fn set_boss_bar(&self, player: PlayerId, bar: BossBar) {
+    fn set_boss_bar(&self, player: PlayerId, slot: BarSlot, bar: BossBar) {
         self.push(Op::SetBossBar {
             player: entity_of(player),
+            slot,
             bar,
         });
     }
@@ -272,7 +274,7 @@ impl Module for SmashAdapterModule {
         world.import::<crate::SmashModule>();
 
         world.component::<OpQueue>().add_trait::<flecs::Singleton>();
-        world.component::<HudBar>();
+        world.component::<PlayerBars>();
 
         let ops = Arc::new(Mutex::new(Vec::new()));
         world.set(OpQueue(Arc::clone(&ops)));
@@ -324,22 +326,37 @@ impl Module for SmashAdapterModule {
                 let world = it.world();
                 let drained =
                     std::mem::take(&mut *queue.0.lock().expect("server op queue poisoned"));
-                // Every player's bar, resolved before any op is applied.
+                // Every player's bars, resolved before any op is applied.
                 //
                 // `world.entity()` hands back its id at once but the
-                // `set(HudBar)` that records it is deferred to the merge, so
-                // two `SetBossBar` ops for one player in one drain would each
-                // see no bar and mint one. Resolving them up front, in one
-                // map, is what makes a second bar impossible rather than
-                // merely unlikely.
-                let mut bars = HashMap::new();
+                // `set(PlayerBars)` that records it is deferred to the merge,
+                // so a second `SetBossBar` for the same player in one drain
+                // still reads the component as it stood at the start of the
+                // tick. Resolving every slot into one map first, and writing
+                // the component back once per player, is what makes a
+                // duplicate bar impossible rather than merely unlikely. Doing
+                // it per slot instead loses the other slot's entity to the
+                // last write, and the tick after that mints a second bar for
+                // it -- two match bars stacked on one screen.
+                let mut bars: HashMap<Entity, PlayerBars> = HashMap::new();
                 for op in &drained {
-                    if let Op::SetBossBar { player, .. } = op
-                        && let Entry::Vacant(slot) = bars.entry(*player)
-                        && let Some(bar) = hud_bar(world, *player)
-                    {
-                        slot.insert(bar);
-                    }
+                    let Op::SetBossBar { player, slot, .. } = op else {
+                        continue;
+                    };
+                    let resolved = match bars.entry(*player) {
+                        Entry::Occupied(held) => held.into_mut(),
+                        Entry::Vacant(empty) => match bars_of(world, *player) {
+                            Some(held) => empty.insert(held),
+                            None => continue,
+                        },
+                    };
+                    resolved.0[slot.index()] = Some(match resolved.0[slot.index()] {
+                        Some(bar) if world.entity_from_id(bar).is_alive() => bar,
+                        _ => mint_bar(world, *player),
+                    });
+                }
+                for (player, resolved) in &bars {
+                    world.entity_from_id(*player).set(*resolved);
                 }
                 for op in drained {
                     apply(world, compose, op, &bars);
@@ -348,7 +365,7 @@ impl Module for SmashAdapterModule {
     }
 }
 
-fn apply(world: WorldRef<'_>, compose: &Compose, op: Op, bars: &HashMap<Entity, Entity>) {
+fn apply(world: WorldRef<'_>, compose: &Compose, op: Op, bars: &HashMap<Entity, PlayerBars>) {
     match op {
         Op::AddVelocity { player, delta } => {
             let entity = world.entity_from_id(player);
@@ -511,8 +528,11 @@ fn apply(world: WorldRef<'_>, compose: &Compose, op: Op, bars: &HashMap<Entity, 
                 &packet,
             );
         }
-        Op::SetBossBar { player, bar } => {
-            let Some(entity) = bars.get(&player) else {
+        Op::SetBossBar { player, slot, bar } => {
+            let Some(entity) = bars
+                .get(&player)
+                .and_then(|held| held.0[slot.index()].as_ref())
+            else {
                 return;
             };
             world
@@ -545,13 +565,31 @@ fn connection_of(world: WorldRef<'_>, player: Entity) -> Option<ConnectionId> {
     entity.try_get::<&ConnectionId>(|id| *id)
 }
 
-/// Which boss bar entity is this player's, making it if they have none.
+/// The bars a player already has, or nothing when they have left.
 ///
-/// The bar this game draws is per player -- it carries a percentage that is
-/// only true of the person reading it -- so its audience is one edge,
+/// An empty set for a player who has never been drawn one, which is the same
+/// answer as "every slot is still to be minted".
+fn bars_of(world: WorldRef<'_>, player: Entity) -> Option<PlayerBars> {
+    let player = world.entity_from_id(player);
+    if !player.is_alive() {
+        return None;
+    }
+    Some(
+        player
+            .try_get::<&PlayerBars>(|bars| *bars)
+            .unwrap_or_default(),
+    )
+}
+
+/// A fresh boss bar entity, shown to `player` alone.
+///
+/// Every bar this game draws is per player -- the match bar carries a
+/// percentage that is only true of the person reading it, and the build stamp
+/// has to reach whoever connects next -- so each one's audience is one edge,
 /// `(ShownTo, player)`. Everything after that is `egress::boss_bar`'s: the
 /// `Add` on the first push, one operation per field that moves after it, and
-/// the `Remove` when the player leaves.
+/// the `Remove` when the player leaves. A slot nobody ever writes to costs no
+/// entity, because this is only called for a slot that is being written.
 ///
 /// A child of the player, so it dies with them under flecs's own
 /// `(ChildOf, OnDeleteTarget, Delete)`. Without that the bar entity would
@@ -559,31 +597,28 @@ fn connection_of(world: WorldRef<'_>, player: Entity) -> Option<ConnectionId> {
 /// nobody restarts is a leak measured in players seen.
 ///
 /// No fog, no darkened sky and no boss music, which is the default `Effects`:
-/// each of them changes how the arena looks or sounds, and this bar is a
-/// readout rather than an event.
-fn hud_bar(world: WorldRef<'_>, player: Entity) -> Option<Entity> {
-    let player = world.entity_from_id(player);
-    if !player.is_alive() {
-        return None;
-    }
-    if let Some(bar) = player.try_get::<&HudBar>(|bar| bar.0)
-        && world.entity_from_id(bar).is_alive()
-    {
-        return Some(bar);
-    }
-    let bar = world
+/// each of them changes how the arena looks or sounds, and these bars are
+/// readouts rather than events.
+fn mint_bar(world: WorldRef<'_>, player: Entity) -> Entity {
+    world
         .entity()
         .child_of(player)
         .add(id::<boss_bar::BossBar>())
         .add((id::<boss_bar::ShownTo>(), player))
-        .id();
-    player.set(HudBar(bar));
-    Some(bar)
+        .id()
 }
 
-/// The boss bar entity a player's HUD writes to.
-#[derive(Component, Debug, Copy, Clone)]
-struct HudBar(Entity);
+/// The boss bar entities a player is being drawn, one per [`BarSlot`].
+///
+/// An array and not a component per slot, so a new slot is an entry in
+/// [`BarSlot::ALL`] rather than a new component nobody remembers to register.
+/// The width is `BarSlot::COUNT`, which is that list's length, and every index
+/// written here comes from [`BarSlot::index`], which is a position in the same
+/// list -- so this cannot be indexed out of bounds by a slot the list knows
+/// about. A slot the list does not know about panics in `index` by name
+/// instead, which is the only remaining way to get this wrong and it says so.
+#[derive(Component, Debug, Copy, Clone, Default)]
+struct PlayerBars([Option<Entity>; BarSlot::COUNT]);
 
 const fn colour(colour: BarColour) -> BossBarColor {
     match colour {

--- a/events/smash/src/lib.rs
+++ b/events/smash/src/lib.rs
@@ -26,10 +26,11 @@ use hyperion::{Crypto, GameServerEndpoint, HyperionCore};
 use hyperion_clap::hyperion_command::CommandRegistry;
 
 use crate::module::{
-    ability::AbilityModule, arena::ArenaModule, damage::DamageModule, effect::EffectModule,
-    hud::HudModule, kit::KitModule, kits::StockKits, knockback::KnockbackModule,
-    lives::LivesModule, lobby::LobbyModule, player::PlayerModule, projectile::ProjectileModule,
-    scoreboard::ScoreboardModule, selector::SelectorModule, sound::SoundModule,
+    ability::AbilityModule, arena::ArenaModule, build_stamp::BuildStampModule,
+    damage::DamageModule, effect::EffectModule, hud::HudModule, kit::KitModule, kits::StockKits,
+    knockback::KnockbackModule, lives::LivesModule, lobby::LobbyModule, player::PlayerModule,
+    projectile::ProjectileModule, scoreboard::ScoreboardModule, selector::SelectorModule,
+    sound::SoundModule,
 };
 
 /// The whole game.
@@ -68,6 +69,11 @@ impl Module for SmashModule {
         world.import::<HudModule>();
         world.import::<SelectorModule>();
         world.import::<StockKits>();
+        // Last, and that placement is load bearing: flecs runs same-phase
+        // systems in the order they were declared, so declaring this after
+        // `HudModule`'s `update_hud` is what puts the match bar above the
+        // build stamp on a joining player's screen rather than below it.
+        world.import::<BuildStampModule>();
     }
 }
 

--- a/events/smash/src/module.rs
+++ b/events/smash/src/module.rs
@@ -1,5 +1,6 @@
 pub mod ability;
 pub mod arena;
+pub mod build_stamp;
 pub mod damage;
 pub mod effect;
 pub mod hud;

--- a/events/smash/src/module/build_stamp.rs
+++ b/events/smash/src/module/build_stamp.rs
@@ -1,0 +1,261 @@
+//! What build the server is running, on the player's screen.
+//!
+//! There is a live server that is redeployed as main moves, and until this
+//! existed the only way to tell whether a change had reached it was to guess
+//! at deploy timing from outside the game. The commit and the time it was made
+//! are the two facts that answer it, so they go where a player is already
+//! looking.
+//!
+//! # Why a second bar and not the lobby's
+//!
+//! The other candidate was [`crate::module::hud::boss_bar`]'s `Phase::Waiting`
+//! arm -- the "Waiting for players 1/2" strip -- and it was rejected for two
+//! reasons that point the same way.
+//!
+//! It is **not always there.** The bar becomes a countdown, then a percentage,
+//! the moment a match starts, so a stamp folded into it answers the question
+//! only for somebody who happens to arrive between matches. The question is
+//! asked at arbitrary times, including by a person who joined a running match
+//! to check, and half the time the lobby bar is a bar about something else.
+//!
+//! It **changes.** That title is a function of the player count, so a stamp
+//! carried inside it is re-sent every time anybody joins or leaves -- as a
+//! whole `Add`, because the title and the fill move together and
+//! `hyperion::egress::boss_bar` collapses two moved fields into one. A build
+//! stamp is constant for the life of a process and should cost exactly one
+//! packet per viewer. Its own bar is the only shape that does.
+//!
+//! What that gives up is a permanent strip of screen in a fighting game, which
+//! is a real cost. It is paid down as far as it goes: the bar is written once
+//! per player and never again, its fill is left empty so it draws no coloured
+//! length, and it is pushed after the match bar so it sits under it rather
+//! than above.
+//!
+//! # Where the values come from
+//!
+//! Three environment variables, set by a wrapper the Nix build puts around the
+//! server binary (see `flake.nix`). Not `env!` in a build script: baking a
+//! commit hash into a crate makes every commit a full workspace recompile, and
+//! the compile is already the floor on the pipeline. A wrapper is a symlink
+//! and three assignments, so a new commit rebuilds that and nothing else.
+//!
+//! A `cargo run` build has none of them set and says so, rather than claiming
+//! a commit it was not built from.
+
+use std::env;
+
+use flecs_ecs::prelude::*;
+
+use crate::{
+    module::player::Player,
+    server::{BarColour, BarSlot, BossBar, NamedColor, PlayerId, ServerHandle, Text},
+};
+
+/// The short commit hash the server was built from, with no dirty marker on
+/// it. That marker is [`DIRTY_VAR`]'s job.
+pub const REV_VAR: &str = "HYPERION_BUILD_REV";
+
+/// When that commit was made, in whole seconds since the unix epoch.
+pub const TIME_VAR: &str = "HYPERION_BUILD_TIME";
+
+/// `1` when the working tree had uncommitted changes at build time.
+pub const DIRTY_VAR: &str = "HYPERION_BUILD_DIRTY";
+
+/// What build this process is.
+///
+/// Every field is optional because the honest answer for a `cargo run` build
+/// is that nobody said. A missing field reads as "unknown" on screen rather
+/// than as a default that would be a lie -- a stamp that says `0000000` is
+/// worse than one that says it does not know.
+#[derive(Component, Debug, Clone, PartialEq, Eq, Default)]
+pub struct BuildStamp {
+    /// The short commit hash, `None` when nothing said.
+    pub rev: Option<String>,
+    /// When that commit was made, in seconds since the unix epoch.
+    pub committed_at: Option<i64>,
+    /// The tree had uncommitted changes when this was built, so the commit
+    /// above names a tree this binary was not compiled from.
+    pub dirty: bool,
+}
+
+impl BuildStamp {
+    /// What the environment says this build is.
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self::parse(
+            env::var(REV_VAR).ok().as_deref(),
+            env::var(TIME_VAR).ok().as_deref(),
+            env::var(DIRTY_VAR).ok().as_deref(),
+        )
+    }
+
+    /// The same, from three strings.
+    ///
+    /// Split out from [`Self::from_env`] because `std::env::set_var` is unsafe
+    /// in edition 2024 and racy in a test binary that runs its tests on
+    /// threads. Everything worth pinning is in here, and it is reachable
+    /// without touching the process environment at all.
+    ///
+    /// A field that is present but unusable -- an empty rev, a time that is
+    /// not a number -- is treated as absent. The bar is a readout and half of
+    /// one is better than none.
+    #[must_use]
+    pub fn parse(rev: Option<&str>, committed_at: Option<&str>, dirty: Option<&str>) -> Self {
+        Self {
+            rev: rev
+                .map(str::trim)
+                .filter(|rev| !rev.is_empty())
+                .map(ToOwned::to_owned),
+            committed_at: committed_at.map(str::trim).and_then(|at| at.parse().ok()),
+            dirty: dirty.map(str::trim) == Some("1"),
+        }
+    }
+}
+
+/// The bar a build stamp draws.
+///
+/// **Empty, and that is deliberate.** A boss bar's fill is a fraction of
+/// something, and a build is not a fraction of anything; leaving it at zero
+/// means the strip draws its frame and its text and no coloured length, which
+/// is the least ink this can cost on a screen somebody is fighting on.
+///
+/// **Red when the tree was dirty.** A dirty build is not the commit it names,
+/// and the whole value of a stamp is that it can be trusted, so the one case
+/// where it cannot be is the one case that is impossible to skim past.
+#[must_use]
+pub fn stamp_bar(stamp: &BuildStamp) -> BossBar {
+    let rev = match (stamp.rev.as_deref(), stamp.dirty) {
+        (Some(rev), true) => format!("{rev} + uncommitted changes"),
+        (Some(rev), false) => rev.to_owned(),
+        // Not "unknown" alone: the reason it is unknown is the useful half,
+        // because it tells a developer looking at their own `cargo run` that
+        // nothing is broken.
+        (None, _) => "unpackaged build".to_owned(),
+    };
+    let title = stamp.committed_at.map_or_else(
+        || format!("build {rev}"),
+        |at| format!("build {rev} \u{b7} {}", utc_minute(at)),
+    );
+    BossBar {
+        title: Text::text(title).color(if stamp.dirty {
+            NamedColor::Red
+        } else {
+            NamedColor::Gray
+        }),
+        progress: 0.0,
+        colour: if stamp.dirty {
+            BarColour::Red
+        } else {
+            BarColour::Blue
+        },
+    }
+}
+
+/// `seconds` since the unix epoch as `YYYY-MM-DD HH:MM UTC`.
+///
+/// **Absolute and not "two hours ago".** A relative age is the friendlier
+/// thing to read and it is the one thing this bar cannot say: it would change
+/// every minute, and a bar that changes is a packet per viewer per change
+/// forever, which is exactly the cost this whole design is built to avoid.
+///
+/// UTC and to the minute, because the reader is comparing it against a deploy
+/// they watched and a commit timestamp they can read out of git, and both of
+/// those are in UTC.
+///
+/// The date arithmetic is Howard Hinnant's `civil_from_days`, from
+/// <https://howardhinnant.github.io/date_algorithms.html>, which is exact for
+/// every year this will ever be handed and needs no table. There are no leap
+/// seconds in unix time, so a day is 86,400 seconds and the split is a
+/// division.
+#[must_use]
+pub fn utc_minute(seconds: i64) -> String {
+    const SECONDS_PER_DAY: i64 = 86_400;
+
+    let days = seconds.div_euclid(SECONDS_PER_DAY);
+    let within = seconds.rem_euclid(SECONDS_PER_DAY);
+    let (hour, minute) = (within / 3600, (within % 3600) / 60);
+
+    // Shift the epoch to 0000-03-01, which puts the leap day at the end of the
+    // 400 year era and makes every month length a straight line.
+    let shifted = days + 719_468;
+    let era = shifted.div_euclid(146_097);
+    let day_of_era = shifted.rem_euclid(146_097);
+    let year_of_era =
+        (day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let march_month = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * march_month + 2) / 5 + 1;
+    let month = if march_month < 10 {
+        march_month + 3
+    } else {
+        march_month - 9
+    };
+    let year = year_of_era + era * 400 + i64::from(month <= 2);
+
+    format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02} UTC")
+}
+
+/// Marks a player who has already been sent the stamp, so it is sent once.
+///
+/// A tag and not a flag inside a record, because it is the query itself that
+/// has to stop matching: once every connected player carries this, the system
+/// below iterates nothing at all rather than iterating everybody to decide
+/// there is nothing to do.
+#[derive(Component, Debug)]
+pub struct StampShown;
+
+/// Registration: the types this file owns, and the stamp itself.
+///
+/// The environment is read here, once, where [`BuildStamp`] is registered. A
+/// test that wants a particular build overwrites the singleton after importing
+/// the game, which is why nothing else in this file ever looks at the
+/// environment again.
+#[derive(Component)]
+pub struct BuildStampComponentsModule;
+
+impl Module for BuildStampComponentsModule {
+    fn module(world: &World) {
+        world.module::<Self>("smash::BuildStampComponents");
+
+        world.component::<StampShown>();
+        world
+            .component::<BuildStamp>()
+            .add_trait::<flecs::Singleton>();
+        world.set(BuildStamp::from_env());
+    }
+}
+
+/// Behaviour: put the stamp on each player's screen, exactly once.
+#[derive(Component)]
+pub struct BuildStampModule;
+
+impl Module for BuildStampModule {
+    fn module(world: &World) {
+        world.module::<Self>("smash::BuildStamp");
+        world.import::<BuildStampComponentsModule>();
+
+        // A system rather than an `OnAdd` observer on `Player`, for the same
+        // reason `smash::draw_projectiles` is one: a player is assembled over
+        // several `set` calls and an observer on the first of them sees an
+        // entity that has no `PlayerId` yet. Matching on what is needed and
+        // skipping what is done sees a whole player or none of one.
+        //
+        // Declared after `HudModule`'s `update_hud` -- `SmashModule` imports
+        // this module last -- so on the tick a player joins, the match bar's
+        // push is queued first and reaches the client first. A client stacks
+        // boss bars in the order it is told about them, so that is what puts
+        // the percentage on top and this underneath it.
+        world
+            .system_named::<&PlayerId>("show_build_stamp")
+            .with(Player::id())
+            .without(StampShown::id())
+            .each_iter(|it, row, id| {
+                let world = it.world();
+                let bar = world.get::<&BuildStamp>(stamp_bar);
+                world.get::<&ServerHandle>(|server| {
+                    server.set_boss_bar(*id, BarSlot::Build, bar.clone());
+                });
+                it.entity(row).add(StampShown::id());
+            });
+    }
+}

--- a/events/smash/src/module/hud.rs
+++ b/events/smash/src/module/hud.rs
@@ -45,7 +45,8 @@ use crate::{
         player::{Health, Player, SelectedSlot},
     },
     server::{
-        BarColour, BossBar, Experience, NamedColor, PlayerId, ServerHandle, Text, Title, TitleTimes,
+        BarColour, BarSlot, BossBar, Experience, NamedColor, PlayerId, ServerHandle, Text, Title,
+        TitleTimes,
     },
 };
 
@@ -591,7 +592,9 @@ impl Module for HudModule {
                             Push::Experience(id, experience) => {
                                 server.set_experience(id, experience);
                             }
-                            Push::Bar(id, bar) => server.set_boss_bar(id, *bar),
+                            Push::Bar(id, bar) => {
+                                server.set_boss_bar(id, BarSlot::Hud, *bar);
+                            }
                         }
                     }
                 });

--- a/events/smash/src/server.rs
+++ b/events/smash/src/server.rs
@@ -247,6 +247,72 @@ pub struct BossBar {
     pub colour: BarColour,
 }
 
+/// Which of a player's bars a [`BossBar`] is written to.
+///
+/// A client draws as many bars as it is sent, stacked, and the two this game
+/// puts up answer questions on completely different clocks: [`Self::Hud`]
+/// changes several times a second, and [`Self::Build`] is written once and is
+/// then true until the process exits. Naming the slot is what lets the second
+/// one exist without the first one overwriting it every tick, and what lets a
+/// test say which bar it is asserting about.
+///
+/// Closed and small on purpose. A slot is a strip of a player's screen, and
+/// this game is a fighting game: adding a variant here is a permanent decision
+/// about how much of the screen is not the arena.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum BarSlot {
+    /// The match bar: knockback percentage, the lobby's state, the result.
+    /// See [`crate::module::hud::boss_bar`].
+    Hud,
+    /// What build the server is running. See
+    /// [`crate::module::build_stamp`].
+    Build,
+}
+
+impl BarSlot {
+    /// Every slot, in the order they are laid out.
+    ///
+    /// The one list. [`Self::COUNT`] is its length and [`Self::index`] is a
+    /// position in it, so neither can drift from it -- an earlier version wrote
+    /// `COUNT = 2` and matched out the indices by hand, which a third variant
+    /// would have left at 2 while `index` returned 2, and the array in the
+    /// adapter would then have panicked out of bounds inside the server's
+    /// `PostUpdate` on the first tick anybody wrote that slot.
+    ///
+    /// Adding a variant still has to add it here; Rust cannot enumerate an
+    /// enum's variants on its own. What is different is the failure: a slot
+    /// missing from this list has no index and says so by name, and
+    /// `every_slot_is_in_all_and_indexes_into_it` in `tests/build_stamp.rs`
+    /// fails before any of that reaches a player.
+    pub const ALL: &'static [Self] = &[Self::Hud, Self::Build];
+    /// How many slots there are, so an adapter can hold one entity per slot in
+    /// an array rather than a map.
+    pub const COUNT: usize = Self::ALL.len();
+
+    /// This slot's place in such an array.
+    ///
+    /// A search of [`Self::ALL`] rather than a second list written as a match,
+    /// which is what makes the result `< COUNT` by construction instead of by
+    /// somebody remembering.
+    ///
+    /// # Panics
+    /// A variant that is not in [`Self::ALL`], which is a bug in this file and
+    /// not a runtime condition. Const-evaluated wherever the caller is const.
+    #[must_use]
+    pub const fn index(self) -> usize {
+        let mut at = 0;
+        // `as u8` and not `==`: a fieldless enum casts in a const fn, and
+        // `PartialEq` is not const.
+        while at < Self::ALL.len() {
+            if Self::ALL[at] as u8 == self as u8 {
+                return at;
+            }
+            at += 1;
+        }
+        panic!("a BarSlot that is missing from BarSlot::ALL has no place in a per-slot array")
+    }
+}
+
 /// How long a title spends fading in, on screen, and fading out, in ticks.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct TitleTimes {
@@ -378,11 +444,11 @@ pub trait Server: Send + Sync + 'static {
     /// Move `player`'s experience bar. See [`Experience`].
     fn set_experience(&self, player: PlayerId, experience: Experience);
 
-    /// Put the bar across the top of `player`'s screen, replacing whatever is
-    /// there. There is no way to take it away, because there is no state of
-    /// the game with nothing worth putting on it: see
-    /// [`crate::module::hud::boss_bar`].
-    fn set_boss_bar(&self, player: PlayerId, bar: BossBar);
+    /// Put a bar across the top of `player`'s screen, replacing whatever is in
+    /// that [`BarSlot`]. There is no way to take one away, because neither
+    /// slot has a state with nothing worth putting on it: see
+    /// [`crate::module::hud::boss_bar`] and [`crate::module::build_stamp`].
+    fn set_boss_bar(&self, player: PlayerId, slot: BarSlot, bar: BossBar);
 
     /// Put a title across the middle of `player`'s screen.
     fn show_title(&self, player: PlayerId, title: Title);

--- a/events/smash/src/server/mock.rs
+++ b/events/smash/src/server/mock.rs
@@ -10,8 +10,8 @@ use std::sync::Mutex;
 use glam::Vec3;
 
 use super::{
-    BossBar, Channel, Experience, HotbarItem, Particles, PlayerId, Server, SidebarLine, Sound,
-    Status, Text, Title,
+    BarSlot, BossBar, Channel, Experience, HotbarItem, Particles, PlayerId, Server, SidebarLine,
+    Sound, Status, Text, Title,
 };
 
 /// One thing the game asked the server to do.
@@ -33,7 +33,7 @@ pub enum Call {
     /// A sound only one player hears.
     SoundTo(PlayerId, Sound),
     Experience(PlayerId, Experience),
-    BossBar(PlayerId, BossBar),
+    BossBar(PlayerId, BarSlot, BossBar),
     Title(PlayerId, Title),
     BroadcastTitle(Title),
 }
@@ -152,13 +152,19 @@ impl MockServer {
             .collect()
     }
 
-    /// Every boss bar pushed to `player`, oldest first.
+    /// Every boss bar pushed to `player` in one slot, oldest first.
+    ///
+    /// Per slot rather than all of them, because the two slots are asserted
+    /// about in opposite directions: a test of the match bar wants the run of
+    /// values it moved through, and a test of the build stamp wants there to
+    /// be exactly one for the life of the process. Merging them would make
+    /// each of those quietly depend on the other.
     #[must_use]
-    pub fn boss_bars_of(&self, player: PlayerId) -> Vec<BossBar> {
+    pub fn boss_bars_of(&self, player: PlayerId, slot: BarSlot) -> Vec<BossBar> {
         self.calls()
             .iter()
             .filter_map(|call| match call {
-                Call::BossBar(id, bar) if *id == player => Some(bar.clone()),
+                Call::BossBar(id, at, bar) if *id == player && *at == slot => Some(bar.clone()),
                 _ => None,
             })
             .collect()
@@ -253,8 +259,8 @@ impl Server for MockServer {
         self.push(Call::Experience(player, experience));
     }
 
-    fn set_boss_bar(&self, player: PlayerId, bar: BossBar) {
-        self.push(Call::BossBar(player, bar));
+    fn set_boss_bar(&self, player: PlayerId, slot: BarSlot, bar: BossBar) {
+        self.push(Call::BossBar(player, slot, bar));
     }
 
     fn show_title(&self, player: PlayerId, title: Title) {

--- a/events/smash/tests/build_stamp.rs
+++ b/events/smash/tests/build_stamp.rs
@@ -1,0 +1,321 @@
+//! The build stamp: what it says, and that it is said exactly once.
+//!
+//! Two halves, and the second one is the whole reason this file exists. The
+//! wording is a pure function of a small struct and is pinned character for
+//! character. The delivery is a whole world, run for hundreds of ticks through
+//! every phase change a lobby has, asserting that the number of times a player
+//! is told what build this is stays at one.
+//!
+//! That second claim is not a micro-optimisation. `hyperion::egress::boss_bar`
+//! turns one `set_boss_bar` whose contents moved into one packet per viewer,
+//! and a stamp that were pushed per tick would be twenty packets a second per
+//! player carrying a string that cannot change until the process exits.
+
+mod harness;
+
+use glam::Vec3;
+use harness::Game;
+use smash::{
+    module::{
+        build_stamp::{BuildStamp, stamp_bar, utc_minute},
+        lobby::{Lobby, LobbyConfig, Phase},
+    },
+    server::{BarColour, BarSlot, NamedColor, PlayerId, TextColor, mock::Call},
+};
+
+/// A stamp for a clean build of one particular commit.
+fn clean() -> BuildStamp {
+    BuildStamp {
+        rev: Some("8f3a21c".to_owned()),
+        committed_at: Some(1_785_348_240),
+        dirty: false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// what it says
+// ---------------------------------------------------------------------------
+
+/// The commit and the minute it was made, in that order, on one line.
+#[test]
+fn the_stamp_names_the_commit_and_when_it_was_made() {
+    let bar = stamp_bar(&clean());
+    assert_eq!(
+        bar.title.plain(),
+        "build 8f3a21c \u{b7} 2026-07-29 18:04 UTC"
+    );
+    assert_eq!(
+        bar.title.runs()[0].color(),
+        Some(TextColor::Named(NamedColor::Gray))
+    );
+    assert_eq!(bar.colour, BarColour::Blue);
+    // Empty, so the strip draws no coloured length. A build is not a fraction
+    // of anything and the fill would be inventing a quantity.
+    assert!(bar.progress.abs() < 1e-9, "{}", bar.progress);
+}
+
+/// A dirty build says so, and says it in red.
+///
+/// The one case where the commit on screen is not the code that is running is
+/// the one case a reader must not skim past, so it changes the colour of the
+/// whole strip rather than adding a word to the end of a line.
+#[test]
+fn a_dirty_build_says_so_and_turns_the_bar_red() {
+    let bar = stamp_bar(&BuildStamp {
+        dirty: true,
+        ..clean()
+    });
+    assert_eq!(
+        bar.title.plain(),
+        "build 8f3a21c + uncommitted changes \u{b7} 2026-07-29 18:04 UTC"
+    );
+    assert_eq!(
+        bar.title.runs()[0].color(),
+        Some(TextColor::Named(NamedColor::Red)),
+        "a stamp that cannot be trusted has to look different"
+    );
+    assert_eq!(bar.colour, BarColour::Red);
+}
+
+/// A build nobody stamped says that, rather than a commit it does not have.
+///
+/// This is the `cargo run` case, and the wording is aimed at the person who
+/// will meet it: a developer on their own machine, who needs to know that the
+/// blank is expected and not a broken deploy.
+#[test]
+fn an_unstamped_build_says_it_is_unpackaged() {
+    let bar = stamp_bar(&BuildStamp::default());
+    assert_eq!(bar.title.plain(), "build unpackaged build");
+    assert_eq!(bar.colour, BarColour::Blue);
+}
+
+/// A rev with no time gets the rev alone, rather than a separator with nothing
+/// after it.
+#[test]
+fn half_a_stamp_is_shown_rather_than_none_of_one() {
+    let bar = stamp_bar(&BuildStamp {
+        committed_at: None,
+        ..clean()
+    });
+    assert_eq!(bar.title.plain(), "build 8f3a21c");
+}
+
+/// The environment is parsed the way the wrapper writes it, and a field that
+/// cannot be used is dropped rather than shown as itself.
+#[test]
+fn a_field_that_is_not_usable_reads_as_absent() {
+    assert_eq!(
+        BuildStamp::parse(Some("8f3a21c"), Some("1785348240"), Some("1")),
+        BuildStamp {
+            rev: Some("8f3a21c".to_owned()),
+            committed_at: Some(1_785_348_240),
+            dirty: true,
+        }
+    );
+    // An empty rev is what an unset variable looks like when something exports
+    // it anyway, and a time that is not a number is what a broken wrapper
+    // produces. Neither is worth putting on a screen.
+    assert_eq!(
+        BuildStamp::parse(Some("   "), Some("not-a-time"), Some("0")),
+        BuildStamp::default()
+    );
+    assert_eq!(BuildStamp::parse(None, None, None), BuildStamp::default());
+    // What the wrapper writes for a source with no git in it: both variables
+    // set, both empty. The flake refuses to emit a time without a rev, because
+    // `lastModified` on such a source is a directory mtime, and an empty
+    // string has to read the same way here as an unset variable or the refusal
+    // would only have moved the problem.
+    assert_eq!(
+        BuildStamp::parse(Some(""), Some(""), Some("0")),
+        BuildStamp::default()
+    );
+    // Anything but exactly `1` is clean, so a wrapper that writes `false` or
+    // `no` does not accidentally mark every build dirty.
+    assert!(!BuildStamp::parse(None, None, Some("true")).dirty);
+}
+
+/// The date arithmetic, at the instants that break a wrong implementation.
+///
+/// A leap day, a century that is not a leap year, and a time before the epoch:
+/// each of the three is a different way to get the arithmetic wrong, and none
+/// of them is reachable by a test that only uses today's date.
+#[test]
+fn the_clock_is_utc_and_survives_the_awkward_dates() {
+    assert_eq!(utc_minute(0), "1970-01-01 00:00 UTC");
+    assert_eq!(utc_minute(1_000_000_000), "2001-09-09 01:46 UTC");
+    assert_eq!(utc_minute(1_785_348_240), "2026-07-29 18:04 UTC");
+    // 2000 is divisible by 400, so it has a 29th of February.
+    assert_eq!(utc_minute(951_782_400), "2000-02-29 00:00 UTC");
+    // 2100 is divisible by 100 and not by 400, so it does not.
+    assert_eq!(utc_minute(4_107_542_400), "2100-03-01 00:00 UTC");
+    // Before the epoch, which is where a truncating division goes wrong.
+    assert_eq!(utc_minute(-1), "1969-12-31 23:59 UTC");
+}
+
+// ---------------------------------------------------------------------------
+// that it reaches a player, once
+// ---------------------------------------------------------------------------
+
+/// Every stamp a player was sent, in order.
+fn stamps_to(game: &Game, player: PlayerId) -> Vec<String> {
+    game.server
+        .boss_bars_of(player, BarSlot::Build)
+        .iter()
+        .map(|bar| bar.title.plain())
+        .collect()
+}
+
+/// The stamp reaches the player, with the words the pure function produced.
+#[test]
+fn a_player_is_told_what_build_they_are_standing_in() {
+    let mut game = Game::new();
+    game.world.set(clean());
+    game.player("p", Vec3::new(0.0, 100.0, 0.0));
+    game.advance(0.05, 1);
+
+    assert_eq!(stamps_to(&game, PlayerId(1)), vec![
+        "build 8f3a21c \u{b7} 2026-07-29 18:04 UTC".to_owned()
+    ]);
+}
+
+/// Once, and not once a tick.
+///
+/// Four hundred ticks with a lobby short enough to run a whole match inside
+/// them, so the run crosses every phase change the game has and the match bar
+/// beside this one is rewritten hundreds of times. The stamp is still one
+/// call, because the tag the system adds is what stops the query matching.
+#[test]
+fn the_stamp_is_sent_once_and_not_once_a_tick() {
+    let mut game = Game::new();
+    game.world.set(clean());
+    game.world.set(LobbyConfig {
+        min_players: 2,
+        full_players: 4,
+        countdown_at_min: 1.0,
+        countdown_at_three_quarters: 0.75,
+        countdown_at_full: 0.5,
+        prepare_seconds: 0.5,
+        match_timeout_seconds: 5.0,
+        results_seconds: 0.5,
+    });
+    game.player("a", Vec3::new(0.0, 100.0, 0.0));
+    game.player("b", Vec3::new(4.0, 100.0, 0.0));
+
+    game.advance(20.0, 400);
+
+    // The run really did move the other bar, or "one stamp" would be a claim
+    // about a world in which nothing happened at all.
+    let match_bars = game.server.boss_bars_of(PlayerId(1), BarSlot::Hud).len();
+    assert!(
+        match_bars > 1,
+        "the match bar never moved, so this proves nothing: {match_bars}"
+    );
+    assert_ne!(
+        game.world.cloned::<&Lobby>().phase,
+        Phase::Waiting,
+        "the lobby never left Waiting, so no phase change was crossed"
+    );
+
+    for player in [PlayerId(1), PlayerId(2)] {
+        let stamps = stamps_to(&game, player);
+        // The count and one example, not the whole run: a bar resent every
+        // tick produces four hundred identical strings, and a failure nobody
+        // can read is one nobody acts on.
+        assert_eq!(
+            stamps.len(),
+            1,
+            "{player:?} was told the build {} times, saying {:?}",
+            stamps.len(),
+            stamps.first()
+        );
+    }
+}
+
+/// Somebody who arrives later gets it too.
+///
+/// The interesting half is that they get it *without* anybody else being told
+/// again: a joiner is a new row in the system's query and not a reason to
+/// redraw the players already standing there.
+#[test]
+fn a_late_joiner_gets_the_stamp_and_nobody_else_gets_it_twice() {
+    let mut game = Game::new();
+    game.world.set(clean());
+    game.player("early", Vec3::new(0.0, 100.0, 0.0));
+    game.advance(1.0, 20);
+    assert_eq!(stamps_to(&game, PlayerId(1)).len(), 1);
+
+    game.server.take();
+    game.player("late", Vec3::new(4.0, 100.0, 0.0));
+    game.advance(1.0, 20);
+
+    assert_eq!(
+        stamps_to(&game, PlayerId(2)).len(),
+        1,
+        "the late joiner was not told what build this is"
+    );
+    assert_eq!(
+        stamps_to(&game, PlayerId(1)),
+        Vec::<String>::new(),
+        "somebody else joining re-sent the stamp to a player who had it"
+    );
+}
+
+/// Every slot is in `BarSlot::ALL`, and its index is a place inside an array
+/// of `BarSlot::COUNT`.
+///
+/// `adapter::PlayerBars` is `[Option<Entity>; BarSlot::COUNT]` and is written
+/// at `slot.index()`, in a system in the server's `PostUpdate`. If those two
+/// ever disagree the failure is an out-of-bounds panic on a live server the
+/// first tick anybody writes the new slot, which is the worst place to find
+/// out and is why this is pinned here rather than trusted.
+#[test]
+fn every_slot_is_in_all_and_indexes_into_it() {
+    // Exhaustive on purpose. A new variant makes this match fail to compile,
+    // so whoever adds one is sent here, and here is where `BarSlot::ALL` is
+    // checked to have grown with it.
+    let listed: Vec<BarSlot> = vec![BarSlot::Hud, BarSlot::Build]
+        .into_iter()
+        .inspect(|slot| match slot {
+            BarSlot::Hud | BarSlot::Build => {}
+        })
+        .collect();
+    assert_eq!(
+        BarSlot::ALL,
+        listed.as_slice(),
+        "a slot is missing from BarSlot::ALL, so its index would panic"
+    );
+
+    assert_eq!(BarSlot::COUNT, BarSlot::ALL.len());
+    for (at, slot) in BarSlot::ALL.iter().enumerate() {
+        assert_eq!(slot.index(), at, "{slot:?} does not index its own position");
+        assert!(
+            slot.index() < BarSlot::COUNT,
+            "{slot:?} indexes past a PlayerBars array"
+        );
+    }
+}
+
+/// The stamp goes to its own slot, so it can never overwrite the match bar.
+///
+/// Both bars are pushed on the tick a player joins. Without the slot the
+/// second of the two would replace the first on the client, and which one
+/// survived would depend on the order two systems happened to be declared in.
+#[test]
+fn the_stamp_and_the_match_bar_are_different_bars() {
+    let mut game = Game::new();
+    game.world.set(clean());
+    game.player("p", Vec3::new(0.0, 100.0, 0.0));
+    game.advance(0.05, 1);
+
+    let slots: Vec<BarSlot> = game
+        .server
+        .calls()
+        .into_iter()
+        .filter_map(|call| match call {
+            Call::BossBar(_, slot, _) => Some(slot),
+            _ => None,
+        })
+        .collect();
+    // The match bar first, so a client stacks the percentage above the stamp.
+    assert_eq!(slots, vec![BarSlot::Hud, BarSlot::Build]);
+}

--- a/events/smash/tests/contract.rs
+++ b/events/smash/tests/contract.rs
@@ -29,6 +29,7 @@ use smash::{
     module::{
         ability::AbilityModule,
         arena::{Arena, ArenaModule},
+        build_stamp::{BuildStampModule, StampShown},
         damage::{Armor, DamageKind, DamageModule, Damaged, hurt},
         effect::{self, EffectModule},
         hud::HudModule,
@@ -515,6 +516,25 @@ fn contracts() -> Vec<Contract> {
                 assert!(
                     smash::module::kit::registry(world).len() >= 10,
                     "the stock kits did not register"
+                );
+            },
+        },
+        Contract {
+            name: "BuildStamp",
+            import: |world| {
+                world.import::<BuildStampModule>();
+            },
+            // Its one system matches `Player` and reads `PlayerId`, which is
+            // the seam's. Everything else it touches -- `BuildStamp` itself and
+            // the `StampShown` tag -- it registers, in its own registration
+            // module, which it imports.
+            requires: &["Player"],
+            runtime_requires: &[],
+            exercise: |world, player| {
+                world.progress_time(0.05);
+                assert!(
+                    player.has(StampShown::id()),
+                    "the stamp was never put on the player's screen"
                 );
             },
         },

--- a/events/smash/tests/hud.rs
+++ b/events/smash/tests/hud.rs
@@ -32,7 +32,9 @@ use smash::{
         lobby::{Lobby, LobbyConfig, Phase},
         player::{Health, SelectedSlot},
     },
-    server::{BarColour, Experience, NamedColor, PlayerId, TextColor, TitleTimes, mock::Call},
+    server::{
+        BarColour, BarSlot, Experience, NamedColor, PlayerId, TextColor, TitleTimes, mock::Call,
+    },
 };
 
 const EPS: f32 = 1e-5;
@@ -780,13 +782,20 @@ fn an_unchanged_screen_sends_nothing() {
             .filter(|call| matches!(call, Call::Experience(..) | Call::BossBar(..)))
             .count()
     };
-    // One, not two. A player with no kit holds an empty slot, whose meter is
+    // Two, not three. A player with no kit holds an empty slot, whose meter is
     // the empty bar a fresh client already draws, so there is nothing to
-    // correct; the boss bar is the only thing the client does not already have.
+    // correct. The two bars are the only things the client does not already
+    // have: the match bar, and the build stamp under it.
     assert_eq!(
         hud_calls(&game),
+        2,
+        "a joining player with no kit needs two pushes: {:?}",
+        game.server.calls()
+    );
+    assert_eq!(
+        game.server.boss_bars_of(PlayerId(1), BarSlot::Build).len(),
         1,
-        "a joining player with no kit needs one push: {:?}",
+        "the build stamp is one of them: {:?}",
         game.server.calls()
     );
 
@@ -813,7 +822,7 @@ fn a_hit_moves_the_percentage_on_the_victims_bar() {
 
     let before = game
         .server
-        .boss_bars_of(PlayerId(2))
+        .boss_bars_of(PlayerId(2), BarSlot::Hud)
         .last()
         .cloned()
         .expect("a bar during a match");
@@ -831,7 +840,7 @@ fn a_hit_moves_the_percentage_on_the_victims_bar() {
 
     let after = game
         .server
-        .boss_bars_of(PlayerId(2))
+        .boss_bars_of(PlayerId(2), BarSlot::Hud)
         .last()
         .cloned()
         .expect("the hit moved the bar");
@@ -945,8 +954,8 @@ fn each_player_gets_their_own_percentage() {
     });
     game.advance(0.05, 2);
 
-    let hit = game.server.boss_bars_of(PlayerId(2));
-    let untouched = game.server.boss_bars_of(PlayerId(1));
+    let hit = game.server.boss_bars_of(PlayerId(2), BarSlot::Hud);
+    let untouched = game.server.boss_bars_of(PlayerId(1), BarSlot::Hud);
     assert_eq!(
         hit.last().map(|bar| bar.title.plain()),
         Some("100%".to_owned())
@@ -1013,7 +1022,10 @@ fn a_player_who_joins_late_gets_a_screen() {
     game.advance(0.05, 1);
 
     assert!(
-        !game.server.boss_bars_of(PlayerId(2)).is_empty(),
+        !game
+            .server
+            .boss_bars_of(PlayerId(2), BarSlot::Hud)
+            .is_empty(),
         "the late joiner got no bar"
     );
     assert_eq!(
@@ -1062,7 +1074,7 @@ fn elimination_switches_the_bar_to_spectating() {
 
     let bar = game
         .server
-        .boss_bars_of(PlayerId(1))
+        .boss_bars_of(PlayerId(1), BarSlot::Hud)
         .last()
         .cloned()
         .expect("a bar");

--- a/flake.nix
+++ b/flake.nix
@@ -1078,7 +1078,10 @@
 
           # Named once and used by both `packages` and the sandboxed checks, so
           # a gate runs the same binary the flake publishes rather than a second
-          # build of it.
+          # build of it. `packages.smash` wraps this one in the build stamp's
+          # environment rather than replacing it: the executable a gate runs and
+          # the executable a host runs are the same file, and what differs is
+          # three variables. See `stamped` for why the gates are left unwrapped.
           gameBinaries = {
             bedwars = named "bedwars" workspace.binaries.bedwars;
             smash = named "smash" workspace.binaries.smash;
@@ -1092,6 +1095,101 @@
             bedwars = named "bedwars" devWorkspace.binaries.bedwars;
             smash = named "smash" devWorkspace.binaries.smash;
           };
+
+          # What build this is, for the strip across a player's screen. Read by
+          # `events/smash/src/module/build_stamp.rs`.
+          buildStamp =
+            let
+              # `self.shortRev` exists only on a clean tree and
+              # `self.dirtyShortRev` only on a dirty one, and a source with no
+              # git in it -- a plain directory, a tarball -- has neither.
+              # Dirtiness is carried by its own variable rather than by the
+              # `-dirty` suffix nix appends, so the game states the fact instead
+              # of parsing a string for it, and so the rev on screen is a hash a
+              # person can paste into `git show`.
+              rev = self.shortRev or (lib.removeSuffix "-dirty" (self.dirtyShortRev or ""));
+            in
+            {
+              inherit rev;
+
+              # `self.lastModified` is the commit's COMMITTER date, and it is
+              # the same number on a dirty tree as on a clean one: nix asks git
+              # for the commit either way rather than falling back to a file
+              # mtime. Measured on this repo at d55a336 -- 1785386760 clean,
+              # 1785386760 dirty, `git log -1 --format=%ct` 1785386760.
+              #
+              # Committer and not author, which are 1785385579 and 1785386760 on
+              # that same commit because it was amended. So a rebased commit's
+              # bar reads when the rebase landed rather than when the work was
+              # written. That is the right answer for the question this bar
+              # exists for -- which build is deployed, and how long ago did that
+              # build come into being -- and it is the wrong answer for "when
+              # was this change authored", which the bar does not claim.
+              #
+              # Nothing at all when there is no rev, and that is the point of
+              # the conditional rather than a nicety. `lastModified` on a
+              # non-git source is the directory's mtime, so without this the bar
+              # renders `build unpackaged build · 2026-07-29 20:41 UTC`: a stamp
+              # that has just admitted it does not know what it is, timed to the
+              # minute. An empty string parses as absent in `BuildStamp::parse`
+              # and the bar drops the whole clause.
+              time = if rev == "" then "" else toString (self.lastModified or 0);
+
+              dirty = if self ? dirtyShortRev then "1" else "0";
+            };
+
+          # The stamp, as an environment a binary is started in.
+          #
+          # A wrapper and not `env!` in a build script, and the difference is
+          # the whole reason this exists: a commit hash compiled into a crate
+          # invalidates that crate and everything downstream on every commit, so
+          # every push would rebuild the workspace. This derivation is a symlink
+          # and three assignments, and it is the only thing a new commit
+          # rebuilds.
+          #
+          # Applied to `packages` and deliberately NOT to the binaries the e2e
+          # gates run. cargoUnit content-addresses every crate unit, so a commit
+          # that changes no smash source leaves the gate's binary bit for bit
+          # identical and the whole gate is reused from the store. Stamping it
+          # would move its path on every commit and re-run all fourteen e2e
+          # gates for a string none of them reads. The gates cover the *reading*
+          # of these variables instead, which is the half that can be wrong in
+          # Rust; `checks.build-stamp` below covers the writing.
+          #
+          # THE COST, AND IT LANDS ON PLAYERS RATHER THAN ON CI. This wrapper's
+          # store path moves on every commit, `packages.smash` is it, and
+          # `nix/modules/game-server.nix` builds `ExecStart` out of
+          # `packages.smash`. So the unit file changes on every commit and
+          # `switch-to-configuration` restarts `hyperion-game-server` on every
+          # deploy -- including deploys of commits that touch nothing in smash,
+          # which used to leave `ExecStart` byte-identical and the running
+          # server alone. A restart drops every connected player.
+          #
+          # The restart is required by the feature: a server cannot report a
+          # commit it was not started with. The SCOPE is not. Narrowing it means
+          # decoupling the stamp from the unit -- an `EnvironmentFile` the
+          # deploy writes, or a stamp read from a path rather than baked into
+          # `ExecStart` -- and that is a different change with its own failure
+          # mode, namely a stamp that can disagree with the binary beside it.
+          # Written down here rather than left to be discovered, because with
+          # continuous apply on, "redeployed as main moves" now means every
+          # player is dropped as main moves.
+          stamped = drv:
+            let
+              main = drv.meta.mainProgram;
+            in
+            pkgs.runCommand "${drv.name}-stamped"
+              {
+                inherit (drv) meta;
+                nativeBuildInputs = [ pkgs.makeWrapper ];
+                passthru = (drv.passthru or { }) // { unstamped = drv; };
+              }
+              ''
+                makeWrapper ${drv}/bin/${main} "$out/bin/${main}" \
+                  --set HYPERION_BUILD_REV ${lib.escapeShellArg buildStamp.rev} \
+                  --set HYPERION_BUILD_TIME ${lib.escapeShellArg buildStamp.time} \
+                  --set HYPERION_BUILD_DIRTY ${lib.escapeShellArg buildStamp.dirty}
+              '';
 
           # `nix flake check` builds every app, which is what proves each one
           # passes shellcheck and that its tools resolve. What CI enforces of
@@ -1396,6 +1494,78 @@
             # No two end to end gates may claim one port. See `e2eOffsets`.
             e2e-ports-distinct = e2ePortsDistinct;
 
+            # The deployed smash binary starts in an environment that says what
+            # build it is. See `stamped` and
+            # `events/smash/src/module/build_stamp.rs`.
+            #
+            # The Rust half is covered by `cargo test -p smash --test
+            # build_stamp`, which pins what each of these three values turns
+            # into on screen. Nothing covered that half's *input* until this:
+            # a rename, a dropped `--set`, or a `buildStamp` attribute that
+            # stopped being threaded all read as a server quietly saying
+            # "unpackaged build" to every player, which is exactly the state
+            # this whole change exists to end and is invisible from any test
+            # that does not look at the wrapper.
+            build-stamp =
+              pkgs.runCommand "hyperion-build-stamp"
+                {
+                  wrapper = lib.getExe (stamped gameBinaries.smash);
+                  binary = lib.getExe gameBinaries.smash;
+                  inherit (buildStamp) rev time dirty;
+                }
+                ''
+                  fail() { echo "FAIL: $1" >&2; exit 1; }
+
+                  # The control. Everything below is a grep, and a grep against
+                  # a file that is not there, or is a binary, or is empty,
+                  # fails for reasons that have nothing to do with the stamp.
+                  [ -f "$wrapper" ] || fail "no wrapper at $wrapper"
+                  grep -qF -- "$binary" "$wrapper" \
+                    || fail "the wrapper does not exec $binary"
+
+                  for name in REV TIME DIRTY; do
+                    grep -q "HYPERION_BUILD_$name=" "$wrapper" \
+                      || fail "the wrapper sets no HYPERION_BUILD_$name"
+                  done
+
+                  # A rev is empty exactly when nix had no git to ask, which is
+                  # true of a tarball and of a plain directory, and is not a
+                  # failure.
+                  if [ -n "$rev" ]; then
+                    # Hex and nothing else. Every other assertion here compares
+                    # the wrapper against the same expression that built it, so
+                    # on VALUES they are tautologies -- if nix changed the
+                    # suffix `removeSuffix` strips, both sides would move
+                    # together and this file would stay green while the bar read
+                    # `abc1234-dirty + uncommitted changes`. What a short commit
+                    # hash looks like is the one property of the value that does
+                    # not come from the expression, so it is the only thing here
+                    # that can catch a wrong one.
+                    case "$rev" in
+                      *[!0-9a-f]*)
+                        fail "the rev is not a short commit hash: $rev" ;;
+                    esac
+                    [ -n "$time" ] \
+                      || fail "there is a rev but no timestamp beside it"
+                    grep -q "HYPERION_BUILD_REV=.*$rev" "$wrapper" \
+                      || fail "the wrapper does not carry the rev $rev"
+                    grep -q "HYPERION_BUILD_TIME=.*$time" "$wrapper" \
+                      || fail "the wrapper does not carry the timestamp $time"
+                  else
+                    # And no timestamp either. A precise minute next to a stamp
+                    # that has just said it does not know what build it is comes
+                    # from `lastModified` falling back to a directory mtime, and
+                    # is worse than saying nothing.
+                    [ -z "$time" ] \
+                      || fail "no rev, but a timestamp of $time: that is a directory mtime dressed as a commit"
+                    echo "no rev: this flake source is not a git tree" >&2
+                  fi
+                  grep -q "HYPERION_BUILD_DIRTY=.*'$dirty'" "$wrapper" \
+                    || fail "the wrapper does not carry dirty=$dirty"
+
+                  echo "rev=$rev time=$time dirty=$dirty" > "$out"
+                '';
+
             # A colour reaches a client as a component field or not at all.
             smash-text-no-legacy-formatting = textGate;
 
@@ -1532,7 +1702,12 @@
 
           packages = {
             default = gameBinaries.bedwars;
-            inherit (gameBinaries) bedwars smash hyperion-proxy;
+            # smash is stamped and the other two are not, because smash is the
+            # only one that reads the stamp: `nix/modules/game-server.nix`
+            # builds its ExecStart out of this package, so this is what puts a
+            # commit on a player's screen on the deployed server.
+            smash = stamped gameBinaries.smash;
+            inherit (gameBinaries) bedwars hyperion-proxy;
             rust-mc-bot = named "rust-mc-bot" workspace.binaries.rust-mc-bot;
 
             minecraft-server-jar = minecraft.serverJar;


### PR DESCRIPTION
ENG-11446.

There is a live smash server at `15.204.111.75:25565` that is redeployed as
main moves, and a player standing in it had no way to tell which build they
were looking at. Every "is my change live yet" question was answered by
guessing at deploy timing from outside the game.

## Read this part even if you skim the rest: every deploy now restarts the server

`packages.smash`'s store path moves on **every** commit, and
`nix/modules/game-server.nix:67` builds `ExecStart` from `packages.smash`. So
the unit file changes on every commit and `switch-to-configuration` restarts
`hyperion-game-server` on every deploy -- including deploys of commits that
touch nothing in smash, which previously left `ExecStart` byte-identical and
the running server alone. A restart drops every connected player.

The restart is required by the feature: a server cannot report a commit it was
not started with. The **scope** is not. Narrowing it means decoupling the stamp
from the unit -- an `EnvironmentFile` the deploy writes, or a stamp read from a
path rather than baked into `ExecStart` -- which is a different change with its
own failure mode, a stamp that can disagree with the binary beside it. Written
down beside `stamped` in `flake.nix` and in the commit message so nobody learns
it from a player. It matters more now that continuous apply is being wired up:
"redeployed as main moves" has become "every player dropped as main moves".

## What is on screen

A second boss bar, under the match bar:

```
build 8f3a21c · 2026-07-29 18:04 UTC
```

Red, and reading `+ uncommitted changes`, when the tree was dirty at build
time. `build unpackaged build` -- with no time after it -- for a `cargo run` or
any source with no git in it.

The bar's fill is left empty, so the strip draws its frame and its text and no
coloured length. A build is not a fraction of anything.

## Why a second bar and not the lobby's

The other candidate was `hud::boss_bar`'s `Phase::Waiting` arm -- the "Waiting
for players 1/2" strip. The reason for rejecting it is written next to the code
in `events/smash/src/module/build_stamp.rs`, and it is two things pointing the
same way.

**It is not always there.** The bar becomes a countdown, then a percentage, the
moment a match starts, so a stamp folded into it answers the question only for
somebody who arrives between matches.

**It changes.** That title is a function of the player count, so a stamp carried
inside it is re-sent every time anybody joins -- as a whole `Add`, because
`egress/boss_bar.rs` collapses two moved fields into one operation.

What that gives up is a permanent strip of screen in a fighting game, which is a
real cost. It is paid down as far as it goes: written once per player and never
again, no coloured fill, and pushed after the match bar so the percentage sits
on top.

## One `Add` per viewer

`show_build_stamp` matches `Player` `.without(StampShown)` and adds that tag as
it pushes, so once every connected player carries it the query matches nothing.
`tests/build_stamp.rs::the_stamp_is_sent_once_and_not_once_a_tick` runs four
hundred ticks through a whole match -- asserting first that the match bar really
did move and the lobby really did leave `Waiting`, so "one stamp" is not a claim
about a world where nothing happened -- then requires exactly one stamp per
player.

Precisely: **one packet per viewer on the wire, and nothing after it.** Not zero
work after it. `egress::boss_bar`'s `Sent::of` clones the title every tick for
every bar-viewer row before comparing, so a second bar is one more allocation
per player per tick for a string that cannot change. That is the pre-existing
egress design rather than anything this adds, and it is the honest shape of the
claim.

Deleting the `.without` produces:

```
thread 'the_stamp_is_sent_once_and_not_once_a_tick' panicked at
events/smash/tests/build_stamp.rs:215:9:
assertion `left == right` failed: PlayerId(1) was told the build 400 times,
saying Some("build 8f3a21c · 2026-07-29 18:04 UTC")
  left: 400
 right: 1
```

## Where the values come from

Three environment variables set by a wrapper the Nix build puts around the
server binary: `HYPERION_BUILD_REV`, `HYPERION_BUILD_TIME` (unix seconds) and
`HYPERION_BUILD_DIRTY`. Read with `std::env::var` at startup.

Not an `env!` in a build script: a commit hash compiled into a crate invalidates
that crate and everything downstream on every commit, so every push would
rebuild the workspace. The wrapper is a symlink and three assignments.

Applied to `packages.smash` and deliberately **not** to the binaries the e2e
gates run. cargoUnit content-addresses every crate unit, so a commit that
changes no smash source leaves the gate's binary bit for bit identical and the
whole gate is reused from the store; stamping it would move its path every
commit and re-run fourteen gates for a string none of them reads. The split
cannot diverge behaviourally -- `stamped` wraps the same derivation -- and the
cost it does have is the restart scope at the top of this description.

### What the timestamp actually is, measured

`self.lastModified` is the commit's **committer** date, and it is the same
number on a dirty tree as on a clean one -- nix asks git for the commit either
way rather than falling back to a file mtime. Measured at d55a336: 1785386760
clean, 1785386760 dirty, `git log -1 --format=%ct` 1785386760. The author date
is 1785385579, twenty minutes earlier, because that commit was amended. So a
rebased commit's bar reads when the rebase landed, not when the work was
written. That is the right answer for "which build is this and how old is it"
and the wrong answer for "when was this authored", which the bar does not claim.
An earlier revision of this PR had a comment asserting the opposite; it was
wrong and is now the measurement above.

**No rev means no time.** A source with no git in it has neither `shortRev` nor
`dirtyShortRev`, but `lastModified` is then the directory's mtime, so the bar
used to render `build unpackaged build · 2026-07-29 20:41 UTC` -- a stamp that
has just admitted it does not know what it is, timed to the minute. The flake
now emits an empty time in that case and the bar drops the clause. Verified by
building the check from a non-git copy of the tree: `rev= time= dirty=0`.

## Gates, and each one watched failing

`checks.build-stamp` covers the writing of the three variables;
`tests/build_stamp.rs` covers the reading; `tests/contract.rs` gains a
`BuildStamp` contract so the module is exercised in a world holding only what it
declares.

Every assertion in `checks.build-stamp` except one compares the wrapper against
the same expression that produced it, so on *values* they are tautologies -- if
nix changed the suffix `removeSuffix` strips, both sides would move together and
the check would stay green while the bar read `abc1234-dirty + uncommitted
changes`. The hex assertion is the one that does not come from the expression,
and it is what closes that:

```
hyperion-build-stamp> FAIL: the rev is not a short commit hash: 6624ab3-dirty
```
(produced by changing `removeSuffix "-dirty"` to `"-DIRTY"`)

```
hyperion-build-stamp> FAIL: no rev, but a timestamp of 1785388325: that is a
                      directory mtime dressed as a commit
```
(produced by emitting the time unconditionally, built from the non-git copy)

```
hyperion-build-stamp> FAIL: the wrapper sets no HYPERION_BUILD_TIME
```
(produced by renaming the variable in the wrapper)

```
thread 'every_slot_is_in_all_and_indexes_into_it' panicked:
assertion `left == right` failed: a slot is missing from BarSlot::ALL, so its
index would panic
  left: [Hud]
 right: [Hud, Build]
```
(produced by dropping a variant from `BarSlot::ALL`; note that every other test
in the suite still passed, because `PlayerBars` lives in the adapter and no unit
test imports it -- the real failure would have been an out-of-bounds panic in
the server's `PostUpdate` on a live host)

## The seam

`Server::set_boss_bar` grew a `BarSlot` (`Hud` or `Build`), because a client
draws as many bars as it is sent and the two here change on completely different
clocks. `BarSlot::ALL` is the one list: `COUNT` is its length and `index()` is a
search of it, so an index can no longer be out of bounds for a slot the list
knows about, and a slot it does not know about panics by name instead of
silently indexing past a `PlayerBars` array.

The adapter holds one bar entity per slot per player and resolves every slot in
one pass before applying any op. Resolving per slot instead loses the other
slot's entity to the last deferred `set`, and the tick after that mints a second
match bar.

## Verified

- `cargo test -p smash` -- 27 test binaries green, 11 of them in
  `tests/build_stamp.rs`.
- `cargo clippy --workspace --all-targets --all-features` and
  `cargo fmt --check` -- clean.
- `nix build .#checks.aarch64-darwin.build-stamp` -- green on a clean tree,
  `rev=003fce0 time=1785388459 dirty=0`, and `git log -1 --format=%ct` is
  1785388459.
- The same check built from a non-git copy of the tree -- green, `rev= time=
  dirty=0`.
- Dev profile: the dev-profile smash server ran eleven minutes with zero
  `ECS_INVALID_OPERATION` lines, which is what covers the adapter's `PlayerBars`
  component. A release e2e gate structurally cannot see a flecs
  use-before-register.

## Not verified

No client has looked at this bar. `smash-hud-e2e` does already exercise the
second bar entity, the second `Add` and the two-slot pass -- the module runs
regardless of environment, so an unstamped gate binary still pushes a
`BarSlot::Build` bar reading `build unpackaged build`. What is unverified is
narrower than that: the **string** on the stamped bar, and the **stacking
order**. ENG-11459.

Stacking order rests on a client drawing bars in the order it is told about them
and on flecs running same-phase systems in declaration order. The test pins the
call ordering; nothing here pins pixels.
