### PR TITLE
feat(smash): implement the double jump (ENG-11440)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,3 +144,37 @@ impl Module for CombatModule {
   `cargo test` that imports your module before trusting it. Reverting a
   registration should reproduce the `ECS_INVALID_OPERATION` abort; that is the
   guard proving it works.
+
+## Mirroring host state: mirror the level, never compute an edge
+
+**The rule.** A system that copies host state onto a game component copies the
+*value*. It does not compute "this just became true". If a consumer needs an
+edge, either keep the memory somewhere that is written after the host state is,
+or mirror the level and make the consumer idempotent.
+
+**Why this exists (ENG-11440).** `events/smash/src/mirror.rs` runs in `OnLoad`.
+hyperion decodes the tick's packets in `OnUpdate` (`ingress/decode.rs`) and
+copies `is_flying` into `MovementTracking::last_tick_flying` in `PreStore`
+(`egress/sync_entity_state.rs`) -- both strictly after. So
+`bit && !hyperions_previous_bit`, evaluated in the mirror, is **always false**:
+the packet lands after the mirror has run, and by its next run hyperion's own
+"previous" has caught up. There is no point in the tick where the mirror can
+see the two disagree.
+
+**Why the test suite cannot catch it.** Every test under `events/smash/tests/`
+drives the mirrored component directly, because the mirror is host-side and a
+mock world has no host. A mirror that can only ever write `false` is therefore
+invisible to all of them: the double jump shipped eleven passing unit tests and
+a green contract while doing nothing at all on a real client. Only
+`Match.prove_double_jump` in `tools/smash-match.py` -- a real client
+double-tapping jump and getting no impulse -- showed it.
+
+**What to do.** Mirror the level, and put the idempotence in the consumer.
+`Flying` is the host's flying bit copied verbatim; `smash::Jump` answers a press
+by clearing that bit through the seam in the same tick, and refuses a press from
+a player standing on the ground. One double tap is one jump because of those two
+properties, not because the mirror was clever.
+
+**When you add a mirror of a host bit, gate it with a real client.** A Rust test
+that sets the component proves the consumer, not the mirror. The two are
+different code and only one of them has this hazard.

--- a/docs/smash-design.md
+++ b/docs/smash-design.md
@@ -245,9 +245,22 @@ Wolf and Spider). Power and height limit are per-kit sheet values.
 get another — is an artefact of the loose ground check, and the relaunch's
 changelog lists fixes in exactly that area.
 
-`events/smash/src/module/player.rs` carries `JumpsLeft` and re-arms it on
-ground contact. The launch impulse itself belongs to the host's physics, so it
-crosses the seam.
+Built, and built the same way. `events/smash/src/module/jump.rs` keeps
+`Flight::Armed` on any playing player who is off the ground with a jump left,
+pushed across the seam only when the answer changes; `src/mirror.rs` copies the
+host's flying bit onto `Flying`; and seeing it true is what spends a
+`JumpsLeft`, clears the flight and adds the velocity. No client mod, because
+the double tap a vanilla client already sends is the input.
+
+Two departures from the citation, both deliberate. `UtilAction.velocity`'s
+`yMax` of 1.0 is not implemented: every uncontrolled kit declares a
+`jump_power` of at least 0.9, so a ceiling there would clamp all twelve of them
+to the same jump and the per-kit number would stop meaning anything. And the
+"triple jump" is refused rather than reproduced — a press that arrives while
+the player is standing on something spends nothing.
+
+`jump_count` is on `KitStats` beside `jump_power`, because the Chicken's
+`[VERIFIED]` eight flaps are a per-kit number and not a constant.
 
 ---
 
@@ -508,11 +521,9 @@ Stated plainly, because these are the parts nobody can see from the code.
    ordinary relationship; the beacon, the descent and the pickup are not built.
 3. **No hunger drain.** `hunger_interval` is carried on every kit and
    `STARVE_DAMAGE` is defined, but nothing ticks it.
-4. **No double-jump impulse.** `JumpsLeft` is tracked and re-armed; applying the
-   velocity is a seam call that is not made yet.
-5. **Assists.** Only the last hit is tracked.
-6. **Seventeen of the twenty-one kits.**
-7. **Teams and the Dominate variant.**
+4. **Assists.** Only the last hit is tracked.
+5. **Seventeen of the twenty-one kits.**
+6. **Teams and the Dominate variant.**
 
 ---
 

--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -39,7 +39,7 @@ use hyperion::{
     },
     net::{Compose, ConnectionId, agnostic, protocol, protocol::Clientbound},
     simulation::{
-        PendingTeleportation, Velocity,
+        Flight as HostFlight, PendingTeleportation, Velocity,
         gamemode::{DefaultGamemode, Gamemode},
         metadata::living_entity::Health,
         skin::PlayerSkin,
@@ -53,8 +53,8 @@ use valence_nbt::{Compound, List, Value};
 use crate::{
     module::kit::{self, Playing},
     server::{
-        BarColour, BarSlot, BossBar, Channel, Experience, HotbarItem, Particles, PlayerId, Server,
-        SidebarLine, Sound, SoundCategory, Status, Text, Title,
+        BarColour, BarSlot, BossBar, Channel, Experience, Flight, HotbarItem, Particles, PlayerId,
+        Server, SidebarLine, Sound, SoundCategory, Status, Text, Title,
     },
 };
 
@@ -70,6 +70,10 @@ enum Op {
     Teleport {
         player: Entity,
         to: Vec3,
+    },
+    SetFlight {
+        player: Entity,
+        flight: Flight,
     },
     SetHealth {
         player: Entity,
@@ -170,6 +174,13 @@ impl Server for HyperionServer {
         self.push(Op::Teleport {
             player: entity_of(player),
             to,
+        });
+    }
+
+    fn set_flight(&self, player: PlayerId, flight: Flight) {
+        self.push(Op::SetFlight {
+            player: entity_of(player),
+            flight,
         });
     }
 
@@ -383,6 +394,27 @@ fn apply(world: WorldRef<'_>, compose: &Compose, op: Op, bars: &HashMap<Entity, 
                 return;
             }
             entity.set(PendingTeleportation::new(to));
+        }
+        Op::SetFlight { player, flight } => {
+            let entity = world.entity_from_id(player);
+            if !entity.is_alive() {
+                return;
+            }
+            // `set` and not `get::<&mut _>`: hyperion sends the abilities
+            // packet from an `OnSet` observer on this component, so a mutation
+            // that skipped the hook would change what the server believes and
+            // tell the client nothing.
+            //
+            // `is_flying` is false in both branches. The serverbound half of
+            // this exchange is the only thing that ever turns it on, and
+            // clearing it here is what ends a take-off the tick it starts:
+            // without it the client stays in creative flight and the double
+            // tap that starts the next jump never happens, because it is
+            // already flying.
+            entity.set(HostFlight {
+                allow: flight.is_armed(),
+                is_flying: false,
+            });
         }
         Op::SetHealth {
             player,

--- a/events/smash/src/lib.rs
+++ b/events/smash/src/lib.rs
@@ -27,10 +27,10 @@ use hyperion_clap::hyperion_command::CommandRegistry;
 
 use crate::module::{
     ability::AbilityModule, arena::ArenaModule, build_stamp::BuildStampModule,
-    damage::DamageModule, effect::EffectModule, hud::HudModule, kit::KitModule, kits::StockKits,
-    knockback::KnockbackModule, lives::LivesModule, lobby::LobbyModule, player::PlayerModule,
-    projectile::ProjectileModule, scoreboard::ScoreboardModule, selector::SelectorModule,
-    sound::SoundModule,
+    damage::DamageModule, effect::EffectModule, hud::HudModule, jump::JumpModule, kit::KitModule,
+    kits::StockKits, knockback::KnockbackModule, lives::LivesModule, lobby::LobbyModule,
+    player::PlayerModule, projectile::ProjectileModule, scoreboard::ScoreboardModule,
+    selector::SelectorModule, sound::SoundModule,
 };
 
 /// The whole game.
@@ -63,6 +63,10 @@ impl Module for SmashModule {
         world.import::<KitModule>();
         world.import::<ArenaModule>();
         world.import::<LivesModule>();
+        // After `Lives`: the double jump reads the two components that say a
+        // player is spectating rather than playing, so that it can leave them
+        // alone.
+        world.import::<JumpModule>();
         world.import::<ProjectileModule>();
         world.import::<LobbyModule>();
         world.import::<ScoreboardModule>();

--- a/events/smash/src/mirror.rs
+++ b/events/smash/src/mirror.rs
@@ -8,12 +8,12 @@
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
-use hyperion::simulation::{MovementTracking, Pitch, Yaw};
+use hyperion::simulation::{Flight, MovementTracking, Pitch, Yaw};
 use hyperion_inventory::PlayerInventory;
 
 use crate::{
     input::hotbar_slot,
-    module::player::{Facing, OnGround, Player, Position, SelectedSlot, Velocity},
+    module::player::{Facing, JumpPressed, OnGround, Player, Position, SelectedSlot, Velocity},
 };
 
 #[derive(Component)]
@@ -29,11 +29,13 @@ impl Module for MirrorModule {
                 &Yaw,
                 &Pitch,
                 &MovementTracking,
+                &Flight,
                 &PlayerInventory,
                 &mut Position,
                 &mut Facing,
                 &mut OnGround,
                 &mut Velocity,
+                &mut JumpPressed,
                 &mut SelectedSlot,
             )>("mirror_player_state")
             .kind(id::<flecs::pipeline::OnLoad>())
@@ -44,11 +46,13 @@ impl Module for MirrorModule {
                     yaw,
                     pitch,
                     tracking,
+                    flight,
                     inventory,
                     position,
                     facing,
                     ground,
                     velocity,
+                    jump_pressed,
                     selected,
                 )| {
                     position.0 = **source;
@@ -60,6 +64,15 @@ impl Module for MirrorModule {
                     // and it is what abilities that scale with speed -- Block
                     // Toss, Iron Hook -- are asking for.
                     velocity.0 = tracking.server_velocity.as_vec3();
+                    // The rising edge, not the bit. `sync_player_entity`
+                    // copies `is_flying` into `last_tick_flying` in PreStore,
+                    // which is after every game system has run, so comparing
+                    // the two here is exactly "the client asked to take off
+                    // during the last tick" and is true for one tick per
+                    // press. Mirroring the level instead would be true for as
+                    // long as the client kept flying, and the game would spend
+                    // a jump on each of those ticks.
+                    jump_pressed.0 = flight.is_flying && !tracking.last_tick_flying;
                     // A cursor outside the hotbar leaves the last slot standing
                     // rather than resetting to zero: the alternative reads as
                     // "you are holding slot 0" and would put slot 0's cooldown

--- a/events/smash/src/mirror.rs
+++ b/events/smash/src/mirror.rs
@@ -5,6 +5,42 @@
 //! iteration precisely because position, facing and ground state arrive as
 //! components rather than as trait calls, and that only holds if one system
 //! owns the copy.
+//!
+//! # A mirror cannot compute a rising edge
+//!
+//! Read this before adding a mirror of a host *bit*, because the obvious thing
+//! to write does not work and does not fail loudly.
+//!
+//! This system runs in `OnLoad`. Two things that decide what a bit looks like
+//! happen strictly after it, every tick:
+//!
+//! | phase | what happens | where |
+//! |---|---|---|
+//! | `OnLoad` | **this system copies** | here |
+//! | `OnUpdate` | hyperion decodes the tick's packets | `ingress/decode.rs:81` |
+//! | `OnUpdate` | the game's own systems run | `smash::*` |
+//! | `PostUpdate` | the adapter drains the write queue | `adapter.rs` |
+//! | `PreStore` | `is_flying` is copied to `last_tick_flying` | `sync_entity_state.rs:471` |
+//!
+//! So `bit && !hyperions_previous_bit` is always false here. The packet that
+//! sets the bit arrives after this system has already run, and by the time it
+//! runs again hyperion's own "previous" has caught up with it. There is no
+//! moment in the tick at which this system can see the two disagree.
+//!
+//! That is exactly the bug [`crate::module::player::Flying`] was written wrong
+//! for the first time, and the way it surfaced is the part worth remembering:
+//! **every Rust test passed.** They drive the mirrored component directly, so
+//! they never exercise the mirror at all, and a mirror that can only ever
+//! write `false` is invisible to all of them. What found it was
+//! `Match.prove_double_jump` in `tools/smash-match.py` -- a real client
+//! double-tapping jump and getting no impulse back.
+//!
+//! Two ways out, and the second is the one taken here. Keep the edge somewhere
+//! that is written after the packet is decoded, or **mirror the level and make
+//! the consumer idempotent**: [`crate::module::jump`] answers a press by
+//! clearing the host bit in the same tick and refuses one from a player
+//! standing on the ground, so reading a level as an edge is sound. If you
+//! mirror a new bit, say which of the two you did and why.
 
 use flecs_ecs::prelude::*;
 use glam::Vec3;
@@ -64,11 +100,11 @@ impl Module for MirrorModule {
                     // and it is what abilities that scale with speed -- Block
                     // Toss, Iron Hook -- are asking for.
                     velocity.0 = tracking.server_velocity.as_vec3();
-                    // A plain copy. An edge computed here would be wrong; see
-                    // `Flying` for why, and for why a level is safe to read as
-                    // a press. One tick of latency, the same one knockback
-                    // already costs, because packets are decoded in `OnUpdate`
-                    // and this runs in `OnLoad`.
+                    // A plain copy, deliberately. An edge computed here is
+                    // always false -- see this module's own documentation for
+                    // the phase ordering that makes it so, and `Flying` for
+                    // why a level is safe to read as a press instead. One tick
+                    // of latency, the same one knockback already costs.
                     flying.0 = flight.is_flying;
                     // A cursor outside the hotbar leaves the last slot standing
                     // rather than resetting to zero: the alternative reads as

--- a/events/smash/src/mirror.rs
+++ b/events/smash/src/mirror.rs
@@ -13,7 +13,7 @@ use hyperion_inventory::PlayerInventory;
 
 use crate::{
     input::hotbar_slot,
-    module::player::{Facing, JumpPressed, OnGround, Player, Position, SelectedSlot, Velocity},
+    module::player::{Facing, Flying, OnGround, Player, Position, SelectedSlot, Velocity},
 };
 
 #[derive(Component)]
@@ -35,7 +35,7 @@ impl Module for MirrorModule {
                 &mut Facing,
                 &mut OnGround,
                 &mut Velocity,
-                &mut JumpPressed,
+                &mut Flying,
                 &mut SelectedSlot,
             )>("mirror_player_state")
             .kind(id::<flecs::pipeline::OnLoad>())
@@ -52,7 +52,7 @@ impl Module for MirrorModule {
                     facing,
                     ground,
                     velocity,
-                    jump_pressed,
+                    flying,
                     selected,
                 )| {
                     position.0 = **source;
@@ -64,15 +64,12 @@ impl Module for MirrorModule {
                     // and it is what abilities that scale with speed -- Block
                     // Toss, Iron Hook -- are asking for.
                     velocity.0 = tracking.server_velocity.as_vec3();
-                    // The rising edge, not the bit. `sync_player_entity`
-                    // copies `is_flying` into `last_tick_flying` in PreStore,
-                    // which is after every game system has run, so comparing
-                    // the two here is exactly "the client asked to take off
-                    // during the last tick" and is true for one tick per
-                    // press. Mirroring the level instead would be true for as
-                    // long as the client kept flying, and the game would spend
-                    // a jump on each of those ticks.
-                    jump_pressed.0 = flight.is_flying && !tracking.last_tick_flying;
+                    // A plain copy. An edge computed here would be wrong; see
+                    // `Flying` for why, and for why a level is safe to read as
+                    // a press. One tick of latency, the same one knockback
+                    // already costs, because packets are decoded in `OnUpdate`
+                    // and this runs in `OnLoad`.
+                    flying.0 = flight.is_flying;
                     // A cursor outside the hotbar leaves the last slot standing
                     // rather than resetting to zero: the alternative reads as
                     // "you are holding slot 0" and would put slot 0's cooldown

--- a/events/smash/src/module.rs
+++ b/events/smash/src/module.rs
@@ -4,6 +4,7 @@ pub mod build_stamp;
 pub mod damage;
 pub mod effect;
 pub mod hud;
+pub mod jump;
 pub mod kit;
 pub mod kits;
 pub mod knockback;

--- a/events/smash/src/module/jump.rs
+++ b/events/smash/src/module/jump.rs
@@ -1,0 +1,220 @@
+//! The mid-air jump, which is vanilla creative flight with the flight taken
+//! out.
+//!
+//! `[SOURCE]` Mineplex's `PerkDoubleJump` grants `setAllowFlight(true)`,
+//! cancels the `PlayerToggleFlightEvent` the client's double tap produces, and
+//! applies a velocity by hand. Nothing about that needs a modified client, and
+//! nothing about it needs a new packet: the serverbound abilities packet a
+//! vanilla client already sends *is* the jump key, and the only thing the
+//! server has to do is refuse the flight and answer with an impulse.
+//!
+//! Three systems, which is the whole mechanic:
+//!
+//! * `arm_double_jump` keeps the client's flight permission equal to "airborne
+//!   with a jump left", pushing it across the seam only when the answer
+//!   changes.
+//! * `spend_double_jump` answers a press: one jump off the counter, the
+//!   permission rewritten so the player is not left flying, and the impulse.
+//! * `restore_double_jump` puts the counter back on ground contact, which is
+//!   what re-arms the whole thing.
+//!
+//! The counter itself is [`JumpsLeft`] and it lives in
+//! [`crate::module::player`] with the rest of the state a player carries. This
+//! module registers no components; it imports the modules that own the ones it
+//! reads.
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+
+use crate::{
+    flecs_ext::EntityViewExt,
+    module::{
+        kit::{KitModule, KitStats, Playing},
+        lives::{Eliminated, LivesModule, RespawnAt},
+        player::{
+            Facing, JumpPressed, JumpsLeft, MayFly, OnGround, Player, PlayerModule, Position,
+        },
+        sound, visuals,
+    },
+    server::{Flight, PlayerId, ServerHandle, Sound, SoundCategory},
+};
+
+/// The lift under a *controlled* jump, in blocks per tick.
+///
+/// `[SOURCE]` `UtilAction.velocity` takes a `yAdd` and Mineplex's jump perks
+/// pass 0.2. Only the controlled kits need it: their jump goes where the
+/// player is looking, so one taken at the horizon would be purely sideways,
+/// and a recovery that buys no height at all is a dodge rather than a
+/// recovery.
+///
+/// `[INFERRED]` The same call takes a `yMax` of 1.0, and that one is
+/// deliberately **not** implemented. Every uncontrolled kit in the roster
+/// declares a `jump_power` of at least 0.9, so a ceiling at 1.0 would clamp
+/// all twelve of them to exactly the same jump and the per-kit number would
+/// stop meaning anything -- which is the shape of bug that made this mechanic
+/// worth writing in the first place. Either the sheet's powers are not what
+/// Mineplex handed that call, or its cap was higher; both readings leave the
+/// jump powers load-bearing and the cap is what has to give.
+const LIFT: f32 = 0.2;
+
+/// How loud a mid-air jump is, against 1.0 for an ordinary ability cast.
+///
+/// Under one. It happens more often than anything else in the game that makes
+/// a noise, and volume is range -- a client culls a sound past `16 * volume`
+/// blocks -- so a crowded arena at 1.0 would be a wall of wind nobody could
+/// hear a hit through.
+const JUMP_VOLUME: f32 = 0.7;
+
+/// The velocity one mid-air jump adds, for a kit and the direction its player
+/// is looking.
+///
+/// Pure and public, so a test can compare an uncontrolled jump against a
+/// controlled one directly instead of inferring the difference from where two
+/// simulated players ended up.
+///
+/// A controlled jump goes where you look and a controlled jump taken looking
+/// at the floor therefore drives you into it. That is Mineplex's behaviour and
+/// it is the price of the reach: Wolf and Spider cross more ground with theirs
+/// than anybody, and the same aim that buys the distance is the aim that can
+/// throw it away.
+#[must_use]
+pub fn impulse(stats: KitStats, facing: Vec3) -> Vec3 {
+    if stats.jump_control {
+        facing.normalize_or_zero() * stats.jump_power + Vec3::Y * LIFT
+    } else {
+        Vec3::Y * stats.jump_power
+    }
+}
+
+/// How many mid-air jumps `player`'s kit allows.
+///
+/// A player who has not picked a kit gets [`KitStats::default`]'s one. The hub
+/// is a place people move around in before a match starts, and a lobby where
+/// the mechanic does not work at all reads as broken rather than as not having
+/// begun.
+#[must_use]
+pub fn allowance(player: EntityView<'_>) -> u8 {
+    stats_of(player).jump_count
+}
+
+/// The stats of the kit `player` is on, or the defaults if they are on none.
+fn stats_of(player: EntityView<'_>) -> KitStats {
+    player
+        .find_target(Playing, |_| true)
+        .and_then(|kit| kit.try_get::<&KitStats>(|stats| *stats))
+        .unwrap_or_default()
+}
+
+#[derive(Component)]
+pub struct JumpModule;
+
+impl Module for JumpModule {
+    fn module(world: &World) {
+        world.module::<Self>("smash::Jump");
+
+        // Behaviour only: every component below belongs to one of these three,
+        // and importing them is what guarantees each is registered before a
+        // system names it. See CLAUDE.md.
+        world.import::<PlayerModule>();
+        world.import::<KitModule>();
+        world.import::<LivesModule>();
+
+        // A dead or eliminated player is a spectator, and a spectator already
+        // flies. Writing an abilities packet at one would take that away and
+        // leave them stuck to the floor of a match they are watching, so both
+        // halves of the mechanic step around them.
+        world
+            .system_named::<(&OnGround, &JumpsLeft, &mut MayFly, &PlayerId)>("arm_double_jump")
+            .with(Player::id())
+            .without(Eliminated::id())
+            .without(RespawnAt::id())
+            .each_iter(|it, _index, (ground, jumps, may_fly, player)| {
+                let armed = !ground.0 && jumps.0 > 0;
+                if armed == may_fly.0 {
+                    return;
+                }
+                may_fly.0 = armed;
+                it.world().get::<&ServerHandle>(|server| {
+                    server.set_flight(*player, Flight::armed(armed));
+                });
+            });
+
+        world
+            .system_named::<(
+                &mut JumpPressed,
+                &OnGround,
+                &Facing,
+                &Position,
+                &mut JumpsLeft,
+                &mut MayFly,
+                &PlayerId,
+            )>("spend_double_jump")
+            .with(Player::id())
+            .without(Eliminated::id())
+            .without(RespawnAt::id())
+            .each_entity(
+                |entity, (pressed, ground, facing, position, jumps, may_fly, player)| {
+                    if !pressed.0 {
+                        return;
+                    }
+                    // Consumed here rather than left for the mirror to
+                    // overwrite next tick. The mirror does clear it, and this
+                    // line is still what bounds the damage if some future host
+                    // reports the flying *bit* instead of the edge: one press
+                    // is one jump, whatever the thing upstream says twice.
+                    pressed.0 = false;
+
+                    let world = entity.world();
+                    let stats = stats_of(entity);
+
+                    // Standing on something spends nothing. The client should
+                    // not have been able to ask -- permission is withdrawn the
+                    // moment they land -- but a packet in flight across the
+                    // tick they landed on arrives after it, and vanilla's own
+                    // "triple jump" is exactly this hole with a looser ground
+                    // check under it.
+                    //
+                    // A press with nothing left to spend is the same case, and
+                    // both still have to be *answered*: the client is flying
+                    // at this instant whether or not the game meant to let it,
+                    // and the packet below is the only thing that puts it back
+                    // down.
+                    let spent = !ground.0 && jumps.0 > 0;
+                    if spent {
+                        jumps.0 -= 1;
+                    }
+                    may_fly.0 = !ground.0 && jumps.0 > 0;
+
+                    let flight = Flight::armed(may_fly.0);
+                    let impulse = impulse(stats, facing.0);
+                    let at = position.0;
+                    world.get::<&ServerHandle>(|server| {
+                        server.set_flight(*player, flight);
+                        if !spent {
+                            return;
+                        }
+                        server.add_velocity(*player, impulse);
+                        server.particles(visuals::updraft(at));
+                        server.play_sound(
+                            at,
+                            Sound::new(sound::DOUBLE_JUMP, SoundCategory::Players)
+                                .volume(JUMP_VOLUME),
+                        );
+                    });
+                },
+            );
+
+        // Touching the ground is what re-arms it -- `[SOURCE]`, and the reason
+        // the counter is not a cooldown. It is also why the known "triple
+        // jump" exists: a ground check loose enough to be true on the way past
+        // a ledge hands back a jump nobody landed for.
+        world
+            .system_named::<(&OnGround, &mut JumpsLeft)>("restore_double_jump")
+            .with(Player::id())
+            .each_entity(|entity, (ground, jumps)| {
+                if ground.0 {
+                    jumps.0 = allowance(entity);
+                }
+            });
+    }
+}

--- a/events/smash/src/module/jump.rs
+++ b/events/smash/src/module/jump.rs
@@ -31,9 +31,7 @@ use crate::{
     module::{
         kit::{KitModule, KitStats, Playing},
         lives::{Eliminated, LivesModule, RespawnAt},
-        player::{
-            Facing, JumpPressed, JumpsLeft, MayFly, OnGround, Player, PlayerModule, Position,
-        },
+        player::{Facing, Flying, JumpsLeft, MayFly, OnGround, Player, PlayerModule, Position},
         sound, visuals,
     },
     server::{Flight, PlayerId, ServerHandle, Sound, SoundCategory},
@@ -141,7 +139,7 @@ impl Module for JumpModule {
 
         world
             .system_named::<(
-                &mut JumpPressed,
+                &Flying,
                 &OnGround,
                 &Facing,
                 &Position,
@@ -153,17 +151,10 @@ impl Module for JumpModule {
             .without(Eliminated::id())
             .without(RespawnAt::id())
             .each_entity(
-                |entity, (pressed, ground, facing, position, jumps, may_fly, player)| {
-                    if !pressed.0 {
+                |entity, (flying, ground, facing, position, jumps, may_fly, player)| {
+                    if !flying.0 {
                         return;
                     }
-                    // Consumed here rather than left for the mirror to
-                    // overwrite next tick. The mirror does clear it, and this
-                    // line is still what bounds the damage if some future host
-                    // reports the flying *bit* instead of the edge: one press
-                    // is one jump, whatever the thing upstream says twice.
-                    pressed.0 = false;
-
                     let world = entity.world();
                     let stats = stats_of(entity);
 

--- a/events/smash/src/module/kit.rs
+++ b/events/smash/src/module/kit.rs
@@ -59,11 +59,24 @@ pub struct KitStats {
     /// Seconds between losing half a hunger shank.
     pub hunger_interval: f32,
     pub max_health: f32,
-    /// Impulse of the double jump.
+    /// Impulse of the double jump, in blocks per tick.
+    ///
+    /// Minecraft's own velocity unit, which is the one Mineplex's sheet was
+    /// written in too: `UtilAction.velocity` scales a unit vector by this and
+    /// hands the result to `setVelocity`. Vanilla's ordinary jump leaves the
+    /// ground at 0.42, so every kit's mid-air jump is more than twice one --
+    /// which is the point, because recovering from a launch is what it is for.
     pub jump_power: f32,
-    /// Whether the double jump goes where you look (Wolf, Spider) or straight
-    /// up (everyone else).
+    /// Whether the double jump goes where you look (Wolf, Spider, Chicken) or
+    /// straight up (everyone else).
     pub jump_control: bool,
+    /// How many mid-air jumps the kit gets before touching ground again.
+    ///
+    /// One for everybody except the Chicken, which has eight. Carried per kit
+    /// rather than as a constant because it is the Chicken's whole identity:
+    /// the lightest kit in the game, launched further by every hit than anyone
+    /// else, and able to fly back from it.
+    pub jump_count: u8,
     /// Present only on kits with an energy bar.
     pub energy: Option<(f32, f32)>,
 }
@@ -79,6 +92,7 @@ impl Default for KitStats {
             max_health: 20.0,
             jump_power: 1.0,
             jump_control: false,
+            jump_count: 1,
             energy: None,
         }
     }
@@ -484,7 +498,7 @@ pub fn apply(world: &World, player: EntityView<'_>, kit: EntityView<'_>) {
         .set(Armor(stats.armor))
         .set(KnockbackTaken(stats.knockback_taken))
         .set(Health::full(stats.max_health))
-        .set(JumpsLeft(1));
+        .set(JumpsLeft(stats.jump_count));
 
     if let Some((max, regen)) = stats.energy {
         player.set(Energy::full(max, regen));

--- a/events/smash/src/module/kits/chicken.rs
+++ b/events/smash/src/module/kits/chicken.rs
@@ -39,6 +39,7 @@ impl Module for Chicken {
             regen: 0.20,
             jump_power: 0.7,
             jump_control: true,
+            jump_count: FLAPS,
             // Flap draws from the energy bar and "rapidly regenerates on the
             // ground".
             energy: Some((100.0, 25.0)),

--- a/events/smash/src/module/lives.rs
+++ b/events/smash/src/module/lives.rs
@@ -12,7 +12,7 @@ use crate::{
     module::{
         arena::Arena,
         damage::{KILL_CREDIT_WINDOW, LastHitAt, LastHitBy, MatchClock},
-        hud, kit,
+        hud, jump, kit,
         player::{self, Health, JumpsLeft, Player, Position},
         sound::{self, PlaysOnDeath},
         visuals,
@@ -430,7 +430,11 @@ impl Module for LivesModule {
                 // deadline with it and would otherwise delete this one.
                 crate::module::effect::clear(world, player.id());
                 player.set(InvulnerableUntil(clock + RESPAWN_INVULNERABLE_SECS));
-                player.set(JumpsLeft(1));
+                // The kit's count and not one: a Chicken that respawned with a
+                // single jump would be the lightest kit in the game with the
+                // recovery of the heaviest, which is the one thing its 200%
+                // knockback taken is balanced against.
+                player.set(JumpsLeft(jump::allowance(player)));
 
                 let hotbar = kit::hotbar(player);
                 world.get::<&ServerHandle>(|server| {

--- a/events/smash/src/module/lives.rs
+++ b/events/smash/src/module/lives.rs
@@ -13,11 +13,11 @@ use crate::{
         arena::Arena,
         damage::{KILL_CREDIT_WINDOW, LastHitAt, LastHitBy, MatchClock},
         hud, jump, kit,
-        player::{self, Health, JumpsLeft, Player, Position},
+        player::{self, Flying, Health, JumpsLeft, MayFly, Player, Position},
         sound::{self, PlaysOnDeath},
         visuals,
     },
-    server::{Channel, NamedColor, PlayerId, ServerHandle, Sound, SoundCategory, Text},
+    server::{Channel, Flight, NamedColor, PlayerId, ServerHandle, Sound, SoundCategory, Text},
 };
 
 /// Mineplex's `MAX_LIVES`.
@@ -435,12 +435,51 @@ impl Module for LivesModule {
                 // recovery of the heaviest, which is the one thing its 200%
                 // knockback taken is balanced against.
                 player.set(JumpsLeft(jump::allowance(player)));
+                // And the flight state that jump count is spent through, all
+                // three of it, because a dead player is filtered out of both
+                // systems that would otherwise maintain them and so arrives
+                // here carrying whatever was true when they died.
+                //
+                // `MayFly` is a write-cache. Left `true` it makes
+                // `arm_double_jump` compare equal and send nothing, while the
+                // client has already reset its own abilities out of band --
+                // vanilla's `GameType.updatePlayerAbilities` sets
+                // `mayfly = false` on the gamemode change that leaving
+                // spectator causes, and does not tell the server. The player
+                // would hold a `JumpsLeft` their client refuses to spend, in
+                // the one situation the mechanic exists for: dying in mid-air
+                // is the normal way to die here, and a fresh respawn is about
+                // to be knocked off again.
+                //
+                // `Flying` is the mirror of the host's bit. A press made on
+                // the tick of death is still set on the host, nothing clears
+                // it while the player is filtered out, and the first tick the
+                // filter lifts spends it as a real jump at the spawn point.
+                player.set(MayFly(false));
+                player.set(Flying(false));
 
                 let hotbar = kit::hotbar(player);
                 world.get::<&ServerHandle>(|server| {
                     server.teleport(*id, at);
                     server.set_health(*id, health.current, health.max);
                     server.set_spectating(*id, false);
+                    // The host's own bit, which is the only thing the mirror
+                    // reads and the only thing that can clear it. Safe next to
+                    // `set_spectating` because both say the same: leaving
+                    // spectator puts the client back in the default gamemode,
+                    // whose abilities are `mayfly = false` too, so whichever
+                    // packet the client applies last it ends up agreeing with
+                    // this. That is not true at the *death* transition, where
+                    // the gamemode says a spectator may fly and this would say
+                    // it may not, so the reset lives here and not there.
+                    //
+                    // Unconditional, and do not make it conditional on
+                    // `MayFly`: that cache is exactly what stopped being
+                    // evidence of what the client believes, because the client
+                    // reset its own abilities on the gamemode change and told
+                    // nobody. Skipping the write when the cache already says
+                    // disarmed is the same bug in a new place.
+                    server.set_flight(*id, Flight::Disarmed);
                     server.set_hotbar(*id, &hotbar);
                 });
             });

--- a/events/smash/src/module/player.rs
+++ b/events/smash/src/module/player.rs
@@ -123,22 +123,28 @@ impl Energy {
 #[derive(Component, Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct JumpsLeft(pub u8);
 
-/// Mirror of the host seeing a client ask to take off.
+/// Mirror of the host having this client in flight.
 ///
-/// True for the one tick a serverbound abilities packet turned flight on, and
-/// false every other tick. A vanilla client sends that packet when the player
-/// double-taps the jump key with flight permitted, so this is the mid-air jump
-/// press and there is no other input that produces one.
+/// A vanilla client turns this on by double-tapping the jump key with flight
+/// permitted, which sends a serverbound abilities packet, and that is the only
+/// mid-air jump input a client without a mod can produce. So
+/// [`crate::module::jump`] reads a true here as a *press*.
 ///
-/// An edge and not the flying bit itself, which is the difference that makes
-/// it safe to read: the bit stays on for as long as the client is flying, and
-/// a system reading the level would spend a jump every tick until something
-/// cleared it.
+/// Reading a level as an edge is sound only because of what the game does with
+/// it. Every press is answered by writing the flight state back across the
+/// seam, which clears the host's flying bit in the same tick, so the next
+/// mirror read is false and one double tap is one jump. Nothing in this game
+/// ever leaves anybody flying, and `smash::Jump::spend_double_jump` refusing a
+/// press from somebody standing on the ground is the other half of that.
 ///
-/// The one mirror the game writes back to, and only ever to clear: whoever
-/// spends the press marks it spent. See `smash::Jump::spend_double_jump`.
+/// An `is_flying && !was_flying_last_tick` edge computed in the mirror is the
+/// tempting alternative and it does not work: hyperion decodes packets in
+/// `OnUpdate` and copies `is_flying` into `MovementTracking::last_tick_flying`
+/// in `PreStore`, both of them after the mirror has run in `OnLoad`, so by the
+/// next mirror read the two are already equal and the edge is gone. Watched:
+/// a real client's double tap produced no impulse at all.
 #[derive(Component, Debug, Default, Copy, Clone, PartialEq, Eq)]
-pub struct JumpPressed(pub bool);
+pub struct Flying(pub bool);
 
 /// What the client was last told about flight, so the arming system sends a
 /// packet when the answer changes rather than twenty times a second.
@@ -185,7 +191,7 @@ impl Module for PlayerModule {
         world.component::<Health>();
         world.component::<Energy>();
         world.component::<JumpsLeft>();
-        world.component::<JumpPressed>();
+        world.component::<Flying>();
         world.component::<MayFly>();
         world.component::<SelectedSlot>();
 
@@ -200,7 +206,7 @@ impl Module for PlayerModule {
             .add_trait::<(flecs::With, OnGround)>()
             .add_trait::<(flecs::With, Health)>()
             .add_trait::<(flecs::With, JumpsLeft)>()
-            .add_trait::<(flecs::With, JumpPressed)>()
+            .add_trait::<(flecs::With, Flying)>()
             .add_trait::<(flecs::With, MayFly)>()
             .add_trait::<(flecs::With, SelectedSlot)>();
 

--- a/events/smash/src/module/player.rs
+++ b/events/smash/src/module/player.rs
@@ -116,8 +116,40 @@ impl Energy {
 }
 
 /// How many double jumps remain before touching ground again.
+///
+/// How many a player starts with is the kit's, not a constant: the Chicken has
+/// eight and everybody else has one. [`crate::module::jump`] is what spends
+/// them and what puts them back.
 #[derive(Component, Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct JumpsLeft(pub u8);
+
+/// Mirror of the host seeing a client ask to take off.
+///
+/// True for the one tick a serverbound abilities packet turned flight on, and
+/// false every other tick. A vanilla client sends that packet when the player
+/// double-taps the jump key with flight permitted, so this is the mid-air jump
+/// press and there is no other input that produces one.
+///
+/// An edge and not the flying bit itself, which is the difference that makes
+/// it safe to read: the bit stays on for as long as the client is flying, and
+/// a system reading the level would spend a jump every tick until something
+/// cleared it.
+///
+/// The one mirror the game writes back to, and only ever to clear: whoever
+/// spends the press marks it spent. See `smash::Jump::spend_double_jump`.
+#[derive(Component, Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct JumpPressed(pub bool);
+
+/// What the client was last told about flight, so the arming system sends a
+/// packet when the answer changes rather than twenty times a second.
+///
+/// The game's own memory of a write it made across the seam. It is not a
+/// mirror: nothing reads it back off the host, because [`crate::server`]
+/// deliberately has no reads. Both halves of that are load-bearing -- a
+/// clientbound abilities packet per airborne player per tick is a fifth of the
+/// game's whole packet budget spent saying nothing changed.
+#[derive(Component, Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct MayFly(pub bool);
 
 /// Mirror of which of the nine hotbar slots the player is holding.
 ///
@@ -153,6 +185,8 @@ impl Module for PlayerModule {
         world.component::<Health>();
         world.component::<Energy>();
         world.component::<JumpsLeft>();
+        world.component::<JumpPressed>();
+        world.component::<MayFly>();
         world.component::<SelectedSlot>();
 
         // A player is never meaningfully without these, and forgetting one is
@@ -166,15 +200,9 @@ impl Module for PlayerModule {
             .add_trait::<(flecs::With, OnGround)>()
             .add_trait::<(flecs::With, Health)>()
             .add_trait::<(flecs::With, JumpsLeft)>()
+            .add_trait::<(flecs::With, JumpPressed)>()
+            .add_trait::<(flecs::With, MayFly)>()
             .add_trait::<(flecs::With, SelectedSlot)>();
-
-        world
-            .system_named::<(&OnGround, &mut JumpsLeft)>("restore_double_jump")
-            .each(|(ground, jumps)| {
-                if ground.0 {
-                    jumps.0 = 1;
-                }
-            });
 
         world
             .system_named::<&mut Energy>("regen_energy")

--- a/events/smash/src/module/player.rs
+++ b/events/smash/src/module/player.rs
@@ -149,11 +149,14 @@ pub struct Flying(pub bool);
 /// What the client was last told about flight, so the arming system sends a
 /// packet when the answer changes rather than twenty times a second.
 ///
-/// The game's own memory of a write it made across the seam. It is not a
+/// The game's own memory of a write it made across the seam, and not a
 /// mirror: nothing reads it back off the host, because [`crate::server`]
-/// deliberately has no reads. Both halves of that are load-bearing -- a
-/// clientbound abilities packet per airborne player per tick is a fifth of the
-/// game's whole packet budget spent saying nothing changed.
+/// deliberately has no reads.
+///
+/// It exists so that a player falling off the map costs one packet rather than
+/// one every tick they are in the air. hyperion answers each write with a
+/// `ClientboundPlayerAbilities`, so without this the arming system would spend
+/// twenty of them a second per airborne player to say nothing had changed.
 #[derive(Component, Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct MayFly(pub bool);
 

--- a/events/smash/src/module/sound.rs
+++ b/events/smash/src/module/sound.rs
@@ -147,6 +147,20 @@ pub const RANGED_HITMARKER: &str = "minecraft:entity.arrow.hit_player";
 /// dropped `Cue::Denied`.
 pub const SELECTION_REFUSED: &str = "minecraft:entity.villager.no";
 
+/// A mid-air jump.
+///
+/// `minecraft:entity.breeze.jump`, which vanilla plays when a Breeze shoves
+/// itself through the air off a burst of wind. That is a description of the
+/// mechanic rather than a resemblance to it, and it is the only sound in the
+/// registry that is one.
+///
+/// A constant and not a kit's voice, on [`IMPACT`]'s reasoning: the double
+/// jump is a rule every kit has, and fifteen timbres for it would say the kits
+/// jump differently when the only things that differ are how far and how
+/// often. The mob's own voice is still heard when the jump is not enough and
+/// they are hit on the way back.
+pub const DOUBLE_JUMP: &str = "minecraft:entity.breeze.jump";
+
 /// One second closer to the start of the match.
 pub const COUNTDOWN_TICK: &str = "minecraft:block.note_block.hat";
 

--- a/events/smash/src/module/visuals.rs
+++ b/events/smash/src/module/visuals.rs
@@ -67,6 +67,21 @@ pub fn teleport(at: Vec3) -> Particles {
         .long_distance(true)
 }
 
+/// Somebody pushing off nothing.
+///
+/// `minecraft:small_gust`, the particle vanilla throws off a wind charge going
+/// off: its one picture of air being shoved somewhere. A flat disc under the
+/// feet rather than a puff around the body, because the fiction of a mid-air
+/// jump is that the air below took the weight, and under the feet is also
+/// where it is legible to the player standing beneath deciding whether to
+/// contest the landing.
+pub fn updraft(at: Vec3) -> Particles {
+    Particles::disc(Particle::SmallGust, at + Vec3::Y * 0.1, 0.6)
+        .points(12)
+        .speed(0.05)
+        .long_distance(true)
+}
+
 /// A player dying here.
 pub fn death(at: Vec3) -> Particles {
     Particles::burst(Particle::Cloud, at + Vec3::Y)

--- a/events/smash/src/server.rs
+++ b/events/smash/src/server.rs
@@ -84,6 +84,43 @@ pub struct SidebarLine {
     pub score: Score,
 }
 
+/// What a client is allowed to do about flying, and the whole of the game's
+/// half of the double jump.
+///
+/// Super Smash Mobs' mid-air jump is vanilla creative flight, abused. A player
+/// with permission to fly who double-taps the jump key sends a serverbound
+/// abilities packet asking to take off, and that packet is the only mid-air
+/// jump input a client without a mod can produce. So the game arms the
+/// permission while a jump is available, waits for the press, and answers it
+/// with an impulse instead of with flight.
+///
+/// Neither variant leaves the player flying, and that is the point of it being
+/// two states rather than the two booleans the protocol carries. A player who
+/// is actually allowed to fly in a Smash match is a player who has left the
+/// game, so "keep flying" is not a thing this seam can be asked for.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum Flight {
+    /// A mid-air jump is available: the client may take off, and the press
+    /// that would is the input the game answers.
+    Armed,
+    /// No mid-air jump. On the ground, or out of them.
+    #[default]
+    Disarmed,
+}
+
+impl Flight {
+    /// Armed exactly when a jump is available.
+    #[must_use]
+    pub const fn armed(armed: bool) -> Self {
+        if armed { Self::Armed } else { Self::Disarmed }
+    }
+
+    #[must_use]
+    pub const fn is_armed(self) -> bool {
+        matches!(self, Self::Armed)
+    }
+}
+
 /// A player as the host server knows them.
 ///
 /// Opaque to the game. The adapter maps this onto whatever the host uses; for
@@ -401,6 +438,15 @@ pub trait Server: Send + Sync + 'static {
     fn add_velocity(&self, player: PlayerId, delta: Vec3);
 
     fn teleport(&self, player: PlayerId, to: Vec3);
+
+    /// Tell the client whether a mid-air jump is available to it. See
+    /// [`Flight`].
+    ///
+    /// Every call also says the player is not flying, which is what makes a
+    /// press a discrete input rather than a state a player can hold: the game
+    /// answers a take-off by putting them straight back on this seam's terms,
+    /// so the next press is a fresh one.
+    fn set_flight(&self, player: PlayerId, flight: Flight);
 
     /// Push the game's authoritative health onto the client's health bar.
     fn set_health(&self, player: PlayerId, health: f32, max: f32);

--- a/events/smash/src/server/mock.rs
+++ b/events/smash/src/server/mock.rs
@@ -10,8 +10,8 @@ use std::sync::Mutex;
 use glam::Vec3;
 
 use super::{
-    BarSlot, BossBar, Channel, Experience, HotbarItem, Particles, PlayerId, Server, SidebarLine,
-    Sound, Status, Text, Title,
+    BarSlot, BossBar, Channel, Experience, Flight, HotbarItem, Particles, PlayerId, Server,
+    SidebarLine, Sound, Status, Text, Title,
 };
 
 /// One thing the game asked the server to do.
@@ -19,6 +19,8 @@ use super::{
 pub enum Call {
     AddVelocity(PlayerId, Vec3),
     Teleport(PlayerId, Vec3),
+    /// Whether the client may take a mid-air jump.
+    Flight(PlayerId, Flight),
     SetHealth(PlayerId, f32, f32),
     /// A potion effect applied to a player.
     Status(PlayerId, Status),
@@ -76,6 +78,23 @@ impl MockServer {
                 _ => None,
             })
             .sum()
+    }
+
+    /// Every flight state pushed to `player`, oldest first.
+    ///
+    /// The whole series and not the last one, because what the double jump has
+    /// to get right is the *sequence*: armed on leaving the ground, disarmed
+    /// once the jumps are spent, and one push per change rather than one a
+    /// tick. A final-state assertion cannot tell those apart.
+    #[must_use]
+    pub fn flight_of(&self, player: PlayerId) -> Vec<Flight> {
+        self.calls()
+            .iter()
+            .filter_map(|call| match call {
+                Call::Flight(id, flight) if *id == player => Some(*flight),
+                _ => None,
+            })
+            .collect()
     }
 
     /// Every status effect applied to `player`, oldest first.
@@ -213,6 +232,10 @@ impl Server for MockServer {
 
     fn teleport(&self, player: PlayerId, to: Vec3) {
         self.push(Call::Teleport(player, to));
+    }
+
+    fn set_flight(&self, player: PlayerId, flight: Flight) {
+        self.push(Call::Flight(player, flight));
     }
 
     fn set_health(&self, player: PlayerId, health: f32, max: f32) {

--- a/events/smash/tests/contract.rs
+++ b/events/smash/tests/contract.rs
@@ -33,12 +33,15 @@ use smash::{
         damage::{Armor, DamageKind, DamageModule, Damaged, hurt},
         effect::{self, EffectModule},
         hud::HudModule,
+        jump::JumpModule,
         kit::{self, KitModule, KitStats},
         kits::StockKits,
         knockback::{Knockback, KnockbackModel, KnockbackModule, KnockbackTaken, Smashed},
         lives::{DeathCause, Lives, LivesModule, kill},
         lobby::{Lobby, LobbyModule, Phase},
-        player::{self, Health, OnGround, Player, PlayerModule, Position},
+        player::{
+            self, Energy, Health, JumpPressed, JumpsLeft, OnGround, Player, PlayerModule, Position,
+        },
         projectile::ProjectileModule,
         scoreboard::ScoreboardModule,
         selector::{self, SelectorModule, TAKEN_BLOCK},
@@ -102,12 +105,16 @@ fn contracts() -> Vec<Contract> {
             requires: &[],
             runtime_requires: &[],
             exercise: |world, player| {
-                // Ground state restores the double jump, and energy regenerates.
-                player.set(OnGround(false));
-                player.set(smash::module::player::JumpsLeft(0));
-                player.set(OnGround(true));
-                world.progress_time(0.05);
-                assert_eq!(player.cloned::<&smash::module::player::JumpsLeft>().0, 1);
+                // Energy regenerates. The double jump is `Jump`'s, below: this
+                // module owns the components it is played on and none of the
+                // rules.
+                player.set(Energy::full(10.0, 4.0));
+                player.get::<&mut Energy>(|energy| energy.current = 0.0);
+                world.progress_time(0.5);
+                assert!(
+                    player.cloned::<&Energy>().current > 0.0,
+                    "energy did not regenerate"
+                );
             },
         },
         Contract {
@@ -359,6 +366,45 @@ fn contracts() -> Vec<Contract> {
                 assert_eq!(
                     player.cloned::<&Lives>().0,
                     smash::module::lives::MAX_LIVES - 1
+                );
+            },
+        },
+        Contract {
+            name: "Jump",
+            import: |world| {
+                world.import::<JumpModule>();
+            },
+            // The counter and the mirrored press are `Player`'s, the jump
+            // power and the per-kit count are `Kit`'s, and the two components
+            // that say a player is spectating rather than playing are
+            // `Lives`'.
+            requires: &["Player", "Kit", "Lives"],
+            runtime_requires: &[],
+            exercise: |world, player| {
+                // A jump is spent and a jump is restored, in that order. Only
+                // the restore used to be checked here, and a restore passes
+                // with the whole mechanic absent -- which is exactly what it
+                // did until ENG-11440.
+                player.set(OnGround(true));
+                world.progress_time(0.05);
+                let allowance = player.cloned::<&JumpsLeft>().0;
+                assert!(allowance > 0, "landing did not hand back a jump");
+
+                player.set(OnGround(false));
+                player.set(JumpPressed(true));
+                world.progress_time(0.05);
+                assert_eq!(
+                    player.cloned::<&JumpsLeft>().0,
+                    allowance - 1,
+                    "a mid-air press spent no jump"
+                );
+
+                player.set(OnGround(true));
+                world.progress_time(0.05);
+                assert_eq!(
+                    player.cloned::<&JumpsLeft>().0,
+                    allowance,
+                    "landing did not put the jump back"
                 );
             },
         },

--- a/events/smash/tests/contract.rs
+++ b/events/smash/tests/contract.rs
@@ -399,6 +399,10 @@ fn contracts() -> Vec<Contract> {
                     "a mid-air press spent no jump"
                 );
 
+                // Cleared before landing, the way the mirror clears it once
+                // the game has answered the press, so the assertion below is
+                // about the restore and nothing else.
+                player.set(Flying(false));
                 player.set(OnGround(true));
                 world.progress_time(0.05);
                 assert_eq!(

--- a/events/smash/tests/contract.rs
+++ b/events/smash/tests/contract.rs
@@ -40,7 +40,7 @@ use smash::{
         lives::{DeathCause, Lives, LivesModule, kill},
         lobby::{Lobby, LobbyModule, Phase},
         player::{
-            self, Energy, Health, JumpPressed, JumpsLeft, OnGround, Player, PlayerModule, Position,
+            self, Energy, Flying, Health, JumpsLeft, OnGround, Player, PlayerModule, Position,
         },
         projectile::ProjectileModule,
         scoreboard::ScoreboardModule,
@@ -391,7 +391,7 @@ fn contracts() -> Vec<Contract> {
                 assert!(allowance > 0, "landing did not hand back a jump");
 
                 player.set(OnGround(false));
-                player.set(JumpPressed(true));
+                player.set(Flying(true));
                 world.progress_time(0.05);
                 assert_eq!(
                     player.cloned::<&JumpsLeft>().0,

--- a/events/smash/tests/jump.rs
+++ b/events/smash/tests/jump.rs
@@ -2,12 +2,16 @@
 //! nothing.
 //!
 //! The input is a serverbound abilities packet, which only a real client
-//! sends, so what these drive is the component `src/mirror.rs` turns that
-//! packet into. That leaves exactly one link uncovered here -- the mirror's own
-//! edge detection -- and `tools/smash-match.py` is where a real client closes
-//! it. Everything downstream of the press is here, on the `MockServer` call
-//! log, because what matters is not that the counter moved but that an impulse
-//! reached a client.
+//! sends, so what these drive is `Flying`, the component `src/mirror.rs` turns
+//! that packet into. Two links are therefore outside them: the mirror's copy
+//! and the adapter's write back onto hyperion's own `Flight`. Both are held by
+//! `Match.prove_double_jump` in `tools/smash-match.py`, and that is not a
+//! formality -- the first version of the mirror could never fire and every
+//! assertion in this file passed anyway.
+//!
+//! Everything downstream of the press is here, and on the `MockServer` call
+//! log rather than on the world, because what matters is not that the counter
+//! moved but that an impulse reached a client.
 
 mod harness;
 

--- a/events/smash/tests/jump.rs
+++ b/events/smash/tests/jump.rs
@@ -20,8 +20,10 @@ use glam::Vec3;
 use harness::{Game, TICK};
 use smash::{
     module::{
+        damage::MatchClock,
         jump,
         kit::{self, KitStats},
+        lives::{DeathCause, RespawnAt, kill},
         player::{Flying, JumpsLeft, MayFly, OnGround, Position},
     },
     server::{Flight, PlayerId, mock::Call},
@@ -403,5 +405,71 @@ fn a_dead_player_is_not_armed() {
         view.cloned::<&Position>().0,
         Vec3::new(0.0, 64.0, 0.0),
         "nothing should have moved them"
+    );
+}
+
+/// Dying in mid-air must not carry the jump you had, or the press you made,
+/// across the respawn.
+///
+/// Both halves of this are the same root cause and neither is visible from
+/// `a_dead_player_is_not_armed` above, which asserts a spectator is left alone
+/// and then stops. `MayFly` is a write-cache and `Flying` is a mirror, and
+/// while a player is dead the two systems that maintain them are filtered out
+/// by `RespawnAt`, so whatever was true at the moment of death is still there
+/// at the moment of return:
+///
+/// * The client resets its own abilities on the gamemode change respawning
+///   causes -- `GameType.updatePlayerAbilities` sets `mayfly = false`, out of
+///   band and without telling the server. A cache that still says `true` means
+///   `arm_double_jump` compares equal and sends nothing, and the player has a
+///   `JumpsLeft` their client will not spend. That is the mechanic failing in
+///   exactly the situation it exists for, because the normal way to die here is
+///   in mid-air and the first thing that happens to a fresh respawn is being
+///   knocked off again.
+/// * A press made on the tick of death is still `true` on the host, so the
+///   first tick the filter stops applying it is spent as a real jump, at the
+///   spawn point, from a keypress made before the player died.
+///
+/// The real-client leg cannot see either: `Match.prove_double_jump` runs in the
+/// hub before anybody has died.
+#[test]
+fn respawning_in_mid_air_hands_back_a_jump_the_client_can_actually_take() {
+    let mut game = Game::new();
+    let player = game.player("recovering", Vec3::new(0.0, 64.0, 0.0));
+    let id = game.world.entity_from_id(player).cloned::<&PlayerId>();
+    let view = game.world.entity_from_id(player);
+
+    // Airborne with a jump in hand, and a press in flight on the tick they die.
+    airborne(&game, player);
+    assert!(view.cloned::<&MayFly>().0, "should be armed before dying");
+    view.set(Flying(true));
+    kill(view, DeathCause::Void);
+
+    // The respawn is gated on the match clock, which only advances while the
+    // lobby says the game is running.
+    game.world.get::<&mut MatchClock>(|clock| clock.0 = 10.0);
+    game.world.progress_time(TICK);
+    assert!(
+        view.try_get::<&RespawnAt>(|r| r.0).is_none(),
+        "the respawn should have landed"
+    );
+
+    game.server.take();
+    // hyperion reaches the host through a teleport the client has to confirm,
+    // so `is_grounded` still reports the pre-death airborne position for a few
+    // ticks. This is the window the bug lives in, not an edge case.
+    view.set(OnGround(false));
+    game.advance(TICK * 3.0, 3);
+
+    assert!(
+        impulses(&game, id).is_empty(),
+        "a press made before dying was replayed at the spawn point: {:?}",
+        impulses(&game, id)
+    );
+    assert_eq!(
+        game.server.flight_of(id),
+        vec![Flight::Armed],
+        "a player who respawned in mid-air was never told they may jump, so the JumpsLeft they \
+         were handed is one the client cannot spend"
     );
 }

--- a/events/smash/tests/jump.rs
+++ b/events/smash/tests/jump.rs
@@ -1,0 +1,400 @@
+//! The mid-air jump: what a press costs, what it buys, and when it buys
+//! nothing.
+//!
+//! The input is a serverbound abilities packet, which only a real client
+//! sends, so what these drive is the component `src/mirror.rs` turns that
+//! packet into. That leaves exactly one link uncovered here -- the mirror's own
+//! edge detection -- and `tools/smash-match.py` is where a real client closes
+//! it. Everything downstream of the press is here, on the `MockServer` call
+//! log, because what matters is not that the counter moved but that an impulse
+//! reached a client.
+
+mod harness;
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use harness::{Game, TICK};
+use smash::{
+    module::{
+        jump,
+        kit::{self, KitStats},
+        player::{JumpPressed, JumpsLeft, MayFly, OnGround, Position},
+    },
+    server::{Flight, PlayerId, mock::Call},
+};
+
+/// A player in mid-air, holding whatever their kit allows them.
+///
+/// A grounded tick first, because `JumpsLeft` defaults to zero and landing is
+/// what fills it: somebody who has never touched the floor of this world has
+/// nothing to spend, which would make every assertion below pass for the wrong
+/// reason.
+fn airborne(game: &Game, player: Entity) {
+    let player = game.world.entity_from_id(player);
+    player.set(OnGround(true));
+    game.world.progress_time(TICK);
+    player.set(OnGround(false));
+    game.world.progress_time(TICK);
+}
+
+/// One press of the jump key, as the mirror reports one.
+///
+/// Set for a tick, which is the shape of the thing being simulated: the mirror
+/// writes the rising edge of the host's flying bit and it is true for one tick
+/// per double tap.
+fn press(game: &Game, player: Entity) {
+    game.world.entity_from_id(player).set(JumpPressed(true));
+    game.world.progress_time(TICK);
+}
+
+/// Every impulse the game asked the host to add to `player`.
+fn impulses(game: &Game, player: PlayerId) -> Vec<Vec3> {
+    game.server
+        .calls()
+        .iter()
+        .filter_map(|call| match call {
+            Call::AddVelocity(id, delta) if *id == player => Some(*delta),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The whole mechanic in one run: airborne, press, launched, and one poorer.
+#[test]
+fn a_mid_air_press_spends_one_jump_and_launches_the_player() {
+    let mut game = Game::new();
+    let player = game.player("jumper", Vec3::new(0.0, 64.0, 0.0));
+    let id = game.world.entity_from_id(player).cloned::<&PlayerId>();
+
+    airborne(&game, player);
+    assert_eq!(
+        game.world.entity_from_id(player).cloned::<&JumpsLeft>().0,
+        1,
+        "leaving the ground should not cost a jump"
+    );
+
+    game.server.take();
+    press(&game, player);
+
+    assert_eq!(
+        game.world.entity_from_id(player).cloned::<&JumpsLeft>().0,
+        0,
+        "the press should have spent the one jump"
+    );
+    let impulses = impulses(&game, id);
+    assert_eq!(
+        impulses.len(),
+        1,
+        "one press is one impulse, got {impulses:?}"
+    );
+    assert!(
+        impulses[0].y > 0.0,
+        "a double jump has to go up; got {:?}",
+        impulses[0]
+    );
+}
+
+/// A press that arrives while the player is standing on something buys
+/// nothing.
+///
+/// The client should never be able to send one -- permission is withdrawn on
+/// landing -- but a packet already in flight arrives after the landing tick,
+/// and the known Mineplex "triple jump" is that hole with a looser ground
+/// check under it.
+#[test]
+fn a_grounded_press_spends_nothing() {
+    let mut game = Game::new();
+    let player = game.player("grounded", Vec3::new(0.0, 64.0, 0.0));
+    let id = game.world.entity_from_id(player).cloned::<&PlayerId>();
+
+    game.world.progress_time(TICK);
+    game.server.take();
+    press(&game, player);
+
+    assert_eq!(
+        game.world.entity_from_id(player).cloned::<&JumpsLeft>().0,
+        1,
+        "a press on the ground should leave the counter alone"
+    );
+    assert!(
+        impulses(&game, id).is_empty(),
+        "a press on the ground launched the player anyway"
+    );
+}
+
+/// A player who has already used their jump gets no second one.
+///
+/// They are still answered across the seam, because whatever the game intended
+/// the client is flying at that instant and something has to put it down.
+#[test]
+fn a_player_out_of_jumps_gets_nothing() {
+    let mut game = Game::new();
+    let player = game.player("spent", Vec3::new(0.0, 64.0, 0.0));
+    let id = game.world.entity_from_id(player).cloned::<&PlayerId>();
+
+    airborne(&game, player);
+    press(&game, player);
+    game.server.take();
+
+    // A second press, with the counter already at zero.
+    press(&game, player);
+
+    assert!(
+        impulses(&game, id).is_empty(),
+        "a player with no jumps left was launched anyway"
+    );
+    assert_eq!(
+        game.server.flight_of(id),
+        vec![Flight::Disarmed],
+        "the client was left flying with nothing to spend"
+    );
+}
+
+/// Permission tracks "airborne with a jump left", and is pushed on change
+/// rather than every tick.
+#[test]
+fn flight_is_armed_on_leaving_the_ground_and_disarmed_once_spent() {
+    let mut game = Game::new();
+    let player = game.player("armer", Vec3::new(0.0, 64.0, 0.0));
+    let id = game.world.entity_from_id(player).cloned::<&PlayerId>();
+
+    // Grounded and holding a jump: nothing to say yet.
+    game.world.progress_time(TICK);
+    assert!(
+        game.server.flight_of(id).is_empty(),
+        "a player standing on the floor was told about flight"
+    );
+
+    airborne(&game, player);
+    // Several ticks in the air with the answer unchanged.
+    game.advance(TICK * 5.0, 5);
+    assert_eq!(
+        game.server.flight_of(id),
+        vec![Flight::Armed],
+        "the arming state should be pushed once, not once a tick"
+    );
+
+    press(&game, player);
+    assert_eq!(
+        game.server.flight_of(id),
+        vec![Flight::Armed, Flight::Disarmed],
+        "spending the last jump should take the permission back"
+    );
+
+    game.advance(TICK * 5.0, 5);
+    assert_eq!(
+        game.server.flight_of(id).len(),
+        2,
+        "an unchanged answer should not be resent"
+    );
+}
+
+/// Landing puts the jump back, which is what re-arms the whole mechanic.
+#[test]
+fn landing_restores_the_jump_and_re_arms_the_client() {
+    let mut game = Game::new();
+    let player = game.player("lander", Vec3::new(0.0, 64.0, 0.0));
+    let id = game.world.entity_from_id(player).cloned::<&PlayerId>();
+    let view = game.world.entity_from_id(player);
+
+    airborne(&game, player);
+    press(&game, player);
+    assert_eq!(view.cloned::<&JumpsLeft>().0, 0);
+
+    view.set(OnGround(true));
+    game.world.progress_time(TICK);
+    assert_eq!(
+        view.cloned::<&JumpsLeft>().0,
+        1,
+        "touching the ground is what re-arms it"
+    );
+
+    game.server.take();
+    view.set(OnGround(false));
+    game.world.progress_time(TICK);
+    assert_eq!(
+        game.server.flight_of(id),
+        vec![Flight::Armed],
+        "leaving the ground again should hand the permission back"
+    );
+}
+
+/// The Chicken's eight, which is why the count is a kit stat.
+///
+/// `[VERIFIED]` on the wiki: "Chicken is the only mob who can double jump eight
+/// times." A count that lived on the mechanic rather than on the kit could not
+/// express that at all, and this is what says so.
+#[test]
+fn the_chicken_flaps_eight_times_and_a_ninth_does_nothing() {
+    let mut game = Game::new();
+    let player = game.player("chicken", Vec3::new(0.0, 64.0, 0.0));
+    let id = game.world.entity_from_id(player).cloned::<&PlayerId>();
+    let view = game.world.entity_from_id(player);
+
+    let chicken = kit::by_name(&game.world, "Chicken").expect("the Chicken kit is registered");
+    kit::apply(&game.world, view, chicken);
+    assert_eq!(
+        view.cloned::<&JumpsLeft>().0,
+        8,
+        "picking the Chicken should hand over eight jumps"
+    );
+
+    airborne(&game, player);
+    game.server.take();
+    for _ in 0..8 {
+        press(&game, player);
+    }
+    assert_eq!(view.cloned::<&JumpsLeft>().0, 0);
+    assert_eq!(
+        impulses(&game, id).len(),
+        8,
+        "eight presses should be eight launches"
+    );
+
+    press(&game, player);
+    assert_eq!(
+        impulses(&game, id).len(),
+        8,
+        "the ninth flap should buy nothing"
+    );
+}
+
+/// Everybody else gets one, and picking a kit is what says so.
+#[test]
+fn an_ordinary_kit_gets_one_jump() {
+    let mut game = Game::new();
+    let player = game.player("wolf", Vec3::new(0.0, 64.0, 0.0));
+    let view = game.world.entity_from_id(player);
+
+    let wolf = kit::by_name(&game.world, "Wolf").expect("the Wolf kit is registered");
+    kit::apply(&game.world, view, wolf);
+    assert_eq!(view.cloned::<&JumpsLeft>().0, 1);
+}
+
+/// A jump is drawn and heard where it happened.
+///
+/// An invisible, silent double jump is the same bug as an invisible ability:
+/// the physics are right and the only symptom is that nobody watching can tell
+/// a recovery from a fall.
+#[test]
+fn a_jump_is_seen_and_heard_where_it_happened() {
+    let mut game = Game::new();
+    let at = Vec3::new(12.0, 70.0, -4.0);
+    let player = game.player("noisy", at);
+
+    airborne(&game, player);
+    game.server.take();
+    press(&game, player);
+
+    let calls = game.server.calls();
+    assert!(
+        calls.iter().any(
+            |call| matches!(call, Call::Particles(effect) if effect.origin().y >= at.y
+                && effect.origin().y < at.y + 1.0)
+        ),
+        "a jump drew nothing at the player's feet: {calls:?}"
+    );
+    let sounds = game.server.sounds();
+    assert_eq!(sounds.len(), 1, "a jump should make exactly one noise");
+    assert_eq!(sounds[0].1.id, smash::module::sound::DOUBLE_JUMP);
+    assert!(
+        sounds[0].0.distance(at) < 1.0,
+        "the jump was heard {:?} away from the player who took it",
+        sounds[0].0 - at
+    );
+}
+
+/// Controlled and uncontrolled are two different jumps, and the kit is what
+/// decides which.
+///
+/// Driven through the pure function rather than through two simulated players,
+/// because what is being compared is the pair of vectors and not where anybody
+/// ended up.
+#[test]
+fn a_controlled_jump_goes_where_the_player_is_looking() {
+    let plain = KitStats::default();
+    let steered = KitStats {
+        jump_control: true,
+        ..KitStats::default()
+    };
+    let look = Vec3::new(0.0, 0.0, 1.0);
+
+    let up = jump::impulse(plain, look);
+    assert_eq!(
+        up,
+        Vec3::Y * plain.jump_power,
+        "an uncontrolled jump goes straight up whatever the player is looking at"
+    );
+
+    let along = jump::impulse(steered, look);
+    assert!(
+        along.z > 0.0,
+        "a controlled jump should carry the player where they look; got {along:?}"
+    );
+    assert!(
+        along.y > 0.0,
+        "a controlled jump still has to gain height; got {along:?}"
+    );
+}
+
+/// A kit's jump power is the thing that reaches the client.
+///
+/// The whole of ENG-11440 was that every kit declared this number and nothing
+/// read it, so the assertion that matters is not that an impulse happened but
+/// that a heavier kit's is bigger.
+#[test]
+fn a_kit_with_more_jump_power_is_launched_further() {
+    let power_of = |name: &str| {
+        let mut game = Game::new();
+        let player = game.player(name, Vec3::new(0.0, 64.0, 0.0));
+        let id = game.world.entity_from_id(player).cloned::<&PlayerId>();
+        let view = game.world.entity_from_id(player);
+        let kit = kit::by_name(&game.world, name).expect("kit is registered");
+        kit::apply(&game.world, view, kit);
+        airborne(&game, player);
+        game.server.take();
+        press(&game, player);
+        impulses(&game, id)
+            .first()
+            .copied()
+            .unwrap_or(Vec3::ZERO)
+            .length()
+    };
+
+    // Slime declares 1.2 and the Iron Golem 0.9, both uncontrolled.
+    assert!(
+        power_of("Slime") > power_of("Iron Golem"),
+        "the Slime's higher jump power did not reach the client"
+    );
+}
+
+/// A player watching the match from the sky is left alone.
+///
+/// A spectator already flies, and an abilities packet that said otherwise
+/// would stick them to the floor of a game they are no longer in.
+#[test]
+fn a_dead_player_is_not_armed() {
+    let mut game = Game::new();
+    let player = game.player("dead", Vec3::new(0.0, 64.0, 0.0));
+    let id = game.world.entity_from_id(player).cloned::<&PlayerId>();
+    let view = game.world.entity_from_id(player);
+
+    view.set(smash::module::lives::RespawnAt(f32::MAX));
+    view.set(OnGround(false));
+    game.server.take();
+    game.advance(TICK * 3.0, 3);
+
+    assert!(
+        game.server.flight_of(id).is_empty(),
+        "a player waiting to respawn was sent an abilities packet"
+    );
+    assert!(
+        !view.cloned::<&MayFly>().0,
+        "a spectating player was armed for a double jump"
+    );
+    assert_eq!(
+        view.cloned::<&Position>().0,
+        Vec3::new(0.0, 64.0, 0.0),
+        "nothing should have moved them"
+    );
+}

--- a/events/smash/tests/jump.rs
+++ b/events/smash/tests/jump.rs
@@ -18,7 +18,7 @@ use smash::{
     module::{
         jump,
         kit::{self, KitStats},
-        player::{JumpPressed, JumpsLeft, MayFly, OnGround, Position},
+        player::{Flying, JumpsLeft, MayFly, OnGround, Position},
     },
     server::{Flight, PlayerId, mock::Call},
 };
@@ -39,12 +39,15 @@ fn airborne(game: &Game, player: Entity) {
 
 /// One press of the jump key, as the mirror reports one.
 ///
-/// Set for a tick, which is the shape of the thing being simulated: the mirror
-/// writes the rising edge of the host's flying bit and it is true for one tick
-/// per double tap.
+/// Set, ticked, and cleared, because that is what the mirror does with it: the
+/// game answers a press by clearing the host's flying bit, so the next mirror
+/// read is false again. Leaving it set would simulate a host that never got
+/// the answer, and the run would spend a jump every tick.
 fn press(game: &Game, player: Entity) {
-    game.world.entity_from_id(player).set(JumpPressed(true));
+    let player = game.world.entity_from_id(player);
+    player.set(Flying(true));
     game.world.progress_time(TICK);
+    player.set(Flying(false));
 }
 
 /// Every impulse the game asked the host to add to `player`.

--- a/events/smash/tests/sound.rs
+++ b/events/smash/tests/sound.rs
@@ -138,6 +138,7 @@ fn every_sound_id_is_one_a_vanilla_client_owns() {
     for (what, id) in [
         ("selection refused", sound::SELECTION_REFUSED),
         ("impact", sound::IMPACT),
+        ("double jump", sound::DOUBLE_JUMP),
         ("projectile hit", sound::PROJECTILE_HIT),
         ("ranged hitmarker", sound::RANGED_HITMARKER),
         ("countdown tick", sound::COUNTDOWN_TICK),

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -1208,11 +1208,13 @@ class Match:
     def prove_double_jump(self):
         """Take a real client into the air and press jump.
 
-        The one leg of the double jump no Rust test can reach. Everything under
-        `events/smash/tests/jump.rs` drives the component `src/mirror.rs`
-        writes; the packet that makes that component true, and the edge
-        detection that turns a held flying bit into one press, only exist when
-        a real client is on the other end of the socket.
+        The two links of the double jump no Rust test can reach. Everything
+        under `events/smash/tests/jump.rs` drives `Flying`, the component the
+        mirror writes; the packet that makes it true and the adapter's write
+        back onto hyperion's own `Flight` only exist when a real client is on
+        the other end of the socket. That is not a formality -- the first
+        version of the mirror could never fire, every Rust test passed, and
+        this is what said so.
 
         Both halves are asserted and the order matters. The server offering
         `CAN_FLY` while the player is airborne is what makes the press possible

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -99,6 +99,7 @@ C2S_CHAT_COMMAND = 0x07
 C2S_KEEP_ALIVE = 0x1C
 C2S_MOVE_PLAYER_POS = 0x1E
 C2S_MOVE_PLAYER_POS_ROT = 0x1F
+C2S_PLAYER_ABILITIES = 0x28
 C2S_PLAYER_ACTION = 0x29
 C2S_SET_CARRIED_ITEM = 0x35
 C2S_SWING = 0x3F
@@ -117,6 +118,7 @@ S2C_DISCONNECT = 0x20
 S2C_KEEP_ALIVE = 0x2C
 S2C_LEVEL_PARTICLES = 0x2F
 S2C_LOGIN = 0x31
+S2C_PLAYER_ABILITIES = 0x40
 S2C_PLAYER_POSITION = 0x48
 S2C_SET_ACTION_BAR_TEXT = 0x57
 S2C_SET_ENTITY_MOTION = 0x65
@@ -128,6 +130,14 @@ S2C_SYSTEM_CHAT = 0x79
 # `ServerboundMovePlayerPacket` packs the ground flag into a bitfield; bit 0 is
 # `ON_GROUND`, which is the only bit hyperion reads.
 ON_GROUND = 1
+
+# `Abilities#FLAG_CAN_FLY` and `#FLAG_FLYING`, the two bits of the abilities
+# byte that the double jump is built out of. The server sets `CAN_FLY` while a
+# mid-air jump is available and the client answers a double tap of the jump key
+# by sending `FLYING` back, which is the whole input: a vanilla client has no
+# other way to tell a server it wants to leave the ground twice.
+ABILITY_CAN_FLY = 4
+ABILITY_FLYING = 2
 
 # Blocks per tick, quantised to 15 bits per component with a shared integer
 # scale. `net.minecraft.network.LpVec3`, and the Rust side of it is
@@ -533,6 +543,9 @@ class MatchClient(base.Client):
         self.sounds = []
         self.last_position_sent = 0.0
         self.alive = True
+        # Whether the server has told this client it may take off. The server
+        # half of the double jump; `double_jump` is the client half.
+        self.may_fly = False
 
     def _log(self, line):
         print("%s [%-3s] %s" % (stamp(self.started), self.name, line), flush=True)
@@ -645,6 +658,18 @@ class MatchClient(base.Client):
             ),
         )
 
+    def double_jump(self):
+        """Double-tap the jump key, which is one abilities packet.
+
+        A vanilla client sends exactly this when the player presses jump in
+        mid-air with flight permitted -- `LocalPlayer#tick` flips
+        `abilities.flying` and `updateAbilities` puts the byte on the wire --
+        and it is the only mid-air jump input a client without a mod can
+        produce. Nothing here fakes a keypress: this *is* the packet.
+        """
+        self.log("-> double jump (abilities, flying)")
+        self.send(C2S_PLAYER_ABILITIES, struct.pack(">b", ABILITY_FLYING))
+
     def aim(self, yaw, pitch=0.0):
         self.yaw = yaw
         self.pitch = pitch
@@ -704,6 +729,7 @@ class Match:
             self.proof["every declared ability was seen"] = None
             self.proof["a projectile was drawn"] = None
             self.proof["the hub shoves you back inside"] = None
+            self.proof["a mid-air jump launched a real client"] = None
             self.proof["cooldowns refused a second use"] = None
         self.proof.update({
             "four in play": None,
@@ -909,6 +935,15 @@ class Match:
             text, _ = take_nbt_string(payload, 0)
             client.action_bar.append(text)
             client.log("<- action bar: %s" % text)
+        elif packet_id == S2C_PLAYER_ABILITIES:
+            # `ClientboundPlayerAbilitiesPacket`: one flags byte, then the two
+            # speeds nothing here reads.
+            flags = payload[0]
+            client.may_fly = bool(flags & ABILITY_CAN_FLY)
+            client.log(
+                "<- abilities flags=0x%02X (may fly: %s)"
+                % (flags, "yes" if client.may_fly else "no")
+            )
         elif packet_id == S2C_SET_ENTITY_MOTION:
             entity, offset = take_var_int(payload)
             motion, _ = take_lp_vec3(payload, offset)
@@ -1168,6 +1203,101 @@ class Match:
             )
 
         self.prove_boundary()
+        self.prove_double_jump()
+
+    def prove_double_jump(self):
+        """Take a real client into the air and press jump.
+
+        The one leg of the double jump no Rust test can reach. Everything under
+        `events/smash/tests/jump.rs` drives the component `src/mirror.rs`
+        writes; the packet that makes that component true, and the edge
+        detection that turns a held flying bit into one press, only exist when
+        a real client is on the other end of the socket.
+
+        Both halves are asserted and the order matters. The server offering
+        `CAN_FLY` while the player is airborne is what makes the press possible
+        at all, and a gate that only watched for the launch could not tell "the
+        jump does nothing" from "the client was never allowed to ask".
+        """
+        if not self.clients:
+            return
+        jumper = self.clients[0]
+        if jumper.entity_id is None:
+            return
+
+        # Level, before anything else. Three kits jump where the player is
+        # looking, and the sweep leaves whoever ran it aiming wherever its last
+        # ability wanted; a controlled jump taken looking at the floor is
+        # *supposed* to drive you into it, so a gate that inherited the sweep's
+        # aim would be red or green depending on which kit went last.
+        jumper.aim(SWEEP_YAW, 0.0)
+
+        # On the floor first: landing is what fills the counter, so a client
+        # that has spent the sweep in the air has nothing to spend.
+        jumper.on_ground = True
+        jumper.walk(
+            [(SWEEP_X, SWEEP_Y, SWEEP_Z)],
+            note="back on the ground before the jump",
+        )
+        self.wait_until(lambda: jumper.arrived(), 15.0)
+        self.wait(0.5)
+
+        # Up, and stay up. `is_grounded` is a block check on the server, so
+        # seven blocks over the hub floor is airborne by the server's own
+        # reckoning rather than by this client's claim.
+        jumper.on_ground = False
+        jumper.walk(
+            [(SWEEP_X, HUB_CLEAR_Y, SWEEP_Z)],
+            note="into the air for a double jump",
+        )
+        self.wait_until(lambda: jumper.arrived(), 15.0)
+
+        if not self.wait_until(lambda: jumper.may_fly, 5.0):
+            self.sweep_failures.append(
+                "%s was %.0f blocks off the hub floor with a jump in hand and "
+                "the server never sent ClientboundPlayerAbilities with CAN_FLY, "
+                "so a vanilla client would have no way to ask for the jump"
+                % (jumper.name, HUB_CLEAR_Y - SWEEP_Y)
+            )
+            self.land(jumper)
+            return
+
+        self.window_motions.clear()
+        jumper.double_jump()
+        # One tick to decode the packet, one for the game to answer it and one
+        # for the queued write to drain, with room to spare.
+        self.wait(1.0)
+
+        launch = self.window_motions.get(jumper.entity_id)
+        if launch is not None and launch[1] > 1e-4:
+            self.prove(
+                "a mid-air jump launched a real client",
+                "%s sent ServerboundPlayerAbilities(flying) %.0f blocks up and "
+                "the server answered with SetEntityMotion (%.3f, %.3f, %.3f)"
+                % ((jumper.name, HUB_CLEAR_Y - SWEEP_Y) + launch),
+            )
+        else:
+            self.sweep_failures.append(
+                "%s double-tapped jump in mid-air and the server sent no upward "
+                "velocity: motion=%r" % (jumper.name, launch)
+            )
+
+        # The jump is spent, so the permission has to come back off: a client
+        # left holding CAN_FLY is a client that can fly around the arena.
+        if not self.wait_until(lambda: not jumper.may_fly, 3.0):
+            self.sweep_failures.append(
+                "%s spent its only jump and the server left CAN_FLY set, so the "
+                "client can keep flying" % jumper.name
+            )
+
+        self.land(jumper)
+
+    def land(self, client):
+        """Put a client back on a sweep spot, so nothing after it reads one
+        stranded in the air."""
+        client.on_ground = True
+        client.walk([(SWEEP_X, SWEEP_Y, SWEEP_Z)])
+        self.wait_until(lambda: client.arrived(), 15.0)
 
     def prove_boundary(self):
         """Walk a client past the hub wall and prove it is shoved back.


### PR DESCRIPTION
Fixes ENG-11440.

## What was wrong

Smash had no double jump. Every part of the mechanic existed except the part
that jumps: fifteen kits declared `jump_power` and three declared
`jump_control`, `JumpsLeft` was registered, attached to every player by a
`With` trait and set to `1` in three places, and **nothing read any of it**.
No code spent a jump and no code applied an impulse.

Recovery from knockback is the whole game. A player launched off the map with
a jump left survives and one without it does not, so a mode that models the
counter and never spends it is a mode missing its defensive half.

## How it works

Vanilla creative flight with the flight taken out, which is how Mineplex's
`PerkDoubleJump` did it and needs no client mod. The server grants flight
permission while a player is airborne with a jump left; a vanilla client
answers a double tap of the jump key with a serverbound abilities packet; the
game turns that into an impulse instead of into flight.

* `server::Flight` and `Server::set_flight` are the new seam verb. Two states,
  `Armed` and `Disarmed`, rather than the protocol's two booleans: neither one
  leaves the player flying, so "keep flying" is not something this seam can be
  asked for.
* `mirror.rs` copies the host's flying bit onto a new `Flying` mirror.
* `module/jump.rs` is the behaviour, and only behaviour: `arm_double_jump`,
  `spend_double_jump`, `restore_double_jump`. It registers no components and
  imports the registration owners of every component it reads, per CLAUDE.md.
* `KitStats::jump_count`, so the Chicken's `[VERIFIED]` eight flaps are
  expressible. `kit::apply` and the respawn path read it instead of hardcoding
  one.
* `visuals::updraft` (`minecraft:small_gust` in a disc under the feet) and
  `sound::DOUBLE_JUMP` (`minecraft:entity.breeze.jump`).

Two deliberate departures from the citation, both marked in
`docs/smash-design.md` and at the constant:

1. `UtilAction.velocity`'s `yMax` of 1.0 is **not** implemented. Every
   uncontrolled kit declares `jump_power >= 0.9`, so with the `+0.2` lift a
   ceiling at 1.0 would clamp all twelve of them to an identical jump and the
   per-kit number would stop meaning anything -- which is the shape of bug this
   PR exists to fix.
2. The known "triple jump" is refused rather than reproduced: a press that
   arrives while the player is standing on something spends nothing.

## The gates, and each one watched red

**`events/smash/tests/jump.rs`**, eleven tests on the `MockServer` call log.
Broken deliberately with `jump_power: 0.0`:

```
---- a_mid_air_press_spends_one_jump_and_launches_the_player stdout ----
a double jump has to go up; got Vec3(0.0, 0.0, 0.0)
---- a_controlled_jump_goes_where_the_player_is_looking stdout ----
a controlled jump should carry the player where they look; got Vec3(0.0, 0.2, 0.0)
test result: FAILED. 9 passed; 2 failed
```

**`tests/contract.rs`**. The Player contract set `JumpsLeft(0)`, ticked and
asserted it was `1` again -- a check that passed with the entire feature
absent, because it exercised only the restore. That is now a Jump contract
that asserts a spend first. Broken deliberately by deleting `jumps.0 -= 1`:

```
every module runs with only what it declares, but these did not:
  Jump: assertion `left == right` failed: a mid-air press spent no jump
  left: 1
 right: 0
```

Note that the restore half stayed green throughout, which is exactly the hole.

**A real-client leg**, `Match.prove_double_jump` in `tools/smash-match.py`.

**This leg is what caught the one real bug in the change, and the unit tests
could not have.** The first version of the mirror computed the take-off as
`flight.is_flying && !tracking.last_tick_flying`. That edge can never fire:
hyperion decodes packets in `OnUpdate` and copies `is_flying` into
`last_tick_flying` in `PreStore`, both strictly after the smash mirror runs in
`OnLoad`, so there is no moment in the tick when the mirror can see the two
disagree. Eleven unit tests and the contract all passed, because they drive the
mirrored component directly and so never exercise the mirror at all. The double
jump was doing nothing whatsoever on a real client:

```
1.91s [P1 ] <- abilities flags=0x04 (may fly: yes)
1.93s [P1 ] -> double jump (abilities, flying)
... no SetEntityMotion
```

Green after the fix, in the leg's real position at the end of the whole
fifteen-kit sweep:

```
277.45s [P1 ] -> walking to (6.0, 65.0, -11.0)  back on the ground before the jump
278.06s [P1 ] -> walking to (6.0, 72.0, -11.0)  into the air for a double jump
279.24s PROVED a mid-air jump launched a real client: P1 sent
        ServerboundPlayerAbilities(flying) 7 blocks up and the server answered
        with SetEntityMotion (0.000, 1.000, 0.000)
```

It costs the gate about three seconds.

The leg asserts both halves in order -- the server offering `CAN_FLY` while the
player is airborne, and the launch that answers the press -- because a gate
that only watched for the launch could not tell "the jump does nothing" from
"the client was never allowed to ask".

## What was run

* `cargo test -p smash` -- 303 passed across 27 binaries.
* `cargo clippy --workspace --all-targets --all-features` -- clean.
* `nix run .#smash-e2e` -- boots the game and joins real clients. Run in both
  profiles. The dev-profile run also covers the ENG-11000 class, since a
  use-before-register would abort the boot; it cannot complete a full sweep for
  a reason that has nothing to do with this branch (ENG-11458, filed: a flecs
  generation passing 64 trips `minecraft_id`'s `debug_assert`), so the
  in-position verification above is from `HYPERION_PROFILE=release`, which is
  what the gate itself uses.
* `nix build .#checks.aarch64-darwin.smash-dev-boot-e2e` -- passed, though on a
  tree from before the mirror fix.

The release run does not come back all green, so here is the differential
against `origin/main` (d8df46f), same command, same machine:

| | this branch | origin/main |
|---|---|---|
| proved | **14 of 16** | 13 of 15 |
| `every declared ability did what it declared` | NOT PROVED | NOT PROVED |
| `match ended, back in the hub` | NOT PROVED | NOT PROVED |
| `a mid-air jump launched a real client` | **proved** | claim does not exist |

Both failures are identical on both sides. The first is `Cow / Mooshroom
Madness` and `Guardian / Target Laser declares buffs_melee and did not do it`,
word for word on both. The second is the script stalling on its `settled`
predicate -- `self.falls == len(self.deaths)`, a fall it initiated that never
produced a death -- and it is worth knowing that a match here can only end by
elimination: `LobbyConfig::default().match_timeout_seconds` is 1200 s against
the client's 300 s budget, so the timeout path is unreachable in this gate.

I ran the branch twice before taking that baseline, because a single red run is
not a finding. Both branch runs stalled at the same place (363.1 s and 365.5 s)
and both proved the double jump identically. Nothing here is a regression, and
the one column that changed changed upwards.

## Two defects found in review, fixed here

Both at the death/respawn boundary, both one root cause: a dead player is
filtered out of `arm_double_jump` and `spend_double_jump` by
`.without(RespawnAt)`, so they arrive at the respawn carrying whatever was true
when they died.

**A player who respawns still airborne had no double jump.** `MayFly` is a
write-cache of what the client was last told. Dying airborne freezes it at
`true`, while the client resets its own abilities out of band — vanilla's
`GameType.updatePlayerAbilities` sets `mayfly = false` on the gamemode change
that leaving spectator causes, and does not tell the server. `arm_double_jump`
then compared equal and sent nothing, so the player held a `JumpsLeft` their
client would refuse to spend. Not a narrow window: `respawn` reaches the host
through a teleport the client has to confirm, so `is_grounded` reports the
pre-death airborne position for several ticks. Dying in mid-air is the normal
way to die in this mode, and a fresh respawn is about to be knocked off again —
the mechanic failing in exactly the situation it exists for.

**A press made on the tick of death was replayed at the respawn.** Same cause
from the other side: the host's flying bit is still set, the adapter's
`SetFlight` is the only thing that ever clears it, and `mirror_player_state` has
no such filter, so it kept copying `is_flying = true` for the whole death
window. The first tick the filter lifted, it spent — a launch, a gust and a
sound at the spawn point from a keypress made before the player died.

The fix is three lines in `lives.rs`'s `respawn`: `MayFly(false)`,
`Flying(false)`, and `set_flight(Flight::Disarmed)`. **On the respawn transition
and deliberately not the death one** — `Op::Spectating` defers gamemode
publication to hyperion's roster, so a `Disarmed` pushed next to
`set_spectating(true)` races it and can tell a spectator it may not fly. At
respawn the two agree, because the default gamemode's abilities are
`mayfly = false` as well, so whichever packet the client applies last it ends up
agreeing with the seam.

Watched each fail on its own before fixing either. First, with nothing applied:

```
a press made before dying was replayed at the spawn point: [Vec3(0.0, 1.0, 0.0)]
```

then with only the `Flying`/`set_flight` half in:

```
a player who respawned in mid-air was never told they may jump, so the
JumpsLeft they were handed is one the client cannot spend
  left: []
 right: [Armed]
```

`a_dead_player_is_not_armed` could not see either: it asserts a spectator is
left alone and stops. Neither could the real-client leg — `prove_double_jump`
runs in the hub before anybody has died.

## Why the level-based mirror is safe

Stronger than "we clear the bit in the same tick", which is only true of the
tick. The durable guard is the `allow: false` written *alongside* it, because
`handlers.rs:440` computes `is_flying = packet.is_flying() && flight.allow`.
Once `allow` is false the client physically cannot re-raise the bit however many
packets it sends, so a level read as a press cannot repeat.

## What arming costs

Counted off the `MockServer` log; double for packets on the wire, given
ENG-11460:

| | seam calls | packets |
|---|---|---|
| an **ordinary vanilla jump**, nobody presses anything | 2 | **4** |
| a Chicken's eight flaps and the landing | 9 | **18** |

The first row is the one to know: arming is driven by leaving the ground, not by
pressing anything, so every jump every player makes now costs four abilities
packets whether or not a double jump is involved. That is the whole of why
ENG-11460 stops being harmless, and the numbers are now in that ticket.

This does not make ENG-11458 worse — the double jump mints no entities, since
`visuals::updraft` broadcasts rather than using the entity-minting emitter.

## This PR touches `CLAUDE.md`

Deliberately, and flagging it because a repo-wide instruction file is not an
ordinary file. The ordering hazard above is not discoverable from the code you
are writing when you walk into it -- you write a rising edge in a mirror, every
test goes green, and nothing tells you the expression is a constant `false`. So
it is recorded in three places, in descending order of how likely you are to be
looking at it: the module documentation of `mirror.rs` with the phase table, the
declaration of `Flying`, and one section in `CLAUDE.md` beside the existing
flecs registration convention, which is the same category of rule.

Disarm auto-merge if you would rather that section came separately.

## Filed rather than fixed

* **ENG-11458** -- the dev profile cannot survive a full smash match, as above.
* **ENG-11460** -- every `set(Flight)` puts two identical
  `ClientboundPlayerAbilities` on the wire, because the two `flecs::OnSet`
  observers at `simulation/mod.rs:608-641` each name both `Flight` and
  `FlyingSpeed` and either write fires both. Harmless until now because almost
  nothing set `Flight`; the numbers above are why it stops being.
* **ENG-11470** -- `match ended, back in the hub` has stopped proving anything,
  found while establishing that this branch did not break it.
* **ENG-11478** -- `ServerHandle` and `PlayerId` are registered only in
  `SmashModule`, a behaviour module nothing can import without a cycle, so the
  flecs import DAG does not cover them and `contract.rs::core` hand-registers
  them instead. Pre-existing (`lives.rs` has the identical dependency) and not
  fixed here, but worth the sentence it was filed with: the guard we think we
  have for that class has a manual patch under it.

## Which tree the real-client proof came from

The `SetEntityMotion (0.000, 1.000, 0.000)` above was measured on this branch
rebased onto **6b201a9**, with the respawn fix in. Main then moved again to
**94933ff** (#1098, the fleet deployment) while that run was going, so the
branch is now rebased one commit further than the tree the run compiled.

Stating it rather than glossing it, because "re-verify on the tree that will
merge" is the whole point. The proof carries in this case and the reason is
checkable: **#1098 touches no Rust at all** — `flake.nix` plus `nix/fleet/*`,
nothing under `events/`, `crates/` or `tools/` — and it modifies no line of the
e2e harness (`smash-e2e`, `runners`, `e2eOffsets`, `HYPERION_E2E`,
`gameBinaries`, `e2e.mkCheck` are all untouched). The game binary under test and
the command that drove it are identical. That is a different situation from the
6b201a9 rebase, which went through the adapter and did need a re-run.

Say the word if you would rather have the literal run on 94933ff anyway; it is
about ten minutes.

## Not verified

`smash-dev-boot-e2e` passed as a nix check, but on the tree from before the
mirror fix -- the run took long enough that the source had moved under it. The
dev-profile boot on the final tree is covered by `nix run .#smash-e2e`, which
compiles and boots the same `debug_assertions`-on binary and had real clients
join it.
