### PR TITLE
feat(smash): health regeneration and hunger, and a gate for every KitStats field (ENG-11450)

### DIFF
--- a/docs/smash-design.md
+++ b/docs/smash-design.md
@@ -153,8 +153,38 @@ on purpose: the old code ran it through armour, which let high-armour kits
 outlast everyone in a stalled game, and the relaunch fixed it. There is no
 sudden death in Super Smash Mobs; the starve timer is what it has instead.
 
+`[WIKI]` The bar is not a one-way clock: "if you do not attack, your hunger bar
+will start depleting, which can be filled back up by hitting other mobs with
+melee or your special skills", and the game's own front page leads with "attack
+enemies to refill your hunger bar". *How much* a hit puts back is stated
+nowhere, so `vitals::FOOD_PER_HIT` is `[APPROXIMATED]` at one food point --
+half a shank, exactly what one drain tick takes off, so a hit buys back an
+interval. It is the only number in the mechanic that is ours.
+
 `Armor::apply` and `DamageKind::is_reduced_by_armor` in
-`events/smash/src/module/damage.rs`.
+`events/smash/src/module/damage.rs`; the drain, the starve tick and the refill
+in `events/smash/src/module/vitals.rs`.
+
+### Regeneration is health per second, and the wiki is not decisive about it
+
+`[SHEET]` + `[WIKI]` Every kit carries a regeneration rate and they are all
+different: 0.40 for Creeper down to 0.15 for Blaze. The wiki lists them as bare
+"0.35 Regen Per Second" with no unit.
+
+`[INFERRED]` The unit implemented is health points -- half-hearts -- per second,
+which is what the kit table below means by "Regen (HP/s)" and the unit the rest
+of the crate counts health in. The wiki's Slime page glosses Slime's 0.35 as
+"regenerating 1 heart in just four seconds", and that fits neither reading:
+half-hearts per second gives 5.7 s to the heart, hearts per second gives 2.9 s.
+One loose sentence is not enough to move the unit, and the disagreement is
+recorded rather than resolved.
+
+Nothing in any source gates regeneration on being out of combat, and the design
+argues against it: health *is* the knockback percentage here, so a regeneration
+that stopped during a fight would be a percentage that only ever went up.
+`vitals::VitalsModule` therefore heals continuously, in combat and out, and
+stops for exactly one condition -- zero health, because the kill plane reads
+`Health::is_dead` in the same tick and a heal off zero would cancel deaths.
 
 ---
 
@@ -519,11 +549,21 @@ Stated plainly, because these are the parts nobody can see from the code.
    `Blocks`.
 2. **No Smash Crystal spawning.** The ultimates exist and are granted through the
    ordinary relationship; the beacon, the descent and the pickup are not built.
-3. **No hunger drain.** `hunger_interval` is carried on every kit and
-   `STARVE_DAMAGE` is defined, but nothing ticks it.
-4. **Assists.** Only the last hit is tracked.
-5. **Seventeen of the twenty-one kits.**
-6. **Teams and the Dominate variant.**
+3. **Assists.** Only the last hit is tracked.
+4. **Seventeen of the twenty-one kits.**
+5. **Teams and the Dominate variant.**
+
+Three things left this list on the same night and the list is shorter than the
+three, because two of them were one entry. Health regeneration and the hunger
+drain are `events/smash/src/module/vitals.rs` (ENG-11450); the double jump is
+`events/smash/src/module/jump.rs` (ENG-11440).
+
+What is still wrong, and is now wrong *visibly* rather than merely declared:
+the per-kit `hunger_interval` values. The changelog puts Zombie, Snowman and
+Wither Skeleton at 7 s and Spider, Wolf and Chicken at 6.25 s, and all six are
+still on the 7.75 s default. That was dead data disagreeing with a changelog
+while nothing read the field; it is a balance defect now that something does.
+ENG-11463, filed rather than folded in.
 
 ---
 

--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -443,14 +443,33 @@ impl Module for SmashAdapterModule {
                 for (player, resolved) in &bars {
                     world.entity_from_id(*player).set(*resolved);
                 }
+                // The same hazard as `bars` above, one type along, and the
+                // reason this is a map rather than a component read per op:
+                // `set(Vitals)` is deferred too, so a `SetHealth` and a
+                // `SetFood` for one player in one drain -- a player who traded
+                // hits, which is a tick that happens constantly -- would have
+                // the second read the component as it stood before the first.
+                // It would send the *default* full health beside the new food
+                // level and snap the client's health bar to full for a frame.
+                // Carried across the loop and written back once per player.
+                let mut vitals: HashMap<Entity, Vitals> = HashMap::new();
                 for op in drained {
-                    apply(world, compose, op, &bars);
+                    apply(world, compose, op, &bars, &mut vitals);
+                }
+                for (player, held) in &vitals {
+                    world.entity_from_id(*player).set(*held);
                 }
             });
     }
 }
 
-fn apply(world: WorldRef<'_>, compose: &Compose, op: Op, bars: &HashMap<Entity, PlayerBars>) {
+fn apply(
+    world: WorldRef<'_>,
+    compose: &Compose,
+    op: Op,
+    bars: &HashMap<Entity, PlayerBars>,
+    vitals: &mut HashMap<Entity, Vitals>,
+) {
     match op {
         Op::AddVelocity { player, delta } => {
             let entity = world.entity_from_id(player);
@@ -503,25 +522,22 @@ fn apply(world: WorldRef<'_>, compose: &Compose, op: Op, bars: &HashMap<Entity, 
             // component is what other players see over the victim's head, and
             // SetHealth is the only thing that moves the victim's own bar.
             entity.set(Health::new(health));
-            let scaled = if max > 0.0 { health * 20.0 / max } else { 0.0 };
-            let vitals = Vitals {
-                scaled_health: scaled,
-                ..vitals_of(entity)
+            let held = vitals.entry(player).or_insert_with(|| vitals_of(entity));
+            held.scaled_health = if max > 0.0 {
+                health * VANILLA_HEALTH / max
+            } else {
+                0.0
             };
-            entity.set(vitals);
-            send_vitals(entity, compose, vitals);
+            send_vitals(entity, compose, *held);
         }
         Op::SetFood { player, food } => {
             let entity = world.entity_from_id(player);
             if !entity.is_alive() {
                 return;
             }
-            let vitals = Vitals {
-                food,
-                ..vitals_of(entity)
-            };
-            entity.set(vitals);
-            send_vitals(entity, compose, vitals);
+            let held = vitals.entry(player).or_insert_with(|| vitals_of(entity));
+            held.food = food;
+            send_vitals(entity, compose, *held);
         }
         Op::Status { player, status } => {
             let entity = world.entity_from_id(player);

--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -80,6 +80,10 @@ enum Op {
         health: f32,
         max: f32,
     },
+    SetFood {
+        player: Entity,
+        food: u8,
+    },
     Status {
         player: Entity,
         status: Status,
@@ -138,6 +142,68 @@ enum Op {
 #[derive(Component)]
 pub struct OpQueue(Arc<Mutex<Vec<Op>>>);
 
+/// Both halves of the client's `SetHealth` packet, as last sent.
+///
+/// Vanilla carries health, food and saturation in one message, and the game
+/// moves health and food on unrelated clocks -- health on every hit, food once
+/// every seven seconds -- so whichever half is not changing has to be
+/// remembered to be re-sent alongside the half that is. On the player entity
+/// because that is where the rest of a player's mirrored state already lives.
+///
+/// The defaults are what a client that has never been told anything is already
+/// drawing, so the first push of either half sends the other one unchanged
+/// rather than blanking it.
+#[derive(Component, Debug, Copy, Clone)]
+struct Vitals {
+    /// Health on vanilla's twenty-point bar, which is the only scale the
+    /// packet has. The game's own maximum is a kit stat and can be anything.
+    scaled_health: f32,
+    /// Food points, `0..=20`.
+    food: u8,
+}
+
+impl Default for Vitals {
+    fn default() -> Self {
+        Self {
+            scaled_health: VANILLA_HEALTH,
+            food: VANILLA_FOOD,
+        }
+    }
+}
+
+/// A full vanilla health bar, and the scale everything is sent on.
+const VANILLA_HEALTH: f32 = 20.0;
+
+/// A full vanilla food bar.
+const VANILLA_FOOD: u8 = 20;
+
+/// Saturation, which this game has no mechanic for.
+///
+/// Sent as a constant because the field is not optional and a client uses it
+/// only to decide how fast the food bar wobbles. Below the drain rate of any
+/// kit, so it never delays a hunger tick.
+const VANILLA_SATURATION: f32 = 5.0;
+
+/// What was last sent to `entity`, or the defaults if nothing has been.
+fn vitals_of(entity: EntityView<'_>) -> Vitals {
+    entity
+        .try_get::<&Vitals>(|vitals| *vitals)
+        .unwrap_or_default()
+}
+
+/// Send the whole packet after one half of it changed.
+fn send_vitals(entity: EntityView<'_>, compose: &Compose, vitals: Vitals) {
+    let Some(connection) = entity.try_get::<&ConnectionId>(|id| *id) else {
+        return;
+    };
+    let packet = SetHealth {
+        health: vitals.scaled_health,
+        food: i32::from(vitals.food),
+        saturation: VANILLA_SATURATION,
+    };
+    let _unused = protocol::send(compose, connection, PacketId::SetHealth.to_raw(), &packet);
+}
+
 /// hyperion's implementation of the game's seam.
 pub struct HyperionServer {
     ops: Arc<Mutex<Vec<Op>>>,
@@ -189,6 +255,13 @@ impl Server for HyperionServer {
             player: entity_of(player),
             health,
             max,
+        });
+    }
+
+    fn set_food(&self, player: PlayerId, food: u8) {
+        self.push(Op::SetFood {
+            player: entity_of(player),
+            food,
         });
     }
 
@@ -286,6 +359,7 @@ impl Module for SmashAdapterModule {
 
         world.component::<OpQueue>().add_trait::<flecs::Singleton>();
         world.component::<PlayerBars>();
+        world.component::<Vitals>();
 
         let ops = Arc::new(Mutex::new(Vec::new()));
         world.set(OpQueue(Arc::clone(&ops)));
@@ -429,17 +503,25 @@ fn apply(world: WorldRef<'_>, compose: &Compose, op: Op, bars: &HashMap<Entity, 
             // component is what other players see over the victim's head, and
             // SetHealth is the only thing that moves the victim's own bar.
             entity.set(Health::new(health));
-            let Some(connection) = entity.try_get::<&ConnectionId>(|id| *id) else {
-                return;
-            };
             let scaled = if max > 0.0 { health * 20.0 / max } else { 0.0 };
-            let packet = SetHealth {
-                health: scaled,
-                food: 20,
-                saturation: 5.0,
+            let vitals = Vitals {
+                scaled_health: scaled,
+                ..vitals_of(entity)
             };
-            let _unused =
-                protocol::send(compose, connection, PacketId::SetHealth.to_raw(), &packet);
+            entity.set(vitals);
+            send_vitals(entity, compose, vitals);
+        }
+        Op::SetFood { player, food } => {
+            let entity = world.entity_from_id(player);
+            if !entity.is_alive() {
+                return;
+            }
+            let vitals = Vitals {
+                food,
+                ..vitals_of(entity)
+            };
+            entity.set(vitals);
+            send_vitals(entity, compose, vitals);
         }
         Op::Status { player, status } => {
             let entity = world.entity_from_id(player);

--- a/events/smash/src/lib.rs
+++ b/events/smash/src/lib.rs
@@ -30,7 +30,7 @@ use crate::module::{
     damage::DamageModule, effect::EffectModule, hud::HudModule, jump::JumpModule, kit::KitModule,
     kits::StockKits, knockback::KnockbackModule, lives::LivesModule, lobby::LobbyModule,
     player::PlayerModule, projectile::ProjectileModule, scoreboard::ScoreboardModule,
-    selector::SelectorModule, sound::SoundModule,
+    selector::SelectorModule, sound::SoundModule, vitals::VitalsModule,
 };
 
 /// The whole game.
@@ -61,6 +61,9 @@ impl Module for SmashModule {
         // whose `MatchClock` every effect's deadline is measured against.
         world.import::<EffectModule>();
         world.import::<KitModule>();
+        // After the kits, whose `apply` is what puts a regeneration rate and a
+        // hunger interval on a player in the first place.
+        world.import::<VitalsModule>();
         world.import::<ArenaModule>();
         world.import::<LivesModule>();
         // After `Lives`: the double jump reads the two components that say a

--- a/events/smash/src/module.rs
+++ b/events/smash/src/module.rs
@@ -16,3 +16,4 @@ pub mod scoreboard;
 pub mod selector;
 pub mod sound;
 pub mod visuals;
+pub mod vitals;

--- a/events/smash/src/module/kit.rs
+++ b/events/smash/src/module/kit.rs
@@ -24,9 +24,9 @@ use crate::{
         knockback::KnockbackTaken,
         player::{Energy, Health, JumpsLeft},
         sound::{self, Levels, PlaysOnCast, PlaysOnDeath, PlaysOnHurt, PlaysOnSelect},
-        vitals::{Hunger, Regen, VitalsComponentsModule},
+        vitals::{FULL, Hunger, Regen, VitalsComponentsModule},
     },
-    server::HotbarItem,
+    server::{HotbarItem, PlayerId, ServerHandle},
 };
 
 /// Tag on kit prefabs.
@@ -504,6 +504,14 @@ pub fn apply(world: &World, player: EntityView<'_>, kit: EntityView<'_>) {
         // half an old kit's clock is nobody's number.
         .set(Hunger::full(stats.hunger_interval))
         .set(JumpsLeft(stats.jump_count));
+
+    // The bar the line above just replaced, told to the player whose bar it is.
+    // `Health` reaches the client on its own through the adapter's `OnSet`
+    // mirror; food has no such mirror, so every write that replaces the whole
+    // bar says so here. `tests/kit_stats.rs` holds both of them to it.
+    if let Some(id) = player.try_get::<&PlayerId>(|id| *id) {
+        world.get::<&ServerHandle>(|server| server.set_food(id, FULL));
+    }
 
     if let Some((max, regen)) = stats.energy {
         player.set(Energy::full(max, regen));

--- a/events/smash/src/module/kit.rs
+++ b/events/smash/src/module/kit.rs
@@ -24,6 +24,7 @@ use crate::{
         knockback::KnockbackTaken,
         player::{Energy, Health, JumpsLeft},
         sound::{self, Levels, PlaysOnCast, PlaysOnDeath, PlaysOnHurt, PlaysOnSelect},
+        vitals::{Hunger, Regen, VitalsComponentsModule},
     },
     server::HotbarItem,
 };
@@ -498,6 +499,10 @@ pub fn apply(world: &World, player: EntityView<'_>, kit: EntityView<'_>) {
         .set(Armor(stats.armor))
         .set(KnockbackTaken(stats.knockback_taken))
         .set(Health::full(stats.max_health))
+        .set(Regen(stats.regen))
+        // A fresh bar, because choosing a kit is choosing its drain rate and
+        // half an old kit's clock is nobody's number.
+        .set(Hunger::full(stats.hunger_interval))
         .set(JumpsLeft(stats.jump_count));
 
     if let Some((max, regen)) = stats.energy {
@@ -702,6 +707,12 @@ pub struct KitModule;
 impl Module for KitModule {
     fn module(world: &World) {
         world.module::<Self>("smash::Kit");
+
+        // `apply` copies the kit's regeneration rate and hunger interval onto
+        // the player, so the components those land in have to exist before
+        // anybody chooses a kit. Registration only: which systems tick them is
+        // `VitalsModule`'s business and not a kit's.
+        world.import::<VitalsComponentsModule>();
 
         // A `/kit` completion is a query over whatever carries this tag, and
         // this is the one place that says what a kit's name is. Nothing else

--- a/events/smash/src/module/lives.rs
+++ b/events/smash/src/module/lives.rs
@@ -369,14 +369,26 @@ impl Module for LivesModule {
 
                 world.get::<&ServerHandle>(|server| {
                     server.particles(visuals::death(at));
-                    match killer_name.as_deref() {
-                        Some(killer_name) => server.broadcast(
+                    // On the *cause* and not merely on whether somebody gets
+                    // the kill, which is how `hud::death_title` has always read
+                    // it. Branching on the killer alone announced every
+                    // unattributed death as a fall, so a player who starved was
+                    // told "nobody to blame but yourself" on their own screen
+                    // while the arena was told they fell off the map. The third
+                    // arm was unreachable until hunger shipped and is routine
+                    // now.
+                    match (killer_name.as_deref(), cause) {
+                        (Some(killer_name), _) => server.broadcast(
                             Channel::Chat,
                             Text::text(format!("{name} was smashed by {killer_name}!")),
                         ),
-                        None => server.broadcast(
+                        (None, DeathCause::Void) => server.broadcast(
                             Channel::Chat,
                             Text::text(format!("{name} fell out of bounds!")),
+                        ),
+                        (None, DeathCause::Damage) => server.broadcast(
+                            Channel::Chat,
+                            Text::text(format!("{name} had nobody to blame but themselves!")),
                         ),
                     }
                     server.set_spectating(*player, true);

--- a/events/smash/src/module/lobby.rs
+++ b/events/smash/src/module/lobby.rs
@@ -24,6 +24,7 @@ use crate::{
         lives::{Eliminated, InvulnerableUntil, Lives, Placement, RespawnAt},
         player::{Health, Player, Position},
         selector, sound,
+        vitals::{Hunger, VitalsComponentsModule},
     },
     server::{Channel, NamedColor, PlayerId, ServerHandle, Sound, SoundCategory, Text},
 };
@@ -344,6 +345,10 @@ impl Module for LobbyModule {
     fn module(world: &World) {
         world.module::<Self>("smash::Lobby");
 
+        // The end of a match refills every food bar, so the component that
+        // holds one has to be registered before `reset` first queries for it.
+        world.import::<VitalsComponentsModule>();
+
         world.component::<Lobby>().add_trait::<flecs::Singleton>();
         world
             .component::<LobbyConfig>()
@@ -519,15 +524,22 @@ fn scatter(world: &WorldRef<'_>) {
 /// * A stale [`InvulnerableUntil`] is the same arithmetic the other way: it
 ///   makes them untouchable, and immune to the kill plane, for that long
 ///   instead.
+///
+/// The food bar is the fourth. Hunger is deliberately *not* refilled by dying
+/// -- an anti-stall clock a player can reset by throwing a life away is not a
+/// clock -- so the only thing that ever refills it is landing a hit, and the
+/// end of a match. Without this a second match starts with whatever everyone
+/// had left, and somebody spawns already starving.
 fn reset(world: &WorldRef<'_>) {
     world.get::<&mut MatchClock>(|clock| clock.0 = 0.0);
     world
-        .query::<(&mut Lives, &mut Health)>()
+        .query::<(&mut Lives, &mut Health, &mut Hunger)>()
         .with(Player::id())
         .build()
-        .each_entity(|player, (lives, health)| {
+        .each_entity(|player, (lives, health, hunger)| {
             *lives = Lives::default();
             health.current = health.max;
+            *hunger = Hunger::full(hunger.interval);
             player.remove(Eliminated::id());
             player.remove(Placement::id());
             player.remove(RespawnAt::id());

--- a/events/smash/src/module/lobby.rs
+++ b/events/smash/src/module/lobby.rs
@@ -532,17 +532,29 @@ fn scatter(world: &WorldRef<'_>) {
 /// had left, and somebody spawns already starving.
 fn reset(world: &WorldRef<'_>) {
     world.get::<&mut MatchClock>(|clock| clock.0 = 0.0);
+    // Refilling the bar is half the job; the client draws whatever it was last
+    // sent, so a refill nobody is told about leaves everyone looking at the
+    // drained bar from the previous match until the next drain tick moves it.
+    // Collected here and pushed below rather than from inside the query, which
+    // is holding `Health` open for the damage path the seam can reach.
+    let mut refilled = Vec::new();
     world
-        .query::<(&mut Lives, &mut Health, &mut Hunger)>()
+        .query::<(&mut Lives, &mut Health, &mut Hunger, &PlayerId)>()
         .with(Player::id())
         .build()
-        .each_entity(|player, (lives, health, hunger)| {
+        .each_entity(|player, (lives, health, hunger, id)| {
             *lives = Lives::default();
             health.current = health.max;
             *hunger = Hunger::full(hunger.interval);
+            refilled.push((*id, hunger.food));
             player.remove(Eliminated::id());
             player.remove(Placement::id());
             player.remove(RespawnAt::id());
             player.remove(InvulnerableUntil::id());
         });
+    world.get::<&ServerHandle>(|server| {
+        for (id, food) in refilled {
+            server.set_food(id, food);
+        }
+    });
 }

--- a/events/smash/src/module/vitals.rs
+++ b/events/smash/src/module/vitals.rs
@@ -1,0 +1,300 @@
+//! The two clocks that run on a player for as long as a match does.
+//!
+//! Health regeneration and hunger are the only things in Super Smash Mobs that
+//! change a player's condition without anybody doing anything, and they pull in
+//! opposite directions. Regen slowly undoes the knockback percentage a player
+//! has accumulated, so a fight you walk away from is a fight you recover from.
+//! Hunger makes walking away cost something, and is what Mineplex has instead
+//! of sudden death: `[SOURCE]` + `[changelog]` there is no timer that ends a
+//! stalled match, only a food bar that empties and then kills everyone still
+//! standing around.
+//!
+//! Both were declared on every kit and implemented by nothing until ENG-11450.
+//! `KitStats::regen` had sixteen distinct tuned values and no reader at all.
+
+use flecs_ecs::prelude::*;
+
+use crate::{
+    module::{
+        damage::{DamageKind, Damaged, STARVE_DAMAGE, hurt},
+        knockback::{Knockback, Smashed},
+        lobby::{Lobby, Phase},
+        player::{Health, Player, Position},
+    },
+    server::{PlayerId, ServerHandle},
+};
+
+/// Health points healed per second, copied off the kit's `regen`.
+///
+/// `[INFERRED]` The unit is health points -- half-hearts -- per second, the
+/// same unit [`Health`] is counted in, which is what the kit table in
+/// `docs/smash-design.md` means by its "Regen (HP/s)" column. The wiki lists
+/// the stat as bare numbers ("0.35 Regen Per Second") and its Slime page
+/// glosses Slime's 0.35 as "regenerating 1 heart in just four seconds". That
+/// prose fits neither reading: half-hearts per second gives 5.7 s to the heart
+/// and hearts per second gives 2.9 s. One loose sentence is not enough to move
+/// off the unit the rest of this crate already counts health in, so it stays,
+/// and the disagreement is written down here rather than being rediscovered.
+///
+/// A component on the player rather than a read through `(Playing, kit)` for
+/// the same reason [`crate::module::knockback::KnockbackTaken`] is one: it is
+/// a number a kit may later want to change mid-match.
+#[derive(Component, Debug, Default, Copy, Clone, PartialEq)]
+pub struct Regen(pub f32);
+
+/// A full food bar, in vanilla's food points: ten shanks of two points each.
+pub const FULL: u8 = 20;
+
+/// Seconds between starve ticks once the bar is empty.
+///
+/// `[SOURCE]` + `[changelog]` "Hunger now deals true damage (0.5 hearts per
+/// tick)". Half a heart is [`STARVE_DAMAGE`], and the tick is vanilla's
+/// once-a-second starvation tick, which is the clock Mineplex left alone.
+pub const STARVE_INTERVAL: f32 = 1.0;
+
+/// Food points a landed hit puts back.
+///
+/// `[APPROXIMATED]`. That hitting people feeds you is not a guess -- the wiki
+/// is explicit that the bar "can be filled back up by hitting other mobs with
+/// melee or your special skills", and the game's own front page leads with
+/// "attack enemies to refill your hunger bar" -- but no source anywhere states
+/// the amount. One point is half a shank, which is exactly what one drain tick
+/// takes away, so the rule this ships with is *a hit buys back an interval*:
+/// a player landing a hit more often than every 7.75 seconds never starves,
+/// and one who stops fighting has about 155 seconds before the bar is empty.
+/// Tune this and nothing else changes; it is deliberately the only number in
+/// the mechanic that is ours.
+pub const FOOD_PER_HIT: u8 = 1;
+
+/// A player's food bar and the clock that drains it.
+///
+/// One component and not three, because a kit change resets all of it at once
+/// and there is no state where two of the three are current and the third is
+/// from the previous kit.
+#[derive(Component, Debug, Copy, Clone, PartialEq)]
+pub struct Hunger {
+    /// Food points remaining, <code>0..=[FULL]</code>.
+    pub food: u8,
+    /// Seconds between losing one food point. The kit's `hunger_interval`.
+    pub interval: f32,
+    /// Seconds accumulated toward the next drain, or toward the next starve
+    /// tick once [`Hunger::food`] is zero.
+    pub elapsed: f32,
+}
+
+impl Hunger {
+    /// A full bar draining every `interval` seconds.
+    #[must_use]
+    pub const fn full(interval: f32) -> Self {
+        Self {
+            food: FULL,
+            interval,
+            elapsed: 0.0,
+        }
+    }
+
+    #[must_use]
+    pub const fn is_starving(self) -> bool {
+        self.food == 0
+    }
+
+    /// Put `points` back on the bar, up to [`FULL`]. Returns whether the
+    /// number changed, so a caller knows whether the client needs telling.
+    pub fn feed(&mut self, points: u8) -> bool {
+        let fed = self.food.saturating_add(points).min(FULL);
+        let changed = fed != self.food;
+        self.food = fed;
+        // Eating resets the clock as well as the number. Without this a player
+        // fed on the last instant before a drain tick loses the point they just
+        // earned, which reads as the refill not having worked.
+        if changed {
+            self.elapsed = 0.0;
+        }
+        changed
+    }
+}
+
+impl Default for Hunger {
+    /// A bar that never drains.
+    ///
+    /// Hunger is a kit stat, so a player with no kit has no hunger clock, and
+    /// an infinite interval says that without a second "is this player playing"
+    /// flag for [`drain`] to consult. [`crate::module::kit::apply`] replaces it
+    /// with the kit's the moment one is chosen.
+    fn default() -> Self {
+        Self::full(f32::INFINITY)
+    }
+}
+
+/// Whether the match is running.
+///
+/// Both clocks are gated on it. In the hub there is nothing to heal from, and a
+/// food bar that drained while a lobby waited for a second player would have
+/// somebody starving on the spawn platform before the countdown started.
+fn playing(world: &WorldRef<'_>) -> bool {
+    world.cloned::<&Lobby>().phase == Phase::Playing
+}
+
+/// Registration only: the components, and the guarantee every player carries
+/// them. No systems -- see `CLAUDE.md`.
+#[derive(Component)]
+pub struct VitalsComponentsModule;
+
+impl Module for VitalsComponentsModule {
+    fn module(world: &World) {
+        world.module::<Self>("smash::VitalsComponents");
+
+        world.component::<Regen>();
+        world.component::<Hunger>();
+        // This module is what makes the two numbers mean anything, so this
+        // module is what says every player has them.
+        world
+            .component::<Player>()
+            .add_trait::<(flecs::With, Regen)>()
+            .add_trait::<(flecs::With, Hunger)>();
+    }
+}
+
+/// The two timers.
+#[derive(Component)]
+pub struct VitalsModule;
+
+impl Module for VitalsModule {
+    fn module(world: &World) {
+        world.module::<Self>("smash::Vitals");
+        world.import::<VitalsComponentsModule>();
+
+        world.system_named::<()>("regenerate_health").run(|mut it| {
+            while it.next() {
+                let world = it.world();
+                if !playing(&world) {
+                    continue;
+                }
+                let dt = it.delta_time();
+                world
+                    .query::<(&Regen, &mut Health)>()
+                    .with(Player::id())
+                    .build()
+                    .each(|(regen, health)| {
+                        // A corpse does not heal, and this is not a
+                        // cosmetic rule. Zero health is the kill plane's
+                        // cue -- `arena::bounds_checks` eliminates anybody
+                        // `is_dead` -- and it reads that within the same
+                        // tick as this runs, in whichever order the two
+                        // systems happen to be registered. A heal off zero
+                        // would therefore be regeneration quietly
+                        // cancelling deaths, on some ticks and not others.
+                        if health.is_dead() {
+                            return;
+                        }
+                        health.heal(regen.0 * dt);
+                    });
+            }
+        });
+
+        world.system_named::<()>("drain_hunger").run(|mut it| {
+            while it.next() {
+                let world = it.world();
+                if !playing(&world) {
+                    continue;
+                }
+                let dt = it.delta_time();
+
+                // Decided first and applied afterwards, for the reason
+                // `smash::tick_effects` is: starving hurts, and `hurt` runs the
+                // whole damage pipeline, which writes the `Health` the query
+                // below is holding open. flecs refuses that from inside the
+                // query that found the player.
+                let mut starved = Vec::new();
+                let mut told = Vec::new();
+
+                world
+                    .query::<(&mut Hunger, &Health, &PlayerId)>()
+                    .with(Player::id())
+                    .build()
+                    .each_entity(|player, (hunger, health, id)| {
+                        // The death path owns a dead player until they respawn.
+                        // Starving one is damage landing on somebody already
+                        // spectating.
+                        if health.is_dead()
+                            || !(hunger.interval.is_finite() && hunger.interval > 0.0)
+                        {
+                            return;
+                        }
+
+                        hunger.elapsed += dt;
+
+                        // Advanced by subtracting an interval rather than by
+                        // zeroing, so a long frame does not push every later
+                        // tick out by however far this one overshot. A `while`
+                        // rather than an `if` for the same reason: a frame
+                        // longer than the interval owes more than one tick.
+                        while hunger.food > 0 && hunger.elapsed >= hunger.interval {
+                            hunger.elapsed -= hunger.interval;
+                            hunger.food -= 1;
+                            told.push((*id, hunger.food));
+                        }
+                        while hunger.is_starving() && hunger.elapsed >= STARVE_INTERVAL {
+                            hunger.elapsed -= STARVE_INTERVAL;
+                            starved.push(player.id());
+                        }
+                    });
+
+                world.get::<&ServerHandle>(|server| {
+                    for (id, food) in told {
+                        server.set_food(id, food);
+                    }
+                });
+
+                for victim in starved {
+                    let victim = world.entity_from_id(victim);
+                    let at = victim.try_get::<&Position>(|position| position.0);
+                    hurt(victim, Damaged {
+                        attacker: None,
+                        amount: STARVE_DAMAGE,
+                        // From where the victim is standing, which resolves to
+                        // no impulse at all: starving is the one damage in the
+                        // game that must not move anybody, or a player who
+                        // stopped fighting would be nudged off the map by their
+                        // own empty stomach.
+                        knockback: Knockback::from(at.unwrap_or_default()),
+                        kind: DamageKind::Environment,
+                    });
+                }
+            }
+        });
+
+        // `Smashed` and not `Damaged`: `Damaged` is emitted at every attempt,
+        // including the ones `apply_damage` refuses for respawn immunity or a
+        // shield, and a hit that was refused is not a hit that fed anybody.
+        // `Smashed` goes out only once the health has actually come off.
+        world
+            .observer_named::<Smashed, ()>("feed_the_attacker")
+            .with(Player::id())
+            .each_iter(|it, index, ()| {
+                let Some(attacker) = it.param().attacker else {
+                    return;
+                };
+                let victim = it.entity(index);
+                // Cow's recoil and Spider's lifesteal both name the caster as
+                // their own attacker. Hurting yourself is not hitting an enemy.
+                if attacker == victim.id() {
+                    return;
+                }
+
+                let world = it.world();
+                let attacker = world.entity_from_id(attacker);
+                let Some(mut hunger) = attacker.try_get::<&Hunger>(|hunger| *hunger) else {
+                    return;
+                };
+                if !hunger.feed(FOOD_PER_HIT) {
+                    return;
+                }
+                attacker.set(hunger);
+
+                if let Some(id) = attacker.try_get::<&PlayerId>(|id| *id) {
+                    world.get::<&ServerHandle>(|server| server.set_food(id, hunger.food));
+                }
+            });
+    }
+}

--- a/events/smash/src/module/vitals.rs
+++ b/events/smash/src/module/vitals.rs
@@ -284,16 +284,27 @@ impl Module for VitalsModule {
 
                 let world = it.world();
                 let attacker = world.entity_from_id(attacker);
-                let Some(mut hunger) = attacker.try_get::<&Hunger>(|hunger| *hunger) else {
-                    return;
-                };
-                if !hunger.feed(FOOD_PER_HIT) {
+                if !attacker.has(Hunger::id()) {
                     return;
                 }
-                attacker.set(hunger);
+                // Written through the live pointer rather than read, copied and
+                // `set` back, which is how `damage.rs` writes `Health` from
+                // inside its own observer and for the same stated reason: a
+                // `set` from inside an observer is a deferred command, so two
+                // hits landing in one frame would both read the same pre-frame
+                // bar and both write one point onto it. No test here
+                // demonstrates that -- driving two `hurt`s inside
+                // `world.defer` fed the attacker twice under both spellings --
+                // so this is the idiom the crate already uses rather than a
+                // measured fix.
+                let (fed, food) =
+                    attacker.get::<&mut Hunger>(|hunger| (hunger.feed(FOOD_PER_HIT), hunger.food));
+                if !fed {
+                    return;
+                }
 
                 if let Some(id) = attacker.try_get::<&PlayerId>(|id| *id) {
-                    world.get::<&ServerHandle>(|server| server.set_food(id, hunger.food));
+                    world.get::<&ServerHandle>(|server| server.set_food(id, food));
                 }
             });
     }

--- a/events/smash/src/module/vitals.rs
+++ b/events/smash/src/module/vitals.rs
@@ -126,6 +126,35 @@ impl Default for Hunger {
     }
 }
 
+/// The number of half-hearts a vanilla client draws for `health`.
+///
+/// The client is sent `current * 20 / max` and renders it on a twenty-step
+/// bar, so this is the finest change anybody can actually see whatever the
+/// kit's pool -- which makes it the right threshold for deciding whether a
+/// regeneration tick is worth a packet.
+///
+/// A whole number and not the float, because the caller compares two of these
+/// and comparing floats for equality is both a lint and a bad habit; rounding
+/// to the step the client draws is the entire point, so the integer is the
+/// honest type. Clamped rather than assumed in range: `Health::heal` caps at
+/// `max` today, and a helper that returns nonsense if that ever changes is a
+/// worse failure than one that saturates.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "clamped to 0..=20 on the line above, which is inside u8 by a wide margin"
+)]
+fn drawn(health: Health) -> u8 {
+    if health.max <= 0.0 {
+        return 0;
+    }
+    let steps = (health.current * VANILLA_BAR_STEPS / health.max).ceil();
+    steps.clamp(0.0, VANILLA_BAR_STEPS) as u8
+}
+
+/// Steps on a vanilla health bar: ten hearts of two.
+const VANILLA_BAR_STEPS: f32 = 20.0;
+
 /// Whether the match is running.
 ///
 /// Both clocks are gated on it. In the hub there is nothing to heal from, and a
@@ -171,11 +200,23 @@ impl Module for VitalsModule {
                     continue;
                 }
                 let dt = it.delta_time();
+                // Health healed here has to be *sent*, and this is the one
+                // `Health` writer in the crate that cannot rely on anything
+                // else to do it. `OnSet` does not fire for a `&mut` query
+                // term -- flecs reaches `flecs_notify_on_set` from `ecs_set`,
+                // `ecs_modified` and add-with-value only -- so
+                // `input::mirror_health_to_host` never sees this write and no
+                // packet is queued. Every other writer (`damage.rs`,
+                // `lives.rs`, Cow, Spider) pairs its write with an explicit
+                // push; this one did not, and the result was a boss bar that
+                // read the component and moved while the client's hearts,
+                // which only move on a packet, did not.
+                let mut told = Vec::new();
                 world
-                    .query::<(&Regen, &mut Health)>()
+                    .query::<(&Regen, &mut Health, &PlayerId)>()
                     .with(Player::id())
                     .build()
-                    .each(|(regen, health)| {
+                    .each(|(regen, health, id)| {
                         // A corpse does not heal, and this is not a
                         // cosmetic rule. Zero health is the kill plane's
                         // cue -- `arena::bounds_checks` eliminates anybody
@@ -187,8 +228,31 @@ impl Module for VitalsModule {
                         if health.is_dead() {
                             return;
                         }
+                        // Before and after, both in hand on this tick, which
+                        // is what lets the push be change-detected with **no
+                        // cached last-sent value anywhere**. A cache would be
+                        // the third instance of the class that has bitten this
+                        // PR twice already -- seam state that has to be
+                        // invalidated when a player dies, respawns or changes
+                        // kit -- and comparing two numbers from the same tick
+                        // needs no invalidating.
+                        let before = *health;
                         health.heal(regen.0 * dt);
+                        // Only when the client would draw something different.
+                        // A vanilla health bar has twenty steps however large
+                        // the kit's pool is, so anything finer is a packet per
+                        // player per tick for a change nobody can see -- the
+                        // same reason `hud::quantise` exists for the boss bar.
+                        if drawn(before) != drawn(*health) {
+                            told.push((*id, health.current, health.max));
+                        }
                     });
+
+                world.get::<&ServerHandle>(|server| {
+                    for (id, current, max) in told {
+                        server.set_health(id, current, max);
+                    }
+                });
             }
         });
 

--- a/events/smash/src/server.rs
+++ b/events/smash/src/server.rs
@@ -451,6 +451,15 @@ pub trait Server: Send + Sync + 'static {
     /// Push the game's authoritative health onto the client's health bar.
     fn set_health(&self, player: PlayerId, health: f32, max: f32);
 
+    /// Push the game's food bar, in vanilla food points (`0..=20`).
+    ///
+    /// Separate from [`Server::set_health`] even though vanilla carries the two
+    /// in one `SetHealth` packet, because the two change on entirely different
+    /// clocks: health moves on every hit, food moves once every seven seconds.
+    /// Reassembling the packet is the adapter's problem and not something
+    /// fifteen callers should have to hold a spare food level for.
+    fn set_food(&self, player: PlayerId, food: u8);
+
     /// Apply a potion effect to `player`, broadcast to everyone near them --
     /// including the player's own client. That inclusion is the whole point of
     /// a status over a faked impulse: the client owns its movement prediction,

--- a/events/smash/src/server.rs
+++ b/events/smash/src/server.rs
@@ -453,11 +453,21 @@ pub trait Server: Send + Sync + 'static {
 
     /// Push the game's food bar, in vanilla food points (`0..=20`).
     ///
-    /// Separate from [`Server::set_health`] even though vanilla carries the two
-    /// in one `SetHealth` packet, because the two change on entirely different
-    /// clocks: health moves on every hit, food moves once every seven seconds.
-    /// Reassembling the packet is the adapter's problem and not something
-    /// fifteen callers should have to hold a spare food level for.
+    /// # Why this is a second method and not a fourth argument on `set_health`
+    ///
+    /// Vanilla carries health, food and saturation in one `SetHealth` packet,
+    /// so a fourth argument is the obvious shape and it is the wrong one: the
+    /// shape of the packet is not the shape of the domain. The two quantities
+    /// move on unrelated clocks -- health on every hit, food once every seven
+    /// seconds -- and no caller ever has both to hand. Damage, a respawn,
+    /// Spider's lifesteal and Cow's two Mooshroom paths would each have had to
+    /// supply a food level they have no opinion about, and a seam whose callers
+    /// invent arguments to satisfy it is a seam that has started lying about
+    /// what it knows.
+    ///
+    /// So each caller says the one thing it actually knows, and reassembling
+    /// the packet is the adapter's job, next to the packet. See
+    /// `adapter::Vitals`, which holds the other half.
     fn set_food(&self, player: PlayerId, food: u8);
 
     /// Apply a potion effect to `player`, broadcast to everyone near them --

--- a/events/smash/src/server/mock.rs
+++ b/events/smash/src/server/mock.rs
@@ -22,6 +22,8 @@ pub enum Call {
     /// Whether the client may take a mid-air jump.
     Flight(PlayerId, Flight),
     SetHealth(PlayerId, f32, f32),
+    /// A food bar, in vanilla food points.
+    SetFood(PlayerId, u8),
     /// A potion effect applied to a player.
     Status(PlayerId, Status),
     SetHotbar(PlayerId, Vec<HotbarItem>),
@@ -240,6 +242,10 @@ impl Server for MockServer {
 
     fn set_health(&self, player: PlayerId, health: f32, max: f32) {
         self.push(Call::SetHealth(player, health, max));
+    }
+
+    fn set_food(&self, player: PlayerId, food: u8) {
+        self.push(Call::SetFood(player, food));
     }
 
     fn status(&self, player: PlayerId, status: Status) {

--- a/events/smash/tests/contract.rs
+++ b/events/smash/tests/contract.rs
@@ -46,6 +46,7 @@ use smash::{
         scoreboard::ScoreboardModule,
         selector::{self, SelectorModule, TAKEN_BLOCK},
         sound::{self, Levels, PlaysOnCast, PlaysOnHurt, SoundModule},
+        vitals::{self, Hunger, Regen, VitalsModule},
     },
     server::{PlayerId, ServerHandle, mock::MockServer},
 };
@@ -324,6 +325,37 @@ fn contracts() -> Vec<Contract> {
                 let kit = kit.prefab();
                 smash::module::kit::apply(world, player, kit);
                 assert!((player.cloned::<&KnockbackTaken>().0 - 1.5).abs() < 1e-6);
+            },
+        },
+        Contract {
+            name: "Vitals",
+            import: |world| {
+                world.import::<VitalsModule>();
+            },
+            // `feed_the_attacker` is an observer on Knockback's `Smashed`
+            // naming Player, and the starve tick emits Damage's `Damaged`.
+            requires: &["Player", "Knockback", "Damage"],
+            // Both clocks read the lobby phase inside a `run` closure, and a
+            // starve tick runs the whole damage pipeline behind it.
+            runtime_requires: &["Lives", "Sound", "Kit", "Lobby"],
+            exercise: |world, player| {
+                world.set(Lobby {
+                    phase: Phase::Playing,
+                    timer: 1.0,
+                });
+                player.set(Regen(2.0));
+                player.set(Hunger::full(0.5));
+                player.get::<&mut Health>(|health| health.current = 1.0);
+
+                world.progress_time(1.0);
+                assert!(
+                    player.cloned::<&Health>().current > 1.0,
+                    "regeneration never ran"
+                );
+                assert!(
+                    player.cloned::<&Hunger>().food < vitals::FULL,
+                    "the food bar never drained"
+                );
             },
         },
         Contract {

--- a/events/smash/tests/kit_stats.rs
+++ b/events/smash/tests/kit_stats.rs
@@ -407,7 +407,12 @@ fn jump_control_changes_which_way_a_double_jump_goes() {
 /// check anywhere notices that nothing reads it.
 #[test]
 fn every_kit_stats_field_is_gated_by_a_test_in_this_file() {
-    const FIELDS: [&str; 9] = [
+    // A slice and not a `[&str; 9]`. The nine is not load-bearing -- the
+    // destructure below is what refuses a tenth field -- and a second place
+    // holding the count is a second place to get it wrong. #1095 reached the
+    // same conclusion from the other direction with `BarSlot::COUNT =
+    // ALL.len()`.
+    const FIELDS: &[&str] = &[
         "melee_damage",
         "armor",
         "knockback_taken",
@@ -440,7 +445,8 @@ fn every_kit_stats_field_is_gated_by_a_test_in_this_file() {
         .collect();
 
     let missing: Vec<&str> = FIELDS
-        .into_iter()
+        .iter()
+        .copied()
         .filter(|field| !gated.iter().any(|name| name.starts_with(field)))
         .collect();
     assert!(

--- a/events/smash/tests/kit_stats.rs
+++ b/events/smash/tests/kit_stats.rs
@@ -28,7 +28,7 @@ use smash::{
         damage::{DamageKind, Damaged, hurt},
         kit::{self, KitStats},
         knockback::Knockback,
-        lobby::{Lobby, Phase},
+        lobby::{Lobby, LobbyConfig, Phase},
         player::{Energy, Flying, Health, OnGround, Position},
         vitals::Hunger,
     },
@@ -313,16 +313,97 @@ fn energy_changes_the_size_and_refill_rate_of_the_bar() {
 }
 
 /// `regen`: health comes back at the kit's rate. ENG-11450.
+///
+/// Read off the **seam call** and not the `Health` component, for the reason
+/// `knockback_taken_changes_how_far_a_hit_launches` already gives: health the
+/// game regenerated and never sent is a bug a state assertion cannot see. This
+/// test read the component in the first version of this file, and that is
+/// exactly the hole it left -- `regenerate_health` heals through a `&mut Health`
+/// query term, `OnSet` does not fire for those, so nothing queued a packet and
+/// the client's hearts never moved while the boss bar (which reads the
+/// component) said otherwise.
 #[test]
 fn regen_changes_how_fast_health_comes_back() {
     let gate = Gate::new(|stats| stats.regen = base().regen * 3.0);
 
     gate.each(|gate, side| gate.hit(side.player, 10.0, DamageKind::Ability));
+    gate.game.server.take();
     gate.advance(4.0);
 
     gate.differ(
-        "the health four seconds of regeneration put back",
-        |gate, side| observable(gate.health(side.player).current),
+        "the health four seconds of regeneration told the client about",
+        |gate, side| {
+            let id = gate.id(side.player);
+            gate.game
+                .server
+                .calls()
+                .iter()
+                .filter_map(|call| match call {
+                    Call::SetHealth(told, health, _) if *told == id => Some(observable(*health)),
+                    _ => None,
+                })
+                .next_back()
+        },
+    );
+}
+
+/// Regeneration sends a packet when the bar moves, not once a tick.
+///
+/// The obvious fix for "regen never reaches the client" is to heal through
+/// `.set(Health)` so the `OnSet` mirror fires, and that is twenty packets a
+/// second per player forever for a bar with twenty steps on it. This pins the
+/// other choice: push only when the half-heart the client draws actually
+/// changes.
+///
+/// The lower bound matters as much as the upper. A test that only capped the
+/// count would pass with regeneration sending nothing at all, which is the
+/// exact bug this whole thread is about.
+#[test]
+fn regeneration_sends_a_packet_per_half_heart_and_not_per_tick() {
+    let gate = Gate::new(|stats| stats.regen = 1.0);
+    // The *variant* side, which is the one `Gate::new` perturbed. Reading
+    // `sides[0]` measures the base kit's 0.25/s instead, and the first version
+    // of this test did exactly that -- it passed, on a number that meant
+    // something other than what this comment claimed.
+    let subject = gate.sides[1].player;
+    let id = gate.id(subject);
+
+    // `Environment`, so armour does not apply and the arithmetic is legible:
+    // ten health off a twenty-point bar is ten half-hearts to climb back.
+    gate.each(|gate, side| gate.hit(side.player, 10.0, DamageKind::Environment));
+    assert_eq!(
+        observable(gate.health(subject).current),
+        observable(10.0),
+        "the hit did not land for what this test's arithmetic assumes"
+    );
+    gate.game.server.take();
+
+    // Ten seconds at 1.0/s covers all ten, in 200 ticks.
+    let seconds = 10.0;
+    gate.advance(seconds);
+    assert_eq!(
+        observable(gate.health(subject).current),
+        observable(20.0),
+        "regeneration did not reach full, so the packet count is of a shorter climb"
+    );
+
+    let sent = gate
+        .game
+        .server
+        .calls()
+        .iter()
+        .filter(|call| matches!(call, Call::SetHealth(told, _, _) if *told == id))
+        .count();
+
+    assert!(
+        sent > 0,
+        "regeneration sent nothing, so the client's hearts never moved"
+    );
+    assert!(
+        sent <= 12,
+        "regeneration sent {sent} packets to climb ten half-hearts; it should send about one per \
+         half-heart, not one per tick over {seconds} seconds at {} Hz",
+        1.0 / harness::TICK
     );
 }
 
@@ -429,49 +510,55 @@ fn jump_count_changes_how_many_double_jumps_a_kit_gets() {
 /// check anywhere notices that nothing reads it.
 #[test]
 fn every_kit_stats_field_is_gated_by_a_test_in_this_file() {
-    // A slice and not a `[&str; 9]`. The nine is not load-bearing -- the
-    // destructure below is what refuses a tenth field -- and a second place
-    // holding the count is a second place to get it wrong. #1095 reached the
-    // same conclusion from the other direction with `BarSlot::COUNT =
-    // ALL.len()`.
-    const FIELDS: &[&str] = &[
-        "melee_damage",
-        "armor",
-        "knockback_taken",
-        "regen",
-        "hunger_interval",
-        "max_health",
-        "jump_power",
-        "jump_control",
-        "jump_count",
-        "energy",
+    // One list, two uses. The macro expands to *both* the exhaustive
+    // destructure and the name slice, so the two cannot disagree: adding a
+    // tenth field breaks compilation at the destructure, and the only edit
+    // that fixes it -- naming the field here -- also puts it in the slice and
+    // therefore demands a test.
+    //
+    // Two hand-written lists is what this replaced, and that version was a lie.
+    // Compilation broke at the destructure only, so a contributor could add
+    // `foo: _` and be green with `foo` ungated -- the same hand-maintained
+    // second copy as #1095's array length. The `jump_count` edit had to touch
+    // both lists for exactly that reason.
+    macro_rules! kit_stats_fields {
+        ($($field:ident),+ $(,)?) => {{
+            let KitStats { $($field: _),+ } = KitStats::default();
+            &[$(stringify!($field)),+]
+        }};
+    }
+
+    let fields: &[&str] = kit_stats_fields![
+        melee_damage,
+        armor,
+        knockback_taken,
+        regen,
+        hunger_interval,
+        max_health,
+        jump_power,
+        jump_control,
+        jump_count,
+        energy,
     ];
 
-    let KitStats {
-        melee_damage: _,
-        armor: _,
-        knockback_taken: _,
-        regen: _,
-        hunger_interval: _,
-        max_health: _,
-        jump_power: _,
-        jump_control: _,
-        jump_count: _,
-        energy: _,
-    } = KitStats::default();
-
     let source = include_str!("kit_stats.rs");
+    // `#[test]` functions only. The scan used to collect every `fn`, which put
+    // the `double_jump` helper in the list and would have let a helper named
+    // `armor_anything` satisfy the `armor` field without a test existing.
     let gated: Vec<&str> = source
         .lines()
-        .filter_map(|line| line.trim().strip_prefix("fn "))
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .windows(2)
+        .filter(|pair| pair[0] == "#[test]")
+        .filter_map(|pair| pair[1].strip_prefix("fn "))
         .filter_map(|line| line.split_once('('))
         .map(|(name, _)| name)
         .collect();
 
-    let missing: Vec<&str> = FIELDS
+    let missing: Vec<&&str> = fields
         .iter()
-        .copied()
-        .filter(|field| !gated.iter().any(|name| name.starts_with(field)))
+        .filter(|field| !gated.iter().any(|name| name.starts_with(*field)))
         .collect();
     assert!(
         missing.is_empty(),
@@ -744,6 +831,21 @@ fn dying_does_not_refill_the_food_bar() {
 #[test]
 fn the_two_clocks_are_off_in_the_hub() {
     let gate = Gate::new(|stats| stats.regen = base().regen * 3.0);
+    // More players required than the four this world has, so `Waiting` is
+    // stable for the whole run rather than a countdown that has not fired yet.
+    //
+    // Setting the phase alone was not enough and the assertion below is how
+    // that was found: the harness's default lobby calls four players a full
+    // house, so sixteen seconds took this to `Preparing`. The test still
+    // passed -- the clocks are gated on `Playing`, which is one phase further
+    // on -- so it was quietly asserting something about `Preparing` while
+    // claiming to be about the hub, and was one config change from asserting
+    // nothing at all.
+    gate.game.world.set(LobbyConfig {
+        min_players: 8,
+        full_players: 16,
+        ..LobbyConfig::default()
+    });
     gate.game.world.set(Lobby {
         phase: Phase::Waiting,
         timer: 0.0,
@@ -752,6 +854,11 @@ fn the_two_clocks_are_off_in_the_hub() {
     gate.each(|gate, side| gate.hit(side.player, 10.0, DamageKind::Ability));
     let hurt_to = gate.health(gate.sides[0].player).current;
     gate.advance(16.0);
+    assert_eq!(
+        gate.game.world.cloned::<&Lobby>().phase,
+        Phase::Waiting,
+        "the lobby left the hub, so this no longer tests what it says"
+    );
 
     assert_eq!(
         observable(gate.health(gate.sides[0].player).current),

--- a/events/smash/tests/kit_stats.rs
+++ b/events/smash/tests/kit_stats.rs
@@ -29,7 +29,7 @@ use smash::{
         kit::{self, KitStats},
         knockback::Knockback,
         lobby::{Lobby, Phase},
-        player::{Energy, Health, OnGround, Position},
+        player::{Energy, Flying, Health, OnGround, Position},
         vitals::Hunger,
     },
     server::{PlayerId, mock::Call},
@@ -338,25 +338,26 @@ fn hunger_interval_changes_how_fast_the_food_bar_drains() {
     });
 }
 
-/// What ENG-11440 has to make happen.
+/// Press the jump key in mid-air, the way a client does.
 ///
-/// There is no entry point for a double jump in the game at all today -- the
-/// press is not routed, `JumpsLeft` is re-armed and never spent, and no
-/// velocity is applied -- so there is nothing this function can call. It is the
-/// one line ENG-11440 replaces, and the two tests below are `#[ignore]` until
-/// it does.
+/// Deliberately the production path and not a shortcut past it. ENG-11440
+/// routes a double jump through vanilla's flight toggle: `arm_double_jump`
+/// grants permission while a player is airborne with jumps left, the client
+/// answers by setting the flying flag, and `spend_double_jump` reads that
+/// mirror. Setting the two mirrors is exactly what the host does with the
+/// packet; nothing here reaches past the systems under test to apply an
+/// impulse itself, which would make these gates decoration.
 fn double_jump(gate: &Gate, side: &Side) {
-    // Airborne, which is the only precondition the game already models.
-    gate.view(side.player).set(OnGround(false));
+    let player = gate.view(side.player);
+    player.set(OnGround(false));
+    // One tick for `arm_double_jump` to grant permission, as it would before a
+    // real client could press anything.
+    gate.advance(harness::TICK);
+    player.set(Flying(true));
 }
 
 /// `jump_power`: the double jump's impulse.
-///
-/// `#[ignore]`: fails until ENG-11440 lands, because nothing applies the
-/// impulse. That failure *is* the finding -- do not delete the test to make the
-/// suite green.
 #[test]
-#[ignore = "ENG-11440: double jump is not implemented; nothing reads jump_power"]
 fn jump_power_changes_how_high_a_double_jump_goes() {
     let gate = Gate::new(|stats| stats.jump_power = base().jump_power * 2.0);
 
@@ -369,10 +370,7 @@ fn jump_power_changes_how_high_a_double_jump_goes() {
 }
 
 /// `jump_control`: whether the double jump goes where you look.
-///
-/// `#[ignore]`: see [`jump_power_changes_how_high_a_double_jump_goes`].
 #[test]
-#[ignore = "ENG-11440: double jump is not implemented; nothing reads jump_control"]
 fn jump_control_changes_which_way_a_double_jump_goes() {
     let gate = Gate::new(|stats| stats.jump_control = !base().jump_control);
 
@@ -388,6 +386,30 @@ fn jump_control_changes_which_way_a_double_jump_goes() {
     gate.differ("the direction the double jump asked for", |gate, side| {
         observable_vec(gate.game.server.total_velocity(gate.id(side.player)))
     });
+}
+
+/// `jump_count`: how many mid-air jumps a kit gets before touching ground.
+///
+/// Arrived with ENG-11440 as a tenth `KitStats` field, and this file refused to
+/// compile until it was named -- `pattern does not mention field jump_count`,
+/// which is the destructure in
+/// [`every_kit_stats_field_is_gated_by_a_test_in_this_file`] doing its job on
+/// its first real test.
+#[test]
+fn jump_count_changes_how_many_double_jumps_a_kit_gets() {
+    let gate = Gate::new(|stats| stats.jump_count = base().jump_count + 3);
+
+    // More presses than the base kit has jumps, so the two sides diverge on
+    // the kit's allowance rather than on how many times the test pressed.
+    for _ in 0..4 {
+        gate.each(double_jump);
+        gate.advance(0.1);
+    }
+
+    gate.differ(
+        "the total impulse a run of mid-air jumps asked for",
+        |gate, side| observable_vec(gate.game.server.total_velocity(gate.id(side.player))),
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -421,6 +443,7 @@ fn every_kit_stats_field_is_gated_by_a_test_in_this_file() {
         "max_health",
         "jump_power",
         "jump_control",
+        "jump_count",
         "energy",
     ];
 
@@ -433,6 +456,7 @@ fn every_kit_stats_field_is_gated_by_a_test_in_this_file() {
         max_health: _,
         jump_power: _,
         jump_control: _,
+        jump_count: _,
         energy: _,
     } = KitStats::default();
 

--- a/events/smash/tests/kit_stats.rs
+++ b/events/smash/tests/kit_stats.rs
@@ -594,6 +594,125 @@ fn landing_a_hit_feeds_the_attacker() {
     );
 }
 
+/// Every write to the food bar reaches the client.
+///
+/// The failure mode this is here for is the one #1096 was blocked on, one
+/// domain over: game state changes, the seam's cached copy is never told, and
+/// the client goes on drawing the old value. `drain_hunger` and
+/// `feed_the_attacker` push because they are the paths somebody thought about;
+/// the two that *replace* the whole bar -- choosing a kit, and the reset
+/// between matches -- are the ones easy to miss, because neither is a hunger
+/// mechanic and both look like plain state initialisation.
+///
+/// Asserted against the seam and not the component. `Hunger::full` obviously
+/// sets the component; the question is whether anybody told the player.
+#[test]
+fn resetting_the_bar_between_matches_tells_the_client() {
+    let gate = Gate::new(|stats| stats.hunger_interval = base().hunger_interval / 8.0);
+
+    // Drain both bars well below full, so a refill is a change worth sending.
+    gate.advance(8.0);
+    let drained = gate.view(gate.sides[1].player).cloned::<&Hunger>().food;
+    assert!(drained < smash::module::vitals::FULL, "nothing drained");
+
+    gate.game.server.take();
+    // The reset hangs off the transition into `Waiting`, which is where a
+    // finished match sends everybody.
+    gate.game.world.set(Lobby {
+        phase: Phase::Ended,
+        timer: 0.0,
+    });
+    gate.advance(1.0);
+
+    for side in &gate.sides {
+        let id = gate.id(side.player);
+        assert_eq!(
+            gate.view(side.player).cloned::<&Hunger>().food,
+            smash::module::vitals::FULL,
+            "the reset did not refill the bar"
+        );
+        assert!(
+            gate.game
+                .server
+                .calls()
+                .iter()
+                .any(|call| matches!(call, Call::SetFood(told, food)
+                    if *told == id && *food == smash::module::vitals::FULL)),
+            "the bar was refilled and the client was never told, so it goes on drawing the \
+             drained one until the next drain tick"
+        );
+    }
+}
+
+/// Choosing a kit tells the client about the bar it just replaced.
+///
+/// The other half of the invariant, and honestly labelled: unlike the reset
+/// above, this is **not** fixing a divergence that is reachable today.
+/// `kit::apply` has one production caller, `lobby::choose`, which refuses a kit
+/// change outside `Waiting | Countdown` -- and in those phases the bar is
+/// always full, because the clocks only run in `Playing` and the reset refills
+/// on the way out. So the push is redundant with the reset right now.
+///
+/// It is here rather than deleted because "every write that replaces the whole
+/// bar tells the client" is the invariant, and an invariant with one exception
+/// is a rule nobody can apply. It is tested rather than left as unexercised
+/// defence, which is the other way this would have been wrong: the day
+/// somebody allows a mid-match kit change, this is already right and this test
+/// already covers it.
+#[test]
+fn choosing_a_kit_tells_the_client_about_the_fresh_bar() {
+    let gate = Gate::new(|stats| stats.hunger_interval = base().hunger_interval / 2.0);
+
+    // `Gate::new` applied a kit to all four players as it built the world.
+    for side in &gate.sides {
+        let id = gate.id(side.player);
+        assert!(
+            gate.game
+                .server
+                .calls()
+                .iter()
+                .any(|call| matches!(call, Call::SetFood(told, food)
+                    if *told == id && *food == smash::module::vitals::FULL)),
+            "choosing a kit replaced the food bar without telling the client"
+        );
+    }
+}
+
+/// Dying does not refill the food bar.
+///
+/// A deliberate balance decision and therefore exactly the kind that regresses
+/// silently, so it is pinned rather than left in a comment. Hunger is what
+/// Super Smash Mobs has instead of sudden death; an anti-stall clock a player
+/// can reset by throwing away one of four lives is not a clock. The only two
+/// things that refill it are landing a hit and the end of the match.
+#[test]
+fn dying_does_not_refill_the_food_bar() {
+    let gate = Gate::new(|stats| stats.hunger_interval = base().hunger_interval / 8.0);
+    let subject = gate.sides[1].player;
+
+    gate.advance(8.0);
+    let before = gate.view(subject).cloned::<&Hunger>().food;
+    assert!(
+        before < smash::module::vitals::FULL,
+        "nothing drained, so this would pass with hunger deleted"
+    );
+
+    smash::module::lives::kill(gate.view(subject), smash::module::lives::DeathCause::Void);
+    // Through the spectate window and back onto a platform.
+    gate.advance(smash::module::lives::DEATH_SPECTATE_SECS + 1.0);
+    assert!(
+        !gate
+            .view(subject)
+            .has(smash::module::lives::RespawnAt::id()),
+        "never respawned, so this says nothing about what a respawn does"
+    );
+
+    assert!(
+        gate.view(subject).cloned::<&Hunger>().food <= before,
+        "dying refilled the food bar, which makes the starve timer optional"
+    );
+}
+
 /// Neither clock runs outside a match.
 ///
 /// A food bar that drained while a lobby waited for a second player would have

--- a/events/smash/tests/kit_stats.rs
+++ b/events/smash/tests/kit_stats.rs
@@ -471,6 +471,49 @@ fn two_identical_kits_fail_the_gate() {
     });
 }
 
+/// The regen scenario reds when `regen` is the field left equal.
+///
+/// The other half of the deletion check, and it catches a different thing.
+/// Deleting `.set(Regen(stats.regen))` proves the field is *read*; this proves
+/// the scenario above is sensitive to `regen` specifically and not to something
+/// else that happens to differ between two kits. It runs
+/// [`regen_changes_how_fast_health_comes_back`] verbatim against a pair whose
+/// `regen` is equal and whose `melee_damage` differs instead -- a field that
+/// cannot touch a health-after-four-seconds read, because nothing in the
+/// scenario swings.
+///
+/// Without it, a `regen` test whose difference actually came from the armour
+/// term would pass with `regen` unimplemented and nobody would know.
+#[test]
+#[should_panic(expected = "nothing in the game reads that field")]
+fn the_regen_gate_reds_when_regen_is_the_field_left_equal() {
+    let gate = Gate::new(|stats| stats.melee_damage = base().melee_damage * 2.0);
+
+    gate.each(|gate, side| gate.hit(side.player, 10.0, DamageKind::Ability));
+    gate.advance(4.0);
+
+    gate.differ(
+        "the health four seconds of regeneration put back",
+        |gate, side| observable(gate.health(side.player).current),
+    );
+}
+
+/// The hunger scenario reds when `hunger_interval` is the field left equal.
+///
+/// Same argument as [`the_regen_gate_reds_when_regen_is_the_field_left_equal`],
+/// for the other mechanic ENG-11450 implements.
+#[test]
+#[should_panic(expected = "nothing in the game reads that field")]
+fn the_hunger_gate_reds_when_the_interval_is_the_field_left_equal() {
+    let gate = Gate::new(|stats| stats.melee_damage = base().melee_damage * 2.0);
+
+    gate.advance(16.0);
+
+    gate.differ("the food bar after sixteen seconds", |gate, side| {
+        gate.view(side.player).cloned::<&Hunger>().food
+    });
+}
+
 /// Starving is what an empty food bar is for.
 ///
 /// The differential above proves `hunger_interval` reaches the bar. This is the

--- a/events/smash/tests/kit_stats.rs
+++ b/events/smash/tests/kit_stats.rs
@@ -1,0 +1,602 @@
+//! Every field of [`KitStats`] has to be able to change the game.
+//!
+//! The gate is one test per field, and each one is the same shape: two players
+//! on kits that are byte-for-byte identical except for that one field, the same
+//! scenario run against both, and a difference required in what a client would
+//! see at the end of it. A field that cannot be made to matter is a field with
+//! no implementation, and it fails here.
+//!
+//! This is deliberately stronger than "every field has a reader", which
+//! `let _ = stats.regen;` satisfies. ENG-11450 is what it is for: `regen`,
+//! `hunger_interval`, `jump_power` and `jump_control` were set by every one of
+//! sixteen kits, several of them tuned against the wiki and argued about in
+//! comments, and read by nothing at all. Nothing failed, because nothing asked
+//! this question.
+//!
+//! The five fields that already worked are gated too, and they are not filler:
+//! they are the evidence that the harness below can tell a difference when
+//! there is one. A gate whose only passing cases are the ones written alongside
+//! the feature is a gate nobody has watched work.
+
+mod harness;
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use harness::Game;
+use smash::{
+    module::{
+        damage::{DamageKind, Damaged, hurt},
+        kit::{self, KitStats},
+        knockback::Knockback,
+        lobby::{Lobby, Phase},
+        player::{Energy, Health, OnGround, Position},
+        vitals::Hunger,
+    },
+    server::{PlayerId, mock::Call},
+};
+
+/// Where the two subjects and their punching bags stand.
+///
+/// Well above the default arena's kill plane, because the gate runs in
+/// [`Phase::Playing`] and that is the phase the floor is armed in. Four
+/// separate columns so no scenario's knockback or splash reaches a player it
+/// was not aimed at.
+const COLUMNS: [Vec3; 4] = [
+    Vec3::new(0.0, 200.0, 0.0),
+    Vec3::new(0.0, 200.0, 60.0),
+    Vec3::new(120.0, 200.0, 0.0),
+    Vec3::new(120.0, 200.0, 60.0),
+];
+
+/// The stats both kits are built from.
+///
+/// Every number is off the default rather than off a real kit, so a test that
+/// perturbs one field is perturbing exactly one thing and the reader does not
+/// have to hold a kit's table in their head to see it.
+fn base() -> KitStats {
+    KitStats {
+        // A bar on both kits by default, so the `energy` test perturbs a
+        // number rather than the presence of the component. Its own test says
+        // what it changes.
+        energy: Some((1.0, 0.1)),
+        ..KitStats::default()
+    }
+}
+
+/// One half of the differential: a player on one of the two kits, and an
+/// identical opponent for them to hit.
+struct Side {
+    player: Entity,
+    foe: Entity,
+}
+
+/// Two players whose kits differ in exactly one [`KitStats`] field.
+struct Gate {
+    game: Game,
+    /// The player on the unmodified kit, first.
+    sides: [Side; 2],
+}
+
+impl Gate {
+    /// Build the world. `mutate` is the single field under test.
+    ///
+    /// Both subjects and both opponents are in one world and one run, so a
+    /// difference between them cannot be run-to-run noise: they share a tick
+    /// count, a random-free simulation and the same lobby phase.
+    fn new(mutate: impl FnOnce(&mut KitStats)) -> Self {
+        let mut game = Game::new();
+
+        let mut variant = base();
+        mutate(&mut variant);
+        assert_ne!(
+            variant,
+            base(),
+            "this test perturbs no field, so it would pass against any implementation"
+        );
+
+        kit::define(&game.world, "GateBase", base()).register();
+        kit::define(&game.world, "GateVariant", variant).register();
+
+        let names = ["base", "base_foe", "variant", "variant_foe"];
+        let spawned: Vec<Entity> = names
+            .iter()
+            .zip(COLUMNS)
+            .map(|(name, at)| game.player(name, at))
+            .collect();
+
+        // Both opponents are on the base kit whichever side they stand on. The
+        // only difference in the world is the one field.
+        for (index, entity) in spawned.iter().enumerate() {
+            let on = if index == 2 {
+                "GateVariant"
+            } else {
+                "GateBase"
+            };
+            let chosen = kit::by_name(&game.world, on).expect("just defined");
+            kit::apply(&game.world, game.world.entity_from_id(*entity), chosen);
+        }
+
+        // The clocks under test only run during a match, so the gate runs
+        // during one. Set rather than waited into: the transitions scatter
+        // players onto spawn points, and four players in one place is not the
+        // scenario any of these tests set up.
+        game.world.set(Lobby {
+            phase: Phase::Playing,
+            timer: 0.0,
+        });
+
+        Self {
+            game,
+            sides: [
+                Side {
+                    player: spawned[0],
+                    foe: spawned[1],
+                },
+                Side {
+                    player: spawned[2],
+                    foe: spawned[3],
+                },
+            ],
+        }
+    }
+
+    fn view(&self, entity: Entity) -> EntityView<'_> {
+        self.game.world.entity_from_id(entity)
+    }
+
+    fn id(&self, entity: Entity) -> PlayerId {
+        self.view(entity).cloned::<&PlayerId>()
+    }
+
+    /// Do the same thing to each side before any of them is read.
+    ///
+    /// Acting on both and only then advancing is what keeps the two sides
+    /// symmetrical: they share one world, so reading one before acting on the
+    /// other would give the first side a head start no assertion could tell
+    /// apart from the field working.
+    fn each(&self, act: impl Fn(&Self, &Side)) {
+        for side in &self.sides {
+            act(self, side);
+        }
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "a scenario is a positive number of seconds, and the longest one here is 16"
+    )]
+    fn advance(&self, seconds: f32) {
+        self.game
+            .advance(seconds, (seconds / harness::TICK).round() as u32);
+    }
+
+    /// The gate itself: read `what` off each side and require the two to
+    /// disagree.
+    fn differ<T: PartialEq + std::fmt::Debug>(&self, what: &str, read: impl Fn(&Self, &Side) -> T) {
+        let base = read(self, &self.sides[0]);
+        let variant = read(self, &self.sides[1]);
+        assert_ne!(
+            base, variant,
+            "the two kits differ in exactly one KitStats field and {what} came out the same, so \
+             nothing in the game reads that field"
+        );
+    }
+
+    /// Hurt `player` for `amount`, from a fixed direction so the knockback is
+    /// the same shape on both sides.
+    fn hit(&self, victim: Entity, amount: f32, kind: DamageKind) {
+        let victim = self.view(victim);
+        let from = victim.cloned::<&Position>().0 - Vec3::X;
+        hurt(victim, Damaged {
+            attacker: None,
+            amount,
+            knockback: Knockback::from(from),
+            kind,
+        });
+    }
+
+    fn health(&self, entity: Entity) -> Health {
+        self.view(entity).cloned::<&Health>()
+    }
+}
+
+/// A float at the precision anybody could act on: three decimals.
+///
+/// Requiring a difference at full `f32` precision would let a field that moves
+/// the twentieth bit of a result count as implemented, and floats do not
+/// implement `Eq` anyway. Three decimals of a health point is a thousandth of a
+/// half-heart, which is far finer than the game or the client can draw and far
+/// coarser than rounding noise.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "health, energy and an impulse are all far inside i64 once scaled by a thousand"
+)]
+fn observable(value: f32) -> i64 {
+    (f64::from(value) * 1000.0).round() as i64
+}
+
+fn observable_vec(value: Vec3) -> [i64; 3] {
+    [
+        observable(value.x),
+        observable(value.y),
+        observable(value.z),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// The nine fields.
+// ---------------------------------------------------------------------------
+
+/// `melee_damage`: a swing takes off the attacker's kit's number.
+#[test]
+fn melee_damage_changes_what_a_swing_takes_off() {
+    let gate = Gate::new(|stats| stats.melee_damage = base().melee_damage * 2.0);
+
+    // Through the game's own melee function and not a number this test picked,
+    // so a `melee_damage` that stopped reading the kit is a failure here rather
+    // than a formula compared against a copy of itself.
+    gate.each(|gate, side| {
+        let clock = gate
+            .game
+            .world
+            .cloned::<&smash::module::damage::MatchClock>()
+            .0;
+        let amount = smash::input::melee_damage(gate.view(side.player), side.foe, clock);
+        gate.hit(side.foe, amount, DamageKind::Melee);
+    });
+    gate.advance(0.05);
+
+    gate.differ("the health left on the player who was hit", |gate, side| {
+        observable(gate.health(side.foe).current)
+    });
+}
+
+/// `armor`: the same hit lands for less on the better-armoured kit.
+#[test]
+fn armor_changes_how_much_of_a_hit_lands() {
+    let gate = Gate::new(|stats| stats.armor = base().armor + 8.0);
+
+    gate.each(|gate, side| gate.hit(side.player, 10.0, DamageKind::Melee));
+    gate.advance(0.05);
+
+    gate.differ("the health left after an identical hit", |gate, side| {
+        observable(gate.health(side.player).current)
+    });
+}
+
+/// `knockback_taken`: the same hit launches the lighter kit further.
+#[test]
+fn knockback_taken_changes_how_far_a_hit_launches() {
+    let gate = Gate::new(|stats| stats.knockback_taken = base().knockback_taken * 1.6);
+
+    gate.each(|gate, side| gate.hit(side.player, 8.0, DamageKind::Melee));
+    gate.advance(0.05);
+
+    // The seam call and not a component: an impulse the game computed and never
+    // sent is a bug a state assertion would miss.
+    gate.differ("the impulse the server was told to apply", |gate, side| {
+        observable_vec(gate.game.server.total_velocity(gate.id(side.player)))
+    });
+}
+
+/// `max_health`: the bigger pool survives a hit the smaller one does not.
+#[test]
+fn max_health_changes_how_much_damage_a_kit_survives() {
+    let gate = Gate::new(|stats| stats.max_health = base().max_health * 2.0);
+
+    gate.each(|gate, side| gate.hit(side.player, base().max_health, DamageKind::Ability));
+    gate.advance(0.05);
+
+    gate.differ(
+        "the health left after a hit for a full base bar",
+        |gate, side| observable(gate.health(side.player).current),
+    );
+}
+
+/// `energy`: the bar refills at the kit's rate.
+#[test]
+fn energy_changes_the_size_and_refill_rate_of_the_bar() {
+    let gate = Gate::new(|stats| stats.energy = Some((3.0, 0.6)));
+
+    // Emptied first, because both bars start full and a full bar hides a regen
+    // rate completely.
+    gate.each(|gate, side| {
+        gate.view(side.player)
+            .get::<&mut Energy>(|energy| energy.current = 0.0);
+    });
+    gate.advance(1.0);
+
+    gate.differ(
+        "the energy a second of regeneration put back",
+        |gate, side| observable(gate.view(side.player).cloned::<&Energy>().current),
+    );
+}
+
+/// `regen`: health comes back at the kit's rate. ENG-11450.
+#[test]
+fn regen_changes_how_fast_health_comes_back() {
+    let gate = Gate::new(|stats| stats.regen = base().regen * 3.0);
+
+    gate.each(|gate, side| gate.hit(side.player, 10.0, DamageKind::Ability));
+    gate.advance(4.0);
+
+    gate.differ(
+        "the health four seconds of regeneration put back",
+        |gate, side| observable(gate.health(side.player).current),
+    );
+}
+
+/// `hunger_interval`: the food bar drains at the kit's rate. ENG-11450.
+#[test]
+fn hunger_interval_changes_how_fast_the_food_bar_drains() {
+    let gate = Gate::new(|stats| stats.hunger_interval = base().hunger_interval / 4.0);
+
+    gate.advance(16.0);
+
+    gate.differ("the food bar after sixteen seconds", |gate, side| {
+        gate.view(side.player).cloned::<&Hunger>().food
+    });
+}
+
+/// What ENG-11440 has to make happen.
+///
+/// There is no entry point for a double jump in the game at all today -- the
+/// press is not routed, `JumpsLeft` is re-armed and never spent, and no
+/// velocity is applied -- so there is nothing this function can call. It is the
+/// one line ENG-11440 replaces, and the two tests below are `#[ignore]` until
+/// it does.
+fn double_jump(gate: &Gate, side: &Side) {
+    // Airborne, which is the only precondition the game already models.
+    gate.view(side.player).set(OnGround(false));
+}
+
+/// `jump_power`: the double jump's impulse.
+///
+/// `#[ignore]`: fails until ENG-11440 lands, because nothing applies the
+/// impulse. That failure *is* the finding -- do not delete the test to make the
+/// suite green.
+#[test]
+#[ignore = "ENG-11440: double jump is not implemented; nothing reads jump_power"]
+fn jump_power_changes_how_high_a_double_jump_goes() {
+    let gate = Gate::new(|stats| stats.jump_power = base().jump_power * 2.0);
+
+    gate.each(double_jump);
+    gate.advance(0.1);
+
+    gate.differ("the impulse the double jump asked for", |gate, side| {
+        observable_vec(gate.game.server.total_velocity(gate.id(side.player)))
+    });
+}
+
+/// `jump_control`: whether the double jump goes where you look.
+///
+/// `#[ignore]`: see [`jump_power_changes_how_high_a_double_jump_goes`].
+#[test]
+#[ignore = "ENG-11440: double jump is not implemented; nothing reads jump_control"]
+fn jump_control_changes_which_way_a_double_jump_goes() {
+    let gate = Gate::new(|stats| stats.jump_control = !base().jump_control);
+
+    // Looking sideways, so a controlled jump and an uncontrolled one point in
+    // measurably different directions rather than in the same one.
+    gate.each(|gate, side| {
+        gate.view(side.player)
+            .set(smash::module::player::Facing(Vec3::X));
+        double_jump(gate, side);
+    });
+    gate.advance(0.1);
+
+    gate.differ("the direction the double jump asked for", |gate, side| {
+        observable_vec(gate.game.server.total_velocity(gate.id(side.player)))
+    });
+}
+
+// ---------------------------------------------------------------------------
+// The part that closes the class.
+// ---------------------------------------------------------------------------
+
+/// Every field of [`KitStats`] is named by a test in this file.
+///
+/// Two halves, and neither works alone. The destructure is exhaustive, so
+/// adding a tenth field to `KitStats` stops this file *compiling* until
+/// somebody names it -- there is no way to add a stat and quietly not gate it.
+/// The source scan then requires that the name it was given here actually
+/// appears in a test above, so naming it in the list without writing the test
+/// fails too.
+///
+/// Without both, ENG-11450 recurs: a field arrives, every kit sets it, and no
+/// check anywhere notices that nothing reads it.
+#[test]
+fn every_kit_stats_field_is_gated_by_a_test_in_this_file() {
+    const FIELDS: [&str; 9] = [
+        "melee_damage",
+        "armor",
+        "knockback_taken",
+        "regen",
+        "hunger_interval",
+        "max_health",
+        "jump_power",
+        "jump_control",
+        "energy",
+    ];
+
+    let KitStats {
+        melee_damage: _,
+        armor: _,
+        knockback_taken: _,
+        regen: _,
+        hunger_interval: _,
+        max_health: _,
+        jump_power: _,
+        jump_control: _,
+        energy: _,
+    } = KitStats::default();
+
+    let source = include_str!("kit_stats.rs");
+    let gated: Vec<&str> = source
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("fn "))
+        .filter_map(|line| line.split_once('('))
+        .map(|(name, _)| name)
+        .collect();
+
+    let missing: Vec<&str> = FIELDS
+        .into_iter()
+        .filter(|field| !gated.iter().any(|name| name.starts_with(field)))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "these KitStats fields have no gate in this file: {missing:?}. Each needs a test giving \
+         two players kits that differ only in it and requiring an observable difference."
+    );
+}
+
+/// The gate can fail.
+///
+/// A differential harness that reported a difference between two identical
+/// worlds would pass every test above for any implementation, including no
+/// implementation. [`Gate::new`] refuses a mutation that changes nothing, which
+/// is the same guard from the other end; this is the one that watches a real
+/// read come out equal.
+#[test]
+#[should_panic(expected = "nothing in the game reads that field")]
+fn two_identical_kits_fail_the_gate() {
+    // A real perturbation, so `Gate::new` is satisfied, read through a quantity
+    // that field cannot touch: `armor` changes how much of a hit lands and
+    // nothing about the food bar.
+    let gate = Gate::new(|stats| stats.armor = base().armor + 8.0);
+    gate.each(|gate, side| gate.hit(side.player, 10.0, DamageKind::Melee));
+    gate.advance(1.0);
+    gate.differ("the food bar", |gate, side| {
+        gate.view(side.player).cloned::<&Hunger>().food
+    });
+}
+
+/// Starving is what an empty food bar is for.
+///
+/// The differential above proves `hunger_interval` reaches the bar. This is the
+/// other half of the mechanic and the reason the field exists at all:
+/// `[SOURCE]` + `[changelog]` "at zero it deals half a heart per second as true
+/// damage", which is Mineplex's replacement for a sudden-death timer.
+#[test]
+fn an_empty_food_bar_starves_a_player_regardless_of_armour() {
+    let gate = Gate::new(|stats| stats.armor = base().armor + 8.0);
+
+    gate.each(|gate, side| {
+        gate.view(side.player).set(Hunger {
+            food: 0,
+            interval: base().hunger_interval,
+            elapsed: 0.0,
+        });
+    });
+    let before = gate.health(gate.sides[0].player).current;
+    gate.advance(2.0);
+
+    let base_side = gate.health(gate.sides[0].player).current;
+    let armoured = gate.health(gate.sides[1].player).current;
+    assert!(
+        base_side < before,
+        "an empty food bar did not starve anybody"
+    );
+    assert_eq!(
+        observable(base_side),
+        observable(armoured),
+        "hunger is true damage, so armour must not change how fast a player starves"
+    );
+}
+
+/// Landing a hit puts food back, which is the counter-pressure the drain is
+/// there to create.
+///
+/// `[WIKI]` "If you do not attack, your hunger bar will start depleting, which
+/// can be filled back up by hitting other mobs with melee or your special
+/// skills."
+#[test]
+fn landing_a_hit_feeds_the_attacker() {
+    let gate = Gate::new(|stats| stats.armor = base().armor + 8.0);
+    let side = &gate.sides[0];
+
+    let hungry = Hunger {
+        food: 4,
+        interval: base().hunger_interval,
+        elapsed: 0.0,
+    };
+    gate.view(side.player).set(hungry);
+
+    let victim = gate.view(side.foe);
+    hurt(victim, Damaged {
+        attacker: Some(side.player),
+        amount: 5.0,
+        knockback: Knockback::from(victim.cloned::<&Position>().0 - Vec3::X),
+        kind: DamageKind::Melee,
+    });
+
+    assert_eq!(
+        gate.view(side.player).cloned::<&Hunger>().food,
+        hungry.food + smash::module::vitals::FOOD_PER_HIT,
+        "landing a hit did not feed the attacker"
+    );
+    assert!(
+        gate.game
+            .server
+            .calls()
+            .iter()
+            .any(|call| matches!(call, Call::SetFood(id, _) if *id == gate.id(side.player))),
+        "the attacker's client was never told their food bar had moved"
+    );
+}
+
+/// Neither clock runs outside a match.
+///
+/// A food bar that drained while a lobby waited for a second player would have
+/// somebody starving on the spawn platform before the countdown started.
+#[test]
+fn the_two_clocks_are_off_in_the_hub() {
+    let gate = Gate::new(|stats| stats.regen = base().regen * 3.0);
+    gate.game.world.set(Lobby {
+        phase: Phase::Waiting,
+        timer: 0.0,
+    });
+
+    gate.each(|gate, side| gate.hit(side.player, 10.0, DamageKind::Ability));
+    let hurt_to = gate.health(gate.sides[0].player).current;
+    gate.advance(16.0);
+
+    assert_eq!(
+        observable(gate.health(gate.sides[0].player).current),
+        observable(hurt_to),
+        "health regenerated in the hub"
+    );
+    assert_eq!(
+        gate.view(gate.sides[0].player).cloned::<&Hunger>().food,
+        smash::module::vitals::FULL,
+        "the food bar drained in the hub"
+    );
+}
+
+/// A player on zero health is not healed back over the line.
+///
+/// `arena::bounds_checks` eliminates anybody `Health::is_dead` and reads that
+/// within the same tick as the regeneration system runs. A heal off zero would
+/// therefore cancel deaths on some ticks and not others, which is the worst
+/// kind of bug to be handed: a kill that sometimes does not count.
+#[test]
+fn regeneration_does_not_resurrect_a_player_on_zero_health() {
+    let gate = Gate::new(|stats| stats.regen = 5.0);
+    let subject = gate.sides[1].player;
+
+    // Queued to respawn, which is what a real corpse is, and what puts them out
+    // of the kill plane's query so the test is about the heal rather than about
+    // what the arena did next.
+    gate.view(subject)
+        .get::<&mut Health>(|health| health.current = 0.0);
+    gate.view(subject)
+        .set(smash::module::lives::RespawnAt(f32::INFINITY));
+
+    gate.advance(1.0);
+
+    assert_eq!(
+        observable(gate.health(subject).current),
+        0,
+        "regeneration healed a player the kill plane had not finished with"
+    );
+}


### PR DESCRIPTION
[ENG-11450](https://linear.app/indexable/issue/ENG-11450)

## The finding

`KitStats` has nine fields and four of them were read by nothing. Every kit set
them, several tuned them against the wiki, and `kits/blaze.rs:8` argues at
length about which of two sources its regeneration number should come from --
while there was no health regeneration in the game at all, and no hunger.

This implements two of the four. `jump_power` and `jump_control` are ENG-11440's
and are untouched here.

## Health regeneration

`vitals::Regen`, copied off the kit by `kit::apply` and healed continuously by
`smash::Vitals::regenerate_health`.

`[INFERRED]` the unit is health points -- half-hearts -- per second, which is
what `docs/smash-design.md`'s "Regen (HP/s)" column means and the unit the rest
of the crate counts health in. The wiki gives the stat no unit ("0.35 Regen Per
Second") and its Slime page glosses 0.35 as "regenerating 1 heart in just four
seconds", which fits neither candidate: half-hearts per second gives 5.7 s to
the heart, hearts per second gives 2.9 s. One loose sentence is not enough to
move the unit, so the disagreement is written down in the doc and beside the
component rather than resolved.

It runs in combat and out. No source gates it on being out of combat, and the
design argues against one: health *is* the knockback percentage in this game, so
a regeneration that paused during a fight would be a percentage that only ever
went up. It stops for exactly one condition -- zero health. `arena::bounds_checks`
eliminates anybody `Health::is_dead` and reads that within the same tick this
system runs, in whichever order the two happen to be registered, so a heal off
zero would cancel deaths on some ticks and not others.

## Hunger

`vitals::Hunger` -- a food bar, the kit's interval, and the clock. One point
drains every `hunger_interval` seconds; at zero it deals `STARVE_DAMAGE` a
second as `DamageKind::Environment`, which is untouched by armour. That is
`[SOURCE]` + `[changelog]` and was already documented; only the ticking was
missing.

Landing a hit puts a point back. `[WIKI]` "if you do not attack, your hunger bar
will start depleting, which can be filled back up by hitting other mobs with
melee or your special skills", and the game's front page leads with "attack
enemies to refill your hunger bar" -- so the refill is not a guess, but *how
much* is stated nowhere. `FOOD_PER_HIT` is `[APPROXIMATED]` at one point: half a
shank, exactly what one drain tick removes, so a hit buys back an interval.
It is deliberately the only number in the mechanic that is ours.

Two decisions worth disagreeing with if you want to:

- **Both clocks are off outside `Phase::Playing`.** A food bar that drained
  while a lobby waited for a second player would have somebody starving on the
  spawn platform before the countdown started.
- **Dying does not refill the bar.** An anti-stall clock a player can reset by
  throwing a life away is not a clock. The end of a match does refill it, in
  `lobby::reset`, or a second match starts with whatever everyone had left.

The refill is hung off `Smashed` and not `Damaged`, because `Damaged` is emitted
at every attempt including the ones `apply_damage` refuses for respawn immunity
or a shield, and a refused hit fed nobody.

## The seam grew one verb

The food bar has to reach the client, and vanilla carries health and food in one
`SetHealth` packet while the two move on completely unrelated clocks -- health on
every hit, food once every seven seconds. `Server::set_food(player, food)` is the
new verb; the adapter keeps the other half of the packet on the player entity and
reassembles it. The alternative was a fourth argument on `set_health` that six
existing callers would each have had to supply a spare food level for.

## The gate, which is the actual point

`events/smash/tests/kit_stats.rs`. One test per `KitStats` field: two players on
kits identical but for that one field, the same scenario run against both, and a
difference required in what a client would see. That is stronger than "every
field has a reader", which `let _ = stats.regen;` satisfies.

All nine are covered, including the five that already worked -- those five are
the evidence the harness can tell a difference when there is one, not filler.
`two_identical_kits_fail_the_gate` is a `should_panic` case proving it can come
out red at all. `jump_power` and `jump_control` are `#[ignore]`d naming
ENG-11440; they fail today and that failure is the finding, not a bug in the
test.

Two things close the class rather than the three instances:

- The field list is an **exhaustive destructure** of `KitStats`, so adding a
  tenth field stops the file compiling until somebody names it. There is no way
  to add a stat and quietly not gate it.
- The name is then checked against the test functions actually present in the
  file, so naming it in the list without writing the test fails too.

### Watched both new gates fail

Deleting `.set(Regen(stats.regen))` from `kit::apply`:

```
test regen_changes_how_fast_health_comes_back ... FAILED

assertion `left != right` failed: the two kits differ in exactly one KitStats
field and the health four seconds of regeneration put back came out the same,
so nothing in the game reads that field
  left: 14000
 right: 14000

test result: FAILED. 12 passed; 1 failed; 2 ignored
```

Deleting `.set(Hunger::full(stats.hunger_interval))`:

```
test hunger_interval_changes_how_fast_the_food_bar_drains ... FAILED

assertion `left != right` failed: the two kits differ in exactly one KitStats
field and the food bar after sixteen seconds came out the same, so nothing in
the game reads that field
  left: 20
 right: 20

test result: FAILED. 12 passed; 1 failed; 2 ignored
```

One test each, no collateral, then restored.

### And watched each gate fail with its own field equalised

Deletion proves the field is *read*. It does not prove the scenario is sensitive
to that field rather than to something else that differs between two kits -- a
`regen` test whose difference actually came from the armour term would pass with
`regen` unimplemented and nobody would know. So each new scenario also runs
verbatim against a pair whose `regen` / `hunger_interval` is **equal** and whose
`melee_damage` differs instead, a field neither read can touch. With
`#[should_panic]` lifted so the values print:

```
thread 'the_regen_gate_reds_when_regen_is_the_field_left_equal' panicked:
assertion `left != right` failed: ... the health four seconds of regeneration
put back came out the same, so nothing in the game reads that field
  left: 15000
 right: 15000

thread 'the_hunger_gate_reds_when_the_interval_is_the_field_left_equal' panicked:
assertion `left != right` failed: ... the food bar after sixteen seconds came
out the same, so nothing in the game reads that field
  left: 18
 right: 18
```

Both are `should_panic`, which passes for *any* panic, so both were also checked
the other way: given the perturbation they are meant to be blind to, they fail
as `note: test did not panic as expected`. Neither is vacuous.

## Checks

- `cargo test -p smash` -- 337 passed, 0 failed, 7 ignored (4 doc-tests and 3
  pre-existing ENG-10852/10951 subprocess aborts; nothing this PR adds is
  ignored).
- `cargo fmt --all --check` -- clean.
- `cargo clippy --all-targets` (workspace, `-D pedantic`) -- clean.
- `nix build .#checks.aarch64-darwin.smash-dev-boot-e2e` -- passes. This is the
  one that matters for a new flecs module: it boots the game server compiled
  with `debug_assertions` on, so a use-before-register aborts during module init
  rather than being compiled out the way every release gate compiles it out.
  A client joins and reaches play state.

## Rebased onto #1095, and it found a bug in this PR

Resolving the two conflicts (`world.component::<Vitals>()` beside the renamed
`PlayerBars`, and the `SmashModule` import list) was mechanical. Reading #1095's
new drain pass rather than resolving around it was not, and it is what caught
the following.

**`set(Vitals)` from inside `apply` is a deferred command.** So a `SetHealth`
and a `SetFood` for the same player in one drain had the second read the
component as it stood before the first — sending the *default* full health
beside the new food level and snapping the client's health bar to full for a
frame. The trigger is a player who both takes a hit and lands one in the same
tick, which in a fighting game is constant.

This is the identical hazard #1095 documents for `PlayerBars` (`world.entity()`
returns an id at once while the `set` recording it waits for the merge), and it
is fixed the same way: one map for the whole drain, seeded from the component,
mutated in order, written back once per player.

**It is not covered by any test**, and that is worth saying rather than
implying. `apply` lives in the adapter and no in-process test imports it — the
same gap #1095 names for `PlayerBars` in its own description. `smash-dev-boot-e2e`
sees registration, not values. Filed as
[ENG-11475](https://linear.app/indexable/issue/ENG-11475), which is ENG-11450's
own finding one layer down: code with no gate.

Also took #1095's `BarSlot::COUNT = ALL.len()` lesson: `FIELDS: [&str; 9]` in the
gate held the field count a second time next to the destructure that actually
enforces it, and is now a slice.

## Rebased again onto #1096, and the guard fired on its first real test

`jump_count` arrived as a tenth `KitStats` field. This file did not silently
pass it — it refused to build:

```
error[E0027]: pattern does not mention field `jump_count`
 --> events/smash/tests/kit_stats.rs:427:9
```

Worth being precise about which half caught it. The **exhaustive destructure**
did. The `FIELDS` slice would not have: a tenth field with no entry and no test
passes the source scan silently, because the scan checks that *listed* names
have tests, not that every field is listed. The two halves are not redundant and
this is the case that shows why.

#1096 landed the double jump but not the `kit_stats.rs` half of the handoff, so
those four edits are here: the tenth field in both places, a `jump_count` gate,
the real press path in `double_jump`, and both `#[ignore]`s gone. **All ten
fields are now gated and nothing in the file is ignored.**

`double_jump` presses through the production path — `OnGround(false)`, one tick
for `arm_double_jump` to grant permission, then the `Flying` mirror the client
sets and `spend_double_jump` reads. Nothing reaches past those systems to apply
an impulse itself, which would have made all three jump gates decoration.

### Both directions on all three jump gates

Pass is not enough, so each was also run with its own field equalised and
`melee_damage` perturbed instead — a field no impulse can reach. All three red:

```
assertion `left != right` failed: ... the impulse the double jump asked for came
out the same, so nothing in the game reads that field
  left: [0, 1000, 0]
 right: [0, 1000, 0]
```

`[0, 1000, 0]` is a straight-up base jump, identical on both sides. Each gate is
sensitive to its own field rather than to something else that differs.

Those three are verified but **not shipped as controls** — only `regen`,
`hunger_interval` and `armor` have shipped `should_panic` controls, so seven of
ten fields have no standing sensitivity check. Making that uniform is a
restructure of the file into a `(field, perturb, scenario)` table rather than
seven more functions, and doing it during this PR's own review is how a gate
stops being reviewable. [ENG-11487](https://linear.app/indexable/issue/ENG-11487).

## A second seam bug, found by being asked the right question

"Does your work have #1096's bug?" — cached seam state never invalidated when
game state changes. It did.

`drain_hunger` and `feed_the_attacker` push to the client because they are the
paths somebody thought about. The two that *replace* the whole bar did not,
because neither looks like a hunger mechanic. `lobby::reset` is the reachable
one: after a match the bar refills to twenty and nothing tells anybody, so every
player spends up to 7.75 seconds watching the previous match's drained bar,
which then jumps to nineteen at the next drain tick. Watched failing:

```
the bar was refilled and the client was never told, so it goes on drawing the
drained one until the next drain tick
```

`kit::apply` is the other write site and its test says plainly that it is **not**
reachable today — its only caller refuses a kit change outside
`Waiting | Countdown`, where the bar is always full. It is held to the invariant
anyway, and tested rather than left as unexercised defence.

Also pinned: dying does not refill the bar. That is a balance decision — an
anti-stall clock a player can reset by throwing away one of four lives is not a
clock — and those regress silently, so it is a test and not a comment.

## Review findings, all four taken

**C1 — regeneration never crossed the seam, and the gate could not see it.**
The worst finding of the set and the ticket's own theme landing inside the
artefact built to prevent it.

`regenerate_health` healed through a `&mut Health` query term. flecs reaches
`flecs_notify_on_set` from `ecs_set`, `ecs_modified` and add-with-value only,
never from query iteration — so `mirror_health_to_host` never fired, no packet
was queued, and **the client's hearts did not move**, while the boss bar (which
reads the component directly) did. Every other `Health` writer in the crate
pairs its write with an explicit push; this one was the exception.

The gate read the `Health` component. Four tests above it,
`knockback_taken_changes_how_far_a_hit_launches` reads the *seam call*, with the
comment *"an impulse the game computed and never sent is a bug a state assertion
would miss"*. The regen gate now reads the seam call too, and against the
unfixed code it reports:

```
assertion `left != right` failed: ... the health four seconds of regeneration
told the client about came out the same
  left: None
 right: None
```

`None` on both sides: not one packet in four seconds.

Not fixed with `.set(Health)`, which fires the mirror twenty times a second per
player. Change detection on the half-heart a client can actually draw — and
**with no cached last-sent value**, because before and after are both in hand on
the same tick. That matters beyond tidiness: a cache is seam state needing
invalidation on death, respawn and kit change, which is the class that bit this
PR twice already. Measured, and pinned by a test with both bounds: **ten packets
to climb ten half-hearts over 200 ticks**, where the naive fix sends 200.

**C2 — a tenth field could still arrive ungated.** `FIELDS` and the destructure
were two hand-written lists with nothing linking them, so compilation broke at
the destructure only and `foo: _` was a green fix — the same hand-maintained
second copy as #1095's array length. One macro now expands to both. Watched both
stages with a dummy eleventh field:

```
error: pattern requires `..` due to inaccessible fields
```
then, after the only edit that compiles:
```
these KitStats fields have no gate in this file: ["dummy_eleventh"]
```

**C3 was already fixed** in the food-bar commit — the review saw an earlier head.

**C4 taken rather than filed.** A starving player was announced to the arena as
having *"fell out of bounds!"*, because the chat line branched on whether anyone
got the kill while `hud::death_title` matches on the cause. Both match the cause
now. The third arm was unreachable until hunger shipped.

Both smaller notes taken. The scan collects `#[test]` functions only, so the
`double_jump` helper no longer counts as a gate. And pinning the phase in
`the_two_clocks_are_off_in_the_hub` immediately showed it had been running in
`Preparing`, not `Waiting` — passing for the right answer by one phase of luck,
on arithmetic I had asserted and got wrong.

One more of my own found while writing the packet-rate test: its first version
measured `sides[0]`, the *base* kit at 0.25/s, while its comment described the
1.0/s variant. It passed on a number that meant something else. Now it reads the
perturbed side, uses `Environment` damage so armour does not enter the
arithmetic, and asserts the start and end health it claims.

## Not fixed here

Six of the fifteen kits carry the wrong `hunger_interval`, all by silently
inheriting the 7.75 s default: Zombie, Wither Skeleton and Snowman should be
7.0, and Spider, Wolf and Chicken 6.25, per the relaunch changelog. Invisible
while nothing read the field; live wrongness now that something does.
[ENG-11463](https://linear.app/indexable/issue/ENG-11463), kept out of this PR
because it edits the same `KitStats { .. }` literals in the same kit files that
ENG-11440 currently has open.

## Not verified

The attacker feed writes through a live `Hunger` pointer rather than a
read-copy-`set` round trip, matching how `damage.rs` writes `Health` from inside
its own observer. I could not construct a case that distinguishes the two: two
`hurt`s inside `world.defer` fed the attacker twice under both spellings, so the
test I wrote for it discriminated nothing and was deleted rather than shipped.
The comment beside the code says as much.
