### PR TITLE
docs(smash): say why an eliminated player's flight cache is left stale

### DIFF
--- a/events/smash/src/module/jump.rs
+++ b/events/smash/src/module/jump.rs
@@ -121,6 +121,26 @@ impl Module for JumpModule {
         // flies. Writing an abilities packet at one would take that away and
         // leave them stuck to the floor of a match they are watching, so both
         // halves of the mechanic step around them.
+        //
+        // Stepping around them leaves `MayFly` and `Flying` stale, and for a
+        // player who respawns that is a bug: `lives.rs`'s `respawn` resets all
+        // three, and the comment there says why it cannot be done at the death
+        // transition instead. For an *eliminated* player nothing resets them
+        // and that is deliberate, not an oversight:
+        //
+        // The stale `allow` bit is inert, because a spectator's flight comes
+        // from their gamemode rather than from this packet. And if `Eliminated`
+        // is ever cleared -- a new match, a return to the hub -- the mechanic
+        // heals itself on the next tick without a jump being granted: the
+        // grounded check in `spend_double_jump` refuses a press from somebody
+        // standing on the floor, and `arm_double_jump` recomputes and pushes
+        // whatever is actually true.
+        //
+        // So do not "fix" this by resetting on death. That is the race the
+        // comment in `respawn` describes -- `Op::Spectating` defers gamemode
+        // publication to hyperion's roster, so a `Disarmed` pushed beside it
+        // can land after the gamemode packet and tell a spectator it may not
+        // fly, on every death rather than only the airborne ones.
         world
             .system_named::<(&OnGround, &JumpsLeft, &mut MayFly, &PlayerId)>("arm_double_jump")
             .with(Player::id())


### PR DESCRIPTION
Comment only. No behaviour change; `cargo test -p smash` and
`cargo clippy --all-targets --all-features` both clean.

Follow-up to #1096, which fixed the respawn half of this and landed before the
review note asking for the other half to be written down.

`arm_double_jump` and `spend_double_jump` both carry `.without(Eliminated)` and
`.without(RespawnAt)`, which leaves `MayFly` and `Flying` stale for anyone
inside that window. For a player who **respawns** that was a real defect — a
`JumpsLeft` the client would not spend, and a press from before death replayed
at the spawn point — and #1096 resets all three in `lives.rs`'s `respawn`.

For an **eliminated** player nothing resets them, and that is deliberate. The
problem is that a deliberate inconsistency with no reason attached looks exactly
like the bug sitting next to it, so the next person to read it either files it
again or "fixes" it by moving the reset to the death transition — which is the
race `respawn` is deliberately avoiding. `Op::Spectating` only sets the
`Gamemode` component and defers publication to hyperion's roster, so a
`Flight::Disarmed` pushed beside `set_spectating(true)` can land *after* the
gamemode packet and tell a spectator it may not fly, on every death rather than
only the airborne ones.

So the comment records the two facts that make leaving it stale correct:

* a spectator's flight comes from their gamemode, not from this packet, so the
  stale `allow` bit is inert;
* if `Eliminated` is ever cleared, the grounded check in `spend_double_jump`
  refuses a press from somebody standing on the floor while `arm_double_jump`
  recomputes and pushes what is actually true — so it heals on the next tick
  without granting a jump.

A known-benign inconsistency with its reason written down costs nothing. The
same inconsistency undocumented costs somebody an hour, or an outage if they
resolve it the wrong way.
