### PR TITLE
test(smash): gate that a controlled jump follows the pitch, not just the yaw (ENG-11450)

### DIFF
--- a/events/smash/tests/kit_stats.rs
+++ b/events/smash/tests/kit_stats.rs
@@ -455,11 +455,16 @@ fn jump_power_changes_how_high_a_double_jump_goes() {
 fn jump_control_changes_which_way_a_double_jump_goes() {
     let gate = Gate::new(|stats| stats.jump_control = !base().jump_control);
 
-    // Looking sideways, so a controlled jump and an uncontrolled one point in
-    // measurably different directions rather than in the same one.
+    // A real yaw *and* a real pitch, not a flat sideways look. `impulse`
+    // normalises the whole facing vector, so the pitch decides how much of the
+    // jump goes upward -- and a purely horizontal `Vec3::X` cannot tell that
+    // apart from an implementation that throws the vertical component away,
+    // because there is no vertical component to throw. Looking up and to the
+    // side is the cheapest facing that exercises both.
+    let facing = Vec3::new(1.0, 1.0, 0.0).normalize();
     gate.each(|gate, side| {
         gate.view(side.player)
-            .set(smash::module::player::Facing(Vec3::X));
+            .set(smash::module::player::Facing(facing));
         double_jump(gate, side);
     });
     gate.advance(0.1);
@@ -467,6 +472,76 @@ fn jump_control_changes_which_way_a_double_jump_goes() {
     gate.differ("the direction the double jump asked for", |gate, side| {
         observable_vec(gate.game.server.total_velocity(gate.id(side.player)))
     });
+}
+
+/// A controlled double jump follows where you look, pitch included.
+///
+/// **Why the gate above is not enough, which I got wrong once before writing
+/// this.** `jump_control_changes_which_way_a_double_jump_goes` is a
+/// differential: it proves the *field matters*, because flipping it changes the
+/// impulse. It cannot prove what the field *does*. Dropping the pitch from
+/// `impulse` -- `Vec3::new(facing.x, 0.0, facing.z)` -- still produces a
+/// controlled jump that differs from an uncontrolled one, so that gate stays
+/// green on a version that ignores where you are looking vertically. I checked;
+/// it does.
+///
+/// This one is a differential on the *facing* rather than on a kit stat, with
+/// both players on the same controlled kit and only their pitch different. A
+/// version that flattens the look cannot tell those two apart, so it reds.
+///
+/// Through the production press path, for the reason the whole file is: the
+/// pure `impulse()` function was already covered, and a field gated only as a
+/// function argument is not gated as something that reaches a client.
+#[test]
+fn a_controlled_double_jump_follows_the_pitch_you_are_looking_at() {
+    let mut game = Game::new();
+    kit::define(&game.world, "PitchGate", KitStats {
+        jump_control: true,
+        ..base()
+    })
+    .register();
+
+    // Same yaw, different pitch: level, and steeply up.
+    let looks = [Vec3::new(1.0, 0.0, 0.0), Vec3::new(1.0, 2.0, 0.0)];
+    let mut players = Vec::new();
+    for (index, look) in looks.iter().enumerate() {
+        players.push(game.player(&format!("pitch{index}"), COLUMNS[index]));
+        let chosen = kit::by_name(&game.world, "PitchGate").expect("just defined");
+        let view = game.world.entity_from_id(players[index]);
+        kit::apply(&game.world, view, chosen);
+        view.set(smash::module::player::Facing(look.normalize()));
+    }
+
+    game.world.set(Lobby {
+        phase: Phase::Playing,
+        timer: 0.0,
+    });
+    for player in &players {
+        game.world.entity_from_id(*player).set(OnGround(false));
+    }
+    game.advance(harness::TICK, 1);
+    for player in &players {
+        game.world.entity_from_id(*player).set(Flying(true));
+    }
+    game.advance(0.1, 2);
+
+    let impulses: Vec<[i64; 3]> = players
+        .iter()
+        .map(|player| {
+            let id = game.world.entity_from_id(*player).cloned::<&PlayerId>();
+            observable_vec(game.server.total_velocity(id))
+        })
+        .collect();
+
+    assert!(
+        impulses.iter().all(|impulse| *impulse != [0, 0, 0]),
+        "neither player jumped, so this compares two absences: {impulses:?}"
+    );
+    assert_ne!(
+        impulses[0], impulses[1],
+        "two players on the same kit looking at different pitches were launched identically, so \
+         the vertical half of where you look is being thrown away"
+    );
 }
 
 /// `jump_count`: how many mid-air jumps a kit gets before touching ground.


### PR DESCRIPTION
Follow-up to #1097 ([ENG-11450](https://linear.app/indexable/issue/ENG-11450)),
test-only. Prompted by the #1096 review's note that `jump_control` coverage
never composes a real look direction.

## The finding is about the gate, not the code

`jump_control_changes_which_way_a_double_jump_goes` (from #1097) is a
**differential**: two kits differing only in `jump_control`, require the impulse
to differ. That proves the *field matters*. It cannot prove what the field
*does*, and I did not appreciate the distinction until I tried to close the gap.

My first attempt was to give the facing a real pitch as well as a yaw, on the
theory that a richer input made a stronger test. Then I mutated `impulse` to
throw the pitch away:

```rust
Vec3::new(facing.x, 0.0, facing.z).normalize_or_zero() * stats.jump_power + Vec3::Y * LIFT
```

and the gate **stayed green** — because a flattened controlled jump still
differs from an uncontrolled one. Both jump differentials tolerate that
mutation. A better input does not fix a differential; the question it asks is
the wrong one.

## The fix is a different shape

A differential on the **facing** rather than on a kit stat: two players, one
controlled kit, same yaw, different pitch, pressed through the production path.
A version that flattens the look cannot tell them apart. Against the mutation:

```
assertion `left != right` failed: two players on the same kit looking at
different pitches were launched identically, so the vertical half of where you
look is being thrown away
  left: [1000, 200, 0]
 right: [1000, 200, 0]
```

Mutation reverted, green.

Driven through `OnGround(false)` → tick → `Flying(true)` — the real press path —
rather than calling `impulse()` directly. The pure function was already covered,
and a field gated only as a function argument is not gated as something that
reaches a client, which is the gap the #1096 review named.

## Checks

- `cargo test -p smash` — 338 passed, 0 failed, 7 ignored (4 doc-tests and 3
  pre-existing ENG-10852/10951 subprocess aborts).
- `cargo fmt --all --check` and `cargo clippy --all-targets` clean.
- No production code changes, so no boot gate rerun: `events/smash/tests/kit_stats.rs`
  is the only file touched.

## Related, not in here

[ENG-11487](https://linear.app/indexable/issue/ENG-11487) — only 3 of 10
`KitStats` fields have standing sensitivity controls. This PR adds a *correctness*
gate for one field rather than making the sensitivity coverage uniform, which is
a restructure of the file into a `(field, perturb, scenario)` table.
