### PR TITLE
test(smash): give the adapter drain a real test (ENG-11475)

### DIFF
--- a/crates/hyperion/Cargo.toml
+++ b/crates/hyperion/Cargo.toml
@@ -69,6 +69,16 @@ valence_registry = { workspace = true }
 valence_server = { workspace = true }
 ordered-float = { workspace = true }
 
+[features]
+# Test-only helpers for building a `Compose` a downstream crate can read back:
+# see `hyperion::net::test_util`. Off by default and enabled by `smash` only
+# under `[dev-dependencies]`, so it is in no published surface for a normal
+# build. `nix/checks/test-util-is-dev-only.nix` fails the build if any
+# non-dev dependency turns it on -- a feature that exists for tests is one
+# careless `features = [..]` away from being load-bearing in production, and
+# by then removing it is a breaking change.
+test-util = []
+
 [dev-dependencies]
 approx = { workspace = true }
 divan = { workspace = true }

--- a/crates/hyperion/src/net/mod.rs
+++ b/crates/hyperion/src/net/mod.rs
@@ -726,13 +726,68 @@ impl IoBuf {
     }
 }
 
-#[cfg(test)]
+/// Helpers for driving this crate's egress from a downstream crate's tests.
+///
+/// Behind the off-by-default `test-util` feature, because everything here
+/// exists to be called from a `#[cfg(test)]` block and nothing in a running
+/// server should reach it.
+///
+/// # Why this is a feature and not four dependencies
+///
+/// Building a readable [`Compose`] from outside `hyperion` needs
+/// [`IoBuf::add_proxy`] (crate-private, and a real API this should not widen),
+/// `libdeflater::CompressionLvl`, `valence_protocol::CompressionThreshold` and
+/// a `tokio` channel; reading a frame back needs `rkyv` and
+/// `hyperion_proxy_proto`. That is six things a consumer would have to depend
+/// on and keep in step to assert on one packet. Two functions behind a flag is
+/// the smaller surface.
+#[cfg(feature = "test-util")]
+pub mod test_util {
+    use bytes::Bytes;
+    use hyperion_proxy_proto::ArchivedServerToProxyMessage;
+    use tokio::sync::mpsc::UnboundedReceiver;
+
+    use super::Compose;
+
+    /// A [`Compose`] wired to one proxy, and that proxy's receiving end.
+    ///
+    /// Everything the game sends to this player lands on the returned channel
+    /// instead of a socket, so a test can read what a client would have been
+    /// told rather than what the game intended to tell them.
+    #[must_use]
+    pub fn compose_with_proxy() -> (Compose, UnboundedReceiver<Bytes>) {
+        let (compose, zero, _one) = super::tests::two_proxies();
+        (compose, zero)
+    }
+
+    /// The raw packet bytes of the next unicast frame, or `None` when the
+    /// channel is empty or the next frame is not a unicast.
+    ///
+    /// The rkyv step lives here rather than in the caller so a consumer needs
+    /// no `rkyv` or `hyperion_proxy_proto` dependency of its own.
+    #[must_use]
+    pub fn next_unicast(rx: &mut UnboundedReceiver<Bytes>) -> Option<Vec<u8>> {
+        let bytes = rx.try_recv().ok()?;
+        // `encode_proxy_message` writes an eight-byte big-endian length before
+        // the rkyv body; see `tests::next_variant` for the alignment argument.
+        let body = &bytes[size_of::<u64>()..];
+        let message = unsafe { rkyv::access_unchecked::<ArchivedServerToProxyMessage<'_>>(body) };
+        match message {
+            ArchivedServerToProxyMessage::Unicast(unicast) => Some(unicast.data.to_vec()),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
 pub(crate) mod tests {
     use std::sync::Arc;
 
     use hyperion_proxy_proto::ArchivedServerToProxyMessage;
 
-    use super::*;
+    // Named rather than a glob: `test-util` compiles this module outside
+    // `cfg(test)`, where the workspace's pedantic `wildcard_imports` applies.
+    use super::{ChannelId, Compose, CompressionLvl, ConnectionId, IoBuf, ProxyId};
     use crate::{CompressionThreshold, Global, common::Shared, simulation::EgressComm};
 
     /// A [`Compose`] with two proxies registered, and the receiving end of each proxy's channel.

--- a/events/smash/Cargo.toml
+++ b/events/smash/Cargo.toml
@@ -25,6 +25,13 @@ valence_nbt = { workspace = true }
 valence_protocol = { workspace = true }
 
 [dev-dependencies]
+# The same `hyperion` the `[dependencies]` entry above pulls in, with the
+# test-only egress helpers turned on. Cargo unifies the two into one build of
+# the crate, so this does *not* enable the feature for the server binary --
+# features are additive per build, and a dev-dependency's are only added to the
+# test build. `nix/checks/test-util-is-dev-only.nix` is what keeps that true
+# rather than merely intended.
+hyperion = { workspace = true, features = ["test-util"] }
 proptest = { workspace = true }
 
 [lints]

--- a/events/smash/src/adapter.rs
+++ b/events/smash/src/adapter.rs
@@ -408,58 +408,66 @@ impl Module for SmashAdapterModule {
             .system_named::<(&OpQueue, &Compose)>("apply_server_ops")
             .kind(id::<flecs::pipeline::PostUpdate>())
             .each_iter(|it, _, (queue, compose)| {
-                let world = it.world();
                 let drained =
                     std::mem::take(&mut *queue.0.lock().expect("server op queue poisoned"));
-                // Every player's bars, resolved before any op is applied.
-                //
-                // `world.entity()` hands back its id at once but the
-                // `set(PlayerBars)` that records it is deferred to the merge,
-                // so a second `SetBossBar` for the same player in one drain
-                // still reads the component as it stood at the start of the
-                // tick. Resolving every slot into one map first, and writing
-                // the component back once per player, is what makes a
-                // duplicate bar impossible rather than merely unlikely. Doing
-                // it per slot instead loses the other slot's entity to the
-                // last write, and the tick after that mints a second bar for
-                // it -- two match bars stacked on one screen.
-                let mut bars: HashMap<Entity, PlayerBars> = HashMap::new();
-                for op in &drained {
-                    let Op::SetBossBar { player, slot, .. } = op else {
-                        continue;
-                    };
-                    let resolved = match bars.entry(*player) {
-                        Entry::Occupied(held) => held.into_mut(),
-                        Entry::Vacant(empty) => match bars_of(world, *player) {
-                            Some(held) => empty.insert(held),
-                            None => continue,
-                        },
-                    };
-                    resolved.0[slot.index()] = Some(match resolved.0[slot.index()] {
-                        Some(bar) if world.entity_from_id(bar).is_alive() => bar,
-                        _ => mint_bar(world, *player),
-                    });
-                }
-                for (player, resolved) in &bars {
-                    world.entity_from_id(*player).set(*resolved);
-                }
-                // The same hazard as `bars` above, one type along, and the
-                // reason this is a map rather than a component read per op:
-                // `set(Vitals)` is deferred too, so a `SetHealth` and a
-                // `SetFood` for one player in one drain -- a player who traded
-                // hits, which is a tick that happens constantly -- would have
-                // the second read the component as it stood before the first.
-                // It would send the *default* full health beside the new food
-                // level and snap the client's health bar to full for a frame.
-                // Carried across the loop and written back once per player.
-                let mut vitals: HashMap<Entity, Vitals> = HashMap::new();
-                for op in drained {
-                    apply(world, compose, op, &bars, &mut vitals);
-                }
-                for (player, held) in &vitals {
-                    world.entity_from_id(*player).set(*held);
-                }
+                drain(it.world(), compose, drained);
             });
+    }
+}
+
+/// Apply one tick's worth of queued ops.
+///
+/// A named function and not the body of the system above, so a test can hand
+/// it a `Vec<Op>` and read what came out. That is not a cosmetic split: **both
+/// defects this drain has had were in this loop rather than in [`apply`]**, in
+/// how per-player state is carried from one op to the next, and a test that
+/// called `apply` directly while threading the maps by hand would have
+/// exercised the half that was never broken. See ENG-11475.
+fn drain(world: WorldRef<'_>, compose: &Compose, drained: Vec<Op>) {
+    // Every player's bars, resolved before any op is applied.
+    //
+    // `world.entity()` hands back its id at once but the `set(PlayerBars)`
+    // that records it is deferred to the merge, so a second `SetBossBar` for
+    // the same player in one drain still reads the component as it stood at
+    // the start of the tick. Resolving every slot into one map first, and
+    // writing the component back once per player, is what makes a duplicate
+    // bar impossible rather than merely unlikely. Doing it per slot instead
+    // loses the other slot's entity to the last write, and the tick after
+    // that mints a second bar for it -- two match bars stacked on one screen.
+    let mut bars: HashMap<Entity, PlayerBars> = HashMap::new();
+    for op in &drained {
+        let Op::SetBossBar { player, slot, .. } = op else {
+            continue;
+        };
+        let resolved = match bars.entry(*player) {
+            Entry::Occupied(held) => held.into_mut(),
+            Entry::Vacant(empty) => match bars_of(world, *player) {
+                Some(held) => empty.insert(held),
+                None => continue,
+            },
+        };
+        resolved.0[slot.index()] = Some(match resolved.0[slot.index()] {
+            Some(bar) if world.entity_from_id(bar).is_alive() => bar,
+            _ => mint_bar(world, *player),
+        });
+    }
+    for (player, resolved) in &bars {
+        world.entity_from_id(*player).set(*resolved);
+    }
+    // The same hazard as `bars` above, one type along, and the reason this is
+    // a map rather than a component read per op: `set(Vitals)` is deferred
+    // too, so a `SetHealth` and a `SetFood` for one player in one drain -- a
+    // player who traded hits, which is a tick that happens constantly --
+    // would have the second read the component as it stood before the first.
+    // It would send the *default* full health beside the new food level and
+    // snap the client's health bar to full for a frame. Carried across the
+    // loop and written back once per player.
+    let mut vitals: HashMap<Entity, Vitals> = HashMap::new();
+    for op in drained {
+        apply(world, compose, op, &bars, &mut vitals);
+    }
+    for (player, held) in &vitals {
+        world.entity_from_id(*player).set(*held);
     }
 }
 
@@ -1008,4 +1016,189 @@ fn json_text(text: &str, color: Option<&str>) -> String {
 #[must_use]
 pub fn minecraft_id(entity: EntityView<'_>) -> i32 {
     entity.minecraft_id()
+}
+
+/// What the drain actually put on the wire.
+///
+/// The gap ENG-11475 exists for: `tests/` drives `MockServer`, which is the
+/// other side of the `Server` trait, so everything from [`Op`] onwards -- the
+/// drain, its per-player maps, and the packets they produce -- was exercised
+/// only by the e2e gates. Those count packets by id, and **both defects this
+/// drain has had emitted exactly the right packet with the wrong contents**.
+///
+/// # The offsets are a known limit, and they are why the layout is spelled out
+///
+/// These read fixed byte offsets into `SetHealth`. That is fine for this packet
+/// -- fixed layout, three fields, no counts -- and it is wrong as a general
+/// approach: a variable-length field earlier in a packet moves everything after
+/// it. **If you are here to add a third case with such a packet, decode it
+/// properly rather than extending the offsets.**
+///
+/// The layout is written out below rather than assumed for a specific reason.
+/// The first version of this hand-guessed the offsets and read `3.6e24`, and
+/// because a wrong offset reads plausible garbage *identically for both frames*
+/// a check shaped as "the two differ" would have passed on a completely misread
+/// packet. An assertion whose verdict is about bytes it is not actually reading
+/// is the same defect one level in.
+#[cfg(test)]
+mod drain_tests {
+    use flecs_ecs::prelude::*;
+    use hyperion::net::{
+        ConnectionId, ProxyId,
+        test_util::{compose_with_proxy, next_unicast},
+    };
+
+    use super::{Op, PlayerBars, Vitals, drain};
+
+    /// `[varint len][00 uncompressed][0x68 SetHealth][f32 BE health][varint food][f32 BE sat]`
+    ///
+    /// Verified against a real frame: `0b 00 68 40e00000 0b 40a00000` is eleven
+    /// bytes of uncompressed `SetHealth` carrying 7.0 health, 11 food and 5.0
+    /// saturation. The `00` is the compression prefix -- zero means the body is
+    /// not compressed, which it never is here because the packet is far under
+    /// the 256-byte threshold.
+    const PACKET_ID: usize = 2;
+    const HEALTH: usize = 3;
+    const FOOD: usize = 7;
+    const SET_HEALTH: u8 = 0x68;
+
+    fn decode_set_health(frame: &[u8]) -> (f32, u8) {
+        assert_eq!(
+            frame[PACKET_ID], SET_HEALTH,
+            "not a SetHealth frame, so the offsets below are reading something else: {frame:02x?}"
+        );
+        let health = f32::from_be_bytes([
+            frame[HEALTH],
+            frame[HEALTH + 1],
+            frame[HEALTH + 2],
+            frame[HEALTH + 3],
+        ]);
+        (health, frame[FOOD])
+    }
+
+    // Every test here runs the drain inside `World::defer`, and that is not
+    // decoration. In production `drain` is the body of a system, where flecs
+    // queues every `set` until the merge -- which is the entire mechanism
+    // behind both defects below. Calling `drain` straight from a test applies
+    // each `set` immediately, so the second op reads what the first one wrote
+    // and *both tests pass against both the fixed and the broken
+    // implementation*. Found by watching them pass on code un-fixed on
+    // purpose. Wrap the drain, or the test is theatre.
+
+    /// A world with the components the drain touches, and one connected player.
+    fn world_with_player() -> (World, Entity) {
+        let world = World::new();
+        world.component::<Vitals>();
+        world.component::<PlayerBars>();
+        world.component::<ConnectionId>();
+        world.component::<hyperion::simulation::metadata::living_entity::Health>();
+        // `mint_bar` builds a bar entity out of these. A bare world registers
+        // nothing, and the workspace's `flecs_manual_registration` turns first
+        // use of an unregistered component into an abort rather than a lazy
+        // registration -- which is ENG-11000's assert doing its job on a test
+        // world instead of a server.
+        world.component::<hyperion::egress::boss_bar::BossBar>();
+        world.component::<hyperion::egress::boss_bar::ShownTo>();
+        world.component::<hyperion::egress::boss_bar::Title>();
+        world.component::<hyperion::egress::boss_bar::Progress>();
+        world.component::<hyperion::egress::boss_bar::Style>();
+        let player = world
+            .entity()
+            .set(ConnectionId::new(1, ProxyId::new(0)))
+            .id();
+        (world, player)
+    }
+
+    /// A `SetFood` after a `SetHealth` in one drain carries the health the
+    /// `SetHealth` set, not the default.
+    ///
+    /// The bug: `set(Vitals)` from inside `apply` is deferred, so reading the
+    /// component per op had the second op see the state from before the first
+    /// and send a full-health bar beside the new food level. A player who takes
+    /// a hit and lands one in the same tick is most exchanges in a fighting
+    /// game.
+    #[test]
+    fn a_food_push_after_a_health_push_keeps_the_health() {
+        let (world, player) = world_with_player();
+        let (compose, mut rx) = compose_with_proxy();
+
+        world.defer(|| {
+            drain((&world).into(), &compose, vec![
+                Op::SetHealth {
+                    player,
+                    health: 7.0,
+                    max: 20.0,
+                },
+                Op::SetFood { player, food: 11 },
+            ]);
+        });
+
+        let mut frames = Vec::new();
+        while let Some(frame) = next_unicast(&mut rx) {
+            frames.push(decode_set_health(&frame));
+        }
+
+        assert_eq!(frames.len(), 2, "expected one frame per op, got {frames:?}");
+        assert_eq!(
+            frames[0],
+            (7.0, 20),
+            "the health push should carry the new health and the untouched full food bar"
+        );
+        assert_eq!(
+            frames[1],
+            (7.0, 11),
+            "the food push should carry the new food beside the health the previous op set, not \
+             the default"
+        );
+    }
+
+    /// Two `SetBossBar` ops for different slots in one drain get two entities.
+    ///
+    /// #1095's half of the same class, and the reason `drain` is a named
+    /// function: resolving slots per op instead of in one pass loses the other
+    /// slot's entity to the last write, and the next tick mints a second bar
+    /// for it -- two match bars stacked on one screen.
+    #[test]
+    fn two_bar_slots_in_one_drain_get_two_entities() {
+        use crate::server::{BarColour, BarSlot, BossBar, Text};
+
+        let (world, player) = world_with_player();
+        let (compose, _rx) = compose_with_proxy();
+
+        let bar = |title: &str| BossBar {
+            title: Text::text(title.to_owned()),
+            progress: 0.5,
+            colour: BarColour::Green,
+        };
+        world.defer(|| {
+            drain((&world).into(), &compose, vec![
+                Op::SetBossBar {
+                    player,
+                    slot: BarSlot::Hud,
+                    bar: bar("hud"),
+                },
+                Op::SetBossBar {
+                    player,
+                    slot: BarSlot::Build,
+                    bar: bar("build"),
+                },
+            ]);
+        });
+
+        let held = world
+            .entity_from_id(player)
+            .try_get::<&PlayerBars>(|bars| *bars)
+            .expect("the drain records the bars it resolved");
+        let hud = held.0[BarSlot::Hud.index()];
+        let build = held.0[BarSlot::Build.index()];
+        assert!(
+            hud.is_some() && build.is_some(),
+            "a slot written in this drain has no entity: {held:?}"
+        );
+        assert_ne!(
+            hud, build,
+            "both slots resolved to the same bar entity, so one of the two bars is drawn over the \
+             other and the next tick mints a duplicate"
+        );
+    }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -570,6 +570,99 @@
                 ''
             );
 
+          # `hyperion`'s `test-util` feature stays a test-only feature.
+          #
+          # It exists so `smash`'s adapter tests can build a readable `Compose`
+          # (ENG-11475). Off by default and enabled by `smash` under
+          # `[dev-dependencies]`, which keeps it out of every normal build --
+          # but nothing about a cargo feature *enforces* that, and one careless
+          # `features = [ "test-util" ]` in a real `[dependencies]` entry makes
+          # it load-bearing in production, after which removing it is a
+          # breaking change. A convention nobody checks is a convention that
+          # has already been broken somewhere.
+          #
+          # Read off the raw manifests rather than `cargo metadata`, so this
+          # answers from the source of truth and needs no build to evaluate.
+          testUtilIsDevOnly =
+            let
+              members = (lib.importTOML ./Cargo.toml).workspace.members;
+              # Everything a normal `cargo build` would consult. `dev-dependencies`
+              # is deliberately absent: that is the one table allowed to ask.
+              shippingTables = [
+                "dependencies"
+                "build-dependencies"
+              ];
+              manifestOf = member: lib.importTOML (./. + "/${member}/Cargo.toml");
+              # `[target.'cfg(..)'.dependencies]` ships too, so it is folded in
+              # rather than trusted to be empty.
+              # Flattened *before* the null filter, not after: the target branch
+              # produces a list per target, so filtering first leaves nulls
+              # nested inside and hands `mapAttrsToList` a null.
+              tablesOf =
+                manifest:
+                lib.filter (table: table != null) (
+                  lib.flatten (
+                    map (name: manifest.${name} or null) shippingTables
+                    ++ lib.mapAttrsToList (
+                      _: target: map (name: target.${name} or null) shippingTables
+                    ) (manifest.target or { })
+                  )
+                );
+              # `hyperion = { workspace = true, features = [..] }` is a set;
+              # `hyperion = "1.0"` is a string and cannot ask for a feature.
+              asksFor = entry: lib.isAttrs entry && lib.elem "test-util" (entry.features or [ ]);
+              offendersIn =
+                member:
+                let
+                  named = lib.flatten (
+                    map (table: lib.mapAttrsToList (name: entry: { inherit name entry; }) table) (
+                      tablesOf (manifestOf member)
+                    )
+                  );
+                in
+                map (found: "${member} -> ${found.name}") (lib.filter (found: asksFor found.entry) named);
+              offenders = lib.flatten (map offendersIn members);
+              # The other half of the guarantee, and the half a manifest scan
+              # cannot see. Under resolver 1 a dev-dependency's features are
+              # unified into the normal build too, so `smash`'s
+              # `[dev-dependencies]` entry would put `test-util` in the server
+              # binary with every manifest above still reading correctly --
+              # this check green, the thing it protects broken. Verified as
+              # well as asserted: `cargo tree -p smash -e features
+              # --no-dev-dependencies` mentions test-util zero times, and with
+              # dev-dependencies once.
+              resolver = (lib.importTOML ./Cargo.toml).workspace.resolver or "1";
+              resolverIsFine = resolver == "2" || resolver == "3";
+            in
+            pkgs.runCommand "hyperion-test-util-is-dev-only" { } (
+              if !resolverIsFine then
+                ''
+                  echo "FAIL: workspace.resolver is ${resolver}." >&2
+                  echo "Resolver 1 unifies dev-dependency features into the normal" >&2
+                  echo "build, so smash's test-only hyperion feature would land in" >&2
+                  echo "the server binary and the manifest scan below would still" >&2
+                  echo "pass. Keep it at 2 or later." >&2
+                  exit 1
+                ''
+              else if offenders == [ ] then
+                ''
+                  echo "ok: ${
+                    toString (lib.length members)
+                  } workspace members, no shipping dependency enables test-util, resolver ${resolver}"
+                  touch "$out"
+                ''
+              else
+                ''
+                  echo "FAIL: test-util is enabled outside [dev-dependencies]:" >&2
+                  ${lib.concatMapStringsSep "\n" (o: ''echo "  ${o}" >&2'') offenders}
+                  echo "" >&2
+                  echo "That feature exists for tests and is off by default. Enabling" >&2
+                  echo "it from a shipping table puts test-only helpers in the server" >&2
+                  echo "binary and makes removing them a breaking change." >&2
+                  exit 1
+                ''
+            );
+
           # Every directory under events/ is a game server crate, so the set of
           # events is read from the tree rather than listed here. A new event
           # directory becomes a `nix run .#<event>` app with no flake edit.
@@ -1594,6 +1687,7 @@
 
             # No two end to end gates may claim one port. See `e2eOffsets`.
             e2e-ports-distinct = e2ePortsDistinct;
+            test-util-is-dev-only = testUtilIsDevOnly;
 
             # The deployed smash binary starts in an environment that says what
             # build it is. See `stamped` and


### PR DESCRIPTION
[ENG-11475](https://linear.app/indexable/issue/ENG-11475). Follows #1095 and #1097,
which each landed a value defect in the same blind spot within an hour of each
other.

## The gap

`events/smash/src/adapter.rs` holds the whole game→host seam, and **nothing
in-process built it**. `tests/` drives `MockServer`, which is the other side of
the `Server` trait, so everything from `Op` onwards — the drain, its per-player
maps, and the packets they produce — was covered only by the e2e gates.

Neither defect could have been caught:

| gate | why it misses |
| -- | -- |
| `cargo test -p smash` | never constructs the adapter |
| `smash-dev-boot-e2e` | sees a use-before-register, not a wrong value |
| e2e clients | count packets by id, and **both defects emitted the right packet with the wrong contents** |

## What this adds

**A `test-util` feature on `hyperion`**, off by default, exposing
`net::test_util::{compose_with_proxy, next_unicast}`: a `Compose` whose egress
lands on a readable channel, plus the rkyv decode step. That is the existing
`#[cfg(test)] two_proxies()` made reachable, not new machinery. Without it a
consumer needs libdeflater, valence_protocol, tokio, rkyv and
hyperion_proxy_proto as dev-dependencies, *and* `IoBuf::add_proxy` made public —
a real API that should not be widened for a test.

**`drain` lifted out of the `apply_server_ops` closure.** Both defects were in
the loop rather than in `apply`, in how per-player state carries from one op to
the next. A test that called `apply` while hand-threading the maps would have
exercised the half that was never broken.

**Two tests, each watched failing against its own pre-fix shape:**

```
left:  (20.0, 11)     # the SetFood frame carrying default full health
right: (7.0, 11)
```
```
a slot written in this drain has no entity: PlayerBars([None, Some(Entity(520))])
```

## Two things I got wrong first, both worth reading

**Both tests run inside `World::defer`, and that is load-bearing.** In
production `drain` is a system body, where flecs queues every `set` until the
merge — which is the entire mechanism behind both defects. Called straight from
a test, each `set` applies immediately, the second op reads what the first
wrote, and **both tests pass against both the fixed and the broken
implementation**. I found that by watching them pass on code I had just
un-fixed on purpose. It is written at the top of the test module, because a
future case added without the wrapper is theatre.

**The byte offsets are a known limit and the layout is spelled out because of
it.** My first version hand-guessed the offsets and read `3.6e24` — and a wrong
offset reads plausible garbage *identically for both frames*, so a check shaped
as "the two differ" would have passed on a completely misread packet. Fine for
`SetHealth`, which is fixed-layout; wrong the moment a packet has a
variable-length field earlier. Said in the file, where the third case gets
added.

## Keeping the feature dev-only

`checks.test-util-is-dev-only` reads every workspace manifest and fails if a
shipping table (`dependencies`, `build-dependencies`, or a `target.*` variant)
enables it. Watched failing — moving smash's entry to `[dependencies]`:

```
FAIL: test-util is enabled outside [dev-dependencies]:
  events/smash -> hyperion
```

**It also asserts `workspace.resolver`, because the manifest half is not the
whole guarantee.** Under resolver 1 a dev-dependency's features unify into the
normal build, so the server binary would get `test-util` with every manifest
still reading correctly — this check green and the thing it protects broken.
That arm was watched too (`FAIL: workspace.resolver is 1.`). Confirmed
empirically as well as asserted: `cargo tree -p smash -e features
--no-dev-dependencies` mentions `test-util` zero times, and once with
dev-dependencies.

## Checks

- `cargo test -p smash` — 340 passed, 0 failed, 7 ignored (4 doc-tests and 3
  pre-existing ENG-10852/10951 aborts).
- `cargo test -p hyperion --lib net` — 10 passed.
- `cargo fmt --all --check`, `cargo clippy --all-targets` — clean.
- `nix build .#checks.aarch64-darwin.test-util-is-dev-only` — green over 30
  workspace members.
- `nix build .#checks.aarch64-darwin.smash-dev-boot-e2e` — green (production
  code moved, so this was rerun).

## Not closed by this

The class is now *tested*, not *prevented*: nothing stops the next
read-modify-write op reintroducing the shape. The enumeration on ENG-11475 lists
the criterion and the commands to re-run it, and records the one adjacent
`PlaySoundTo`/`Teleport` ordering wrinkle as out-of-class rather than a third
instance.
