### PR TITLE
fix(smash): a melee bonus that runs out, and a probe that can see it (ENG-11399)

### DIFF
--- a/events/smash/src/input.rs
+++ b/events/smash/src/input.rs
@@ -134,8 +134,7 @@ impl Module for InputModule {
                     let Some(origin) = attacker.try_get::<&Position>(|position| position.0) else {
                         continue;
                     };
-                    let clock = world.get::<&crate::module::damage::MatchClock>(|clock| clock.0);
-                    let amount = melee_damage(attacker, victim.id(), clock);
+                    let amount = melee_damage(attacker, victim.id());
 
                     damage::hurt(victim, Damaged {
                         attacker: Some(attacker.id()),
@@ -258,13 +257,13 @@ pub(crate) fn hotbar_slot(cursor: u16) -> Option<u8> {
 /// `buffs_melee` assertion in the suite goes on passing and only a real client
 /// notices.
 #[must_use]
-pub fn melee_damage(attacker: EntityView<'_>, victim: Entity, now: f32) -> f32 {
+pub fn melee_damage(attacker: EntityView<'_>, victim: Entity) -> f32 {
     let base = attacker
         .find_target(Playing, |_| true)
         .and_then(|kit| kit.try_get::<&KitStats>(|stats| stats.melee_damage))
         .unwrap_or(1.0);
     let bonus = attacker
-        .try_get::<&MeleeBonus>(|bonus| bonus.applies_to(victim, now))
+        .try_get::<&MeleeBonus>(|bonus| bonus.applies_to(victim))
         .unwrap_or(0.0);
     base + bonus
 }

--- a/events/smash/src/module/damage.rs
+++ b/events/smash/src/module/damage.rs
@@ -81,16 +81,31 @@ pub struct MeleeBonus {
     pub flat: f32,
     /// `None` means it applies to every victim.
     pub against: Option<Entity>,
-    /// Match clock time after which it stops counting. Kits that want a
-    /// permanent bonus set this to infinity.
-    pub until: f32,
+    /// Seconds of bonus left, counted down by `expire_melee_bonus`.
+    ///
+    /// Delta time and not a [`MatchClock`] deadline, for the reason
+    /// [`crate::module::effect::Expires`] gives about itself: that clock only
+    /// advances in `Phase::Playing`, so a deadline measured against it is
+    /// unreachable everywhere else and the bonus becomes permanent. Because
+    /// this component sits on the player rather than on the kit, permanent
+    /// also meant it survived the results screen, the next lobby and a change
+    /// of kit.
+    ///
+    /// That is what made `buffs_melee` unprovable in `nix run .#smash-e2e`
+    /// (ENG-11399), whose whole ability sweep runs in the hub: the second press
+    /// of Target Laser was measured against a baseline swing that already
+    /// carried the first press's bonus, so the swing could not get any harder
+    /// and a working ability read as broken.
+    ///
+    /// `f32::INFINITY` for a bonus that is meant never to run out.
+    pub remaining: f32,
 }
 
 impl MeleeBonus {
-    /// The addition this bonus makes to a swing at `victim` at time `now`.
+    /// The addition this bonus makes to a swing at `victim`.
     #[must_use]
-    pub fn applies_to(self, victim: Entity, now: f32) -> f32 {
-        if now >= self.until {
+    pub fn applies_to(self, victim: Entity) -> f32 {
+        if self.remaining <= 0.0 {
             return 0.0;
         }
         match self.against {
@@ -225,6 +240,20 @@ impl Module for DamageModule {
             .component::<MatchClock>()
             .add_trait::<flecs::Singleton>();
         world.set(MatchClock::default());
+
+        // Delta time, not the match clock the deadline used to be measured
+        // against: see [`MeleeBonus::remaining`]. Removed rather than left
+        // sitting at zero so a lapsed bonus leaves nothing behind on the
+        // player, and so `f32::INFINITY` -- which subtraction never moves --
+        // is the one value that stays.
+        world
+            .system_named::<&mut MeleeBonus>("expire_melee_bonus")
+            .each_iter(|it, index, bonus| {
+                bonus.remaining -= it.delta_time();
+                if bonus.remaining <= 0.0 {
+                    it.entity(index).remove(MeleeBonus::id());
+                }
+            });
 
         // Health is written here and read by the knockback observer this one
         // emits into. flecs tracks that at runtime and panics on the overlap,

--- a/events/smash/src/module/kits/cow.rs
+++ b/events/smash/src/module/kits/cow.rs
@@ -203,14 +203,13 @@ fn mooshroom_madness(cast: &Cast<'_>) {
     cast.server.set_health(cast.player, current, max);
 
     // `against: None`, because the wiki's +1 is against everybody -- unlike
-    // Guardian's mark, which is the other user of this component. The deadline
+    // Guardian's mark, which is the other user of this component. The duration
     // is the ability layer's own, so the bonus and the mode cannot disagree
     // about when they end.
-    let now = cast.world.cloned::<&crate::module::damage::MatchClock>().0;
     cast.caster.set(MeleeBonus {
         flat: MOOSHROOM_BONUS_DAMAGE,
         against: None,
-        until: now + ability::ULTIMATE_SECONDS,
+        remaining: ability::ULTIMATE_SECONDS,
     });
 
     effect::afflict(

--- a/events/smash/src/module/kits/guardian.rs
+++ b/events/smash/src/module/kits/guardian.rs
@@ -227,7 +227,7 @@ fn target_laser(cast: &Cast<'_>) {
     cast.caster.set(crate::module::damage::MeleeBonus {
         flat: LASER_BONUS_DAMAGE,
         against: Some(victim),
-        until: now + LASER_SECONDS,
+        remaining: LASER_SECONDS,
     });
 
     // The beam on top of the flare above, and then again every beat until the

--- a/events/smash/src/module/kits/wolf.rs
+++ b/events/smash/src/module/kits/wolf.rs
@@ -143,10 +143,9 @@ impl Module for Wolf {
                 if !plays(attacker, "Wolf") {
                     return;
                 }
-                let now = world.get::<&crate::module::damage::MatchClock>(|clock| clock.0);
                 let ceiling = RAVAGE_MAX_DAMAGE - 5.0;
                 let current = attacker
-                    .try_get::<&MeleeBonus>(|bonus| bonus.applies_to(attacker.id(), now))
+                    .try_get::<&MeleeBonus>(|bonus| bonus.applies_to(attacker.id()))
                     // `applies_to` is asked about the attacker itself only to
                     // reuse the expiry check; Ravage is never targeted, so any
                     // entity would answer the same.
@@ -154,7 +153,7 @@ impl Module for Wolf {
                 attacker.set(MeleeBonus {
                     flat: (current + RAVAGE_PER_STACK).min(ceiling),
                     against: None,
-                    until: now + RAVAGE_DECAY_SECS,
+                    remaining: RAVAGE_DECAY_SECS,
                 });
             });
     }
@@ -263,14 +262,13 @@ fn wolf_strike(cast: &Cast<'_>) {
 /// recharge much faster" is a Wolf Strike on a beat -- the kit's own lunge,
 /// arriving faster than its seven-second cooldown ever allows.
 fn frenzy(cast: &Cast<'_>) {
-    let now = cast.world.cloned::<&crate::module::damage::MatchClock>().0;
     // Strength III is +3 in vanilla's own table, which is also exactly the gap
     // between Wolf's base 5 and the 8 its own Ravage ceiling reaches -- so a
     // frenzied Wolf starts where a Wolf who has been landing hits ends up.
     cast.caster.set(MeleeBonus {
         flat: FRENZY_BONUS_DAMAGE,
         against: None,
-        until: now + ability::ULTIMATE_SECONDS,
+        remaining: ability::ULTIMATE_SECONDS,
     });
 
     effect::afflict(

--- a/events/smash/tests/abilities.rs
+++ b/events/smash/tests/abilities.rs
@@ -195,11 +195,7 @@ fn observed(bench: &Bench, observable: Observable, before: &Snapshot, held: bool
         // Measured rather than read off a component: what a player experiences
         // is the next swing hurting more, and a bonus that never reaches the
         // melee path is a bonus that does not exist.
-        Observable::BuffsMelee => {
-            let clock = bench.game.world.cloned::<&MatchClock>().0;
-            let boosted = melee_damage(bench, clock);
-            boosted > before.baseline_melee + 1e-3
-        }
+        Observable::BuffsMelee => melee_damage(bench) > before.baseline_melee + 1e-3,
         // The distinguishing word is *keeps*. Every ability can take health off
         // somebody once, and reading a single drop would pass for all fifty-one
         // of them. So the clock is advanced with nothing cast, and what is
@@ -321,8 +317,8 @@ fn probe_hit(bench: &Bench) -> bool {
 /// does. Under that version, deleting the bonus lookup from the swing path
 /// would have left every `buffs_melee` assertion green and the failure would
 /// have surfaced only in `nix run .#smash-e2e`, where a real client swings.
-fn melee_damage(bench: &Bench, now: f32) -> f32 {
-    let amount = smash::input::melee_damage(bench.caster(), bench.near, now);
+fn melee_damage(bench: &Bench) -> f32 {
+    let amount = smash::input::melee_damage(bench.caster(), bench.near);
 
     let victim = bench.game.world.entity_from_id(bench.near);
     let before = victim.cloned::<&Health>().current;
@@ -357,8 +353,7 @@ fn snapshot(bench: &Bench) -> Snapshot {
         .entity_from_id(bench.caster)
         .get::<&mut Health>(|health| health.current = health.max * 0.5);
 
-    let clock = bench.game.world.cloned::<&MatchClock>().0;
-    let baseline_melee = melee_damage(bench, clock);
+    let baseline_melee = melee_damage(bench);
     // Undo the probe swing so the ability under test sees a full-health victim.
     let victim = bench.game.world.entity_from_id(bench.near);
     victim.get::<&mut Health>(|health| health.current = health.max);
@@ -467,6 +462,90 @@ fn every_declared_effect_actually_happens() {
     }
 
     assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Longer than the longest melee bonus any ability grants, which is an
+/// ultimate's own window. A kit that grants a longer one has to raise this with
+/// it, and fails the test below rather than quietly outlasting it.
+const PAST_EVERY_MELEE_BONUS: f32 = ability::ULTIMATE_SECONDS + 1.0;
+
+/// A melee bonus runs out even where the match clock does not run.
+///
+/// [`smash::module::damage::MeleeBonus`] used to carry a `MatchClock` deadline,
+/// and the lobby advances that clock only in `Phase::Playing`. Everywhere else
+/// -- the hub, the results screen, this bench -- it is pinned, so the deadline
+/// is unreachable and the bonus is permanent; and because the component sits on
+/// the player rather than on the kit, permanent outlasted a change of kit too.
+///
+/// [`every_declared_effect_actually_happens`] structurally cannot catch that.
+/// It builds a fresh [`Bench`] per ability and presses once, so no bonus is
+/// ever still alive when the next measurement is taken. What noticed was
+/// `nix run .#smash-e2e`, whose sweep runs entirely in the hub and presses each
+/// ability three times: the second press was measured against a baseline swing
+/// that already carried the first press's bonus, so the swing could not get any
+/// harder and two working abilities read as broken (ENG-11399).
+///
+/// So the clock being frozen is asserted here rather than assumed. A version of
+/// this that let the clock run would pass against the very deadline it exists
+/// to refuse.
+#[test]
+fn a_melee_bonus_runs_out_even_though_the_match_clock_does_not() {
+    let manifest = ability::manifest(&Game::new().world);
+    let mut checked = 0;
+
+    for entry in manifest
+        .iter()
+        .filter(|entry| entry.proves.contains(&Observable::BuffsMelee))
+    {
+        let bench = Bench::new();
+        bench.reset(entry.kit);
+        bench.arm(entry);
+
+        let base = smash::input::melee_damage(bench.caster(), bench.near);
+        bench.press(entry);
+        // One tick, because the `set` an ability makes from inside an observer
+        // is deferred to the end of the frame.
+        bench.game.advance(TICK, 1);
+        let boosted = smash::input::melee_damage(bench.caster(), bench.near);
+        assert!(
+            boosted > base + 1e-3,
+            "{} / {}: the press left the swing at {base}",
+            entry.kit,
+            entry.name
+        );
+
+        let frozen = bench.game.world.cloned::<&MatchClock>().0;
+        bench.game.advance(PAST_EVERY_MELEE_BONUS, 200);
+        let now = bench.game.world.cloned::<&MatchClock>().0;
+        assert!(
+            (now - frozen).abs() < 1e-6,
+            "the bench's match clock ran from {frozen} to {now}, so this proves nothing about a \
+             deadline that is unreachable while it is stopped"
+        );
+        // The swing first, because that is the claim a player can feel; the
+        // component going away is the housekeeping behind it.
+        let after = smash::input::melee_damage(bench.caster(), bench.near);
+        assert!(
+            (after - base).abs() < 1e-3,
+            "{} / {}: the swing still takes {after} rather than {base}, {PAST_EVERY_MELEE_BONUS} \
+             seconds after a bonus that was supposed to run out",
+            entry.kit,
+            entry.name
+        );
+        assert!(
+            !bench.caster().has(smash::module::damage::MeleeBonus::id()),
+            "{} / {}: a lapsed bonus was left on the player",
+            entry.kit,
+            entry.name
+        );
+
+        checked += 1;
+    }
+
+    assert!(
+        checked > 0,
+        "no ability in the registry declares buffs_melee, so this test looked at nothing"
+    );
 }
 
 /// Every ability draws something on the press that fires it.

--- a/events/smash/tests/properties.rs
+++ b/events/smash/tests/properties.rs
@@ -337,24 +337,28 @@ proptest! {
     }
 
     /// A melee bonus applies only to who it names and only while it lasts.
+    ///
+    /// `remaining` is generated down through zero and below, because that is
+    /// where a bonus ends up: `expire_melee_bonus` subtracts a whole frame's
+    /// delta time and then asks, so the value the last swing of a lapsing
+    /// bonus sees is negative rather than exactly zero.
     #[test]
     fn a_melee_bonus_respects_its_target_and_its_expiry(
         flat in 0.0f32..10.0,
-        until in 0.0f32..100.0,
-        now in 0.0f32..100.0,
+        remaining in -5.0f32..100.0,
         targeted in any::<bool>(),
     ) {
         let marked = Entity::new(42);
         let other = Entity::new(43);
-        let bonus = MeleeBonus { flat, against: targeted.then_some(marked), until };
+        let bonus = MeleeBonus { flat, against: targeted.then_some(marked), remaining };
 
-        if now >= until {
-            prop_assert_eq!(bonus.applies_to(marked, now), 0.0, "an expired bonus still applied");
-            prop_assert_eq!(bonus.applies_to(other, now), 0.0);
+        if remaining <= 0.0 {
+            prop_assert_eq!(bonus.applies_to(marked), 0.0, "an expired bonus still applied");
+            prop_assert_eq!(bonus.applies_to(other), 0.0);
         } else {
-            prop_assert_eq!(bonus.applies_to(marked, now), flat);
+            prop_assert_eq!(bonus.applies_to(marked), flat);
             prop_assert_eq!(
-                bonus.applies_to(other, now),
+                bonus.applies_to(other),
                 if targeted { 0.0 } else { flat },
                 "a bonus aimed at one player reached another"
             );

--- a/tools/smash-match.py
+++ b/tools/smash-match.py
@@ -452,6 +452,45 @@ LINGER_WINDOW = 1.5
 # window it is trying to measure and turn a working shield into a failure.
 SHIELD_PROBE_WINDOW = 0.4
 
+# The health the melee probe wants its victim standing on before it swings.
+#
+# `ClientboundSetHealth` is scaled to twenty whatever the kit's real maximum is,
+# so this number means the same thing for every kit in the roster.
+#
+# Not a full bar: the abilities that declare `buffs_melee` are the ones spending
+# the window hitting the same player the probe swings at, and demanding twenty
+# would mean never getting a reading during a Mooshroom Madness. What it has to
+# clear is one swing, so that health cannot hit the floor mid-reading and turn a
+# hard hit into a soft one -- and the hardest swing in the roster is under ten
+# on this scale, whatever the kit.
+MELEE_PROBE_HEADROOM = 12.0
+
+# How long the victim has to go without a health packet before the probe swings.
+#
+# Shorter than the fastest beat anything in the roster runs -- Cow's herd and
+# Wolf's Frenzy are both every two seconds -- or no window ever opens.
+MELEE_PROBE_QUIET = 0.3
+
+# How long to keep looking for that window before giving up on a reading.
+MELEE_PROBE_SETTLE = 1.5
+
+# How long after the swing to collect health packets before deciding which of
+# them was the swing. Every melee answer in the transcript came back inside
+# 70 ms; wider than that only lets more of somebody else's damage in.
+MELEE_PROBE_WINDOW = 0.25
+
+# How many swings the probe may take looking for one it can attribute.
+#
+# Bounded from above and not just for time. Every try is a real melee hit, and
+# Wolf's Ravage adds a stack to the attacker on every melee hit, so the probe's
+# own retries make the next swing harder -- which is the game working, but it
+# means a probe that retried indefinitely would saturate Ravage at its ceiling
+# and then read a baseline the ultimate cannot beat, because Frenzy's bonus is
+# exactly that same ceiling. Three tries leaves at most two stacks standing when
+# the last one is measured, one short of the ceiling, so the ultimate is still
+# visible above it.
+MELEE_PROBE_TRIES = 3
+
 
 def load_item_names():
     """`minecraft:item` registry ids to names, in network-id order.
@@ -521,6 +560,12 @@ class MatchClient(base.Client):
         self.yaw = 0.0
         self.pitch = 0.0
         self.health = None
+        # Every health this client has been sent, in order, and when the last
+        # one arrived. The melee probe needs both: it reads the *first* packet
+        # after its swing rather than where health ends up, and it waits for a
+        # gap in this stream before swinging at all. See `measure_melee`.
+        self.health_log = []
+        self.health_at = 0.0
         self.spawns = []
         self.kit = None
         self.hotbar = {}
@@ -722,6 +767,12 @@ class Match:
         # What the sweep found, one line per ability, for the report.
         self.sweep_results = []
         self.sweep_failures = []
+        # How many times `measure_melee` gave up on the ability being exercised
+        # right now. Counted so a `buffs_melee` failure can say which of the two
+        # things went wrong. Reporting "declares buffs_melee and did not do it"
+        # when the probe never managed a reading is how ENG-11399 got filed
+        # against the harness on a night when the game was also broken.
+        self.melee_unmeasured = 0
         # Failures found after the sweep has already reported, which is
         # everything the match phase notices. `sweep_failures` is folded
         # into a proof inside `sweep`, so anything appended to it later
@@ -869,6 +920,8 @@ class Match:
             # saturation nothing here reads.
             health = struct.unpack(">f", payload[:4])[0]
             client.health = health
+            client.health_log.append(health)
+            client.health_at = time.time()
             client.log("<- health %.2f/20" % health)
         elif packet_id == S2C_ADD_ENTITY:
             # `ClientboundAddEntityPacket`: entity id (varint), uuid (16 bytes),
@@ -1485,25 +1538,110 @@ class Match:
             return False
         return landed_before and not self.hit_caster()
 
-    def measure_melee(self):
-        """What one melee swing at the near victim takes off, right now."""
-        attacker, victim = self.clients[0], self.clients[1]
-        before = victim.health
-        attacker.attack(victim)
-        self.wait_until(
-            lambda: victim.health is not None
-            and before is not None
-            and victim.health < before - 0.05,
-            2.0,
+    def revive_near_victim(self):
+        """Stand the near victim back up, and say whether it landed.
+
+        Re-picking the kit they are already on, which is the game's own way of
+        saying "start of a life" and the only heal this harness has; `stage`
+        uses it for the same reason at the top of every attempt.
+
+        Needed a second time here because the melee probe runs *after* the
+        observation window, by which point the ability under test has had two
+        seconds to work on the very player the probe swings at. The sweep used
+        to swing at a corpse: Mooshroom Madness spends that window throwing cows
+        and had killed the victim outright, and Target Laser spends it standing
+        in the fallout of the two abilities tested before it, which had done the
+        same. A swing that lands on nought health takes nothing off, and reads
+        exactly like a swing that was never buffed.
+        """
+        victim = self.clients[1]
+        mob = victim.kit
+        if mob is None:
+            return False
+        victim.kit = None
+        victim.command("kit %s" % mob)
+        return self.wait_until(
+            lambda: victim.kit == mob
+            and victim.health is not None
+            and victim.health >= MELEE_PROBE_HEADROOM,
+            5.0,
         )
-        if before is None or victim.health is None:
+
+    def measure_melee(self):
+        """What one melee swing at the near victim takes off, right now.
+
+        `None` when no swing could be attributed, which the caller must not
+        round into zero: a probe that answers 0.0 because it could not measure
+        anything is a baseline every later swing beats, and `buffs_melee` would
+        then pass for an ability that does nothing at all.
+
+        This used to return "health the victim lost in the two seconds after the
+        swing", which is not the swing. It is the swing plus everything else in
+        flight, and during an ultimate it is mostly everything else. Wolf's
+        Frenzy passed the sweep on exactly that reading: 5.60, of which 4.48 was
+        the swing and 1.12 was a lunge that happened to arrive in the same pump.
+        Cow's and Guardian's failed on the other end of it, swinging at a victim
+        the ability under test had already killed.
+
+        So a reading is only taken when it can be told apart from everything
+        else: the victim is stood back up, given `MELEE_PROBE_QUIET` with
+        nothing landing on them, hit once, and then *exactly one* health packet
+        has to arrive inside `MELEE_PROBE_WINDOW`. Two packets means something
+        else landed alongside the swing and neither of them can be called the
+        swing -- which is not a guess to be resolved by taking the larger, it is
+        a reading to be taken again. The sweep's own leftovers are what make
+        that necessary: Zombie's Horde was still hitting the victim for 2.5 two
+        kits later, and landed in the same tick as a probe swing.
+        """
+        attacker, victim = self.clients[0], self.clients[1]
+        silent = 0
+
+        for _ in range(MELEE_PROBE_TRIES):
+            if (
+                victim.health is None or victim.health < MELEE_PROBE_HEADROOM
+            ) and not self.revive_near_victim():
+                self.log("the melee probe could not stand %s back up" % victim.name)
+                self.melee_unmeasured += 1
+                return None
+            if not self.wait_until(
+                lambda: time.time() - victim.health_at >= MELEE_PROBE_QUIET,
+                MELEE_PROBE_SETTLE,
+            ):
+                continue
+            before = victim.health
+            if before is None or before < MELEE_PROBE_HEADROOM:
+                continue
+
+            seen = len(victim.health_log)
+            attacker.attack(victim)
+            self.wait(MELEE_PROBE_WINDOW)
+            landed = victim.health_log[seen:]
+            if len(landed) == 1:
+                return before - landed[0]
+            if landed:
+                self.log(
+                    "%d health packets arrived with the melee probe's swing at %s, "
+                    "so none of them is the swing; probing again"
+                    % (len(landed), victim.name)
+                )
+            else:
+                silent += 1
+
+        if silent == MELEE_PROBE_TRIES:
+            # Every swing was answered with nothing at all. That is a real zero
+            # -- the swing takes nothing off -- and not a failed measurement.
             return 0.0
-        return before - victim.health
+        self.log(
+            "no melee swing at %s could be told apart from the damage around it"
+            % victim.name
+        )
+        self.melee_unmeasured += 1
+        return None
 
     def baseline(self, entry):
         # The melee probe is taken before the health snapshot, or the swing it
         # makes reads as the ability having hurt somebody.
-        melee = self.measure_melee() if "buffs_melee" in entry["proves"] else 0.0
+        melee = self.measure_melee() if "buffs_melee" in entry["proves"] else None
         self.window_motions.clear()
         self.window_particles.clear()
         for client in self.clients:
@@ -1574,7 +1712,14 @@ class Match:
 
         if "buffs_melee" in entry["proves"]:
             after = self.measure_melee()
-            if after > before["melee"] + 0.05:
+            # Both readings or neither. `measure_melee` answers `None` when it
+            # could not take an honest reading, and treating that as zero would
+            # give the after-probe a baseline it beats by standing still.
+            if (
+                before["melee"] is not None
+                and after is not None
+                and after > before["melee"] + 0.05
+            ):
                 found["buffs_melee"] = (
                     "a melee swing took %.2f health where the same swing took "
                     "%.2f before" % (after, before["melee"])
@@ -1664,6 +1809,7 @@ class Match:
     def exercise(self, entry):
         label = "%s / %s" % (entry["kit"], entry["name"])
         outstanding = list(entry["proves"])
+        self.melee_unmeasured = 0
         evidence = []
         heard = False
         seen = False
@@ -1713,8 +1859,17 @@ class Match:
                 self.wait(entry["cooldown"] + 0.5)
 
         if outstanding:
+            unreadable = ""
+            if "buffs_melee" in outstanding and self.melee_unmeasured:
+                unreadable = (
+                    "; the melee probe gave up %d times because it could not "
+                    "tell its own swing apart from the damage around the "
+                    "victim, so this may be the probe and not the ability"
+                    % self.melee_unmeasured
+                )
             self.sweep_failures.append(
-                "%s declares %s and did not do it" % (label, ", ".join(outstanding))
+                "%s declares %s and did not do it%s"
+                % (label, ", ".join(outstanding), unreadable)
             )
         if not heard:
             self.sound_failures.append(


### PR DESCRIPTION
`nix run .#smash-e2e` has failed two abilities on `buffs_melee` on every branch and on `origin/main` for long enough that the red became the background:

```
ABILITY FAILED Cow / Mooshroom Madness declares buffs_melee and did not do it
ABILITY FAILED Guardian / Target Laser declares buffs_melee and did not do it
```

ENG-11399 was filed on the belief that the probe was broken and the game was fine. **Both were broken**, in ways that hid each other, and either fix alone leaves the gate red. Two commits, one each.

## The game: a melee bonus never ran out outside a match

`MeleeBonus.until` was a `MatchClock` deadline, and `lobby.rs:369` advances that clock only in `Phase::Playing`. The sweep runs entirely in the hub, where the clock is pinned, so the bonus was permanent — and because the component sits on the player rather than the kit, it survived a change of kit too.

P2 is Spider, 11 armour, so every raw point of damage arrives on the wire as exactly 0.56 and each number below is an integer:

| Guardian / Target Laser | baseline swing | after the press |
| -- | -- | -- |
| attempt 1 | 3.36 = 6.0 raw | victim already dead |
| attempt 2 | 3.92 = **7.0 raw** | 3.92 = 7.0 raw |
| attempt 3 | 3.92 = **7.0 raw** | 3.92 = 7.0 raw |

Guardian's base melee is 5.0. Attempt 2's *baseline* — before any press, 21 s after attempt 1 cast an eight-second mark — already carries the +2. Attempt 1's baseline of 6.0 is 5.0 plus the +1 Cow's Mooshroom Madness left on the same player 95 s and one kit change earlier.

`effect.rs:84` already documents this hazard for `Expires`, which counts down by delta time because a `MatchClock` deadline "never ticks at all in the hub or in a test". `MeleeBonus` now does the same.

It is player-facing, not only gate-facing: a Guardian's mark, a frenzied Wolf's Strength and a Mooshroom's +1 all kept working through the results screen and into the next lobby.

## The probe: it swung at a corpse and measured a window, not a swing

`measure_melee` returned "health lost in the two seconds after the swing", which is the swing plus everything else in flight. Cow's and Guardian's after-probes swung at victims the ability under test had already killed. And Wolf **passed for the wrong reason** — its after-probe read 5.60, of which 4.48 was the swing and 1.12 was a Frenzy lunge arriving in the same pump; pumped separately it would have read 1.12 and failed. So the "Wolf passes, therefore the component works" inference in ENG-11399 never held either.

The probe now stands the victim back up, waits for a quiet window, swings once, and requires **exactly one** health packet in a 0.25 s window — two packets is a reading to be taken again, not a puzzle to be settled by taking the larger. When it cannot get a clean one it answers `None`, not `0.0`, and the failure line says the probe gave up rather than blaming the ability.

## Watched failing, then passing

New Rust guard, `a_melee_bonus_runs_out_even_though_the_match_clock_does_not`. It asserts the clock has **not** moved before asserting the bonus lapsed anyway — a version that let the clock run would pass against the very deadline it exists to refuse — and refuses an empty manifest. With the countdown neutered:

```
thread 'a_melee_bonus_runs_out_even_though_the_match_clock_does_not' panicked at
events/smash/tests/abilities.rs:528:9:
Wolf / Frenzy: the swing still takes 8 rather than 5, 21 seconds after a bonus
that was supposed to run out
test result: FAILED. 13 passed; 1 failed
```

Restored: `test result: ok. 14 passed; 0 failed`.

`every_declared_effect_actually_happens` structurally cannot catch this: it builds a fresh `Bench` per ability and presses once, so no bonus is ever still alive when the next measurement is taken. The bug needs two presses against one stopped clock.

## The gate, before and after

Same command, same machine, dev profile:

```
before:  ABILITY FAILED Cow / Mooshroom Madness declares buffs_melee and did not do it
         ABILITY FAILED Guardian / Target Laser declares buffs_melee and did not do it
         RESULT: 2 of 15 steps did not happen

after:   175.05s  PROVED every declared ability did what it declared: 51 abilities
         fired by a real client, each one checked against the effects its own
         registry entry names
```

Every reading is a single attributed packet:

| | baseline | after the press |
| -- | -- | -- |
| Wolf / Frenzy | 2.80 = 5.0 raw | 4.48 = 8.0 raw |
| Cow / Mooshroom Madness | 3.36 = 6.0 raw | 3.92 = 7.0 raw |
| Guardian / Target Laser | 2.80 = 5.0 raw | 3.92 = 7.0 raw |

Each baseline is the kit's declared melee; each after is that plus exactly the bonus the wiki gives the ability.

## The probe was then pointed at a broken game

A probe repaired against a repaired game, never tested against a broken one, is
a green light you cannot trust. So with the fix in place, the bonus lookup was
deleted from the swing path — the exact regression `input::melee_damage`'s doc
comment warns about — and the gate run again:

```
353.82s  ABILITY FAILED Wolf / Frenzy declares buffs_melee and did not do it
353.82s  ABILITY FAILED Cow / Mooshroom Madness declares buffs_melee and did not do it
353.82s  ABILITY FAILED Guardian / Target Laser declares buffs_melee and did not do it;
         the melee probe gave up 2 times because it could not tell its own swing apart
         from the damage around the victim, so this may be the probe and not the ability
```

Three things in that output rather than one.

The probe **is** a live check: delete the bonus and it goes red, so its green is
load-bearing.

**Wolf fails too.** Under the old probe Wolf passed on a broken component by
picking up a Frenzy lunge in the same pump. Under the new one, with the bonus
genuinely gone, it fails like the other two. That is the "Wolf passes by luck"
claim confirmed from the other direction.

And Guardian's line shows an **unmeasurable reading failing the check rather
than skipping it** — the probe gave up twice, said so, and the ability still
failed on the reading it did get. The all-three-give-up shape (where the check
must still fail, and the annotation is the only thing standing between a reader
and the wrong conclusion) was driven through the real `exercise` separately;
see "Not verified".

## What this deliberately does not fix

**The rest of the frozen-clock class.** `guardian.rs:128` (`Marked`), `wolf.rs:192` (`Tackled`) and `wither_skeleton.rs:127` measure deadlines against the same clock and do become permanent in the hub. **ENG-11497**, which also carries a correction: I first wrote that `lives.rs:418` means a player who dies in the hub never respawns, and that is wrong. `lives::kill` has one call site, in `bounds_checks` under `Policy::Eliminate`, and the hub is `Policy::PushBack` — so nothing kills a player in the hub, `RespawnAt` is never written there, and the frozen comparison has no operand to be wrong about. `lobby.rs:reset()` closes the cross-match route too. The class is a latent trap, not a live bug; I checked before it stood as fact.

**A player can sit on zero health in the hub forever.** That is the thing actually visible in the transcript — P2 on 0.00 for 22 seconds, recovering only because the harness re-picked their kit — and it has nothing to do with the clock. The `PushBack` arm never reads `health.is_dead()`, and there is no health regen on this branch (`KitStats.regen` is declared, only `regen_energy` exists). Filed separately as **ENG-11514**.

**`match ended, back in the hub`** is still `NOT PROVED`. That is ENG-11470, untouched, and getting the abilities green is what puts it back in view.

## Not verified

The **all-three-tries-give-up** variant of the failure line was driven through the real `exercise` from a Python harness with `measure_melee` forced, not through a live sweep — as was the control showing the clause absent when readings were clean. Two attempts to watch that shape in a real run were killed mid-sweep by **ENG-11458**: the dev-profile server panics on `Entity ID is too large for Minecraft` once an entity slot passes generation 63, at 291 s in one run and 148 s in the next. Pre-existing on `origin/main` and unrelated to this change, but it means a long `nix run .#smash-e2e` can die before it reports, and a short one that dies quietly should not be read as a pass. The partial variant (probe gave up twice, ability still failed) *was* seen live, in the broken-game run above.

Nothing here has been looked at by a human in a real client. The claim is about packets.

## Verified

* `cargo test -p smash` — 27 test binaries, all green.
* `cargo fmt --all --check` — clean.
* `cargo clippy --all-targets` — clean (`-D clippy::pedantic`).
* `nix run .#smash-e2e` — the sweep verdict above, on this exact tree. The only edit after that run was a comment on `MELEE_PROBE_TRIES`.

Every hyperion workflow is `workflow_dispatch:` and the repo has no required status checks, so these local runs are the whole gate.

Refs ENG-11399, ENG-11497, ENG-11514

---
🤖 Opened by Claude Code (claude-opus-5).
