### PR TITLE
fix(smash): drop the stale third argument to melee_damage in kit_stats (ENG-12034)

### DIFF
--- a/events/smash/tests/kit_stats.rs
+++ b/events/smash/tests/kit_stats.rs
@@ -236,12 +236,7 @@ fn melee_damage_changes_what_a_swing_takes_off() {
     // so a `melee_damage` that stopped reading the kit is a failure here rather
     // than a formula compared against a copy of itself.
     gate.each(|gate, side| {
-        let clock = gate
-            .game
-            .world
-            .cloned::<&smash::module::damage::MatchClock>()
-            .0;
-        let amount = smash::input::melee_damage(gate.view(side.player), side.foe, clock);
+        let amount = smash::input::melee_damage(gate.view(side.player), side.foe);
         gate.hit(side.foe, amount, DamageKind::Melee);
     });
     gate.advance(0.05);


### PR DESCRIPTION
`cargo check --workspace --all-targets` has been failing on main since
#1103, which narrowed `smash::input::melee_damage` from three parameters
to two and updated `tests/abilities.rs` and `tests/properties.rs` but not
`tests/kit_stats.rs`:

    error[E0061]: this function takes 2 arguments but 3 arguments were supplied
       --> events/smash/tests/kit_stats.rs:244:22
        |
    244 |         let amount = smash::input::melee_damage(gate.view(side.player), side.foe, clock);
        |                                                                                   ----- unexpected argument #3 of type `f32`

The `MatchClock` read that produced `clock` goes with it; `melee_damage`
reads the kit's base and the `MeleeBonus`, and the bonus decides its own
expiry, so a caller has nothing to say about the clock.

Nothing caught this. `checks.clippy` builds `--all-targets` and would
have, but the repo has no enforced required status checks -- the header
of `nix/ci/flake-gate.nix` says so -- and every workflow is
`workflow_dispatch:`. That gap is the second half of ENG-12034 and is not
addressed here.

Verified:

    $ cargo test -p smash --test kit_stats
    test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

Refs ENG-12034

---
🤖 Opened by Claude Code (Claude Opus via Claude Code).