### PR TITLE
fix(hot-reload): repair the index probe on ELF, and split the packaging so a rules edit moves one store path (ENG-12043, ENG-12035)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3907,6 +3907,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "smash-rules"
+version = "0.1.0"
+dependencies = [
+ "flecs_ecs",
+ "hyperion-hot-reload",
+ "tracing",
+]
+
+[[package]]
 name = "snafu"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     'crates/packet-channel',
     'events/bedwars',
     'events/smash',
+    'events/smash-rules',
     'tools/rust-mc-bot',
 ]
 resolver = '2'

--- a/crates/hyperion-hot-reload/index-probe.sh
+++ b/crates/hyperion-hot-reload/index-probe.sh
@@ -41,6 +41,13 @@ sysroot_lib="$(rustc --print sysroot)/lib/rustlib/$host_triple/lib"
 # If it comes back, so does the blanket impl.
 flags="--cfg tokio_unstable -C prefer-dynamic"
 flags="$flags -C link-arg=-Wl,-rpath,$sysroot_lib -C link-arg=-Wl,-rpath,$target/debug"
+# `deps/` as well as `debug/`, because the two dylibs are named differently
+# there. Cargo gives a workspace member's dylib an unhashed copy in
+# `target/debug` (`libhyperion.so`), but a dependency's dylib exists only in
+# `target/debug/deps` under its metadata hash -- and the DT_NEEDED entry names
+# the hashed file. So `libhyperion.so` resolved and `libflecs_ecs-<hash>.so`
+# did not, which is the one library the whole probe is about.
+flags="$flags -C link-arg=-Wl,-rpath,$target/debug/deps"
 if [ "$ext" = so ]; then
   flags="$flags -C link-arg=-Wl,--undefined-version"
 fi

--- a/events/smash-rules/Cargo.toml
+++ b/events/smash-rules/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+authors = ["Andrew Gazelka <andrew.gazelka@gmail.com>"]
+edition.workspace = true
+name = "smash-rules"
+publish = false
+version.workspace = true
+
+# A dylib and not a cdylib. `cdylib` would give this its own copy of every Rust
+# dependency, including `flecs_ecs`, and two `flecs_ecs` copies in one process
+# is two `INDEX_POOL`s indexing one world two different ways --
+# `checks.hot-reload-index-probe` exists to catch exactly that.
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+flecs_ecs = { workspace = true }
+hyperion-hot-reload = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/events/smash-rules/src/lib.rs
+++ b/events/smash-rules/src/lib.rs
@@ -1,0 +1,80 @@
+//! smash's reloadable rules.
+//!
+//! This crate is the unit of hot reload: its store path is what
+//! `nix/modules/game-server.nix` puts in `X-Reload-Triggers`, so an edit here
+//! reaches a running server as `systemctl reload` and an edit anywhere else
+//! reaches it as a restart. That boundary is the source split and nothing else
+//! -- see `docs/hot-reload.md`, "Packaging: three derivations".
+//!
+//! # What may live here, and what may not
+//!
+//! Systems and observers only. **No `world.component::<T>()`.** A component's
+//! layout has to have exactly one definition in the process, and that
+//! definition lives in the host, because a system compiled against one layout
+//! reading a world that holds another is silent memory corruption rather than
+//! an error. The host registers; this crate reads and writes.
+//!
+//! The gate in `hyperion-hot-reload` enforces the consequence rather than the
+//! rule: it refuses a reload whose component schemas moved. Keeping
+//! registration out of here is what makes that refusal never fire in normal
+//! work.
+//!
+//! # Deliberately trivial, for now
+//!
+//! One system that logs. The deployment half -- reload-not-restart, the
+//! surviving player connection, the title -- is being proven against this
+//! before smash's real rules are migrated into it, because the refactor has no
+//! unknowns and the deployment has all of them. `docs/hot-reload.md` explains
+//! why that order is the reverse of the order they were designed in.
+
+use flecs_ecs::prelude::*;
+
+/// How many ticks between heartbeat lines.
+///
+/// A whole second at 20 tps. Frequent enough that a reload's effect shows up in
+/// the journal while somebody is watching for it, rare enough that it is not
+/// the reason the journal fills.
+const TICKS_PER_BEAT: u64 = 20;
+
+/// What the heartbeat says.
+///
+/// Editing this string is the canonical rules-only change: it moves this
+/// crate's store path and nothing else's, so the deploy that carries it must
+/// reload rather than restart. The reload proof drives exactly this edit.
+const BEAT: &str = "smash rules heartbeat";
+
+/// Behaviour, and no registration. See the module docs for why that split is
+/// load bearing rather than tidy.
+#[derive(Component)]
+pub struct SmashRulesModule;
+
+impl Module for SmashRulesModule {
+    fn module(world: &World) {
+        world.module::<Self>("smash::Rules");
+
+        // Counted in the closure rather than read from a component, because a
+        // component would be registration and registration belongs to the
+        // host. A `static` inside the dylib is re-initialised by each new
+        // build, which is the honest behaviour for a counter that is not game
+        // state: nothing migrates it and nothing should.
+        let mut ticks: u64 = 0;
+        world
+            .system_named::<()>("smash_rules_heartbeat")
+            .kind(id::<flecs::pipeline::OnUpdate>())
+            .run(move |mut it| {
+                while it.next() {
+                    ticks += 1;
+                    if ticks.is_multiple_of(TICKS_PER_BEAT) {
+                        tracing::info!("{BEAT}");
+                    }
+                }
+            });
+    }
+}
+
+hyperion_hot_reload::export_module! {
+    name: "smash-rules",
+    register: |world| {
+        world.import::<SmashRulesModule>();
+    },
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1172,6 +1172,16 @@
             }
           );
 
+          # The hot-reload packaging: the engine's dylibs, the server binary
+          # `ExecStart` names, and the rules dylib `X-Reload-Triggers` names.
+          # Kept out of `cargoUnit` because that builder is rlib-only, and split
+          # across three derivations because a rules edit has to move exactly
+          # one store path. See nix/hot-reload/packaging.nix.
+          hotReload = import ./nix/hot-reload/packaging.nix {
+            inherit lib pkgs workspace rustToolchain nativeBuildInputs;
+            root = ./.;
+          };
+
           # The same game servers, compiled with `debug_assertions` on -- the
           # dev profile `nix run .#smash` runs and the operator actually plays.
           # This exists only for the boot gate: a release build compiles out the
@@ -1417,6 +1427,43 @@
             # sandbox, shared with nothing. Same shape as `clippy` above and
             # for the same reason -- prefer-dynamic artifacts are not the
             # release rlibs `cargoUnit` produces, so there is nothing to reuse.
+            # The source split the reload boundary is made of, asserted on the
+            # trees themselves rather than on a rebuild.
+            #
+            # `ExecStart` must not move when only the rules change, and a store
+            # path is a function of a derivation's inputs, so the question is
+            # exactly whether the rules crate's code is an input to the server.
+            # Checking that directly costs a `diff` and no compile, and it fails
+            # for the same reason the feature would: if this stub is ever the
+            # real file, every rules edit moves `ExecStart` and every apply
+            # restarts, dropping every connected player while the pipeline stays
+            # green.
+            hot-reload-source-split = pkgs.runCommand "hyperion-hot-reload-source-split" { } ''
+              set -eu
+              server=${hotReload.serverSource}/events/smash-rules/src/lib.rs
+              rules=${hotReload.rulesSource}/events/smash-rules/src/lib.rs
+              engine=${hotReload.dylibSource}/events/smash/src/lib.rs
+
+              if [ -s "$server" ]; then
+                echo "smash-server's source carries the real rules crate." >&2
+                echo "Every rules edit would move ExecStart and restart the server." >&2
+                exit 1
+              fi
+              if [ ! -s "$rules" ]; then
+                echo "smash-rules' source carries a stub, not the rules crate." >&2
+                exit 1
+              fi
+              if [ -s "$engine" ]; then
+                echo "hyperion-dylibs' source carries the smash host crate." >&2
+                echo "A host edit would move the engine dylibs and restart." >&2
+                exit 1
+              fi
+              # The real file has to actually be the one in the tree, not merely
+              # non-empty: a stub that grew a comment would pass the size test.
+              cmp "$rules" ${./events/smash-rules/src/lib.rs}
+              touch $out
+            '';
+
             hot-reload-index-probe = pkgs.runCommandCC "hyperion-hot-reload-index-probe" {
               inherit nativeBuildInputs;
               # Dev profile, so every C build script in the graph compiles at
@@ -1953,6 +2000,7 @@
             smash = stamped gameBinaries.smash;
             inherit (gameBinaries) bedwars hyperion-proxy;
             rust-mc-bot = named "rust-mc-bot" workspace.binaries.rust-mc-bot;
+            inherit (hotReload) hyperion-dylibs smash-server smash-rules;
 
             minecraft-server-jar = minecraft.serverJar;
             minecraft-data = minecraft.generatedData;

--- a/flake.nix
+++ b/flake.nix
@@ -748,7 +748,12 @@
             # cannot say different things about the same tree.
             hot-reload-index-probe = {
               deps = [ pkgs.cmake pkgs.pkg-config ];
-              text = ''exec ./crates/hyperion-hot-reload/index-probe.sh "$@"'';
+              # Through `bash` rather than the script's own shebang. The
+              # sandbox has no `/usr/bin/env`, so `#!/usr/bin/env bash` is a
+              # `bad interpreter` there and the check failed before running a
+              # line of the probe. It passed on darwin, where that path exists,
+              # which is how the ELF half stayed unverified.
+              text = ''exec bash ./crates/hyperion-hot-reload/index-probe.sh "$@"'';
             };
 
             # The game server and the proxy authenticate to each other with

--- a/flake.nix
+++ b/flake.nix
@@ -1475,6 +1475,13 @@
               cp -r ${workspaceArgs.src}/. .
               chmod -R u+w .
               ${workspace.cargoConfigScript}
+              # `pipefail` because the probe's status is the one that matters
+              # and `tee` would otherwise report for it. Both assertions are
+              # kept: the exit code catches a probe that dies before saying
+              # anything, and the grep catches one that exits 0 having measured
+              # nothing. A run that printed PROBE_OK and then failed would pass
+              # on the grep alone, which is the case pipefail adds.
+              set -o pipefail
               ${lib.getExe runners.hot-reload-index-probe} | tee $out
               grep -q PROBE_OK $out
             '';

--- a/nix/hot-reload/packaging.nix
+++ b/nix/hot-reload/packaging.nix
@@ -155,7 +155,8 @@ let
   # freshness by comparing them and everything unpacked from the store shares
   # one normalised timestamp.
   seed = ''
-    tar -C . -xf ${hyperion-dylibs}/share/cargo-target.tar
+    mkdir -p target
+    tar -C target -xf ${hyperion-dylibs}/share/cargo-target.tar
     find target -exec touch -d "2100-01-01" {} +
   '';
 

--- a/nix/hot-reload/packaging.nix
+++ b/nix/hot-reload/packaging.nix
@@ -1,0 +1,199 @@
+# Packaging for hot reload: three derivations, split by source, so that a
+# rules-only change moves exactly one store path.
+#
+# The whole feature rests on one property. `nix/modules/game-server.nix` puts
+# the rules dylib in `X-Reload-Triggers` and the server binary in `ExecStart`,
+# and nixpkgs' unit handling reloads a unit whose `[Service]` section is
+# unchanged and whose reload triggers differ. So a rules edit may move the rules
+# dylib and must not move the server binary. If it moves both, the deploy
+# degrades to a restart, every player is dropped, and every gate stays green --
+# which is why `checks.hot-reload-source-split` asserts the split instead of
+# trusting this file to be right.
+#
+# A store path is a function of a derivation's inputs, so "which paths move" is
+# decided entirely by which sources reach which derivation:
+#
+#   hyperion-dylibs  crates/*                          an engine change
+#   smash-server     crates/* + events/smash           a component or engine change
+#   smash-rules      crates/* + events/smash + rules   a rules change
+#
+# Nobody has to remember the rule. A component's layout lives in the host crate
+# and a system's body lives in the rules crate, so the source split is the rule.
+#
+# See docs/hot-reload.md, "Packaging: three derivations, because two would
+# restart", for the measurements behind this.
+{ lib, pkgs, workspace, rustToolchain, nativeBuildInputs, root }:
+let
+  # Read from the manifest rather than restated here, so a new member cannot be
+  # silently omitted from the stub list and fail one derivation much later.
+  members = (lib.importTOML (root + "/Cargo.toml")).workspace.members;
+  crateMembers = lib.filter (member: lib.hasPrefix "crates/" member) members;
+
+  rootFiles = map (file: root + "/${file}") [
+    "Cargo.toml"
+    "Cargo.lock"
+    "rust-toolchain.toml"
+    "clippy.toml"
+    "rustfmt.toml"
+  ];
+
+  # A source tree holding the real code of `realMembers` and a stub for every
+  # other workspace member.
+  #
+  # The stub is not tidiness. Cargo parses every member of a workspace before it
+  # builds any of it, and a member with no target file fails the whole resolve:
+  #
+  #     error: failed to load manifest for workspace member `events/bedwars`
+  #     Caused by: no targets specified in the manifest
+  #       either src/lib.rs, src/main.rs, a [lib] section, or [[bin]] section
+  #       must be present
+  #
+  # So a derivation cannot simply omit a member's directory. An empty
+  # `src/lib.rs` is the smallest thing that lets cargo parse a member it will
+  # never build, and its content is constant, which is what keeps the omitted
+  # member's real source out of this derivation's inputs.
+  #
+  # The filtering happens at eval time through `lib.fileset`, whose store path
+  # is a function of the included files alone. Filtering inside the builder
+  # instead would make the whole tree an input and defeat the entire split.
+  mkSource =
+    { pname, realMembers }:
+    let
+      filtered = lib.fileset.toSource {
+        inherit root;
+        fileset = lib.fileset.unions (
+          rootFiles
+          ++ map (member: root + "/${member}/Cargo.toml") members
+          ++ map (member: root + "/${member}") realMembers
+        );
+      };
+      stubbed = lib.subtractLists realMembers members;
+    in
+    pkgs.runCommand "hyperion-source-${pname}" { } ''
+      cp -r ${filtered} "$out"
+      chmod -R u+w "$out"
+      for member in ${lib.escapeShellArgs stubbed}; do
+        mkdir -p "$out/$member/src"
+        : > "$out/$member/src/lib.rs"
+      done
+    '';
+
+  dylibSource = mkSource {
+    pname = "dylibs";
+    realMembers = crateMembers;
+  };
+  serverSource = mkSource {
+    pname = "server";
+    realMembers = crateMembers ++ [ "events/smash" ];
+  };
+  rulesSource = mkSource {
+    pname = "rules";
+    realMembers = crateMembers ++ [ "events/smash" "events/smash-rules" ];
+  };
+
+  profile = "release";
+  sysrootLib = "${rustToolchain}/lib/rustlib/${pkgs.stdenv.hostPlatform.rust.rustcTarget}/lib";
+  inherit (pkgs.stdenv.hostPlatform) extensions;
+
+  # The link recipe `crates/hyperion-hot-reload/index-probe.sh` proves, with
+  # store paths where that script has `target/debug`.
+  #
+  # `-C prefer-dynamic` is the load-bearing flag: it makes the server binary and
+  # the rules dylib resolve `hyperion`, and through it the one `flecs_ecs` that
+  # owns the component-index pool, to a shared image rather than each linking
+  # its own static copy. `checks.hot-reload-index-probe` is what proves that
+  # holds; this is only the flags.
+  rustFlags =
+    libDirs:
+    lib.concatStringsSep " " (
+      [ "--cfg tokio_unstable" "-C prefer-dynamic" ]
+      ++ map (dir: "-C link-arg=-Wl,-rpath,${dir}") libDirs
+      # `flecs_ecs`'s build script installs a version script naming four globs,
+      # and ld treats a pattern that matches nothing as an error by default.
+      ++ lib.optional pkgs.stdenv.hostPlatform.isElf "-C link-arg=-Wl,--undefined-version"
+    );
+
+  common = {
+    inherit nativeBuildInputs;
+    # Every C build script in the graph answers `_FORTIFY_SOURCE` with a
+    # `#warning` at -O0, and an autoconf probe reading stderr then misreads its
+    # own test as a compile failure. `checks.clippy` met this first.
+    hardeningDisable = [ "fortify" ];
+  };
+
+  setup = source: ''
+    cp -r ${source}/. .
+    chmod -R u+w .
+    ${workspace.cargoConfigScript}
+  '';
+
+  # Reuse the engine's artifacts rather than compiling equivalents of them.
+  #
+  # This is not a build-time optimisation, it is what makes the boundary sound.
+  # If the server and the rules each compiled their own `hyperion`, each would
+  # get its own `-C metadata` hash -- the source ids differ, because the two
+  # source trees are different store paths -- and the mangled symbol names would
+  # not match across the `dlopen` boundary. Reusing one target directory means
+  # both link artifacts that are the same bytes, so "one copy of flecs in the
+  # process" is a fact about the build graph rather than a coincidence between
+  # two builds that happen to agree.
+  #
+  # Artifact mtimes are moved ahead of the sources', because cargo decides
+  # freshness by comparing them and everything unpacked from the store shares
+  # one normalised timestamp.
+  seed = ''
+    tar -C . -xf ${hyperion-dylibs}/share/cargo-target.tar
+    find target -exec touch -d "2100-01-01" {} +
+  '';
+
+  # The engine, built once, as the dylibs everything else resolves at runtime.
+  hyperion-dylibs = pkgs.runCommandCC "hyperion-dylibs" common ''
+    ${setup dylibSource}
+    export RUSTFLAGS=${lib.escapeShellArg (rustFlags [ sysrootLib "$ORIGIN" ])}
+    cargo build --profile ${profile} --offline -p hyperion
+
+    mkdir -p "$out/lib" "$out/share"
+    # `deps/` as well as the profile directory: cargo leaves an unhashed copy of
+    # a workspace member's dylib in `target/${profile}`, but a dependency's
+    # dylib only in `deps/`, under the metadata hash DT_NEEDED actually names.
+    cp target/${profile}/*${extensions.sharedLibrary} "$out/lib/"
+    cp target/${profile}/deps/libflecs_ecs-*${extensions.sharedLibrary} "$out/lib/"
+    tar -C target -cf "$out/share/cargo-target.tar" ${profile}
+  '';
+
+  # What `ExecStart` names. Moves on a component or engine change, which is
+  # exactly when a restart is correct: a component's layout is defined here, and
+  # a system compiled against a layout the world no longer holds is memory
+  # corruption rather than a stale build.
+  smash-server = pkgs.runCommandCC "smash-server" (common // { meta.mainProgram = "smash"; }) ''
+    ${setup serverSource}
+    ${seed}
+    export RUSTFLAGS=${lib.escapeShellArg (rustFlags [ sysrootLib "${hyperion-dylibs}/lib" ])}
+    cargo build --profile ${profile} --offline -p smash
+
+    mkdir -p "$out/bin"
+    cp target/${profile}/smash "$out/bin/smash"
+  '';
+
+  # What `X-Reload-Triggers` names, and the only path a rules-only change is
+  # allowed to move.
+  smash-rules = pkgs.runCommandCC "smash-rules" common ''
+    ${setup rulesSource}
+    ${seed}
+    export RUSTFLAGS=${lib.escapeShellArg (rustFlags [ sysrootLib "${hyperion-dylibs}/lib" ])}
+    cargo build --profile ${profile} --offline -p smash-rules
+
+    mkdir -p "$out/lib"
+    cp target/${profile}/libsmash_rules${extensions.sharedLibrary} "$out/lib/"
+  '';
+in
+{
+  inherit
+    hyperion-dylibs
+    smash-server
+    smash-rules
+    dylibSource
+    serverSource
+    rulesSource
+    ;
+}

--- a/nix/hot-reload/packaging.nix
+++ b/nix/hot-reload/packaging.nix
@@ -142,6 +142,14 @@ let
 
   # Reuse the engine's artifacts rather than compiling equivalents of them.
   #
+  # THIS DOES NOT YET HOLD; see ENG-12053. Measured on x86_64-linux, the rules
+  # dylib asks for `libflecs_ecs-2c5aa556f4fa166e.so` while this derivation
+  # ships `libflecs_ecs-c4fb60682bf29e00.so`, so the seed was not reused for
+  # that crate and it was recompiled -- most likely because `-p hyperion` and
+  # `-p smash-rules` resolve different features onto it. Two compilations is
+  # two `INDEX_POOL`s, which is what `checks.hot-reload-index-probe` rejects.
+  # The paragraph below is the intent, not yet the fact.
+  #
   # This is not a build-time optimisation, it is what makes the boundary sound.
   # If the server and the rules each compiled their own `hyperion`, each would
   # get its own `-C metadata` hash -- the source ids differ, because the two

--- a/nix/hot-reload/packaging.nix
+++ b/nix/hot-reload/packaging.nix
@@ -56,15 +56,21 @@ let
   # The filtering happens at eval time through `lib.fileset`, whose store path
   # is a function of the included files alone. Filtering inside the builder
   # instead would make the whole tree an input and defeat the entire split.
+  # `realDirs` is separate from `realMembers` because not every path
+  # dependency is a workspace member: `crates/hyperion-clap-macros` is depended
+  # on by `crates/hyperion-clap` and appears in no `members` list, so a fileset
+  # built from members alone omits it and cargo fails the whole resolve with
+  # `failed to read crates/hyperion-clap-macros/Cargo.toml`. Taking `crates` as
+  # a directory covers the members and their private neighbours in one rule.
   mkSource =
-    { pname, realMembers }:
+    { pname, realDirs, realMembers }:
     let
       filtered = lib.fileset.toSource {
         inherit root;
         fileset = lib.fileset.unions (
           rootFiles
           ++ map (member: root + "/${member}/Cargo.toml") members
-          ++ map (member: root + "/${member}") realMembers
+          ++ map (dir: root + "/${dir}") realDirs
         );
       };
       stubbed = lib.subtractLists realMembers members;
@@ -80,14 +86,17 @@ let
 
   dylibSource = mkSource {
     pname = "dylibs";
+    realDirs = [ "crates" ];
     realMembers = crateMembers;
   };
   serverSource = mkSource {
     pname = "server";
+    realDirs = [ "crates" "events/smash" ];
     realMembers = crateMembers ++ [ "events/smash" ];
   };
   rulesSource = mkSource {
     pname = "rules";
+    realDirs = [ "crates" "events/smash" "events/smash-rules" ];
     realMembers = crateMembers ++ [ "events/smash" "events/smash-rules" ];
   };
 

--- a/nix/hot-reload/packaging.nix
+++ b/nix/hot-reload/packaging.nix
@@ -114,7 +114,11 @@ let
     );
 
   common = {
-    inherit nativeBuildInputs;
+    # The toolchain explicitly: flake.nix's `nativeBuildInputs` is the C and
+    # build-tool half and does not carry cargo. Every other cargo build in this
+    # flake reaches it through a `writeShellApplication`'s `runtimeInputs`,
+    # which these derivations do not go through.
+    nativeBuildInputs = nativeBuildInputs ++ [ rustToolchain ];
     # Every C build script in the graph answers `_FORTIFY_SOURCE` with a
     # `#warning` at -O0, and an autoconf probe reading stderr then misreads its
     # own test as a compile failure. `checks.clippy` met this first.


### PR DESCRIPTION
Rebased onto `main` and rewritten. ENG-12035, ENG-12043, ENG-12053.

**What changed about this PR.** Its original subject, making `hyperion` a dylib so the
host and a dlopened module share one `flecs_ecs` component-index pool, **is already on
main**. #1107 was stacked on this branch and squash-merged as 59d6258, which carried this
branch's whole diff with it. Replaying the original commit onto main produces an empty
commit, and git drops it.

What did *not* reach main is that the recipe was broken on ELF, and the check that would
have said so could not run there. So this PR is now the ELF repair plus the packaging
built on top of it.

## The check passed on darwin and could not run on linux

Two failures, and the first is why nobody knew about the second.

**It could not start the script.** The runner invoked
`./crates/hyperion-hot-reload/index-probe.sh` through its `#!/usr/bin/env bash` shebang,
and the nix sandbox has no `/usr/bin/env`:

```
/nix/store/y6dfmd0...-hot-reload-index-probe/bin/hot-reload-index-probe: \
  /build/crates/hyperion-hot-reload/index-probe.sh: /usr/bin/env: bad interpreter: No such file or directory
```

darwin has that path, so the same check passed there. A gate that cannot start reports
identically to a gate that found nothing.

**The binary could not resolve `libflecs_ecs`.** With that fixed, the cargo build succeeds
and the probe does not start. The recipe set one rpath, `$target/debug`, which is right for
a workspace member's dylib and wrong for a dependency's: cargo leaves an unhashed copy of a
member's dylib in `target/debug` but a dependency's dylib only in `target/debug/deps`,
under the metadata hash `DT_NEEDED` names.

```
$ ldd target/debug/hot-reload-index-probe
    libhyperion.so => .../target/debug/libhyperion.so (0x00007f7f2bc00000)
    libflecs_ecs-c4b1a70a43230940.so => not found
```

So `libhyperion` resolved and `libflecs_ecs` did not, which is the one library the probe
exists to reason about.

**The probe's exit code was being discarded.** It runs through `| tee $out`, so the
pipeline reported tee's status. Only `grep -q PROBE_OK` stood between a failing probe and a
green check, which covers a probe that dies early but not one that prints `PROBE_OK` and
then fails. `set -o pipefail` restores it; both assertions stay.

## Verified on x86_64-linux

dev-compute-6, on this branch as rebased, through the gates rather than by hand:

```
$ nix build .#checks.x86_64-linux.hot-reload-index-probe \
            .#checks.x86_64-linux.hot-reload-source-split --no-link --print-out-paths -L
hyperion-hot-reload-index-probe> host indices: [1, 2, 3, 4] (max 4)
hyperion-hot-reload-index-probe> module's own type index: 5
hyperion-hot-reload-index-probe> hyperion::simulation::Position index: host 4, module 4
hyperion-hot-reload-index-probe> SHARED_POOL=true
hyperion-hot-reload-index-probe> SHARED_HYPERION_INDEX=true
hyperion-hot-reload-index-probe> PROBE_OK
/nix/store/h38j8hgnfg3i1gyplwzzg488g67zi5vm-hyperion-hot-reload-index-probe
/nix/store/98y15h6npdkw66h1dk76p8av7q9crl4y-hyperion-hot-reload-source-split
rc=0
```

Re-ran the probe on aarch64-darwin after the rpath change and it still prints `PROBE_OK`:
an extra rpath that resolves nothing on that platform is inert.

## Packaging: three derivations, split by source

The reload boundary is not a flag, it is which sources reach which derivation. A rules edit
**may** move the rules dylib and **must not** move the server binary, or every apply
restarts and drops every player while the pipeline stays green.

| derivation | source | moves on |
| --- | --- | --- |
| `hyperion-dylibs` | `crates/*` | an engine change |
| `smash-server` (`ExecStart`) | `crates/*` + `events/smash` | a component or engine change |
| `smash-rules` (`X-Reload-Triggers`) | the above + `events/smash-rules` | a rules change |

Measured by evaluating the three `drvPath`s, editing one file, and evaluating again:

```
edit events/smash-rules/src/lib.rs -> smash-rules                                (reload)
edit events/smash/src/lib.rs       -> smash-server, smash-rules                  (restart)
edit crates/hyperion/src/lib.rs    -> hyperion-dylibs, smash-server, smash-rules (restart)
```

`checks.hot-reload-source-split` asserts this on the source trees themselves, costing a
`diff` and no compile. Watched it fail rather than assumed: giving `smash-server` the real
rules source exits 1 with `smash-server's source carries the real rules crate. / Every
rules edit would move ExecStart and restart the server.`

Two things that were not obvious: cargo parses every workspace member before building any
of it, so a derivation cannot omit a member's directory (an empty `src/lib.rs` stub is the
fix); and `crates/hyperion-clap-macros` is a path dependency in no `members` list, so the
fileset takes `crates` as a directory.

## What is NOT done, and is tracked as ENG-12053

The packaging does **not** yet satisfy the shared-pool precondition it exists to serve.
Building all three on x86_64-linux:

- `hyperion-dylibs` builds (release, 43.39s) shipping `libhyperion.so` and both
  `libflecs_ecs*.so`.
- `smash-rules` builds: `libsmash_rules.so`, 213 KB.
- `smash-server` **does not link**: 8 undefined LMDB symbols from
  `libhyperion_permission-*.rlib` via heed/lmdb-sys, under `-C prefer-dynamic`.
- `ldd libsmash_rules.so` wants `libhyperion_hot_reload.so`, which `hyperion-dylibs` does
  not export, and `libflecs_ecs-2c5aa556f4fa166e.so`, **a different hash from the
  `c4fb60682bf29e00` shipped**. flecs was recompiled rather than reused, so the two halves
  would hold separate `INDEX_POOL`s.

The comment in `nix/hot-reload/packaging.nix` that claimed the shared target directory made
this a build-graph fact is annotated in place as intent rather than fact, rather than left
to read as true.

Also not done: no reload IPC, no tick loop, no title, no systemd wiring. `events/smash-rules`
is deliberately trivial (one system that logs) so the deployment half can be proven against
it before smash's real rules move in.

Authored by Claude Opus via Claude Code.
