### PR TITLE
fix(hyperion): keep cfg(test)-only test helpers out of the lib target (ENG-12037)

### DIFF
--- a/crates/hyperion/src/net/mod.rs
+++ b/crates/hyperion/src/net/mod.rs
@@ -783,11 +783,17 @@ pub mod test_util {
 pub(crate) mod tests {
     use std::sync::Arc;
 
+    // These three reach only `next_variant` and the `#[test]` functions at the
+    // bottom of this module, all of which are `cfg(test)`. Under `test-util`
+    // alone they are unused imports and `-D warnings` rejects them.
+    #[cfg(test)]
     use hyperion_proxy_proto::ArchivedServerToProxyMessage;
 
+    #[cfg(test)]
+    use super::{ChannelId, ConnectionId};
     // Named rather than a glob: `test-util` compiles this module outside
     // `cfg(test)`, where the workspace's pedantic `wildcard_imports` applies.
-    use super::{ChannelId, Compose, CompressionLvl, ConnectionId, IoBuf, ProxyId};
+    use super::{Compose, CompressionLvl, IoBuf, ProxyId};
     use crate::{CompressionThreshold, Global, common::Shared, simulation::EgressComm};
 
     /// A [`Compose`] with two proxies registered, and the receiving end of each proxy's channel.
@@ -821,6 +827,14 @@ pub(crate) mod tests {
     }
 
     /// Reads one framed message off a proxy's channel and tells you which variant it was.
+    ///
+    /// `cfg(test)` and not `test-util`, because the only callers are this crate's own
+    /// tests. `test-util` compiles this module into the LIB target, where an item nothing
+    /// outside `cfg(test)` calls is dead code -- and `checks.clippy` runs
+    /// `--all-targets --all-features -- -D warnings`, so dead code there is a build
+    /// failure rather than a warning. Widen this to the whole module the day something
+    /// outside the crate needs it.
+    #[cfg(test)]
     pub fn next_variant(
         rx: &mut tokio::sync::mpsc::UnboundedReceiver<bytes::Bytes>,
     ) -> Option<String> {

--- a/events/smash/tests/kit_stats.rs
+++ b/events/smash/tests/kit_stats.rs
@@ -236,12 +236,7 @@ fn melee_damage_changes_what_a_swing_takes_off() {
     // so a `melee_damage` that stopped reading the kit is a failure here rather
     // than a formula compared against a copy of itself.
     gate.each(|gate, side| {
-        let clock = gate
-            .game
-            .world
-            .cloned::<&smash::module::damage::MatchClock>()
-            .0;
-        let amount = smash::input::melee_damage(gate.view(side.player), side.foe, clock);
+        let amount = smash::input::melee_damage(gate.view(side.player), side.foe);
         gate.hit(side.foe, amount, DamageKind::Melee);
     });
     gate.advance(0.05);


### PR DESCRIPTION
`nix build .#checks.<system>.clippy` fails on main:

    error: unused imports: `ChannelId` and `ConnectionId`
       --> crates/hyperion/src/net/mod.rs:790:17
    error: function `next_variant` is never used
       --> crates/hyperion/src/net/mod.rs:824:12
    error: could not compile `hyperion` (lib) due to 2 previous errors

The cause is an interaction between a feature and a target that appears under
one combination only. `net::tests` is `#[cfg(any(test, feature = "test-util"))]`,
and the check runs `cargo clippy --all-targets --all-features -- -D warnings`.
`--all-features` turns `test-util` on, so the module compiles into the LIB
target with `cfg(test)` OFF -- and `next_variant`, `ChannelId`, `ConnectionId`
and `ArchivedServerToProxyMessage` are reached only from the `#[test]` functions
at the bottom of that same module. In the lib target they are dead code and
three unused imports, and `-D warnings` makes that a build failure.

Under a plain `cargo check` they are warnings, which is why nothing shows up
locally. Under `cargo clippy --all-targets` without `--all-features` they do not
appear at all, because the module is then `cfg(test)`-only and the test target
does use them.

Narrowed to `cfg(test)` rather than allowed, because the crate is the only
consumer. `test-util` exists so other crates' tests can reach `two_proxies`,
`compose_with_proxy` and `next_unicast`, and those stay exactly as they were.
Widen these four again the day something outside the crate needs them.

Nothing caught it. The repo has no enforced required status checks -- the header
of `nix/ci/flake-gate.nix` says so -- and every workflow is
`workflow_dispatch:`. #1094 landed this check four days ago to close exactly
this class of miss, and the binding that would run it does not exist. That gap
is the second half of ENG-12037 and ENG-12034 and is not addressed here.

Verified, on top of #1104 (without which the run stops at ENG-12034's error
first):

    $ cargo clippy --all-targets --all-features -- -D warnings
    rc=0
    $ cargo test -p hyperion --lib
    test result: ok. 61 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

Refs ENG-12037

---
🤖 Opened by Claude Code (Claude Opus via Claude Code).

## Stacked

Based on #1104 (ENG-12034). Without it the clippy run stops at that error first.