### PR TITLE
docs(hot-reload): replace the packaging guess with three measurements (ENG-12035)

### DIFF
--- a/crates/hyperion-hot-reload/demo/index-probe-host/src/main.rs
+++ b/crates/hyperion-hot-reload/demo/index-probe-host/src/main.rs
@@ -63,9 +63,9 @@ fn main() {
         "host and module allocate component indices from separate pools: the module got \
          {module_index} after the host had already taken up to {host_max}.\nThis is the expected \
          result on a default build, and the probe is the reason to know it. Passing needs the \
-         dylib recipe in docs/hot-reload.md: `hyperion` built as a dylib and everything compiled \
-         with `-C prefer-dynamic -C link-arg=-Wl,--undefined-version -C \
-         link-arg=-Wl,--allow-shlib-undefined`."
+         dylib recipe in docs/hot-reload.md: `hyperion` and `flecs_ecs` built as dylibs and \
+         everything compiled with `-C prefer-dynamic`. Run `nix run .#hot-reload-index-probe`, \
+         which applies exactly that recipe."
     );
     println!("PROBE_OK");
 }

--- a/crates/hyperion-hot-reload/index-probe.sh
+++ b/crates/hyperion-hot-reload/index-probe.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Answers one question: do a host binary and a dlopened module dylib draw component
+# indices from one shared pool?
+#
+# `flecs_ecs`'s derive emits a `static INDEX` per component type, initialised from a
+# process-global `INDEX_POOL`, and that index is a slot in the world's component array.
+# Two copies of `flecs_ecs` in one process is two pools, so a module writes into a slot
+# the host never filled -- consistently on each side, with nothing raising an error.
+# Nothing in the hot-reload gate detects this; see `docs/hot-reload.md`.
+#
+# The probe binary reports what it measured and asserts on it, so this script's job is
+# only to build both halves with the recipe that makes the pool shared and then run it.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+root=$(pwd)
+target=${CARGO_TARGET_DIR:-$root/target}
+
+case "$(uname -s)" in
+  Darwin) ext=dylib ;;
+  *)      ext=so ;;
+esac
+host_triple=$(rustc -vV | sed -n 's/^host: //p')
+sysroot_lib="$(rustc --print sysroot)/lib/rustlib/$host_triple/lib"
+
+# `-C prefer-dynamic` is what makes both halves resolve `hyperion` -- and through it the
+# one `flecs_ecs` that owns the pool -- to a shared image rather than each linking its
+# own static copy. The two rpaths are what lets the result start: with prefer-dynamic,
+# libstd is a dylib in the sysroot and rustc adds no rpath for it, and the workspace's
+# own dylibs live beside the binary.
+#
+# `--undefined-version` is for the version script `flecs_ecs`'s build.rs installs. It
+# names four globs (`ecs_*`, `flecs_*`, `Ecs*`, `FLECS_*`) and lld/bfd treat a pattern
+# that matches nothing as an error by default.
+#
+# There is deliberately no `--allow-shlib-undefined` here. It used to be required
+# because `simulation/metadata/mod.rs` handed every metadata component a blanket
+# `impl PartialOrd where $type: PartialOrd`, unsatisfiable for the seven whose inner
+# type is a glam `Quat` or `Vec3`; rustc never codegened those `partial_cmp` bodies and
+# still listed them in the dylib's export table. That impl is gone, so the flag is too.
+# If it comes back, so does the blanket impl.
+flags="--cfg tokio_unstable -C prefer-dynamic"
+flags="$flags -C link-arg=-Wl,-rpath,$sysroot_lib -C link-arg=-Wl,-rpath,$target/debug"
+if [ "$ext" = so ]; then
+  flags="$flags -C link-arg=-Wl,--undefined-version"
+fi
+export RUSTFLAGS="$flags"
+
+cargo build -q \
+  -p hyperion-hot-reload-index-probe \
+  -p hyperion-hot-reload-index-probe-module
+
+exec "$target/debug/hot-reload-index-probe" \
+  "$target/debug/libhyperion_hot_reload_index_probe_module.$ext"

--- a/crates/hyperion/Cargo.toml
+++ b/crates/hyperion/Cargo.toml
@@ -92,6 +92,15 @@ serial_test = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+[lib]
+# A dylib as well as an rlib so a dynamically loaded game module and this host resolve
+# `hyperion` -- and through it the one `flecs_ecs` that owns the process-global pool
+# handing out component indices -- to a single shared image. Two copies index one world
+# two different ways, consistently on each side, with nothing raising an error. See
+# `docs/hot-reload.md`. The rlib stays first so a consumer linking statically is
+# unaffected.
+crate-type = ["rlib", "dylib"]
+
 [lints]
 workspace = true
 

--- a/crates/hyperion/src/simulation/metadata/mod.rs
+++ b/crates/hyperion/src/simulation/metadata/mod.rs
@@ -208,16 +208,6 @@ macro_rules! define_metadata_component {
             value: $type,
         }
 
-        #[allow(warnings)]
-        impl PartialOrd for $name
-        where
-            $type: PartialOrd,
-        {
-            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-                self.value.partial_cmp(&other.value)
-            }
-        }
-
         impl Metadata for $name {
             type Type = $type;
 

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -555,9 +555,15 @@ rebuild and a restart.**
    directory means the second configuration may not have taken effect. Treat the build-time
    cost as unmeasured rather than as shown to be zero, and measure it properly if CI wall
    time matters.
-3. Host and every module build with
-   `-C prefer-dynamic -C link-arg=-Wl,--undefined-version -C link-arg=-Wl,--allow-shlib-undefined`,
-   plus rpaths to the rust sysroot and to wherever the dylibs land.
+3. Host and every module build with `-C prefer-dynamic`, plus rpaths to the rust sysroot
+   and to wherever the dylibs land. On ELF add `-C link-arg=-Wl,--undefined-version`: the
+   version script `flecs_ecs`'s build script installs names four globs and both bfd and
+   lld treat a pattern matching nothing as an error.
+
+   `crates/hyperion-hot-reload/index-probe.sh` is that recipe, written once.
+   `nix run .#hot-reload-index-probe` runs it, and `checks.hot-reload-index-probe` is the
+   same script as a derivation, so the gate and the command a contributor runs by hand
+   cannot disagree about the same tree.
 
 What makes the pool shared is step 1 and nothing else. It is tempting to think a module has
 to *reference* `hyperion-hot-reload` to end up on the shared runtime — an earlier version of
@@ -565,17 +571,20 @@ the probe carried a call to `AbiToken::current()` with a comment claiming exactl
 Removing the dependency entirely leaves the probe passing. The dependency being a dylib is
 what shares it; a consumer's import list has nothing to do with it.
 
-`--allow-shlib-undefined` is not a shrug. `simulation/metadata/mod.rs` hand-writes
+**`--allow-shlib-undefined` is gone, and what it stood for is fixed.**
+`simulation/metadata/mod.rs` used to hand-write
 `impl PartialOrd for $name where $type: PartialOrd`, and for 7 metadata types that bound is
 unsatisfiable because glam's `Quat` and `Vec3` have no `PartialOrd`. rustc never codegens
-those `partial_cmp` bodies but still lists them in the dylib's export list. They cannot be
-called — calling one fails to compile on the same unsatisfiable bound — so allowing them
-undefined is sound. Removing the blanket impl from that macro would remove the need for the
-flag, and is the better fix.
+those `partial_cmp` bodies and still lists them in the dylib's export list, so a consumer
+needed the flag to link at all. The blanket impl is deleted rather than tolerated: it had
+exactly one caller in the whole workspace, `events/bedwars/src/module/regeneration.rs`
+comparing two `Health`, and that now compares through `Health`'s own `Deref` to `f32`. So
+the flag is not in the recipe, and if it ever needs to come back, that is the signal a
+blanket impl came back with it.
 
-**Steps 1 and 2 are not landed.** They were verified through a local `[patch]` against a
-copy of the fork checkout. Landing them means a commit in `andrewgazelka/Flecs-Rust` and a
-repin here.
+**Steps 1 and 2 are landed.** `flecs_ecs` carries the dylib change at
+`andrewgazelka/Flecs-Rust` `f09dc53` and `Cargo.toml` pins it; `crates/hyperion` carries
+`crate-type = ["rlib", "dylib"]`.
 
 ## Deploying a reload
 
@@ -642,28 +651,30 @@ anything here.
 
 ## Handing this off: what is left, in order
 
-The mechanism is proven and the deployment is not built. Four steps remain. The third is
-the risky one; the rest are known work.
+The mechanism is proven and the deployment is not built. The third step below is the risky
+one; the rest are known work.
 
-**1. Make `hyperion` a dylib and settle the build flags.** `crate-type = ["dylib", "rlib"]`
-plus `-C prefer-dynamic -C link-arg=-Wl,--undefined-version
--C link-arg=-Wl,--allow-shlib-undefined` everywhere. Small edit, wide blast radius: it
-changes how every consumer links, and a plain `cargo test` without those flags will not
-link the result. Confirm by running `demo/index-probe-host`, which should print `PROBE_OK`.
+**Done: make `hyperion` a dylib and settle the build flags.** `crate-type` on
+`crates/hyperion`, `-C prefer-dynamic` everywhere, and the ELF-only
+`-Wl,--undefined-version`. Wide blast radius -- it changes how every consumer links, and a
+plain `cargo build` without those flags builds a host whose pool a module cannot share.
+`checks.hot-reload-index-probe` gates it, and the guard was watched failing: dropping
+`-C prefer-dynamic` from the recipe reproduces this document's own unshared numbers,
+module index 1 against a host that had already taken up to 4.
 
-**2. Split `SmashModule` out of `events/smash` into its own crate, built as a dylib with
+**1. Split `SmashModule` out of `events/smash` into its own crate, built as a dylib with
 `export_module!`.** The rules already avoid the host seam by design, but they reach into
 `crate::server`, `crate::flecs_ext` and about fifteen `hyperion::` items, so this is a real
 refactor rather than a file move. Registration modules stay in the host per the section
 above.
 
-**3. Package it. This is the risky step.** The game server binary and the module dylib have
-to be separate store paths, both built with the flags from step 1, with rpaths that resolve
-in the nix store rather than in `target/debug`. Nothing here is verified — every
-measurement in this document was taken from a cargo build, not a nix one. Expect the
-surprises to be here.
+**2. Package it. This is the risky step.** The game server binary and the module dylib have
+to be separate store paths, both built with the flags above, with rpaths that resolve in
+the nix store rather than in `target/debug`. `checks.hot-reload-index-probe` is the first
+nix build of the recipe and it is a `cargo build` inside a sandbox, not a `cargoUnit`
+artifact, so it proves the flags and not the packaging. Expect the surprises here.
 
-**4. Wire the NixOS module and the fleet spec.** Designed in "Deploying a reload" above:
+**3. Wire the NixOS module and the fleet spec.** Designed in "Deploying a reload" above:
 `reloadTriggers`, the stable `/etc` path, and an `ExecReload` client that exits non-zero on
 a refusal. Small, and the design is settled.
 

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -420,7 +420,14 @@ Stated plainly, because these are the parts a reader cannot see for themselves.
   `nix build .#checks.<system>.hot-reload-demo .#checks.<system>.hot-reload-registry-guard`.
 - **The deployment half is designed, not shipped.** Nothing here is wired to `ix apply`,
   to a systemd unit, or to hyperion's own modules. See "Deploying a reload" below for the
-  shape and what is missing.
+  shape and what is missing, and "Packaging: three derivations" for the part that is now
+  measured rather than assumed.
+
+- **The packaged server does not satisfy the shared-pool precondition.** `hyperion` is a
+  dylib and the fleet's binary does not link it as one, because `cargoUnit` builds without
+  `-C prefer-dynamic`. `checks.hot-reload-index-probe` gates the recipe; nothing yet gates
+  the artifact a host runs. Until the packaging lands, loading a module into the deployed
+  server is the exact configuration the probe exists to reject.
 
 ## Linux, and the one copy of flecs everything depends on
 
@@ -668,15 +675,103 @@ module index 1 against a host that had already taken up to 4.
 refactor rather than a file move. Registration modules stay in the host per the section
 above.
 
-**2. Package it. This is the risky step.** The game server binary and the module dylib have
-to be separate store paths, both built with the flags above, with rpaths that resolve in
-the nix store rather than in `target/debug`. `checks.hot-reload-index-probe` is the first
-nix build of the recipe and it is a `cargo build` inside a sandbox, not a `cargoUnit`
-artifact, so it proves the flags and not the packaging. Expect the surprises here.
+**2. Package it.** No longer the unknown it was; see "Packaging: three derivations, because
+two would restart" below, which replaces the guesswork with a measured design.
 
 **3. Wire the NixOS module and the fleet spec.** Designed in "Deploying a reload" above:
 `reloadTriggers`, the stable `/etc` path, and an `ExecReload` client that exits non-zero on
 a refusal. Small, and the design is settled.
+
+### Do the deployment half first, against a module with nothing in it
+
+The order above is the order the pieces were designed in, and it is the wrong order to
+build them in. Reversed:
+
+- **The rules split has no unknowns.** It is nineteen files, 111 `world.component::<T>()`
+  calls and 30 system declarations, moved across a crate boundary. Large, mechanical, and
+  nothing about it can surprise anyone.
+- **The deployment half has all of them.** systemd's reload-versus-restart decision, the
+  `/etc` indirection, rpaths that resolve in the store, the `stamped` wrapper that puts a
+  per-commit path inside `[Service]`, and whether a title reaches a connected player at
+  all. Every one of those is a fact about a running host.
+
+So build the loader, the socket, the `ExecReload` client, the title and the NixOS wiring
+against a **trivial** rules module that registers nothing and does one visible thing. That
+proves reload-not-restart, the surviving player connection and the title on a dev node
+without waiting for the split. Then migrate smash's rules into that module a domain at a
+time, each migration a small PR that is already covered by the existing test suite.
+
+The failure this avoids is the expensive one: finishing a nineteen-file refactor and only
+then discovering that `[Service]` differs on every apply and nothing ever reloads.
+
+## Packaging: three derivations, because two would restart
+
+Three things were measured, and together they settle the design.
+
+**`cargoUnit` cannot build the module dylib.** Its library support is rlib-only and says so
+in an assertion rather than in a comment:
+
+```
+# M2: this builder is rlib-only (the filename and extern-path hardcode
+# `.rlib`). Reject an artifact that is clearly not an rlib/rmeta so a
+# cdylib/staticlib/proc-macro mistake fails loud at eval, not at link.
+  Only plain rlib libraries are supported (not cdylib/staticlib/proc-macro).
+```
+
+`workspace.libraries.<name>` is therefore not a route to `libsmash_rules.so`, and neither
+is `mkPrebuiltLibraryUnit`.
+
+**The binary the fleet runs today links nothing from the workspace dynamically.** It is a
+`cargoUnit` build with no `-C prefer-dynamic`, so `crate-type = ["rlib", "dylib"]` on
+`hyperion` changes what is *available* and not what is *linked*:
+
+```
+$ otool -L /nix/store/yjlf...-smash-0.1.0/bin/smash
+    /System/Library/Frameworks/Security.framework/...
+    /System/Library/Frameworks/SystemConfiguration.framework/...
+    /System/Library/Frameworks/CoreFoundation.framework/...
+    /nix/store/0ky9...-libiconv-115.100.1/lib/libiconv.2.dylib
+    /usr/lib/libSystem.B.dylib
+$ find /nix/store/yjlf...-smash-0.1.0 -name '*.dylib' -o -name '*.so'
+(nothing)
+```
+
+Five entries, all system. No `libhyperion`, no `libflecs_ecs`, and no dylib shipped beside
+the binary. A module loaded into *that* process gets its own pool, which is the
+configuration the probe exists to reject. So the packaged server has to leave the
+`cargoUnit` path too, not only the module.
+
+**A multi-output derivation would defeat the whole feature.** The obvious repair — one
+cargo build emitting the binary and the dylib as two outputs — is wrong, and quietly so.
+Every output of a derivation moves when any input does, so a rules-only edit would move the
+binary's store path, `ExecStart` would differ, and systemd would restart. The gate would
+pass, the reload would never be attempted, and the only symptom is that players get dropped
+on a deploy that should have been invisible.
+
+What the boundary actually requires is that **the module's store path moves when the host's
+does not**, and a store path is a function of a derivation's inputs. So the boundary is a
+statement about which sources reach which derivation:
+
+| derivation | source | what moves it |
+| --- | --- | --- |
+| `hyperion-dylibs` | `crates/hyperion` and its graph | an engine change |
+| `smash-server` (`ExecStart`) | the host crate: registration modules, loader, tick loop | a component or engine change |
+| `smash-rules` (`reloadTriggers`) | the rules crate: systems and observers | a rules change |
+
+The last two both link `hyperion-dylibs` by rpath into the store, which is what keeps one
+`flecs_ecs` in the process. A component's layout lives in the host crate, so changing it
+moves `smash-server` and systemd restarts. A system's body lives in the rules crate, so
+changing it moves only `smash-rules` and systemd reloads. Nobody has to remember the rule;
+it is the source split.
+
+**The part that will actually cost time is the source filter, and it is worth naming now.**
+Each derivation needs a `src` narrow enough that an unrelated commit does not move it, and
+wide enough that cargo can resolve the workspace: the root `Cargo.toml`, `Cargo.lock`, and
+the member directories in that crate's dependency graph. Get it wrong in the loose
+direction and `smash-server` moves on every commit, which is the `stamped` wrapper's bug
+wearing a different hat, and every apply restarts. There is a cheap gate for it: build the
+three derivations, touch a file in the rules crate, rebuild, and assert that exactly one of
+the three paths changed.
 
 ### Adopting it costs no scheduled restart
 

--- a/events/bedwars/src/module/regeneration.rs
+++ b/events/bedwars/src/module/regeneration.rs
@@ -44,7 +44,14 @@ impl Module for RegenerationModule {
             |(last_damaged, prev_health, health, compose)| {
                 let current_tick = compose.global().tick;
 
-                if *health < *prev_health {
+                // Through `Health`'s `Deref` to `f32` rather than on `Health` itself.
+                // The metadata macro used to hand every component a blanket
+                // `impl PartialOrd where $type: PartialOrd`; for the seven whose
+                // inner type is a glam `Quat` or `Vec3` that bound is unsatisfiable,
+                // and rustc still listed those uncallable `partial_cmp` bodies in the
+                // dylib's export table, forcing `-Wl,--allow-shlib-undefined` on every
+                // consumer. See `docs/hot-reload.md`.
+                if **health < **prev_health {
                     last_damaged.tick = current_tick;
                 }
 

--- a/events/smash/tests/kit_stats.rs
+++ b/events/smash/tests/kit_stats.rs
@@ -236,12 +236,7 @@ fn melee_damage_changes_what_a_swing_takes_off() {
     // so a `melee_damage` that stopped reading the kit is a failure here rather
     // than a formula compared against a copy of itself.
     gate.each(|gate, side| {
-        let clock = gate
-            .game
-            .world
-            .cloned::<&smash::module::damage::MatchClock>()
-            .0;
-        let amount = smash::input::melee_damage(gate.view(side.player), side.foe, clock);
+        let amount = smash::input::melee_damage(gate.view(side.player), side.foe);
         gate.hit(side.foe, amount, DamageKind::Melee);
     });
     gate.advance(0.05);

--- a/flake.nix
+++ b/flake.nix
@@ -739,6 +739,18 @@
               text = ''exec ./crates/hyperion-hot-reload/demo.sh "$@"'';
             };
 
+            # Whether the host binary and a dlopened module draw component
+            # indices from one pool. Everything the reload gate checks rests on
+            # this, and nothing it checks would notice if it were false: both
+            # sides stay internally consistent and simply disagree about which
+            # slot is which. `checks.hot-reload-index-probe` runs this same
+            # script, so the gate and the command a contributor runs by hand
+            # cannot say different things about the same tree.
+            hot-reload-index-probe = {
+              deps = [ pkgs.cmake pkgs.pkg-config ];
+              text = ''exec ./crates/hyperion-hot-reload/index-probe.sh "$@"'';
+            };
+
             # The game server and the proxy authenticate to each other with
             # mTLS, so a fresh clone cannot run until a CA and two leaf certs
             # exist. That is the only thing between `git clone` and a running
@@ -1381,6 +1393,38 @@
               ${workspace.cargoConfigScript}
               ${lib.getExe checkScripts.lint}
               touch $out
+            '';
+
+            # Runs the shared-pool probe rather than only shellchecking it.
+            # `scripts` puts every `nix run` app in `checks`, so
+            # `checks.hot-reload-index-probe` already existed -- as the SCRIPT,
+            # whose build runs shellcheck over a cargo invocation and never
+            # runs cargo. That is the same gap #1094 found in `checks.lint`.
+            #
+            # This is the one invariant the reload gate cannot check for
+            # itself. `AbiToken` compares a rustc version, an ABI integer and
+            # the address of a static, and all three pass while the host and a
+            # module index one world through two different `INDEX_POOL`s. So
+            # the thing that would catch a regression is a build of both halves
+            # and a comparison of allocation order, which is what the probe is.
+            #
+            # Cost: a dev-profile build of `hyperion` and its graph inside the
+            # sandbox, shared with nothing. Same shape as `clippy` above and
+            # for the same reason -- prefer-dynamic artifacts are not the
+            # release rlibs `cargoUnit` produces, so there is nothing to reuse.
+            hot-reload-index-probe = pkgs.runCommandCC "hyperion-hot-reload-index-probe" {
+              inherit nativeBuildInputs;
+              # Dev profile, so every C build script in the graph compiles at
+              # -O0 and glibc answers `_FORTIFY_SOURCE` with a `#warning`. An
+              # autoconf probe reading stderr then misreads its own test as a
+              # compile failure; see `clippy` above, which met this first.
+              hardeningDisable = [ "fortify" ];
+            } ''
+              cp -r ${workspaceArgs.src}/. .
+              chmod -R u+w .
+              ${workspace.cargoConfigScript}
+              ${lib.getExe runners.hot-reload-index-probe} | tee $out
+              grep -q PROBE_OK $out
             '';
           };
 


### PR DESCRIPTION
The handoff called packaging "the risky step" and said to expect the
surprises there. Three of them are now measured rather than guessed, and
together they settle the design.

`cargoUnit` cannot build the module dylib. Its library support is
rlib-only, and the index repo says so in an assertion rather than a
comment: "Only plain rlib libraries are supported (not
cdylib/staticlib/proc-macro)". So neither `workspace.libraries.<name>`
nor `mkPrebuiltLibraryUnit` is a route to `libsmash_rules.so`.

The binary the fleet runs today links nothing from the workspace
dynamically. `crate-type = ["rlib", "dylib"]` on `hyperion` changed what
is available, not what is linked, because `cargoUnit` builds without
`-C prefer-dynamic`:

    $ otool -L /nix/store/yjlf...-smash-0.1.0/bin/smash
    (five entries, all system; no libhyperion, no libflecs_ecs)
    $ find /nix/store/yjlf...-smash-0.1.0 -name '*.dylib' -o -name '*.so'
    (nothing)

So the packaged server has to leave the `cargoUnit` path as well, and
loading a module into the deployed binary today would be the exact
configuration `checks.hot-reload-index-probe` exists to reject. That is
now in "Not done" rather than left to be discovered.

A multi-output derivation would defeat the feature, quietly. One cargo
build emitting the binary and the dylib as two outputs is the obvious
repair and it is wrong: every output moves when any input does, so a
rules-only edit moves the binary's path, `ExecStart` differs, and systemd
restarts. The gate passes, the reload is never attempted, and the only
symptom is dropped players on a deploy that should have been invisible.

What the boundary requires is that the module's path move when the host's
does not, and a store path is a function of a derivation's inputs. So it
is three derivations split by source: `hyperion-dylibs`, `smash-server`
(ExecStart, holds the registration modules) and `smash-rules`
(reloadTriggers, holds the systems). Nobody has to remember the rule that
a component change restarts and a rules change reloads; it is the source
split. The cost that is worth naming in advance is the source filter, and
the gate for it is cheap: build the three, touch a file in the rules
crate, rebuild, assert exactly one path moved.

Also reverses the build order. The rules split has no unknowns -- 19
files, 111 `world.component::<T>()` calls, 30 system declarations moved
across a crate boundary -- while every unknown left is a fact about a
running host. So build the loader, socket, `ExecReload` client, title and
NixOS wiring against a trivial rules module first, prove
reload-not-restart and a surviving player on a dev node, then migrate
smash's rules a domain at a time under the existing test suite. The
failure this avoids is finishing a nineteen-file refactor and only then
finding that `[Service]` differs on every apply and nothing ever reloads.

Refs ENG-12035

---
🤖 Opened by Claude Code (Claude Opus via Claude Code).

## Stacked

Based on #1105, which is based on #1104.