### PR TITLE
fix(hot-reload): make the index probe run, and link, on ELF (ENG-12043)

### DIFF
--- a/crates/hyperion-hot-reload/index-probe.sh
+++ b/crates/hyperion-hot-reload/index-probe.sh
@@ -41,6 +41,13 @@ sysroot_lib="$(rustc --print sysroot)/lib/rustlib/$host_triple/lib"
 # If it comes back, so does the blanket impl.
 flags="--cfg tokio_unstable -C prefer-dynamic"
 flags="$flags -C link-arg=-Wl,-rpath,$sysroot_lib -C link-arg=-Wl,-rpath,$target/debug"
+# `deps/` as well as `debug/`, because the two dylibs are named differently
+# there. Cargo gives a workspace member's dylib an unhashed copy in
+# `target/debug` (`libhyperion.so`), but a dependency's dylib exists only in
+# `target/debug/deps` under its metadata hash -- and the DT_NEEDED entry names
+# the hashed file. So `libhyperion.so` resolved and `libflecs_ecs-<hash>.so`
+# did not, which is the one library the whole probe is about.
+flags="$flags -C link-arg=-Wl,-rpath,$target/debug/deps"
 if [ "$ext" = so ]; then
   flags="$flags -C link-arg=-Wl,--undefined-version"
 fi

--- a/flake.nix
+++ b/flake.nix
@@ -748,7 +748,12 @@
             # cannot say different things about the same tree.
             hot-reload-index-probe = {
               deps = [ pkgs.cmake pkgs.pkg-config ];
-              text = ''exec ./crates/hyperion-hot-reload/index-probe.sh "$@"'';
+              # Through `bash` rather than the script's own shebang. The
+              # sandbox has no `/usr/bin/env`, so `#!/usr/bin/env bash` is a
+              # `bad interpreter` there and the check failed before running a
+              # line of the probe. It passed on darwin, where that path exists,
+              # which is how the ELF half stayed unverified.
+              text = ''exec bash ./crates/hyperion-hot-reload/index-probe.sh "$@"'';
             };
 
             # The game server and the proxy authenticate to each other with


### PR DESCRIPTION
Closes ENG-12043. Stacked on #1105; retarget to `main` when that merges.

`checks.hot-reload-index-probe` landed in #1105 green on aarch64-darwin. On
x86_64-linux it failed twice, and the first failure is why nobody knew about the
second.

**It could not start the script.** The runner invoked
`./crates/hyperion-hot-reload/index-probe.sh` through its `#!/usr/bin/env bash`
shebang, and the nix sandbox has no `/usr/bin/env`:

```
/nix/store/y6dfmd0...-hot-reload-index-probe/bin/hot-reload-index-probe: \
  /build/crates/hyperion-hot-reload/index-probe.sh: /usr/bin/env: bad interpreter: No such file or directory
```

darwin has that path, so the same check passed there. A gate that cannot start
reports identically to a gate that found nothing, which is exactly how #1105's
ELF half kept a green check while being unverified.

**The binary could not resolve `libflecs_ecs`.** With the above fixed, the cargo
build succeeds and the probe does not start:

```
error while loading shared libraries: libflecs_ecs-c4b1a70a43230940.so: cannot open shared object file
```

The recipe set one rpath, `$target/debug`. That is right for a workspace member's
dylib and wrong for a dependency's: cargo puts an unhashed copy of a member's
dylib in `target/debug`, but a dependency's dylib exists only in
`target/debug/deps` under its metadata hash, and `DT_NEEDED` names the hashed
file.

```
$ ldd target/debug/hot-reload-index-probe
    libhyperion.so => .../target/debug/libhyperion.so (0x00007f7f2bc00000)
    libflecs_ecs-c4b1a70a43230940.so => not found
```

So `libhyperion` resolved and `libflecs_ecs` did not, which is the one library the
probe exists to reason about.

## Verified

Through the gate, on dev-compute-6 (x86_64-linux, 32 cores), not by hand:

```
$ nix build .#checks.x86_64-linux.hot-reload-index-probe --no-link --print-out-paths -L
hyperion-hot-reload-index-probe> host indices: [1, 2, 3, 4] (max 4)
hyperion-hot-reload-index-probe> module's own type index: 5
hyperion-hot-reload-index-probe> hyperion::simulation::Position index: host 4, module 4
hyperion-hot-reload-index-probe> SHARED_POOL=true
hyperion-hot-reload-index-probe> SHARED_HYPERION_INDEX=true
hyperion-hot-reload-index-probe> PROBE_OK
/nix/store/5008fid7cjz6f5div013vhdcdamk5p5m-hyperion-hot-reload-index-probe
```

Re-run on aarch64-darwin after the change and it still prints `PROBE_OK` -- an
extra rpath that resolves nothing on that platform is inert.

## What this does not do

It does not gate the artifact a host runs. The fleet's `smash` binary is a
`cargoUnit` build with no `-C prefer-dynamic` and links nothing from the
workspace dynamically, so the shared-pool precondition still does not hold for
the deployed server. That is the packaging work, tracked separately.

Authored by Claude Opus via Claude Code.
