### PR TITLE
feat(projectile): stop arrows at terrain, and bound the voxel walk under it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3889,6 +3889,7 @@ dependencies = [
  "anyhow",
  "clap",
  "flecs_ecs",
+ "geometry",
  "glam",
  "hyperion",
  "hyperion-clap",

--- a/crates/geometry/src/lib.rs
+++ b/crates/geometry/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod aabb;
 pub mod ray;
+pub mod sweep;

--- a/crates/geometry/src/ray.rs
+++ b/crates/geometry/src/ray.rs
@@ -63,9 +63,38 @@ impl Ray {
 
     /// Efficiently traverse through grid cells that the ray intersects using the Amanatides and Woo algorithm.
     /// Returns an iterator over the grid cells ([`IVec3`]) that the ray passes through.
+    ///
+    /// Unbounded in `t`: it runs until it leaves the box. Anything asking about
+    /// a finite length of ray -- one tick of a projectile, a player's reach --
+    /// wants [`Self::voxel_traversal_until`] instead, which is the difference
+    /// between walking four cells and walking to the edge of the coordinate
+    /// space.
     #[inline]
     pub fn voxel_traversal(&self, bounds_min: IVec3, bounds_max: IVec3) -> VoxelTraversal {
-        let current_pos = self.origin.as_ivec3();
+        self.voxel_traversal_until(bounds_min, bounds_max, f32::INFINITY)
+    }
+
+    /// The same traversal, stopping once the ray has travelled `max_t`.
+    ///
+    /// `t` is in units of [`Self::direction`], so a ray built with
+    /// [`Self::from_points`] is bounded to the segment by `max_t == 1.0`.
+    ///
+    /// The bound is a real cost, not a tidiness: an axis-aligned ray in an
+    /// empty world visits every cell out to the coordinate bound, and the only
+    /// reason that was survivable was that it usually found *something*.
+    #[inline]
+    pub fn voxel_traversal_until(
+        &self,
+        bounds_min: IVec3,
+        bounds_max: IVec3,
+        max_t: f32,
+    ) -> VoxelTraversal {
+        // `floor`, not `as_ivec3`. The cast truncates towards zero, which is
+        // the same thing for a positive coordinate and one cell out for a
+        // negative one -- so every traversal that began at a negative
+        // coordinate began in the wrong cell, and half of any Minecraft map is
+        // at a negative coordinate.
+        let current_pos = self.origin.floor().as_ivec3();
 
         // Determine stepping direction for each axis
         let step = IVec3::new(
@@ -104,6 +133,8 @@ impl Ray {
             t_delta,
             bounds_min,
             bounds_max,
+            t_entry: 0.0,
+            max_t,
         }
     }
 }
@@ -117,12 +148,21 @@ pub struct VoxelTraversal {
     t_delta: Vec3,
     bounds_min: IVec3,
     bounds_max: IVec3,
+    /// How far along the ray the current cell was entered.
+    t_entry: f32,
+    /// The last `t` worth reporting a cell for.
+    max_t: f32,
 }
 
 impl Iterator for VoxelTraversal {
     type Item = IVec3;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // Past the end of the ray the caller asked about.
+        if self.t_entry > self.max_t {
+            return None;
+        }
+
         // Check if current position is within bounds
         if self.current_pos.x < self.bounds_min.x
             || self.current_pos.x > self.bounds_max.x
@@ -136,19 +176,26 @@ impl Iterator for VoxelTraversal {
 
         let current = self.current_pos;
 
-        // Determine which axis to step along (the one with minimum t_max)
+        // Determine which axis to step along (the one with minimum t_max).
+        // Exactly one axis per step, never two at once: stepping both across a
+        // shared corner would skip the two cells that meet there, which is a
+        // projectile passing through a corner it could not fit through.
         if self.t_max.x < self.t_max.y {
             if self.t_max.x < self.t_max.z {
+                self.t_entry = self.t_max.x;
                 self.current_pos.x += self.step.x;
                 self.t_max.x += self.t_delta.x;
             } else {
+                self.t_entry = self.t_max.z;
                 self.current_pos.z += self.step.z;
                 self.t_max.z += self.t_delta.z;
             }
         } else if self.t_max.y < self.t_max.z {
+            self.t_entry = self.t_max.y;
             self.current_pos.y += self.step.y;
             self.t_max.y += self.t_delta.y;
         } else {
+            self.t_entry = self.t_max.z;
             self.current_pos.z += self.step.z;
             self.t_max.z += self.t_delta.z;
         }
@@ -186,6 +233,66 @@ mod tests {
             for (a, b) in voxels.iter().tuple_windows() {
                 assert_eq!(b - a, direction);
             }
+        }
+    }
+
+    #[test]
+    fn traversal_starts_in_the_cell_containing_a_negative_origin() {
+        // `as_ivec3` truncates towards zero, so this used to start at cell 0.
+        let ray = Ray::new(Vec3::new(-0.5, -0.5, -0.5), Vec3::X);
+        let first = ray
+            .voxel_traversal(IVec3::MIN, IVec3::MAX)
+            .next()
+            .expect("a traversal yields the cell it starts in");
+        assert_eq!(first, IVec3::new(-1, -1, -1));
+    }
+
+    #[test]
+    fn a_bounded_traversal_stops_at_the_end_of_the_segment() {
+        // The bound is closed: a cell entered at exactly `t == max_t` is
+        // reported, because the segment does touch it and a collision box
+        // flush against that boundary is a real contact. Here the far end is
+        // x == 4.0, so cell 4 is the last one, and cell 5 is not.
+        let ray = Ray::from_points(Vec3::new(0.5, 0.5, 0.5), Vec3::new(4.0, 0.5, 0.5));
+        let voxels = ray
+            .voxel_traversal_until(IVec3::MIN, IVec3::MAX, 1.0)
+            .collect::<Vec<_>>();
+        assert_eq!(voxels, vec![
+            IVec3::new(0, 0, 0),
+            IVec3::new(1, 0, 0),
+            IVec3::new(2, 0, 0),
+            IVec3::new(3, 0, 0),
+            IVec3::new(4, 0, 0),
+        ]);
+    }
+
+    #[test]
+    fn a_zero_length_ray_yields_only_the_cell_it_is_in() {
+        let ray = Ray::new(Vec3::new(0.5, 0.5, 0.5), Vec3::ZERO);
+        let voxels = ray
+            .voxel_traversal_until(IVec3::MIN, IVec3::MAX, 1.0)
+            .collect::<Vec<_>>();
+        assert_eq!(voxels, vec![IVec3::ZERO]);
+    }
+
+    #[test]
+    fn a_diagonal_traversal_steps_one_axis_at_a_time() {
+        // Never two axes in one step: a segment that stepped x and y together
+        // would jump the corner and skip both cells that meet there.
+        let ray = Ray::from_points(Vec3::new(0.5, 0.5, 0.5), Vec3::new(3.5, 3.5, 0.5));
+        for pair in ray
+            .voxel_traversal_until(IVec3::MIN, IVec3::MAX, 1.0)
+            .collect::<Vec<_>>()
+            .windows(2)
+        {
+            let delta = pair[1] - pair[0];
+            assert_eq!(
+                delta.abs().element_sum(),
+                1,
+                "stepped {delta} in one move, from {} to {}",
+                pair[0],
+                pair[1]
+            );
         }
     }
 }

--- a/crates/geometry/src/sweep.rs
+++ b/crates/geometry/src/sweep.rs
@@ -1,0 +1,339 @@
+//! Sweeping a segment through a voxel grid and stopping at the first solid
+//! surface it meets.
+//!
+//! The one implementation of "what does this projectile hit". Everything that
+//! moves a projectile a whole tick at a time needs it, and the tempting cheap
+//! version -- sample the endpoint, ask whether that block is solid -- is a hole
+//! rather than a test: an arrow travelling sixty blocks a second covers three
+//! blocks between ticks, so two of every three blocks it passes through are
+//! never looked at and a one-block wall is something it flies straight over.
+//!
+//! [`first_block_hit`] is generic over where the shapes come from, deliberately.
+//! The block store answers from loaded chunks and a test answers from a set of
+//! coordinates it wrote by hand, and the traversal that decides which cells to
+//! ask about is the same code in both cases. That is what makes the unit tests
+//! below evidence about the shipped path rather than about a second copy of it.
+
+use glam::{IVec3, Vec3};
+
+use crate::{aabb::Aabb, ray::Ray};
+
+/// Where a swept segment first met a block.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BlockHit {
+    /// How far along the segment contact happened, as a fraction in `0.0..=1.0`.
+    ///
+    /// A fraction and not a distance in blocks, because that is what the caller
+    /// has to compare against: a hit at `time` is at `from.lerp(to, time)`, and
+    /// two candidate hits on the same segment are ordered by it without anyone
+    /// having to agree on a unit first.
+    pub time: f32,
+    /// The block that stopped it.
+    pub block: IVec3,
+    /// Where on that block's surface contact happened.
+    pub point: Vec3,
+    /// The unit normal of the face crossed, pointing out of the block.
+    ///
+    /// [`Vec3::ZERO`] when the segment began already inside the shape, because
+    /// then no face was crossed and any answer would be invented.
+    pub normal: Vec3,
+}
+
+/// The first block surface on the segment `from` -> `to`, or `None` if it is
+/// clear.
+///
+/// `shapes` is asked for the collision boxes of one block, in that block's own
+/// coordinates (a full cube is `(0,0,0)..(1,1,1)`); it is called at most once
+/// per cell the segment passes through, in the order they are met. An empty
+/// iterator means the segment passes through -- air, and anything else with no
+/// collision box, are the same answer.
+///
+/// A segment that starts inside a solid block hits it at `time == 0.0`. That is
+/// the honest answer rather than an edge case to skip past: an arrow loosed
+/// from inside a wall has not travelled anywhere before it is stopped.
+pub fn first_block_hit<I>(
+    from: Vec3,
+    to: Vec3,
+    mut shapes: impl FnMut(IVec3) -> I,
+) -> Option<BlockHit>
+where
+    I: IntoIterator<Item = Aabb>,
+{
+    let ray = Ray::from_points(from, to);
+
+    // The segment is the bound, not a box drawn around the world. Traversal
+    // stops at `t == 1` -- one tick of travel -- so a shot into an empty sky
+    // walks the handful of cells it actually crosses rather than every cell out
+    // to the edge of the coordinate space.
+    for block in ray.voxel_traversal_until(IVec3::MIN, IVec3::MAX, 1.0) {
+        let offset = block.as_vec3();
+        let mut nearest: Option<(f32, Aabb)> = None;
+
+        for shape in shapes(block) {
+            let shape = shape + offset;
+            let Some(time) = shape.intersect_ray(&ray) else {
+                continue;
+            };
+            let time = time.into_inner();
+            // Past the end of this tick's travel: a real hit, on a later tick.
+            if time > 1.0 {
+                continue;
+            }
+            if nearest.is_none_or(|(nearest, _)| time < nearest) {
+                nearest = Some((time, shape));
+            }
+        }
+
+        // Cells arrive in increasing order of entry time and a block's collision
+        // boxes are inside it, so the first cell with any hit holds the earliest
+        // hit on the whole segment. No need to look further.
+        if let Some((time, shape)) = nearest {
+            return Some(BlockHit {
+                time,
+                block,
+                point: ray.at(time),
+                normal: face_normal(shape, ray, time),
+            });
+        }
+    }
+
+    None
+}
+
+/// Which face of `shape` the ray crossed to enter it at `time`.
+///
+/// The slab entry times recomputed rather than carried out of
+/// [`Aabb::intersect_ray`]: it returns the largest of the three and the axis it
+/// came from is the answer here, so the choice is between widening that
+/// signature for one caller and redoing three divisions. The divisions are
+/// cheaper than the coupling.
+fn face_normal(shape: Aabb, ray: Ray, time: f32) -> Vec3 {
+    let direction = ray.direction();
+    let origin = ray.origin();
+
+    let mut normal = Vec3::ZERO;
+    // The unclamped slab entry: the largest of the three per-axis entry times,
+    // which is the intersection time before `intersect_ray` clamps it to zero.
+    // Taking the maximum rather than filtering against `time` is what keeps
+    // this robust -- the winning axis reproduces `time` to the last bit only
+    // when it is computed the same way, and a comparison against a separately
+    // rounded value picks no axis at all every so often.
+    let mut entered_at = f32::NEG_INFINITY;
+
+    for axis in 0..3 {
+        // Parallel to this pair of faces: it crossed neither.
+        if direction[axis] == 0.0 {
+            continue;
+        }
+        let sign = if direction[axis] > 0.0 { 1.0 } else { -1.0 };
+        let near = if sign > 0.0 {
+            shape.min[axis]
+        } else {
+            shape.max[axis]
+        };
+        let entry = (near - origin[axis]) / direction[axis];
+        if entry > entered_at {
+            entered_at = entry;
+            normal = Vec3::ZERO;
+            normal[axis] = -sign;
+        }
+    }
+
+    // Entered before the segment began, which means it did not enter at all:
+    // it started inside. No face was crossed, so there is no face normal.
+    debug_assert!(
+        entered_at <= time || time > 0.0,
+        "a hit at t == 0 cannot have entered after it"
+    );
+    if entered_at < 0.0 { Vec3::ZERO } else { normal }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    /// A world of full cubes at the listed coordinates, which is what a test
+    /// about traversal wants: the question is which cells get looked at and in
+    /// what order, and a slab would only make the arithmetic harder to read.
+    fn cubes(solid: impl IntoIterator<Item = IVec3>) -> impl Fn(IVec3) -> Option<Aabb> {
+        let solid: HashSet<IVec3> = solid.into_iter().collect();
+        move |block| {
+            solid
+                .contains(&block)
+                .then(|| Aabb::new(Vec3::ZERO, Vec3::ONE))
+        }
+    }
+
+    #[test]
+    fn axis_aligned_shot_stops_at_the_near_face() {
+        let world = cubes([IVec3::new(5, 0, 0)]);
+        let hit = first_block_hit(Vec3::new(0.5, 0.5, 0.5), Vec3::new(10.5, 0.5, 0.5), &world)
+            .expect("a wall five blocks along +X is on the segment");
+
+        assert_eq!(hit.block, IVec3::new(5, 0, 0));
+        // Entered at x == 5, having started at x == 0.5 and aiming for 10.5.
+        assert!((hit.point.x - 5.0).abs() < 1e-4, "point: {}", hit.point);
+        assert!((hit.time - 0.45).abs() < 1e-4, "time: {}", hit.time);
+        assert_eq!(hit.normal, Vec3::NEG_X);
+    }
+
+    #[test]
+    fn open_ground_is_a_miss() {
+        let world = cubes([IVec3::new(5, 0, 0)]);
+        // Same wall, one block higher than the segment.
+        let hit = first_block_hit(Vec3::new(0.5, 1.5, 0.5), Vec3::new(10.5, 1.5, 0.5), &world);
+        assert_eq!(hit, None);
+    }
+
+    #[test]
+    fn a_wall_beyond_the_end_of_the_segment_is_not_hit_yet() {
+        let world = cubes([IVec3::new(5, 0, 0)]);
+        // One tick's travel that stops short of the wall. The old unbounded
+        // scan reported this as a hit and an arrow stopped in mid-air metres
+        // before anything was in the way.
+        let hit = first_block_hit(Vec3::new(0.5, 0.5, 0.5), Vec3::new(3.5, 0.5, 0.5), &world);
+        assert_eq!(hit, None);
+    }
+
+    #[test]
+    fn a_fast_shot_cannot_tunnel_through_a_one_block_wall() {
+        let world = cubes([IVec3::new(5, 0, 0)]);
+        // Sixty blocks in one step: both endpoints are in air and only the
+        // cells between them say otherwise.
+        let hit = first_block_hit(Vec3::new(0.5, 0.5, 0.5), Vec3::new(60.5, 0.5, 0.5), &world)
+            .expect("the wall is between the endpoints even though neither is in it");
+        assert_eq!(hit.block, IVec3::new(5, 0, 0));
+    }
+
+    #[test]
+    fn a_diagonal_shot_meets_the_blocks_it_passes_through() {
+        // A staircase of blocks along the diagonal. The segment crosses the
+        // second one; the first sits behind the start.
+        let world = cubes([IVec3::new(3, 3, 0)]);
+        let hit = first_block_hit(Vec3::new(0.5, 0.5, 0.5), Vec3::new(6.5, 6.5, 0.5), &world)
+            .expect("the diagonal passes through (3, 3, 0)");
+        assert_eq!(hit.block, IVec3::new(3, 3, 0));
+        // Entered through whichever face it reached first; on an exact diagonal
+        // through a corner that is a tie, and either face is a truthful answer.
+        assert!(
+            hit.normal == Vec3::NEG_X || hit.normal == Vec3::NEG_Y,
+            "normal: {}",
+            hit.normal
+        );
+    }
+
+    #[test]
+    fn a_corner_the_segment_misses_does_not_stop_it() {
+        // Two blocks meeting at a corner with a gap on the diagonal between
+        // them. A traversal that steps both axes at once would step through the
+        // shared corner and report neither; one that steps a single axis per
+        // cell visits one of the two and stops.
+        let world = cubes([IVec3::new(1, 0, 0), IVec3::new(0, 1, 0)]);
+        let hit = first_block_hit(Vec3::new(0.5, 0.5, 0.5), Vec3::new(1.5, 1.5, 0.5), &world)
+            .expect("a segment through the shared corner is stopped by one of the two");
+        assert!(
+            hit.block == IVec3::new(1, 0, 0) || hit.block == IVec3::new(0, 1, 0),
+            "block: {}",
+            hit.block
+        );
+    }
+
+    #[test]
+    fn negative_coordinates_traverse_the_same_as_positive_ones() {
+        // `as_ivec3` truncates towards zero, so a start at x == -0.5 used to be
+        // read as cell 0 rather than cell -1: everything fired in the negative
+        // half of a map began its traversal one cell off, and half of every map
+        // is in the negative half.
+        let world = cubes([IVec3::new(-5, -1, -1)]);
+        let hit = first_block_hit(
+            Vec3::new(-0.5, -0.5, -0.5),
+            Vec3::new(-10.5, -0.5, -0.5),
+            &world,
+        )
+        .expect("a wall five blocks along -X is on the segment");
+
+        assert_eq!(hit.block, IVec3::new(-5, -1, -1));
+        // Entered through the +X face, at x == -4.
+        assert!((hit.point.x + 4.0).abs() < 1e-4, "point: {}", hit.point);
+        assert_eq!(hit.normal, Vec3::X);
+    }
+
+    #[test]
+    fn every_axis_and_sign_stops_at_the_same_distance() {
+        for axis in 0..3 {
+            for sign in [1.0_f32, -1.0] {
+                let mut direction = Vec3::ZERO;
+                direction[axis] = sign;
+
+                let mut wall = IVec3::ZERO;
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "5 and -6 are exactly representable"
+                )]
+                let along = (5.0 * sign) as i32 - i32::from(sign < 0.0);
+                wall[axis] = along;
+
+                let world = cubes([wall]);
+                let from = Vec3::splat(0.5);
+                let hit = first_block_hit(from, from + direction * 10.0, &world)
+                    .unwrap_or_else(|| panic!("axis {axis} sign {sign} should hit {wall}"));
+
+                assert_eq!(hit.block, wall, "axis {axis} sign {sign}");
+                let mut expected = Vec3::ZERO;
+                expected[axis] = -sign;
+                assert_eq!(hit.normal, expected, "axis {axis} sign {sign}");
+            }
+        }
+    }
+
+    #[test]
+    fn a_segment_starting_inside_a_block_is_stopped_where_it_started() {
+        let world = cubes([IVec3::ZERO]);
+        let hit = first_block_hit(Vec3::splat(0.5), Vec3::new(10.5, 0.5, 0.5), &world)
+            .expect("a shot from inside a wall does not get out of it");
+
+        assert_eq!(hit.block, IVec3::ZERO);
+        assert!((hit.time - 0.0).abs() < 1e-6, "time: {}", hit.time);
+        assert_eq!(hit.point, Vec3::splat(0.5));
+        // No face was crossed, so there is no face normal to report.
+        assert_eq!(hit.normal, Vec3::ZERO);
+    }
+
+    #[test]
+    fn a_zero_length_segment_in_air_hits_nothing() {
+        let world = cubes([IVec3::new(5, 0, 0)]);
+        let at = Vec3::splat(0.5);
+        assert_eq!(first_block_hit(at, at, &world), None);
+    }
+
+    #[test]
+    fn the_nearest_of_several_blocks_is_the_one_reported() {
+        let world = cubes([
+            IVec3::new(2, 0, 0),
+            IVec3::new(5, 0, 0),
+            IVec3::new(9, 0, 0),
+        ]);
+        let hit = first_block_hit(Vec3::new(0.5, 0.5, 0.5), Vec3::new(10.5, 0.5, 0.5), &world)
+            .expect("three walls ahead, one of them first");
+        assert_eq!(hit.block, IVec3::new(2, 0, 0));
+    }
+
+    #[test]
+    fn a_partial_shape_is_missed_where_a_full_cube_would_be_hit() {
+        // The bottom half of the cell only: a slab. A segment through the top
+        // half passes over it, which is the whole reason shapes are asked for
+        // per block rather than a solid/not-solid bit.
+        let slab = |block: IVec3| {
+            (block == IVec3::new(5, 0, 0)).then(|| Aabb::new(Vec3::ZERO, Vec3::new(1.0, 0.5, 1.0)))
+        };
+        assert_eq!(
+            first_block_hit(Vec3::new(0.5, 0.8, 0.5), Vec3::new(10.5, 0.8, 0.5), &slab),
+            None
+        );
+        let hit = first_block_hit(Vec3::new(0.5, 0.2, 0.5), Vec3::new(10.5, 0.2, 0.5), &slab)
+            .expect("a segment through the lower half meets the slab");
+        assert_eq!(hit.block, IVec3::new(5, 0, 0));
+    }
+}

--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -543,10 +543,15 @@ impl Module for EntityStateSyncModule {
                 if velocity.0 != Vec3::ZERO {
                     let center = **position;
 
-                    // getting max distance
-                    let distance = velocity.0.length();
-
-                    let ray = geometry::ray::Ray::new(center, velocity.0) * distance;
+                    // The ray *is* this tick's travel: `Velocity` is blocks per
+                    // tick, so the segment runs from here to here-plus-velocity
+                    // and `t == 1` is the far end of it. It used to be scaled by
+                    // the velocity's own length as well, which asked about a
+                    // segment `|v|` times too long, and against an unbounded
+                    // block scan that meant an arrow stopped dead as soon as
+                    // anything was ahead of it on its heading rather than when
+                    // it got there.
+                    let ray = geometry::ray::Ray::new(center, velocity.0);
 
                     let Some(collision) = get_first_collision(ray, &world, Some(owner.entity))
                     else {

--- a/crates/hyperion/src/simulation/blocks/mod.rs
+++ b/crates/hyperion/src/simulation/blocks/mod.rs
@@ -60,6 +60,10 @@ pub enum TrySetBlockDeltaError {
 
 #[derive(Debug, Copy, Clone)]
 pub struct RayCollision {
+    /// How far along the ray contact happened, in units of the ray's
+    /// direction: `0.0` at the origin and `1.0` at `origin + direction`. A
+    /// fraction and not a count of blocks, so it compares directly against
+    /// what [`geometry::aabb::Aabb::intersect_ray`] returns for the same ray.
     pub distance: f32,
     pub location: IVec3,
     pub point: Vec3,
@@ -120,42 +124,43 @@ impl Blocks {
         })
     }
 
+    /// The first block surface on the segment `ray.origin()` ->
+    /// `ray.origin() + ray.direction()`, or `None` if it is clear.
+    ///
+    /// **The direction is the whole of the length asked about.** A caller with
+    /// a start and an end builds the ray with [`Ray::from_points`]; a caller
+    /// with a reach scales a unit direction by it. Anything beyond that is a
+    /// hit on a later tick and is not reported, which is the difference between
+    /// an arrow stopping at the wall in front of it and an arrow stopping in
+    /// mid-air because there is a wall somewhere out along its heading.
+    ///
+    /// Full block collision shapes, so a slab, a stair and a fence are each hit
+    /// where they actually are rather than anywhere in their cell.
     #[must_use]
     pub fn first_collision(&self, ray: Ray) -> Option<RayCollision> {
-        // Define bounds for the voxel traversal
-        let bounds_min = IVec3::new(i32::MIN / 2, -64, i32::MIN / 2);
-        let bounds_max = IVec3::new(i32::MAX / 2, 320, i32::MAX / 2);
+        let hit = geometry::sweep::first_block_hit(
+            ray.origin(),
+            ray.origin() + ray.direction(),
+            |cell| {
+                self.get_block(cell).into_iter().flat_map(|block| {
+                    block
+                        .collision_shapes()
+                        .map(|shape| Aabb::new(shape.min().as_vec3(), shape.max().as_vec3()))
+                })
+            },
+        )?;
 
-        // Use voxel traversal to efficiently walk through blocks
-        for cell in ray.voxel_traversal(bounds_min, bounds_max) {
-            if let Some(block) = self.get_block(cell) {
-                let origin = cell.as_vec3();
-
-                // Check collision with block shapes
-                let collision = block
-                    .collision_shapes()
-                    .map(|shape| Aabb::new(shape.min().as_vec3(), shape.max().as_vec3()))
-                    .map(|shape| shape + origin)
-                    .filter_map(|shape| shape.intersect_ray(&ray))
-                    .min();
-
-                if let Some(distance) = collision {
-                    let distance = distance.into_inner();
-                    let collision_point = ray.origin() + ray.direction() * distance;
-                    let collision_normal = (collision_point - origin).normalize();
-
-                    return Some(RayCollision {
-                        distance,
-                        location: cell,
-                        point: collision_point,
-                        normal: collision_normal,
-                        block,
-                    });
-                }
-            }
-        }
-
-        None
+        Some(RayCollision {
+            distance: hit.time,
+            location: hit.block,
+            point: hit.point,
+            normal: hit.normal,
+            // A second lookup rather than carrying the state out through the
+            // traversal: the shape source is a `BlockState` here and a set of
+            // coordinates in a test, and threading a payload through
+            // `first_block_hit` for one of the two would buy one map lookup.
+            block: self.get_block(hit.block)?,
+        })
     }
 
     #[must_use]

--- a/crates/hyperion/src/spatial/mod.rs
+++ b/crates/hyperion/src/spatial/mod.rs
@@ -83,6 +83,15 @@ pub fn get_first_collision(
             (entity, distance_to_entity)
         });
 
+    // The same length of ray both sides. `Blocks::first_collision` reports
+    // nothing past `t == 1`, and the BVH has no such bound, so without this an
+    // entity thirty blocks along the heading beats the wall a metre ahead --
+    // and beats it *because* the block side was fixed, which is the shape of
+    // regression that arrives looking like a fix.
+    if distance_to_entity > 1.0 {
+        return block.map(Either::Right);
+    }
+
     match block {
         Some(block_collision) if block_collision.distance <= distance_to_entity => {
             Some(Either::Right(block_collision))

--- a/docs/smash-design.md
+++ b/docs/smash-design.md
@@ -511,12 +511,25 @@ Honest list.
 Judged against readability at each step, and where they conflicted the choice is
 recorded.
 
-**Reads do not cross the seam.** Position, rotation and ground state are mirror
-components written by the adapter once per tick, so the per-tick hot paths — the
-cooldown tick, the arena bounds check, projectile integration — are plain
-component iteration with no virtual calls. Only writes go through the `Server`
-trait, and writes happen on hit, on death and on kit change, never per entity
-per tick.
+**Reads do not cross the `Server` seam.** Position, rotation and ground state
+are mirror components written by the adapter once per tick, so the per-tick hot
+paths — the cooldown tick, the arena bounds check, projectile integration — are
+plain component iteration with no virtual calls. Only writes go through the
+`Server` trait, and writes happen on hit, on death and on kit change, never per
+entity per tick.
+
+**The one read that does cross a seam is terrain**, and it has its own:
+`BlockWorld` in `src/module/blocks.rs`, one method, defaulting to `OpenAir`.
+Terrain is the case the mirror cannot serve — millions of blocks, a handful
+looked at per tick, and an authoritative copy that already exists on the host,
+so copying it would be maintaining a second one that drifts the moment anybody
+places a block. It is a separate trait rather than a tenth `Server` method
+because `Server` is a list of things the game asks the host to *do*, and because
+a default of "nothing is solid" means every test that is not about terrain, and
+the whole of the mock, needs no implementation at all. The cost is one virtual
+call per projectile per tick, and the call answers the whole segment rather than
+one block, so the traversal stays in `geometry::sweep` where the host's block
+store and the tests' `Cubes` share it.
 
 **Ability behaviour is a function pointer.** Zero allocation, one indirect call
 per activation.
@@ -542,11 +555,15 @@ per hit.
 
 Stated plainly, because these are the parts nobody can see from the code.
 
-1. **No block world.** Projectiles expire on a timer and on entity contact only;
-   they do not collide with terrain. Fissure resolves its fourteen columns
-   immediately instead of walking a block wall. Enderman's Block Toss does not
-   check that there is air above the block it picks up. All three need hyperion's
-   `Blocks`.
+1. **Only projectiles read the block world.** Projectiles now sweep their
+   tick's travel against terrain and stop at the first surface, through the
+   read seam in `src/module/blocks.rs`; the rest of the list here still does
+   not. Fissure resolves its fourteen columns immediately instead of walking a
+   block wall, and Enderman's Block Toss does not check that there is air above
+   the block it picks up. Both want the same seam, which now exists. What a
+   projectile does *about* an impact is also still one thing for every kind --
+   it sticks and expires -- so a Sulphur Bomb that meets a wall stops there
+   rather than detonating (ENG-12055).
 2. **No Smash Crystal spawning.** The ultimates exist and are granted through the
    ordinary relationship; the beacon, the descent and the pickup are not built.
 3. **Assists.** Only the last hit is tracked.

--- a/events/smash/Cargo.toml
+++ b/events/smash/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 anyhow = { workspace = true }
 clap = { workspace = true }
 flecs_ecs = { workspace = true }
+geometry = { workspace = true }
 glam = { workspace = true }
 hyperion = { workspace = true }
 hyperion-event-runner = { workspace = true }

--- a/events/smash/src/lib.rs
+++ b/events/smash/src/lib.rs
@@ -18,6 +18,7 @@ pub mod mirror;
 pub mod module;
 pub mod server;
 pub mod terrain;
+pub mod terrain_seam;
 
 use std::net::SocketAddr;
 
@@ -106,6 +107,10 @@ impl Module for SmashHost {
         // After the adapter, because building the maps writes the `Arena`
         // singleton the game half registered.
         world.import::<crate::terrain::MapModule>();
+        // Points the game's terrain reads at hyperion's block store. Without
+        // it the game half keeps its `OpenAir` default and projectiles fly
+        // through the arena, which is what they did before this existed.
+        world.import::<crate::terrain_seam::TerrainSeamModule>();
         // After the adapter too: it draws the game half's projectiles, whose
         // `Projectile`, `Visual` and `Flight` the adapter's `SmashModule`
         // import is what registers.

--- a/events/smash/src/module.rs
+++ b/events/smash/src/module.rs
@@ -1,5 +1,6 @@
 pub mod ability;
 pub mod arena;
+pub mod blocks;
 pub mod build_stamp;
 pub mod damage;
 pub mod effect;

--- a/events/smash/src/module/blocks.rs
+++ b/events/smash/src/module/blocks.rs
@@ -1,0 +1,144 @@
+//! What the game is allowed to ask about the block world.
+//!
+//! The second seam, and the only read that crosses one. [`crate::server`] is
+//! the write seam and carries no reads on purpose -- position, facing and
+//! ground state arrive as mirrored components instead, because reading them is
+//! a per-player-per-tick hot path and a mirror turns it into plain component
+//! iteration. Terrain cannot be mirrored: it is millions of blocks, almost none
+//! of which any tick looks at, and the one authoritative copy already exists on
+//! the host. So this asks, rather than copies.
+//!
+//! Deliberately one method, and deliberately the *whole* question. A seam
+//! spelled "is this block solid" would put the traversal on the game side and
+//! cost a virtual call per cell; asking for the answer to the whole segment
+//! costs one call per projectile per tick and leaves the traversal in
+//! [`geometry::sweep`], where the block store and this crate's tests share it.
+//!
+//! The default is [`OpenAir`]. A world with [`crate::SmashModule`] and nothing
+//! else -- which is every test under `tests/` and the whole of the mock -- has
+//! no terrain, and saying so explicitly is what keeps the game half runnable
+//! with no host anywhere near it.
+
+use std::{collections::HashSet, sync::Arc};
+
+use flecs_ecs::prelude::*;
+use geometry::aabb::Aabb;
+/// Where a swept segment first met a block.
+///
+/// Re-exported rather than redefined: the block store and this seam are
+/// answering the same question, and a second struct with the same four fields
+/// would be a conversion nobody reads and one field that eventually disagrees.
+pub use geometry::sweep::BlockHit;
+use glam::{IVec3, Vec3};
+
+/// The block world, as the game sees it.
+///
+/// `world` is handed in rather than captured because the host's block store is
+/// a flecs singleton: an `Arc<dyn BlockWorld>` outlives any borrow of flecs
+/// storage, so the implementation looks the store up per call. Every caller has
+/// a world in hand already, so this costs nothing at the call site.
+pub trait BlockWorld: Send + Sync + 'static {
+    /// The first block surface on the segment `from` -> `to`, or `None` if it
+    /// is clear.
+    ///
+    /// A segment and not a point. A projectile is integrated a whole tick at a
+    /// time and Barrage's arrows travel sixty blocks a second, so an endpoint
+    /// test skips two of every three blocks on the path and a one-block wall is
+    /// something an arrow flies through. The same reasoning that made
+    /// `nearest_target` measure against a segment applies here, for the same
+    /// reason.
+    fn sweep(&self, world: WorldRef<'_>, from: Vec3, to: Vec3) -> Option<BlockHit>;
+}
+
+/// Nothing is solid. The default, and what every test that is not about terrain
+/// gets.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OpenAir;
+
+impl BlockWorld for OpenAir {
+    fn sweep(&self, _: WorldRef<'_>, _: Vec3, _: Vec3) -> Option<BlockHit> {
+        None
+    }
+}
+
+/// A block world of full cubes at the listed coordinates.
+///
+/// For tests, and for anything that wants terrain without a Minecraft server:
+/// it answers through the same [`geometry::sweep::first_block_hit`] the host's
+/// block store answers through, so a test built on it is evidence about the
+/// shipped traversal rather than about a second copy of it. What it does not
+/// carry is partial shapes -- everything here is a full cube.
+#[derive(Debug, Default, Clone)]
+pub struct Cubes(HashSet<IVec3>);
+
+impl Cubes {
+    #[must_use]
+    pub fn new(solid: impl IntoIterator<Item = IVec3>) -> Self {
+        Self(solid.into_iter().collect())
+    }
+
+    /// An axis-aligned wall filling the inclusive box between two corners.
+    #[must_use]
+    pub fn wall(min: IVec3, max: IVec3) -> Self {
+        let mut solid = HashSet::new();
+        for x in min.x..=max.x {
+            for y in min.y..=max.y {
+                for z in min.z..=max.z {
+                    solid.insert(IVec3::new(x, y, z));
+                }
+            }
+        }
+        Self(solid)
+    }
+}
+
+impl BlockWorld for Cubes {
+    fn sweep(&self, _: WorldRef<'_>, from: Vec3, to: Vec3) -> Option<BlockHit> {
+        geometry::sweep::first_block_hit(from, to, |block| {
+            self.0
+                .contains(&block)
+                .then(|| Aabb::new(Vec3::ZERO, Vec3::ONE))
+        })
+    }
+}
+
+/// Singleton holding the live [`BlockWorld`].
+///
+/// The same shape as [`crate::server::ServerHandle`], for the same reason:
+/// systems name `&BlockWorldHandle` as an ordinary query term and flecs
+/// resolves it once per table rather than once per entity.
+#[derive(Component)]
+pub struct BlockWorldHandle(pub Arc<dyn BlockWorld>);
+
+impl BlockWorldHandle {
+    pub fn new(blocks: impl BlockWorld) -> Self {
+        Self(Arc::new(blocks))
+    }
+}
+
+impl core::ops::Deref for BlockWorldHandle {
+    type Target = dyn BlockWorld;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+/// Registration module for the block-world seam: types only, no systems.
+///
+/// Installs [`OpenAir`] as the singleton's value in the same place the
+/// singleton is registered, per the root `CLAUDE.md`: a bare `world.set` stores
+/// a value without registering the type, which is an abort in a dev build and
+/// silence in a release one.
+#[derive(Component)]
+pub struct BlockWorldComponentsModule;
+
+impl Module for BlockWorldComponentsModule {
+    fn module(world: &World) {
+        world.module::<Self>("smash::Blocks");
+        world
+            .component::<BlockWorldHandle>()
+            .add_trait::<flecs::Singleton>();
+        world.set(BlockWorldHandle::new(OpenAir));
+    }
+}

--- a/events/smash/src/module/projectile.rs
+++ b/events/smash/src/module/projectile.rs
@@ -5,10 +5,13 @@
 //! function pointer rather than four ability implementations each with their own
 //! flight loop.
 //!
-//! There is no block collision here: that needs the host's world, which is on
-//! the far side of the seam. Projectiles expire on a timer and on entity
-//! contact. `docs/smash-design.md` lists this as one of the two places the
-//! simulation is deliberately incomplete pending the hyperion wiring.
+//! Block collision is a swept segment against [`crate::module::blocks`], the
+//! read seam onto the host's terrain, and it is checked before the entity
+//! search so a player standing behind a wall cannot be shot through it.
+//! A projectile that meets a block stops on its surface, sticks there for
+//! [`STUCK_SECONDS`], and expires. A world with no terrain seam installed --
+//! every test that is not about terrain, and the whole of the mock -- answers
+//! "clear" and the flight is exactly what it was before.
 //!
 //! What the flight above is authoritative for is the *hit*. What a client sees
 //! is drawn separately, by `crate::draw` on the host, off the [`Visual`] this
@@ -23,6 +26,7 @@ use hyperion::simulation::{entity_kind::EntityKind, projectile_motion::EYE_HEIGH
 use crate::{
     flecs_ext::WorldRefExt,
     module::{
+        blocks::{BlockWorldComponentsModule, BlockWorldHandle},
         damage::{DamageKind, Damaged, hurt},
         knockback::Knockback,
         player::{Health, Player, Position},
@@ -34,6 +38,27 @@ use crate::{
 /// Tag on projectile entities.
 #[derive(Component, Debug)]
 pub struct Projectile;
+
+/// A projectile that has hit a block and is embedded in it.
+///
+/// A tag rather than a zeroed velocity, because "stopped" and "stopped by
+/// something" need to be different states. `fly` excludes stuck projectiles
+/// outright: a projectile whose sweep starts on the face it just hit hits that
+/// face again every tick, which would replay the impact sound forever, and one
+/// sitting still is a point a player can walk into and be shot by a projectile
+/// that is no longer going anywhere. Neither is a check to add inside `fly` --
+/// they are the same statement, that a stuck projectile is done moving and done
+/// hitting, and a query term says it once.
+#[derive(Component, Debug)]
+pub struct Stuck;
+
+/// How long a projectile stays visible in the block it hit.
+///
+/// Vanilla leaves an arrow in a wall for a minute. This is a fighting game
+/// played in a small arena: long enough to read the impact as an impact, short
+/// enough that a Barrage volley does not leave the far wall bristling for the
+/// rest of the match.
+pub const STUCK_SECONDS: f32 = 1.0;
 
 /// What a projectile is drawn as.
 ///
@@ -131,15 +156,29 @@ pub fn fire(
         .add((FiredBy, shooter));
 }
 
+/// Registration module for projectiles: the component set and nothing else.
+///
+/// Split from [`ProjectileModule`] per the root `CLAUDE.md`. A consumer that
+/// wants the *types* -- `crate::draw` on the host decorates a projectile it
+/// never integrates -- imports this without dragging in the flight systems.
+///
+/// Prefixed, and it has to be. flecs registers a module entity under its bare
+/// Rust type name before the body that renames it runs, so two crates in one
+/// world cannot each have a `ProjectileComponentsModule` -- and
+/// `hyperion::simulation::projectile_motion` already does. The collision is an
+/// `ecs_assert`, which means a dev build aborts on boot and a release build,
+/// where flecs asserts are compiled out, silently treats the two modules as one
+/// (ENG-12054). This name is what keeps that from happening; do not shorten it.
 #[derive(Component)]
-pub struct ProjectileModule;
+pub struct SmashProjectileComponentsModule;
 
-impl Module for ProjectileModule {
+impl Module for SmashProjectileComponentsModule {
     fn module(world: &World) {
         world.module::<Self>("smash::Projectile");
 
         // Final: a projectile is a leaf, never an inheritance base.
         world.component::<Projectile>().add_trait::<flecs::Final>();
+        world.component::<Stuck>().add_trait::<flecs::Final>();
         world.component::<Visual>();
         world.component::<Flight>();
         world.component::<Payload>();
@@ -156,15 +195,40 @@ impl Module for ProjectileModule {
             .add(flecs::Exclusive)
             .add_trait::<flecs::DontFragment>()
             .add_trait::<(flecs::OnDeleteTarget, flecs::Delete)>();
+    }
+}
+
+/// Behavior module for projectiles: integration, block collision and the hit.
+#[derive(Component)]
+pub struct ProjectileModule;
+
+impl Module for ProjectileModule {
+    fn module(world: &World) {
+        // Imports before the scope claim, and that order is load bearing.
+        // `world.module` creates `smash::Projectile` the first time and
+        // thereafter only sets the scope to it, so whichever of the two modules
+        // runs first owns the path. Letting the registration module own it is
+        // what keeps `Flight` and friends at `smash.Projectile.Flight` whether
+        // they were reached through this module or imported on their own.
+        world.import::<SmashProjectileComponentsModule>();
+        // `fly` reads the terrain seam's singleton, so the module that
+        // registers it is imported here rather than assumed. A full boot
+        // happens to register it first; a standalone import of this module
+        // would not, and the difference between the two is invisible in a
+        // release build.
+        world.import::<BlockWorldComponentsModule>();
+        world.module::<Self>("smash::Projectile");
 
         world
             .system_named::<(&mut Flight, &Payload)>("fly")
+            .without(Stuck::id())
             .each_iter(|it, index, (flight, payload)| {
                 let dt = it.delta_time();
                 let projectile = it.entity(index);
+                let world = projectile.world();
                 let from = flight.position;
                 flight.velocity.y = flight.gravity.mul_add(-dt, flight.velocity.y);
-                flight.position += flight.velocity * dt;
+                let mut to = flight.velocity.mul_add(Vec3::splat(dt), from);
                 flight.seconds_left -= dt;
 
                 if flight.seconds_left <= 0.0 {
@@ -172,18 +236,44 @@ impl Module for ProjectileModule {
                     return;
                 }
 
+                // The terrain sweep before the entity search, and the search
+                // then runs over the *clipped* segment. That ordering is the
+                // whole of "you cannot be shot through a wall": a player
+                // standing behind one is not on the segment the arrow got to
+                // travel, so `nearest_target` never sees them.
+                let impact = world.get::<&BlockWorldHandle>(|blocks| blocks.sweep(world, from, to));
+                if let Some(impact) = impact {
+                    to = impact.point;
+                }
+                flight.position = to;
+
                 let shooter = projectile.target(FiredBy, 0).map(|e| e.id());
-                let Some((victim, at)) = nearest_target(
-                    projectile.world(),
-                    from,
-                    flight.position,
-                    flight.radius,
-                    shooter,
-                ) else {
+                let Some((victim, at)) = nearest_target(world, from, to, flight.radius, shooter)
+                else {
+                    if let Some(impact) = impact {
+                        // Stopped on the surface it met, and left there to be
+                        // seen. `Flight` is what `crate::draw` reads in
+                        // `PostUpdate`, so writing the impact point above is
+                        // what puts the picture in the wall rather than a
+                        // tick's travel past it.
+                        flight.velocity = Vec3::ZERO;
+                        flight.gravity = 0.0;
+                        flight.seconds_left = flight.seconds_left.min(STUCK_SECONDS);
+                        projectile.add(Stuck::id());
+                        world.get::<&ServerHandle>(|server| {
+                            // `Neutral`, not `Players`: an arrow striking
+                            // terrain is a thing that happened in the world,
+                            // and vanilla's own `AbstractArrow` puts it on that
+                            // slider. The hit on a player stays on `Players`.
+                            server.play_sound(
+                                impact.point,
+                                Sound::new(sound::PROJECTILE_HIT, SoundCategory::Neutral),
+                            );
+                        });
+                    }
                     return;
                 };
 
-                let world = projectile.world();
                 let victim = world.entity_at(victim);
                 hurt(victim, Damaged {
                     attacker: shooter,
@@ -219,6 +309,20 @@ impl Module for ProjectileModule {
                     }
                 });
                 projectile.destruct();
+            });
+
+        // Stuck projectiles are excluded from `fly` entirely, so something has
+        // to run their clock. A second system and not a branch inside `fly`,
+        // because the two states share nothing: this one neither moves nor
+        // hits, it only counts down.
+        world
+            .system_named::<&mut Flight>("expire_stuck")
+            .with(Stuck::id())
+            .each_iter(|it, index, flight| {
+                flight.seconds_left -= it.delta_time();
+                if flight.seconds_left <= 0.0 {
+                    it.entity(index).destruct();
+                }
             });
     }
 }

--- a/events/smash/src/terrain_seam.rs
+++ b/events/smash/src/terrain_seam.rs
@@ -1,0 +1,59 @@
+//! The host half of the block-world seam: hyperion's `Blocks` answering the
+//! game's terrain reads.
+//!
+//! The mirror in `crate::mirror` copies host state onto game components once a
+//! tick, which is the right shape for a player's position and the wrong one for
+//! a world of blocks: there are millions of them, a tick looks at a handful, and
+//! copying them would be maintaining a second authority that drifts the moment
+//! anything places a block. So terrain is asked for rather than copied, and this
+//! is the answering half.
+//!
+//! It is three lines of substance because the traversal is not here. Both sides
+//! of the seam go through [`geometry::sweep::first_block_hit`] -- the block
+//! store's own [`Blocks::first_collision`] is a wrapper over it, and so is the
+//! [`crate::module::blocks::Cubes`] a test builds a wall from. One traversal,
+//! two sources of shapes, which is what makes a test about a `Cubes` wall
+//! evidence about a real one.
+
+use flecs_ecs::prelude::*;
+use glam::Vec3;
+use hyperion::simulation::blocks::Blocks;
+
+use crate::module::blocks::{BlockHit, BlockWorld, BlockWorldComponentsModule, BlockWorldHandle};
+
+/// hyperion's loaded chunks, as a [`BlockWorld`].
+///
+/// Carries no state: the block store is a singleton on the world handed to
+/// [`BlockWorld::sweep`], because an `Arc<dyn BlockWorld>` outlives any borrow
+/// of flecs storage and so cannot hold one.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct HyperionBlocks;
+
+impl BlockWorld for HyperionBlocks {
+    fn sweep(&self, world: WorldRef<'_>, from: Vec3, to: Vec3) -> Option<BlockHit> {
+        world.get::<&Blocks>(|blocks| {
+            let hit = blocks.first_collision(geometry::ray::Ray::from_points(from, to))?;
+            Some(BlockHit {
+                time: hit.distance,
+                block: hit.location,
+                point: hit.point,
+                normal: hit.normal,
+            })
+        })
+    }
+}
+
+/// Replaces the game half's `OpenAir` default with the real block store.
+#[derive(Component)]
+pub struct TerrainSeamModule;
+
+impl Module for TerrainSeamModule {
+    fn module(world: &World) {
+        // The singleton this overwrites is registered by the game half, so the
+        // module that registers it is imported rather than assumed: a `set` of
+        // an unregistered component is an abort in a dev build and silence in a
+        // release one.
+        world.import::<BlockWorldComponentsModule>();
+        world.set(BlockWorldHandle::new(HyperionBlocks));
+    }
+}

--- a/events/smash/tests/projectile_blocks.rs
+++ b/events/smash/tests/projectile_blocks.rs
@@ -1,0 +1,316 @@
+//! Arrows stop at walls.
+//!
+//! Projectiles were point particles that flew through the arena until their
+//! timer ran out, so every shot on every map was taken as if the geometry were
+//! not there: a player behind a pillar was as shootable as one in the open.
+//! These are the game-level half of the fix. The traversal itself is unit
+//! tested in `crates/geometry/src/sweep.rs`; what is checked here is that a
+//! whole `smash` world, driven through its own tick, puts the arrow in the wall
+//! and leaves the player behind it alone.
+
+mod harness;
+
+use flecs_ecs::prelude::*;
+use glam::{IVec3, Vec3};
+use harness::{Game, TICK};
+use smash::{
+    module::{
+        blocks::{BlockWorldHandle, Cubes},
+        damage::{DamageKind, Damaged, hurt},
+        player::{Health, Position},
+        projectile::{Flight, Payload, Projectile, Stuck, Visual, fire},
+    },
+    server::{Sound, SoundCategory, mock::Call},
+};
+
+/// hyperion's `EntityKind::Arrow`, which is what a real bow fires.
+const fn arrow_visual() -> Visual {
+    Visual(hyperion::simulation::entity_kind::EntityKind::Arrow)
+}
+
+/// A world whose only terrain is a wall standing in the plane `x == 10`,
+/// two blocks either side of the shooting line.
+fn walled(game: &Game) {
+    game.world.set(BlockWorldHandle::new(Cubes::wall(
+        IVec3::new(10, -2, -2),
+        IVec3::new(10, 4, 2),
+    )));
+}
+
+/// The state of every projectile left in the world, as `(position, stuck)`.
+fn projectiles(game: &Game) -> Vec<(Vec3, bool)> {
+    let mut found = Vec::new();
+    game.world
+        .query::<&Flight>()
+        .with(Projectile::id())
+        .build()
+        .each_entity(|entity, flight| {
+            found.push((flight.position, entity.has(Stuck::id())));
+        });
+    found
+}
+
+/// Fire one flat, fast arrow along +X from the origin.
+///
+/// Sixty blocks a second is a full-draw Barrage arrow, which is three blocks a
+/// tick: fast enough that a one-block wall sits between two consecutive
+/// endpoints and only the cells between them say it is there.
+fn shoot(game: &Game, shooter: Entity) {
+    let shooter = game.world.entity_from_id(shooter);
+    fire(
+        shooter.world(),
+        shooter,
+        arrow_visual(),
+        Flight {
+            position: Vec3::new(0.5, 0.0, 0.5),
+            velocity: Vec3::X * 60.0,
+            gravity: 0.0,
+            seconds_left: 3.0,
+            radius: 0.4,
+        },
+        Payload::new(6.0, 1.0),
+    );
+}
+
+#[test]
+fn an_arrow_stops_at_the_wall_instead_of_passing_through_it() {
+    let mut game = Game::new();
+    walled(&game);
+    let shooter = game.player("shooter", Vec3::new(0.0, 0.0, 0.0));
+
+    shoot(&game, shooter);
+    // One tick moves it three blocks, so it takes four to reach x == 10 --
+    // and every one of those ticks is a three-block step that a point sample
+    // would have skipped two thirds of.
+    game.advance(TICK * 6.0, 6);
+
+    let left = projectiles(&game);
+    assert_eq!(
+        left.len(),
+        1,
+        "the arrow should still exist, stuck: {left:?}"
+    );
+    let (at, stuck) = left[0];
+    assert!(stuck, "an arrow that met a wall is stuck in it: {left:?}");
+    assert!(
+        (at.x - 10.0).abs() < 1e-3,
+        "the arrow stopped at x = {}, and the wall's near face is x = 10",
+        at.x
+    );
+}
+
+#[test]
+fn an_arrow_over_open_ground_flies_exactly_as_it_did_before() {
+    let mut game = Game::new();
+    // No terrain seam installed: `OpenAir`, which is what every other test in
+    // this directory runs with.
+    let shooter = game.player("shooter", Vec3::new(0.0, 0.0, 0.0));
+
+    shoot(&game, shooter);
+    game.advance(TICK * 6.0, 6);
+
+    let left = projectiles(&game);
+    assert_eq!(left.len(), 1, "nothing stops it: {left:?}");
+    let (at, stuck) = left[0];
+    assert!(!stuck, "there is nothing to stick in: {left:?}");
+    // Six ticks at sixty blocks a second is eighteen blocks, well past where
+    // the wall stood in the test above.
+    assert!(
+        at.x > 17.0,
+        "the arrow should be eighteen blocks out, it is at x = {}",
+        at.x
+    );
+}
+
+#[test]
+fn a_player_behind_the_wall_is_not_hit_through_it() {
+    let mut game = Game::new();
+    walled(&game);
+    let shooter = game.player("shooter", Vec3::new(0.0, 0.0, 0.0));
+    // Standing one block past the wall, dead on the shooting line. Before the
+    // sweep the arrow crossed the wall in a single step and took them with it.
+    let victim = game.player("victim", Vec3::new(11.5, 0.0, 0.5));
+
+    shoot(&game, shooter);
+    game.advance(TICK * 6.0, 6);
+
+    let health = game
+        .world
+        .entity_from_id(victim)
+        .try_get::<&Health>(|health| health.current)
+        .expect("a player has health");
+    let max = game
+        .world
+        .entity_from_id(victim)
+        .try_get::<&Health>(|health| health.max)
+        .expect("a player has health");
+    assert!(
+        (health - max).abs() < 1e-6,
+        "the victim was shot through a wall: {health} of {max}"
+    );
+
+    // The control, in the same test, because without it this passes for a
+    // world where the arrow could never have reached them anyway -- a victim
+    // half a block off the flight line, a wall in the wrong place, a `fire`
+    // that silently did nothing. The identical setup with no wall must hit.
+    let mut open = Game::new();
+    let shooter = open.player("shooter", Vec3::new(0.0, 0.0, 0.0));
+    let victim = open.player("victim", Vec3::new(11.5, 0.0, 0.5));
+    shoot(&open, shooter);
+    open.advance(TICK * 6.0, 6);
+
+    let (health, max) = open
+        .world
+        .entity_from_id(victim)
+        .try_get::<&Health>(|health| (health.current, health.max))
+        .expect("a player has health");
+    assert!(
+        health < max,
+        "the control shot missed too, so the test above proves nothing: {health} of {max}"
+    );
+}
+
+#[test]
+fn a_player_in_front_of_the_wall_is_still_hit() {
+    let mut game = Game::new();
+    walled(&game);
+    let shooter = game.player("shooter", Vec3::new(0.0, 0.0, 0.0));
+    // The mirror image of the test above: same wall, victim on this side of
+    // it. Clipping the segment must not clip away the hits that should land.
+    let victim = game.player("victim", Vec3::new(6.0, 0.0, 0.5));
+
+    shoot(&game, shooter);
+    game.advance(TICK * 6.0, 6);
+
+    let health = game
+        .world
+        .entity_from_id(victim)
+        .try_get::<&Health>(|health| health.current)
+        .expect("a player has health");
+    let max = game
+        .world
+        .entity_from_id(victim)
+        .try_get::<&Health>(|health| health.max)
+        .expect("a player has health");
+    assert!(
+        health < max,
+        "the victim stood in the open and took nothing: {health} of {max}"
+    );
+}
+
+#[test]
+fn the_impact_is_audible_at_the_point_it_happened() {
+    let mut game = Game::new();
+    walled(&game);
+    let shooter = game.player("shooter", Vec3::new(0.0, 0.0, 0.0));
+
+    shoot(&game, shooter);
+    game.server.take();
+    game.advance(TICK * 6.0, 6);
+
+    let impacts: Vec<Vec3> = game
+        .server
+        .calls()
+        .iter()
+        .filter_map(|call| match call {
+            Call::Sound(at, sound)
+                if *sound
+                    == Sound::new(smash::module::sound::PROJECTILE_HIT, SoundCategory::Neutral) =>
+            {
+                Some(*at)
+            }
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(impacts.len(), 1, "one arrow, one impact: {impacts:?}");
+    assert!(
+        (impacts[0].x - 10.0).abs() < 1e-3,
+        "the sound played at x = {}, and the wall's near face is x = 10",
+        impacts[0].x
+    );
+}
+
+#[test]
+fn a_stuck_arrow_does_not_shoot_whoever_walks_into_it() {
+    let mut game = Game::new();
+    walled(&game);
+    let shooter = game.player("shooter", Vec3::new(0.0, 0.0, 0.0));
+    let bystander = game.player("bystander", Vec3::new(30.0, 0.0, 30.0));
+
+    shoot(&game, shooter);
+    game.advance(TICK * 6.0, 6);
+    assert!(
+        projectiles(&game).iter().any(|(_, stuck)| *stuck),
+        "the arrow should be stuck before this test means anything"
+    );
+
+    // Walk them onto it. A stuck projectile is excluded from the flight system
+    // outright, so there is nothing left to hit them with.
+    game.world
+        .entity_from_id(bystander)
+        .set(Position(Vec3::new(9.8, 0.0, 0.5)));
+    game.advance(TICK * 4.0, 4);
+
+    let health = game
+        .world
+        .entity_from_id(bystander)
+        .try_get::<&Health>(|health| health.current)
+        .expect("a player has health");
+    let max = game
+        .world
+        .entity_from_id(bystander)
+        .try_get::<&Health>(|health| health.max)
+        .expect("a player has health");
+    assert!(
+        (health - max).abs() < 1e-6,
+        "a stuck arrow shot a passer-by: {health} of {max}"
+    );
+}
+
+#[test]
+fn a_stuck_arrow_stops_existing() {
+    let mut game = Game::new();
+    walled(&game);
+    let shooter = game.player("shooter", Vec3::new(0.0, 0.0, 0.0));
+
+    shoot(&game, shooter);
+    game.advance(TICK * 6.0, 6);
+    assert!(
+        !projectiles(&game).is_empty(),
+        "it should be stuck in the wall at this point"
+    );
+
+    // Past `STUCK_SECONDS`. Left forever, a Barrage volley would carpet the
+    // far wall for the rest of the match.
+    game.advance(smash::module::projectile::STUCK_SECONDS + TICK, 25);
+    assert!(
+        projectiles(&game).is_empty(),
+        "the arrow is still in the wall: {:?}",
+        projectiles(&game)
+    );
+}
+
+/// The damage path is untouched by any of this: a hit is still a hit.
+#[test]
+fn direct_damage_is_unaffected() {
+    let mut game = Game::new();
+    walled(&game);
+    let attacker = game.player("attacker", Vec3::ZERO);
+    let victim = game.player("victim", Vec3::new(1.0, 0.0, 0.0));
+
+    hurt(game.world.entity_from_id(victim), Damaged {
+        attacker: Some(attacker),
+        amount: 5.0,
+        knockback: smash::module::knockback::Knockback::from(Vec3::ZERO),
+        kind: DamageKind::Projectile,
+    });
+    game.advance(TICK, 1);
+
+    let health = game
+        .world
+        .entity_from_id(victim)
+        .try_get::<&Health>(|health| health.current)
+        .expect("a player has health");
+    assert!(health < 20.0, "the victim took nothing: {health}");
+}


### PR DESCRIPTION
Fixes [ENG-12056](https://linear.app/indexable/issue/ENG-12056). Arrows stop at walls.

## The problem

Smash projectiles were point particles integrated with no reference to the world. They flew through walls, floors and pillars until their timer ran out, so every shot on every map was taken as if the geometry were not there — a player behind a pillar was exactly as shootable as one standing in the open.

Two bugs underneath it, both of which had to be fixed before a correct sweep was possible at all:

**`Blocks::first_collision` was unbounded in `t`.** It walked voxels until it left `y ∈ [-64, 320]`, so a near-horizontal ray in an empty world visited cells out to `i32::MAX / 2`. The only reason that was survivable is that it usually found something. `update_projectile_positions` compounded it: `Ray::new(center, velocity) * distance` where `distance = velocity.length()` asks about a segment `|v|` times too long, so hyperion's own arrows stopped as soon as *anything* was ahead of them on their heading rather than when they got there.

**The traversal started in the wrong cell for negative coordinates.** `Ray::voxel_traversal` began at `self.origin.as_ivec3()`, and the cast truncates towards zero: an origin at `x = -0.5` was read as cell `0` rather than cell `-1`. Half of any Minecraft map is at a negative coordinate.

## What this does

**One traversal, two sources of shapes.** `geometry::sweep::first_block_hit(from, to, shapes)` is the single swept-voxel implementation, generic over where the block shapes come from. `Blocks::first_collision` is a wrapper over it; so is the `Cubes` fixture smash's tests build a wall from. That is what makes a test about a `Cubes` wall evidence about the shipped traversal rather than about a second copy of it.

**`Ray::voxel_traversal_until(min, max, max_t)`** plus the `floor` fix. The bound is the segment, not a box drawn around the world.

**A read seam for terrain.** `smash::module::blocks::BlockWorld` is one method, defaulting to `OpenAir`. `Server` stays write-only — position and ground state are mirrored components because that is a per-player-per-tick hot path — but terrain cannot be mirrored (millions of blocks, a handful read per tick, an authoritative copy that already exists on the host), so it gets its own trait rather than a tenth `Server` method. The default means every existing test and the whole mock need no implementation. `terrain_seam.rs` points it at hyperion's `Blocks` on the host.

**The sweep runs before the entity search, and the search runs over the clipped segment.** That ordering is the whole of "you cannot be shot through a wall": a player behind one is not on the segment the arrow got to travel, so `nearest_target` never sees them. `spatial::get_first_collision` also gained the matching `t ≤ 1` bound on its entity side — bounding blocks without bounding entities would have biased every comparison towards entities, which is a regression arriving in the shape of a fix.

**On impact** the projectile stops on the surface, sticks for `STUCK_SECONDS`, plays `entity.arrow.hit` at the impact point, and expires. `Stuck` is a tag so `fly` excludes it outright: a projectile whose next sweep starts on the face it just hit would hit that face again every tick and replay the sound forever.

## Block shapes

**Handled:** full block collision shapes on the host path. `Blocks::first_collision` asks valence for `BlockState::collision_shapes()` per block, so a slab, a stair and a fence are hit where they actually are rather than anywhere in their cell — including the case where a segment through the top half of a slab's cell correctly misses. There is a unit test for exactly that.

**Not handled:** the `Cubes` test fixture is full cubes only. That is a fixture, not the shipped path.

## Verification

`crates/geometry` — 31 tests, all green. The traversal cases:

```
test ray::tests::traversal_starts_in_the_cell_containing_a_negative_origin ... ok
test ray::tests::a_bounded_traversal_stops_at_the_end_of_the_segment ... ok
test ray::tests::a_diagonal_traversal_steps_one_axis_at_a_time ... ok
test ray::tests::a_zero_length_ray_yields_only_the_cell_it_is_in ... ok
test sweep::tests::axis_aligned_shot_stops_at_the_near_face ... ok
test sweep::tests::every_axis_and_sign_stops_at_the_same_distance ... ok
test sweep::tests::a_diagonal_shot_meets_the_blocks_it_passes_through ... ok
test sweep::tests::a_corner_the_segment_misses_does_not_stop_it ... ok
test sweep::tests::a_fast_shot_cannot_tunnel_through_a_one_block_wall ... ok
test sweep::tests::negative_coordinates_traverse_the_same_as_positive_ones ... ok
test sweep::tests::a_segment_starting_inside_a_block_is_stopped_where_it_started ... ok
test sweep::tests::a_wall_beyond_the_end_of_the_segment_is_not_hit_yet ... ok
test sweep::tests::a_partial_shape_is_missed_where_a_full_cube_would_be_hit ... ok
test sweep::tests::the_nearest_of_several_blocks_is_the_one_reported ... ok
test sweep::tests::a_zero_length_segment_in_air_hits_nothing ... ok
test sweep::tests::open_ground_is_a_miss ... ok
```

`events/smash/tests/projectile_blocks.rs` — a whole smash world driven through its own tick, firing a 60 blocks/second arrow (three blocks a tick, so the wall sits between two consecutive endpoints and only the cells between them say it is there):

```
test an_arrow_stops_at_the_wall_instead_of_passing_through_it ... ok
test an_arrow_over_open_ground_flies_exactly_as_it_did_before ... ok
test a_player_behind_the_wall_is_not_hit_through_it ... ok
test a_player_in_front_of_the_wall_is_still_hit ... ok
test the_impact_is_audible_at_the_point_it_happened ... ok
test a_stuck_arrow_does_not_shoot_whoever_walks_into_it ... ok
test a_stuck_arrow_stops_existing ... ok
test direct_damage_is_unaffected ... ok
```

The whole of `events/smash` (about 350 tests) and the whole of `crates/hyperion` are green, and `cargo clippy -p geometry -p hyperion -p smash --all-targets --all-features -- -D warnings` is clean.

**The guards were watched failing, not merely written.** Reverting the `floor()` fix fails exactly the two tests written for it and nothing else:

```
ray::tests::traversal_starts_in_the_cell_containing_a_negative_origin
sweep::tests::negative_coordinates_traverse_the_same_as_positive_ones
test result: FAILED. 29 passed; 2 failed
```

Stubbing the sweep out to `None` fails five of the eight game-level tests, and exactly the right five — the three that stay green are open ground, the hit that should still land, and direct damage:

```
test result: FAILED. 3 passed; 5 failed
```

`a_player_behind_the_wall_is_not_hit_through_it` carries its own control in the same test: the identical shot with no wall must land, or the assertion proves nothing.

**Dev profile, not just the gates.** Booting `smash` with `debug_assertions` on found a failure every release gate is structurally blind to: `smash`'s new `ProjectileComponentsModule` collided with `hyperion::simulation::projectile_motion::ProjectileComponentsModule`, because flecs registers a module under its bare Rust type name before the body that renames it runs. In a release build flecs asserts are compiled out and the two modules silently alias. Filed as [ENG-12054](https://linear.app/indexable/issue/ENG-12054); worked around here by prefixing the type, with a comment saying it may not be shortened. After the rename the dev binary boots clean and runs for 41 s with no assert.

## What is not done

- **Per-ability reactions to a block impact** — [ENG-12055](https://linear.app/indexable/issue/ENG-12055). Every projectile does the same thing on a wall: it sticks. `Payload::on_hit` only fires on entity contact, so a Creeper Sulphur Bomb that meets a wall a metre from its target now stops dead instead of flying through and doing nothing. Neither is what anyone wants, but nothing regressed. The face normal is computed and currently discarded, which is the other half of that ticket.
- **A real-client gate.** `tools/smash-bow-check.py` drives a bow with a real client and reads the arrow off the wire; `nix run .#smash-bow-e2e` was run against this branch and its result is reported in a comment below. No *new* real-client assertion was added — the natural one ("an arrow fired straight down from a player standing on solid ground stops within a block") belongs in that script and is a follow-up.
- Fissure and Enderman's Block Toss still do not read blocks. They now have a seam to read through; `docs/smash-design.md` is updated to say so.

---

Written by Claude Opus via Claude Code. Reviewed by a human before merge, per the repo's one-approval rule.
