### PR TITLE
feat(hyperion): the tick rate the loop managed, and a ping that was measured (ENG-12065)

### DIFF
--- a/crates/hyperion/src/common/mod.rs
+++ b/crates/hyperion/src/common/mod.rs
@@ -15,6 +15,14 @@ pub mod util;
 
 pub use command_channel::CommandChannel;
 
+/// How many ticks a second the game loop is paced to.
+///
+/// The number flecs is given in [`crate::HyperionCore`] and the ceiling
+/// [`crate::egress::tab_list`] prints the measured rate against, so the two
+/// cannot drift apart and the footer cannot quote a target the loop is not
+/// actually aiming at.
+pub const TICKS_PER_SECOND: f32 = 20.0;
+
 /// Shared data that is shared between the ECS framework and the IO thread.
 pub struct Shared {
     /// The compression level to use for the server. This is how long a packet needs to be before it is compressed.

--- a/crates/hyperion/src/egress/mod.rs
+++ b/crates/hyperion/src/egress/mod.rs
@@ -18,19 +18,23 @@ use crate::{
 pub mod boss_bar;
 mod channel;
 pub mod metadata;
+pub mod ping;
 pub mod player_join;
 pub mod server_load;
 mod stats;
 pub mod sync_chunks;
 mod sync_entity_state;
+pub mod tab_list;
 
 use boss_bar::BossBarModule;
 use channel::ChannelModule;
+use ping::PingModule;
 use player_join::PlayerJoinModule;
 use server_load::ServerLoadModule;
 use stats::StatsModule;
 use sync_chunks::SyncChunksModule;
 use sync_entity_state::EntityStateSyncModule;
+use tab_list::TabListModule;
 
 #[derive(Component)]
 pub struct EgressModule;
@@ -49,6 +53,8 @@ impl Module for EgressModule {
         world.import::<ChannelModule>();
         world.import::<BossBarModule>();
         world.import::<ServerLoadModule>();
+        world.import::<TabListModule>();
+        world.import::<PingModule>();
 
         system!("broadcast_chunk_deltas", world, &Compose, &mut Blocks,)
             .kind(id::<flecs::pipeline::OnUpdate>())

--- a/crates/hyperion/src/egress/ping.rs
+++ b/crates/hyperion/src/egress/ping.rs
@@ -1,0 +1,492 @@
+//! Per-player round trip time, and the ping bars the tab list draws from it.
+//!
+//! # There was no measurement to be stale
+//!
+//! `roster::entry_of` sent `ping: 0` and `list.rs` forwarded it once, at join,
+//! and that was the whole of it. The reason was not a forgotten update: it was
+//! that **nothing on either side of the connection ever asked**. The game
+//! server routed a serverbound `keep_alive` to `Route::Ignore` and never sent a
+//! clientbound one, so the client -- which only ever answers a keep-alive and
+//! never starts one -- had nothing to answer. `0` was not a reading taken once
+//! and left; it was the absence of a reading, drawn as a full five bars.
+//!
+//! # The proxy does not answer keep-alives, so this measures the player
+//!
+//! This is the one place the design could quietly lie. hyperion puts a proxy
+//! between the client and the game server, and a proxy that answered
+//! keep-alives itself would leave the game server timing the *proxy*, which
+//! would look like a plausible ping and be a measurement of the wrong thing.
+//!
+//! It does not. `crates/hyperion-proxy` contains no keep-alive handling at all
+//! -- the player-to-server direction in `player.rs` reads bytes off the socket
+//! and forwards the frames without parsing an id -- but that is an argument,
+//! not a measurement. `tools/tab-list-check.py` is the measurement: a real
+//! client answers keep-alives, watches a latency arrive, then **stops
+//! answering** while staying otherwise busy. The reading falls back to
+//! "unknown", and comes back when it answers again. Nothing between the client
+//! and the game server can produce that, so the thing being timed is the
+//! player.
+//!
+//! # What is in the number: one tick of it is this server
+//!
+//! Send to encode here, out through the proxy, to the client, back through the
+//! proxy, and in again as far as the tick that decodes it. Two things ride
+//! along with the network time and both are named rather than subtracted out:
+//!
+//! - **the proxy hops**, which are part of what a player waits for and belong
+//!   in a number labelled "ping",
+//! - **one whole tick of inbound scheduling**, because `ingress::decode`'s
+//!   `recv_data` drains queued frames once per tick and the probe goes out at
+//!   the end of one, so an answer cannot be seen before the next.
+//!
+//! The second is not a worst case, it is the floor, and it is big. Measured in
+//! the gate, on loopback, where the true round trip is under a millisecond:
+//! **58 ms and 61 ms**, against a tick of 59 ms on a loop that was managing
+//! 17 tps. Essentially all of the reading was this server waiting for its own
+//! next tick.
+//!
+//! So read the number as *the player's round trip plus about a tick*, and note
+//! what that costs at the bar thresholds below: with a ~50-60 ms offset, a
+//! player whose real ping is 100 ms is drawn at four bars rather than five.
+//! The bar is never wrong by more than one step, and it is biased one way.
+//!
+//! Removing it means timestamping a frame when it arrives rather than when it
+//! is decoded, which is a change to the packet channel every connection shares
+//! and is deliberately not made here. Having the *proxy* stamp arrival is the
+//! other option and is worse: it needs a clock shared by two hosts to mean
+//! anything.
+//!
+//! # One probe at a time
+//!
+//! A new keep-alive goes out only once the last one is answered or has timed
+//! out, so an id can never be ambiguous and a slow client is probed less
+//! rather than being handed a queue it cannot drain. A probe unanswered for
+//! [`Global::keep_alive_timeout`](crate::Global::keep_alive_timeout) drops the
+//! reading back to "no reading" and starts a new one. hyperion still does not
+//! disconnect anyone over it -- `simulation::handlers` says the same -- so the
+//! effect is confined to the readout.
+
+use std::time::{Duration, Instant};
+
+use flecs_ecs::prelude::*;
+use hyperion_minecraft_proto::{
+    generated::packet_id::play::clientbound::PacketId, packets::play::clientbound::KeepAlive,
+};
+use tracing::error;
+
+use crate::{
+    egress::player_join::{PlayerInfoActions, PlayerList, PlayerListEntry},
+    net::{Compose, ConnectionId, protocol::send},
+    simulation::{PacketState, Uuid},
+};
+
+/// How long to wait, after a probe is answered, before sending the next.
+///
+/// Two seconds costs one ten-byte packet per player per two seconds -- 5 KB/s
+/// across ten thousand players, against the per-player-per-tick position
+/// updates the same link already carries -- and bounds how stale a bar can be
+/// at two seconds plus one round trip. Probing faster would buy resolution the
+/// five-bar display cannot show.
+const PERIOD: Duration = Duration::from_secs(2);
+
+/// The latency that means "no reading", which is the client's own
+/// `PING_UNKNOWN_SPRITE` case rather than a number invented to stand in for
+/// one.
+pub const UNKNOWN: i32 = -1;
+
+/// The ping bar the vanilla client draws for a latency in milliseconds.
+///
+/// Read off `PlayerTabOverlay.extractPingIcon` in the 26.2 client jar (sha1
+/// `2dc72797acbc1b63fc16a11c4ac393605f453754`, which is the jar
+/// `nix/minecraft-version.json` already pins):
+///
+/// ```java
+/// Identifier sprite = info.getLatency() < 0 ? PING_UNKNOWN_SPRITE
+///     : (info.getLatency() < 150 ? PING_5_SPRITE
+///     : (info.getLatency() < 300 ? PING_4_SPRITE
+///     : (info.getLatency() < 600 ? PING_3_SPRITE
+///     : (info.getLatency() < 1000 ? PING_2_SPRITE : PING_1_SPRITE))));
+/// ```
+///
+/// Six sprites, five of them bars. Vanilla draws the icon and never the
+/// number, so this enum is the whole of what a player can see, which is why it
+/// and not the millisecond is what decides whether an update is worth sending.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Bars {
+    /// No reading yet, or the last probe timed out.
+    Unknown,
+    /// A second or worse.
+    One,
+    /// 600..1000 ms.
+    Two,
+    /// 300..600 ms.
+    Three,
+    /// 150..300 ms.
+    Four,
+    /// Under 150 ms.
+    Five,
+}
+
+/// Which bar `latency` milliseconds draws.
+#[must_use]
+pub const fn bars(latency: i32) -> Bars {
+    if latency < 0 {
+        Bars::Unknown
+    } else if latency < 150 {
+        Bars::Five
+    } else if latency < 300 {
+        Bars::Four
+    } else if latency < 600 {
+        Bars::Three
+    } else if latency < 1000 {
+        Bars::Two
+    } else {
+        Bars::One
+    }
+}
+
+/// A probe waiting for its answer.
+#[derive(Debug, Clone, Copy)]
+struct Probe {
+    /// The value the client echoes back.
+    id: i64,
+    /// When it went out.
+    sent: Instant,
+}
+
+/// One player's round trip time.
+#[derive(Component, Debug, Default)]
+pub struct Ping {
+    /// The probe waiting to be answered, if any.
+    pending: Option<Probe>,
+    /// When the last probe went out, answered or not.
+    last_probe: Option<Instant>,
+    /// Strictly increasing per connection, so an answer to a probe that
+    /// already timed out cannot be mistaken for the current one.
+    next_id: i64,
+    /// The last measured round trip.
+    ///
+    /// `None` before the first answer and again after one times out, which is
+    /// the difference between "not measured" and "measured as fast".
+    pub rtt: Option<Duration>,
+    /// The latency this player's tab list entry was last published with.
+    published: Option<i32>,
+}
+
+impl Ping {
+    /// The latency to put on the wire: whole milliseconds, or [`UNKNOWN`].
+    ///
+    /// The real measurement and not the bucket. Only the *resend* is quantised
+    /// to bars, so anything that reads the number -- a client that draws it,
+    /// a mod, a capture -- gets a true reading that is merely updated at bar
+    /// granularity, rather than a rounded one.
+    #[must_use]
+    pub fn latency(&self) -> i32 {
+        let Some(rtt) = self.rtt else {
+            return UNKNOWN;
+        };
+        i32::try_from(rtt.as_millis()).unwrap_or(i32::MAX)
+    }
+
+    /// The id of the probe to send now, if one is due.
+    fn probe(&mut self, now: Instant, period: Duration, timeout: Duration) -> Option<i64> {
+        if let Some(pending) = self.pending {
+            if now.duration_since(pending.sent) < timeout {
+                return None;
+            }
+            // Nothing came back in time, so there is no reading any more.
+            // Keeping the old one would draw a live bar for a client that has
+            // gone quiet, which is the one thing a ping display must not do.
+            self.rtt = None;
+            self.pending = None;
+        }
+
+        if let Some(last) = self.last_probe
+            && now.duration_since(last) < period
+        {
+            return None;
+        }
+
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
+        self.pending = Some(Probe { id, sent: now });
+        self.last_probe = Some(now);
+        Some(id)
+    }
+
+    /// Fold an answer in, and say whether it was the one being waited on.
+    ///
+    /// A client that echoes something else, or answers twice, moves nothing:
+    /// a reading is only taken for the probe currently outstanding.
+    fn answer(&mut self, id: i64, now: Instant) -> bool {
+        let Some(pending) = self.pending else {
+            return false;
+        };
+        if pending.id != id {
+            return false;
+        }
+        self.pending = None;
+        self.rtt = Some(now.saturating_duration_since(pending.sent));
+        true
+    }
+
+    /// Whether the bar this player draws differs from the one every client was
+    /// last told to draw.
+    fn moved(&self) -> bool {
+        self.published
+            .is_none_or(|published| bars(published) != bars(self.latency()))
+    }
+}
+
+/// Fold a client's keep-alive answer into its [`Ping`].
+///
+/// Called from `simulation::handlers`, which owns the serverbound routing
+/// table; the measurement lives here with the probe that started it.
+pub fn absorb_answer(entity: EntityView<'_>, id: i64) {
+    entity.try_get::<&mut Ping>(|ping| {
+        ping.answer(id, Instant::now());
+    });
+}
+
+/// Registration module for the ping readout: the [`Ping`] component.
+///
+/// Registration only, per the flecs convention in the root `CLAUDE.md`, and
+/// deliberately only the type. The other half of the wiring -- that every
+/// `Player` carries a `Ping`, so nothing on the join path has to remember to
+/// add one -- is a statement about `Player`, so it is declared by the module
+/// that owns `Player`, alongside the identical statements about `CursorItem`
+/// and `InventoryState`. `SimComponentsModule` imports this for the component
+/// to point at.
+#[derive(Component)]
+pub struct PingComponentsModule;
+
+impl Module for PingComponentsModule {
+    fn module(world: &World) {
+        world.component::<Ping>();
+    }
+}
+
+/// Behavior module for the ping readout: the probe that measures and the
+/// change-only update that publishes.
+#[derive(Component)]
+pub struct PingModule;
+
+impl Module for PingModule {
+    fn module(world: &World) {
+        world.import::<PingComponentsModule>();
+
+        // PreStore, so an answer decoded this tick in OnUpdate is folded in
+        // before this decides whether to probe again or what to publish.
+        system!("probe_ping", world, &Compose, &ConnectionId, &mut Ping)
+            .with_enum(PacketState::Play)
+            .kind(id::<flecs::pipeline::PreStore>())
+            .each(|(compose, connection_id, ping)| {
+                let timeout = compose.global().keep_alive_timeout;
+                let Some(id) = ping.probe(Instant::now(), PERIOD, timeout) else {
+                    return;
+                };
+                let packet = KeepAlive(id);
+                if let Err(error) = send(
+                    compose,
+                    *connection_id,
+                    PacketId::KeepAlive.to_raw(),
+                    &packet,
+                ) {
+                    error!("failed to send a keep-alive probe: {error}");
+                }
+            });
+
+        let players = world
+            .query::<(&Uuid, &mut Ping)>()
+            .with_enum(PacketState::Play)
+            .build();
+
+        // One packet for everyone whose bar moved, not one packet per player
+        // and not the whole roster: `PlayerInfoUpdate` carries a list, and
+        // `UPDATE_LATENCY` alone writes a uuid and an int per entry.
+        world
+            .system_named::<&Compose>("publish_ping")
+            .kind(id::<flecs::pipeline::PreStore>())
+            .each(move |compose| {
+                let mut entries = Vec::new();
+                players.each(|(uuid, ping)| {
+                    if ping.moved() {
+                        entries.push(PlayerListEntry {
+                            uuid: uuid.0,
+                            ping: ping.latency(),
+                            ..PlayerListEntry::default()
+                        });
+                    }
+                });
+                if entries.is_empty() {
+                    return;
+                }
+
+                let update = PlayerList {
+                    actions: PlayerInfoActions::UPDATE_LATENCY,
+                    entries,
+                };
+                if let Err(error) = compose.broadcast(&update).send() {
+                    error!("failed to publish ping updates: {error}");
+                    // `published` is left alone, so the same set goes out
+                    // again next tick rather than being recorded as delivered.
+                    return;
+                }
+
+                players.each(|(_, ping)| {
+                    if ping.moved() {
+                        let latency = ping.latency();
+                        ping.published = Some(latency);
+                    }
+                });
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every threshold in `extractPingIcon`, on both sides. An off-by-one here
+    /// draws the wrong icon and nothing else notices.
+    #[test]
+    fn the_buckets_are_the_clients_own_thresholds() {
+        assert_eq!(bars(-1), Bars::Unknown);
+        assert_eq!(bars(UNKNOWN), Bars::Unknown);
+        assert_eq!(bars(0), Bars::Five);
+        assert_eq!(bars(149), Bars::Five);
+        assert_eq!(bars(150), Bars::Four);
+        assert_eq!(bars(299), Bars::Four);
+        assert_eq!(bars(300), Bars::Three);
+        assert_eq!(bars(599), Bars::Three);
+        assert_eq!(bars(600), Bars::Two);
+        assert_eq!(bars(999), Bars::Two);
+        assert_eq!(bars(1000), Bars::One);
+        assert_eq!(bars(i32::MAX), Bars::One);
+    }
+
+    /// A round trip is the time between the probe going out and its own answer
+    /// coming back.
+    #[test]
+    fn an_answered_probe_is_the_time_it_took() {
+        let mut ping = Ping::default();
+        let start = Instant::now();
+
+        assert_eq!(ping.latency(), UNKNOWN, "nothing has been measured yet");
+        let id = ping.probe(start, PERIOD, Duration::from_secs(20)).unwrap();
+
+        assert!(ping.answer(id, start + Duration::from_millis(42)));
+        assert_eq!(ping.rtt, Some(Duration::from_millis(42)));
+        assert_eq!(ping.latency(), 42);
+        assert_eq!(bars(ping.latency()), Bars::Five);
+    }
+
+    /// Only one probe is outstanding, so a second is not sent until the first
+    /// is answered and the period has passed.
+    #[test]
+    fn a_probe_waits_for_its_answer_and_then_for_the_period() {
+        let mut ping = Ping::default();
+        let start = Instant::now();
+        let timeout = Duration::from_secs(20);
+
+        let first = ping.probe(start, PERIOD, timeout).unwrap();
+        // Unanswered: nothing else goes out however long it has been, short of
+        // the timeout.
+        assert_eq!(ping.probe(start + PERIOD * 2, PERIOD, timeout), None);
+
+        assert!(ping.answer(first, start + Duration::from_millis(10)));
+        // Answered, but the period has not passed.
+        assert_eq!(
+            ping.probe(start + Duration::from_millis(20), PERIOD, timeout),
+            None
+        );
+
+        let second = ping.probe(start + PERIOD, PERIOD, timeout).unwrap();
+        assert_ne!(
+            first, second,
+            "ids must not repeat while a stale one is live"
+        );
+    }
+
+    /// An echo of something else moves nothing. A client answering a probe
+    /// that already timed out must not be credited to the one now in flight.
+    #[test]
+    fn an_answer_to_the_wrong_probe_is_ignored() {
+        let mut ping = Ping::default();
+        let start = Instant::now();
+        let timeout = Duration::from_secs(20);
+
+        let first = ping.probe(start, PERIOD, timeout).unwrap();
+        assert!(!ping.answer(first.wrapping_add(1), start + Duration::from_millis(5)));
+        assert_eq!(ping.rtt, None);
+
+        // The real one still lands.
+        assert!(ping.answer(first, start + Duration::from_millis(5)));
+        assert_eq!(ping.latency(), 5);
+
+        // And a repeat of it does not, because nothing is outstanding.
+        assert!(!ping.answer(first, start + Duration::from_secs(9)));
+        assert_eq!(ping.latency(), 5);
+    }
+
+    /// A client that stops answering loses its reading rather than keeping a
+    /// stale live bar, and is probed again.
+    #[test]
+    fn a_timed_out_probe_drops_the_reading() {
+        let mut ping = Ping::default();
+        let start = Instant::now();
+        let timeout = Duration::from_secs(20);
+
+        let first = ping.probe(start, PERIOD, timeout).unwrap();
+        assert!(ping.answer(first, start + Duration::from_millis(30)));
+        assert_eq!(bars(ping.latency()), Bars::Five);
+
+        let second = ping.probe(start + PERIOD, PERIOD, timeout).unwrap();
+        // Still inside the timeout: the last good reading stands.
+        assert_eq!(ping.probe(start + PERIOD * 2, PERIOD, timeout), None);
+        assert_eq!(bars(ping.latency()), Bars::Five);
+
+        // Past it: no reading, and a fresh probe.
+        let third = ping
+            .probe(start + PERIOD + timeout, PERIOD, timeout)
+            .unwrap();
+        assert_eq!(ping.rtt, None);
+        assert_eq!(ping.latency(), UNKNOWN);
+        assert_eq!(bars(ping.latency()), Bars::Unknown);
+        assert_ne!(second, third);
+    }
+
+    /// An update is sent when the bar moves and not when the millisecond does,
+    /// which is the whole reason the roster is not re-sent every tick.
+    #[test]
+    fn a_millisecond_that_does_not_move_a_bar_publishes_nothing() {
+        let mut ping = Ping::default();
+        let start = Instant::now();
+        let timeout = Duration::from_secs(20);
+
+        // Nothing published yet, so the first reading always goes out --
+        // including the "unknown" a player has before their first answer.
+        assert!(ping.moved());
+        ping.published = Some(ping.latency());
+        assert!(!ping.moved());
+
+        // A real reading in a different bucket moves the bar.
+        let id = ping.probe(start, PERIOD, timeout).unwrap();
+        assert!(ping.answer(id, start + Duration::from_millis(40)));
+        assert!(ping.moved());
+        ping.published = Some(ping.latency());
+
+        // 40 ms to 120 ms is a big change in the number and no change at all
+        // in what the player sees, so it sends nothing.
+        let id = ping.probe(start + PERIOD, PERIOD, timeout).unwrap();
+        assert!(ping.answer(id, start + PERIOD + Duration::from_millis(120)));
+        assert_eq!(ping.latency(), 120);
+        assert!(!ping.moved());
+
+        // Crossing 150 ms does.
+        let id = ping.probe(start + PERIOD * 2, PERIOD, timeout).unwrap();
+        assert!(ping.answer(id, start + PERIOD * 2 + Duration::from_millis(150)));
+        assert_eq!(bars(ping.latency()), Bars::Four);
+        assert!(ping.moved());
+    }
+}

--- a/crates/hyperion/src/egress/player_join/roster.rs
+++ b/crates/hyperion/src/egress/player_join/roster.rs
@@ -64,6 +64,7 @@ use tracing::error;
 use crate::{
     egress::{
         metadata::show_all,
+        ping::{self, Ping},
         player_join::{PlayerInfoActions, PlayerList, PlayerListEntry, SkinProperty},
     },
     net::{Channel, Compose, ConnectionId, DataBundle, protocol::Clientbound},
@@ -100,7 +101,13 @@ pub fn entry_of(entity: EntityView<'_>) -> Option<PlayerListEntry> {
         username,
         properties,
         listed: true,
-        ping: 0,
+        // The measurement, or `UNKNOWN` when there is not one yet, which is
+        // the state a player is in for their first couple of seconds. A `0`
+        // here used to draw five full bars for a reading nothing had taken;
+        // see `egress::ping`.
+        ping: entity
+            .try_get::<&Ping>(Ping::latency)
+            .unwrap_or(ping::UNKNOWN),
         game_mode: gamemode::of(entity).to_game_type(),
         // `None` makes the client fall back to the profile name, which is what
         // the player typed. Two players may share it; nothing on the wire is

--- a/crates/hyperion/src/egress/tab_list.rs
+++ b/crates/hyperion/src/egress/tab_list.rs
@@ -1,0 +1,455 @@
+//! The tab list header and footer, and the server's own tick rate in it.
+//!
+//! Server telemetry is not a game concept, which is why the tick rate lives
+//! here and not in an event crate -- the same reasoning as
+//! [`crate::egress::server_load`], and the same honesty rule adapted to a
+//! surface that has no bar to fill:
+//!
+//! > **both numbers are printed, the first is what the loop did and the second
+//! > is what it was paced to.**
+//!
+//! ```text
+//! TPS 19.8 / 20.0
+//! 3 players online
+//! ```
+//!
+//! A server keeping up prints them equal. That is the only way `20.0` can
+//! appear, so a vanity constant cannot masquerade as a measurement: it would
+//! have to survive [`Tps::absorb`], which counts real ticks.
+//!
+//! # Why a count of ticks and not flecs's frame time
+//!
+//! `world.info().frame_time_total` is the time spent *inside* frames, so it
+//! excludes the sleep flecs does to hold 20 Hz. A rate derived from it answers
+//! "how fast could this server tick" and reads near-infinite on an idle one,
+//! which is a different question wearing the same units. Ticks per wall-clock
+//! second is the number an operator means, and the only way to get it is to
+//! count ticks against a clock that does not stop.
+//!
+//! One sample cannot carry a rate, so the first [`WINDOW`] reports
+//! `TPS sampling` rather than a guess -- the same refusal
+//! [`server_load`](crate::egress::server_load) makes for its first CPU window.
+//!
+//! # Who writes what
+//!
+//! The header is left for the event crate; hyperion writes the footer. The
+//! split is arbitrary but it has to be *somewhere*, because both halves ride
+//! in one packet and two writers with no rule fight every tick. That is not
+//! hypothetical: bedwars used to broadcast a whole `TabList` unconditionally,
+//! every tick, to every player.
+//!
+//! Nothing is sent unless the rendered text changed, which is what makes the
+//! per-tick broadcast go away: at a steady 20.00 tps the label is stable and
+//! this module sends nothing at all. A joining client is unicast the current
+//! text instead, because a change-only broadcast is invisible to anyone who
+//! was not connected when it happened.
+
+use std::{
+    collections::VecDeque,
+    sync::atomic::Ordering,
+    time::{Duration, Instant},
+};
+
+use flecs_ecs::prelude::*;
+use hyperion_minecraft_proto::{
+    generated::packet_id::play::clientbound::PacketId,
+    packets::play::clientbound::TabList as TabListPacket, text::NamedColor,
+};
+use tracing::error;
+
+// Re-exported so an event crate writing the header names the text type
+// without reaching into the boss bar module for it.
+pub use crate::egress::boss_bar::Text;
+use crate::{
+    TICKS_PER_SECOND,
+    net::{Channel, Compose, ConnectionId, protocol::Clientbound},
+};
+
+/// How long a tick-rate window is.
+///
+/// Five seconds and not one: a one second window at 20 tps counts twenty
+/// ticks, so a single scheduler hiccup reads as 19.0 and the footer flickers
+/// at a number nobody can act on. A hundred ticks resolves to 0.2 tps, which
+/// is finer than the one decimal the label prints.
+const WINDOW: Duration = Duration::from_secs(5);
+
+/// The rolling window the tick rate is measured over.
+#[derive(Component, Debug, Default)]
+pub struct Tps {
+    /// When each tick inside the open window ran, oldest first.
+    ticks: VecDeque<Instant>,
+    /// The very first tick, which is the only thing that can say whether this
+    /// server has been up for a whole window yet.
+    ///
+    /// Not derivable from `ticks`, and assuming otherwise is the bug this
+    /// field exists to fix: entries older than [`WINDOW`] are dropped, so the
+    /// oldest one retained is always *inside* the window and the span between
+    /// it and now is always a little short of a whole one. Gating on that span
+    /// therefore never opens -- except on perfectly regular ticks, where an
+    /// entry lands exactly on the boundary and is kept. That is precisely the
+    /// fixture the unit tests used, so they passed while a real server showed
+    /// `TPS sampling` forever.
+    first: Option<Instant>,
+    /// Ticks per second over the last full window.
+    ///
+    /// `None` until [`WINDOW`] has elapsed. A partial window divided by the
+    /// whole window reads low, and a partial window divided by itself is one
+    /// sample pretending to be a rate.
+    pub rate: Option<f32>,
+}
+
+impl Tps {
+    /// Fold one tick in.
+    fn absorb(&mut self, now: Instant) {
+        self.ticks.push_back(now);
+        let first = *self.first.get_or_insert(now);
+
+        while let Some(&oldest) = self.ticks.front() {
+            if now.duration_since(oldest) > WINDOW {
+                self.ticks.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        // Whether a whole window has passed is a question about the clock, not
+        // about what survived the pop above. See [`Self::first`].
+        if now.duration_since(first) < WINDOW {
+            return;
+        }
+
+        let Some(&oldest) = self.ticks.front() else {
+            return;
+        };
+        let span = now.duration_since(oldest);
+        if span.is_zero() {
+            return;
+        }
+
+        // `n` timestamps span `n - 1` intervals, and it is the intervals that
+        // have a rate. Counting the timestamps instead reports 20.2 tps on a
+        // server holding exactly 20, because both endpoints of a closed window
+        // are inside it.
+        //
+        // The rate is taken against the span of the entries actually retained
+        // rather than against `WINDOW`, so dropping the oldest tick does not
+        // read as a slower server. The subtraction cannot wrap: a non-zero
+        // span needs two distinct entries.
+        let intervals = self.ticks.len().saturating_sub(1);
+        self.rate = Some(intervals as f32 / span.as_secs_f32());
+    }
+}
+
+/// The two halves of the tab list, as the text they will be sent as.
+///
+/// [`Text`] and never a `String` for the reason
+/// [`boss_bar`](crate::egress::boss_bar) gives: a component cannot smuggle a
+/// colour in as `§` markup.
+#[derive(Component, Debug)]
+pub struct TabList {
+    /// Drawn above the player list. Left for the event crate.
+    pub header: Text,
+    /// Drawn below it. Written by [`TabListModule`].
+    pub footer: Text,
+    /// What every client currently has, so a tick that changes nothing sends
+    /// nothing.
+    sent: Option<(Text, Text)>,
+}
+
+impl Default for TabList {
+    fn default() -> Self {
+        Self {
+            header: Text::text(""),
+            footer: Text::text(""),
+            sent: None,
+        }
+    }
+}
+
+impl TabList {
+    /// Whether the text differs from what the clients were last told.
+    fn changed(&self) -> bool {
+        !self
+            .sent
+            .as_ref()
+            .is_some_and(|(header, footer)| *header == self.header && *footer == self.footer)
+    }
+}
+
+/// The footer for a server that measured `rate` ticks per second while paced
+/// to `target`, with `players` connected.
+///
+/// Both numbers, always, and one colour regardless of either: a colour change
+/// is an alarm, and `server_load`'s note on why its bars have no thresholds
+/// applies here unchanged.
+#[must_use]
+pub fn footer_readout(rate: Option<f32>, target: f32, players: usize) -> Text {
+    let plural = if players == 1 { "player" } else { "players" };
+    let tail = Text::text(format!("\n{players} {plural} online")).color(NamedColor::Gray);
+
+    let Some(rate) = rate else {
+        return Text::text("TPS sampling")
+            .color(NamedColor::Gray)
+            .append(tail);
+    };
+    Text::text(format!("TPS {rate:.1} / {target:.1}"))
+        .color(NamedColor::Aqua)
+        .append(tail)
+}
+
+/// Send the current header and footer to one client.
+fn unicast(compose: &Compose, list: &TabList, connection_id: ConnectionId) -> anyhow::Result<()> {
+    let packet = TabListPacket {
+        header: list.header.to_tag(),
+        footer: list.footer.to_tag(),
+    };
+    compose.unicast(
+        Clientbound::new(PacketId::TabList.to_raw(), &packet),
+        connection_id,
+    )
+}
+
+/// Registration module for the tab list: the [`TabList`] text and the [`Tps`]
+/// window, both singletons.
+///
+/// Registration only, per the flecs convention in the root `CLAUDE.md`. An
+/// event crate that wants to write the header imports this and nothing else.
+#[derive(Component)]
+pub struct TabListComponentsModule;
+
+impl Module for TabListComponentsModule {
+    fn module(world: &World) {
+        // Registered with the trait before the value is set. A bare `set`
+        // stores the value without registering the type, which is the
+        // dev-only ECS_INVALID_OPERATION abort of ENG-11000.
+        world.component::<Tps>().add_trait::<flecs::Singleton>();
+        world.set(Tps::default());
+
+        world.component::<TabList>().add_trait::<flecs::Singleton>();
+        world.set(TabList::default());
+    }
+}
+
+/// Behavior module for the tab list: the tick sampler, the change-only
+/// broadcast, and the unicast that catches a joining client up.
+#[derive(Component)]
+pub struct TabListModule;
+
+impl Module for TabListModule {
+    fn module(world: &World) {
+        world.import::<TabListComponentsModule>();
+
+        // PreStore, so a reading taken this tick is on `TabList` before
+        // `tab_list_sync` runs in OnStore and reaches the wire the same tick
+        // rather than the next one. Same placement, and the same reason, as
+        // `server_load_sample`.
+        world
+            .system_named::<(&Compose, &mut Tps, &mut TabList)>("tab_list_sample")
+            .kind(id::<flecs::pipeline::PreStore>())
+            .each(|(compose, tps, list)| {
+                tps.absorb(Instant::now());
+                let players = compose.global().player_count.load(Ordering::Relaxed);
+                let footer = footer_readout(tps.rate, TICKS_PER_SECOND, players);
+                if list.footer != footer {
+                    list.footer = footer;
+                }
+            });
+
+        world
+            .system_named::<(&Compose, &mut TabList)>("tab_list_sync")
+            .kind(id::<flecs::pipeline::OnStore>())
+            .each(|(compose, list)| {
+                if !list.changed() {
+                    return;
+                }
+                let packet = TabListPacket {
+                    header: list.header.to_tag(),
+                    footer: list.footer.to_tag(),
+                };
+                let sent = compose
+                    .broadcast(Clientbound::new(PacketId::TabList.to_raw(), &packet))
+                    .send();
+                if let Err(error) = sent {
+                    error!("failed to broadcast the tab list: {error}");
+                    return;
+                }
+                // Recorded only on a send that worked, so a failed encode is
+                // retried next tick rather than remembered as delivered.
+                list.sent = Some((list.header.clone(), list.footer.clone()));
+            });
+
+        // A change-only broadcast is invisible to anyone who was not connected
+        // when the change happened, so a joining client is handed the current
+        // text. `Channel` is added at the end of `enter_world`, which is after
+        // the roster goes out, so this rides along with the rest of the join
+        // burst.
+        world
+            .observer_named::<flecs::OnAdd, ()>("tab_list_on_join")
+            .with(id::<Channel>())
+            .each_entity(|entity, ()| {
+                let Some(connection_id) = entity.try_get::<&ConnectionId>(|id| *id) else {
+                    return;
+                };
+                entity
+                    .world()
+                    .get::<(&Compose, &TabList)>(|(compose, list)| {
+                        if let Err(error) = unicast(compose, list, connection_id) {
+                            error!("failed to send the tab list to a joining player: {error}");
+                        }
+                    });
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One tick has no rate in it, and neither has any number of ticks over
+    /// less than a window.
+    #[test]
+    fn a_partial_window_reports_nothing_rather_than_a_guess() {
+        let mut tps = Tps::default();
+        let start = Instant::now();
+        tps.absorb(start);
+        assert_eq!(tps.rate, None);
+        assert_eq!(
+            footer_readout(tps.rate, 20.0, 0).plain(),
+            "TPS sampling\n0 players online"
+        );
+
+        // Four seconds of perfect ticking is still not a window.
+        for tick in 1..=80 {
+            tps.absorb(start + Duration::from_millis(50 * tick));
+        }
+        assert_eq!(tps.rate, None);
+    }
+
+    /// A server holding the pace prints the pace, and prints it *because* it
+    /// counted a hundred intervals, not because 20.0 was typed anywhere.
+    #[test]
+    fn a_server_keeping_up_reads_exactly_the_target() {
+        let mut tps = Tps::default();
+        let start = Instant::now();
+        for tick in 0..=200 {
+            tps.absorb(start + Duration::from_millis(50 * tick));
+        }
+        assert_eq!(tps.rate, Some(20.0));
+        assert_eq!(
+            footer_readout(tps.rate, 20.0, 3).plain(),
+            "TPS 20.0 / 20.0\n3 players online"
+        );
+    }
+
+    /// The number the whole feature exists for: a server that fell behind says
+    /// so. Ten ticks a second is half the pace, and the label prints the half
+    /// beside the whole rather than normalising one away.
+    #[test]
+    fn a_server_falling_behind_prints_what_it_managed() {
+        let mut tps = Tps::default();
+        let start = Instant::now();
+        for tick in 0..=100 {
+            tps.absorb(start + Duration::from_millis(100 * tick));
+        }
+        assert_eq!(tps.rate, Some(10.0));
+        assert_eq!(
+            footer_readout(tps.rate, 20.0, 1).plain(),
+            "TPS 10.0 / 20.0\n1 player online"
+        );
+    }
+
+    /// The window slides: a burst of slow ticks ages out and the reading
+    /// recovers, rather than being held down by a stall that is over.
+    #[test]
+    fn the_window_forgets_a_stall_once_it_is_out_of_range() {
+        let mut tps = Tps::default();
+        let start = Instant::now();
+        // Six seconds at half pace.
+        for tick in 0..=60 {
+            tps.absorb(start + Duration::from_millis(100 * tick));
+        }
+        assert_eq!(tps.rate, Some(10.0));
+
+        // Then six seconds at full pace, which is more than one window, so
+        // nothing from the slow stretch is left in it.
+        let recovered = start + Duration::from_millis(6000);
+        for tick in 1..=120 {
+            tps.absorb(recovered + Duration::from_millis(50 * tick));
+        }
+        assert_eq!(tps.rate, Some(20.0));
+    }
+
+    /// Real ticks are not evenly spaced, and this is the test that says so.
+    ///
+    /// Every other test here feeds exact multiples of 50 ms, which quietly
+    /// makes one entry land *exactly* on the window boundary and survive the
+    /// pop -- so the retained span comes out at exactly [`WINDOW`]. A real
+    /// server jitters, no entry lands on the boundary, the retained span is
+    /// always a hair under a window, and a readiness check written against
+    /// that span never fires. That shipped: the gate showed `TPS sampling`
+    /// with `n=83 span=4988ms` for twenty seconds while six unit tests passed.
+    ///
+    /// So the fixture here is deliberately irregular, and the assertion is the
+    /// one those six could not make: that a rate appears at all.
+    #[test]
+    fn a_server_whose_ticks_jitter_still_reports_a_rate() {
+        let mut tps = Tps::default();
+        let start = Instant::now();
+
+        // A small LCG, so the offsets neither repeat on a period that divides
+        // the window nor land on a whole millisecond boundary pattern.
+        let mut seed = 12_345_u64;
+        let mut at = start;
+        let mut ticks = 0_u32;
+        for _ in 0..400 {
+            seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+            let jitter = u64::from((seed >> 33) as u32 % 9_000);
+            at += Duration::from_micros(46_000 + jitter);
+            tps.absorb(at);
+            ticks += 1;
+            if ticks > 120 {
+                assert!(
+                    tps.rate.is_some(),
+                    "after {ticks} jittered ticks over {:?} there is still no rate",
+                    at.duration_since(start)
+                );
+            }
+        }
+
+        // ~50.5 ms a tick on average, so a shade under 20.
+        let rate = tps.rate.expect("a rate after 400 ticks");
+        assert!(
+            (19.0..=20.5).contains(&rate),
+            "{rate} tps is not what a 46-55 ms tick produces"
+        );
+    }
+
+    /// The window is bounded, so a server that runs for a week holds a hundred
+    /// timestamps and not a week of them.
+    #[test]
+    fn the_window_does_not_grow_without_bound() {
+        let mut tps = Tps::default();
+        let start = Instant::now();
+        for tick in 0..=20_000 {
+            tps.absorb(start + Duration::from_millis(50 * tick));
+        }
+        assert_eq!(tps.ticks.len(), 101);
+    }
+
+    /// Nothing is sent for a tick that changed nothing, which is what stops
+    /// this being the per-tick broadcast it replaces.
+    #[test]
+    fn an_unchanged_label_is_not_resent() {
+        let mut list = TabList::default();
+        assert!(
+            list.changed(),
+            "a client that has been told nothing needs telling"
+        );
+
+        list.sent = Some((list.header.clone(), list.footer.clone()));
+        assert!(!list.changed());
+
+        list.footer = footer_readout(Some(19.8), 20.0, 2);
+        assert!(list.changed());
+    }
+}

--- a/crates/hyperion/src/lib.rs
+++ b/crates/hyperion/src/lib.rs
@@ -259,10 +259,8 @@ impl HyperionCore {
             value: shutdown.clone(),
         });
 
-        world.component::<Prev>();
-
         // Minecraft tick rate is 20 ticks per second
-        world.set_target_fps(20.0);
+        world.set_target_fps(TICKS_PER_SECOND);
 
         // todo: sadly this requires u32
         // .bit("on_fire", *EntityFlags::ON_FIRE)
@@ -330,7 +328,6 @@ impl HyperionCore {
             .component::<StreamLookup>()
             .add_trait::<flecs::Singleton>();
         world.component::<EntitySize>();
-        world.component::<IgnMap>().add_trait::<flecs::Singleton>();
 
         world
             .component::<config::Config>()

--- a/crates/hyperion/src/simulation/handlers.rs
+++ b/crates/hyperion/src/simulation/handlers.rs
@@ -149,6 +149,7 @@ pub fn route(id: i32) -> Route {
         PacketId::ClientInformation => Route::Act(client_information),
         PacketId::CommandSuggestion => Route::Act(command_suggestion),
         PacketId::Interact => Route::Act(interact),
+        PacketId::KeepAlive => Route::Act(keep_alive),
         PacketId::ContainerClose => Route::Act(container_close),
         PacketId::MovePlayerPos => Route::Act(move_player_pos),
         PacketId::MovePlayerPosRot => Route::Act(move_player_pos_rot),
@@ -169,8 +170,9 @@ pub fn route(id: i32) -> Route {
         //
         // - `client_tick_end` arrives every tick, `chunk_batch_received` after
         //   every batch, and this server sends chunks without pacing them.
-        // - `keep_alive`, `pong` and `ping_request` are liveness only; nothing
-        //   here times a connection out on them yet.
+        // - `pong` and `ping_request` are liveness only; nothing here times a
+        //   connection out on them yet. `keep_alive` used to be in this list
+        //   and is not any more: it is what `egress::ping` measures with.
         // - `chat_ack` and `chat_session_update` belong to signed chat, which
         //   this server does not verify.
         // - `player_loaded` is the client saying its terrain finished loading,
@@ -184,7 +186,6 @@ pub fn route(id: i32) -> Route {
         | PacketId::ClientTickEnd
         | PacketId::CookieResponse
         | PacketId::CustomPayload
-        | PacketId::KeepAlive
         | PacketId::PingRequest
         | PacketId::PlayerLoaded
         | PacketId::Pong
@@ -375,6 +376,20 @@ fn command_suggestion(body: &[u8], query: &mut PacketSwitchQuery<'_>) -> anyhow:
         },
         query,
     )
+}
+
+/// A client's answer to the keep-alive [`crate::egress::ping`] sent it.
+///
+/// The clock is read here, at the first point in the process that has the
+/// answer, because everything between this and the probe is what the number
+/// is meant to contain. What it cannot see is the wait before this system ran
+/// at all, which is up to one tick and is named in that module's docs.
+fn keep_alive(body: &[u8], query: &mut PacketSwitchQuery<'_>) -> anyhow::Result<()> {
+    let c2s::KeepAlive(id) = decode_body(body)?;
+
+    crate::egress::ping::absorb_answer(query.view, id);
+
+    Ok(())
 }
 
 fn container_close(body: &[u8], query: &mut PacketSwitchQuery<'_>) -> anyhow::Result<()> {

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -284,6 +284,10 @@ impl Module for SimComponentsModule {
         // `Player`-implies-`InventoryState` traits below have a registered
         // component to point at.
         world.import::<inventory::InventoryComponentsModule>();
+        // Same reason, for the `Player`-implies-`Ping` trait: the round trip
+        // measurement is `egress::ping`'s, but "a player has one" is a
+        // statement about `Player`, which this module owns.
+        world.import::<crate::egress::ping::PingComponentsModule>();
         // Registers every remaining simulation component and sets the
         // `MetadataPrefabs` singleton, which `SimModule`'s observers read back
         // to pick a prefab base per entity kind.
@@ -335,6 +339,15 @@ impl Module for ReflectionComponentsModule {
 /// registers as an opaque serialised through `Display` because flecs aborts if
 /// a type is registered as both a struct and an opaque.
 fn register_reflection(world: &World) {
+    // `Prev` is a relation and `metadata::register_prefabs`, further down
+    // this module's own registration chain, builds `(Prev, T)` pairs out of
+    // it, so it has to be a registered entity before any of them exist. It
+    // used to be registered only by `HyperionCore`, which meant importing
+    // `SimComponentsModule` into a bare world -- the thing the convention in
+    // the root `CLAUDE.md` promises works -- aborted a dev build with
+    // `ECS_INVALID_OPERATION: Component hyperion::Prev is not registered`.
+    world.component::<crate::Prev>();
+
     component!(world, VarInt).member(id::<i32>(), "x");
 
     // `EntitySize` registers as an opaque, which needs the component to exist
@@ -416,6 +429,10 @@ fn register_components(world: &World) -> MetadataPrefabs {
     world.component::<command::SuggestionLabel>();
     world.component::<command::FixedSuggestions>();
 
+    // Registered with its trait before `component!` annotates it, and before
+    // anything sets it. Only `HyperionCore` used to do this, which is why
+    // importing this module alone aborted here in a dev build.
+    world.component::<IgnMap>().add_trait::<flecs::Singleton>();
     component!(world, IgnMap);
 
     world.component::<Name>();
@@ -452,6 +469,9 @@ fn register_components(world: &World) -> MetadataPrefabs {
     world
         .component::<Player>()
         .add_trait::<(flecs::With, hyperion_inventory::InventoryState)>();
+    world
+        .component::<Player>()
+        .add_trait::<(flecs::With, crate::egress::ping::Ping)>();
 
     prefabs
 }

--- a/crates/hyperion/tests/registration_modules.rs
+++ b/crates/hyperion/tests/registration_modules.rs
@@ -14,14 +14,18 @@
 //! shows up as a failed assertion naming the type rather than as an abort with
 //! no attribution.
 
-use flecs_ecs::core::{ComponentId, World, WorldGet};
+use flecs_ecs::core::{ComponentId, World, WorldGet, id};
 use hyperion::{
-    egress::sync_chunks::{ChunkSendQueue, SyncChunksComponentsModule},
+    egress::{
+        ping::{Ping, PingComponentsModule},
+        sync_chunks::{ChunkSendQueue, SyncChunksComponentsModule},
+        tab_list::{TabList, TabListComponentsModule, Tps},
+    },
     ingress::{
         IngressComponentsModule, PendingRemove, ServerPingResponse,
         decode::{DecodeComponentsModule, Decompressor},
     },
-    simulation::inventory::InventoryComponentsModule,
+    simulation::{IgnMap, Player, SimComponentsModule, inventory::InventoryComponentsModule},
     spatial::{Spatial, SpatialComponentsModule, SpatialIndex},
 };
 use hyperion_inventory::{CursorItem, InventoryState, OpenInventory, PlayerInventory};
@@ -105,4 +109,79 @@ fn ingress_components_module_registers_the_inbound_edge_standalone() {
     assert_registered::<PendingRemove>(&world);
     assert_registered::<ServerPingResponse>(&world);
     world.get::<&ServerPingResponse>(|_| ());
+}
+
+#[test]
+#[serial]
+fn tab_list_components_module_registers_both_singletons_standalone() {
+    let world = World::new();
+    world.import::<TabListComponentsModule>();
+
+    assert_registered::<TabList>(&world);
+    assert_registered::<Tps>(&world);
+    // Both defaults are installed by the module that registers the type, so a
+    // `get` reaching them at all is the assertion.
+    world.get::<&TabList>(|_| ());
+    world.get::<&Tps>(|_| ());
+
+    assert!(
+        world.try_lookup("tab_list_sample").is_none(),
+        "a registration module must install no systems"
+    );
+    assert!(
+        world.try_lookup("tab_list_sync").is_none(),
+        "a registration module must install no systems"
+    );
+}
+
+#[test]
+#[serial]
+fn ping_components_module_registers_the_readout_standalone() {
+    let world = World::new();
+    world.import::<PingComponentsModule>();
+
+    assert_registered::<Ping>(&world);
+
+    assert!(
+        world.try_lookup("probe_ping").is_none(),
+        "a registration module must install no systems"
+    );
+    assert!(
+        world.try_lookup("publish_ping").is_none(),
+        "a registration module must install no systems"
+    );
+}
+
+/// The whole simulation registration layer, standing on its own.
+///
+/// The premise of every test above, applied to the module they all sit under.
+/// It did not hold: `Prev` and `IgnMap` were registered only by
+/// `HyperionCore`, so importing `SimComponentsModule` into a bare world -- the
+/// thing this convention exists to make possible -- aborted a dev build with
+/// `ECS_INVALID_OPERATION` before reaching the first assertion. Both are now
+/// registered by the simulation's own DAG, and this is the guard that keeps
+/// the next one from going unnoticed until a consumer trips over it.
+#[test]
+#[serial]
+fn sim_components_module_stands_alone() {
+    let world = World::new();
+    world.import::<SimComponentsModule>();
+
+    assert_registered::<Player>(&world);
+    assert_registered::<IgnMap>(&world);
+
+    // A `Player` carries a `Ping` without anyone on the join path adding one.
+    // The trait is declared here rather than by `PingComponentsModule` because
+    // it is a statement about `Player`; the assertion is here for the same
+    // reason.
+    let player = world.entity().add(id::<Player>());
+    assert!(
+        player.has(id::<Ping>()),
+        "a Player should carry a Ping without anyone adding one"
+    );
+
+    assert!(
+        world.try_lookup("probe_ping").is_none(),
+        "a registration module must install no systems"
+    );
 }

--- a/events/bedwars/src/lib.rs
+++ b/events/bedwars/src/lib.rs
@@ -14,7 +14,7 @@ use valence_text::IntoText;
 use crate::module::{
     attack::AttackModule, block::BlockModule, bow::BowModule, chat::ChatModule,
     damage::DamageModule, regeneration::RegenerationModule, spawn::SpawnModule,
-    tab_list::TabListModule, vanish::VanishModule,
+    tab_list::BedwarsTabListModule, vanish::VanishModule,
 };
 
 mod command;
@@ -119,7 +119,7 @@ impl Module for BedwarsModule {
 
         world.import::<SpawnModule>();
         world.import::<ChatModule>();
-        world.import::<TabListModule>();
+        world.import::<BedwarsTabListModule>();
         world.import::<BlockModule>();
         world.import::<AttackModule>();
         world.import::<BowModule>();

--- a/events/bedwars/src/module/tab_list.rs
+++ b/events/bedwars/src/module/tab_list.rs
@@ -1,29 +1,61 @@
+//! The tab list header, and the same numbers on the console.
+//!
+//! The packet itself is not sent from here. `hyperion::egress::tab_list` owns
+//! the `TabList` singleton and broadcasts it when it changes; this module
+//! writes the header half and lets that happen. Before that split existed both
+//! halves were built and broadcast here, unconditionally, to every player,
+//! twenty times a second.
+//!
+//! The tick-time averages are still worth showing next to the tick *rate* the
+//! footer carries: a rate says whether the server kept up, and the three
+//! averages say how much headroom it had while doing it.
+
 use flecs_ecs::{
-    core::{SystemAPI, World},
+    core::{SystemAPI, World, WorldGet},
     macros::{Component, system},
     prelude::Module,
 };
 use hyperion::{
-    hyperion_minecraft_proto::{
-        generated::packet_id::play::clientbound::PacketId, packets::play::clientbound::TabList,
-        text::Component,
-    },
-    net::{Compose, protocol::Clientbound},
+    egress::tab_list::{TabList, TabListComponentsModule, Text},
+    hyperion_minecraft_proto::text::NamedColor,
+    net::Compose,
 };
 use tracing::{info, info_span};
 
+/// Named for the crate it belongs to, not for what it does, and that is
+/// load bearing: flecs names a module entity after the **last segment** of
+/// its type path and nothing else, so this and
+/// `hyperion::egress::tab_list::TabListModule` were one name in one flat
+/// namespace. A dev build aborts on the collision --
+/// `entity symbol inconsistent: bedwars::module::tab_list::TabListModule
+/// (provided) vs. hyperion::egress::tab_list::TabListModule (existing)` --
+/// and a release build, where that assert is compiled out, quietly treats
+/// the import as already done and installs none of this.
 #[derive(Component)]
-pub struct TabListModule;
+pub struct BedwarsTabListModule;
 
-/// One console line per second at the 20 Hz tick rate.
+/// One console line, and one header rebuild, per second at the 20 Hz tick
+/// rate.
+///
+/// The header is rate limited rather than written every tick because a
+/// millisecond average to two decimals moves on every single one, and
+/// `tab_list_sync` sends whenever the text changes: writing it at tick rate
+/// would put the per-tick broadcast straight back. Nobody reads a number that
+/// changes twenty times a second anyway.
 const TICKS_PER_LOG: u32 = 20;
 
-impl Module for TabListModule {
-    #[allow(clippy::excessive_nesting)]
+/// How many samples the longest window holds.
+const WINDOW_TICKS: usize = 20 * 60;
+
+impl Module for BedwarsTabListModule {
     fn module(world: &World) {
+        // The header is written into a component this module does not own, so
+        // the module that registers it is imported rather than assumed.
+        world.import::<TabListComponentsModule>();
+
         let mode = env!("RUN_MODE");
 
-        let mut tick_times = Vec::with_capacity(20 * 60); // 20 ticks per second, 60 seconds
+        let mut tick_times = Vec::with_capacity(WINDOW_TICKS);
         let mut last_frame_time_total = 0.0;
         let mut ticks_since_log = 0u32;
 
@@ -43,7 +75,7 @@ impl Module for TabListModule {
             last_frame_time_total = current_frame_time_total;
 
             tick_times.push(ms_per_tick);
-            if tick_times.len() > 20 * 60 {
+            if tick_times.len() > WINDOW_TICKS {
                 tick_times.remove(0);
             }
 
@@ -51,38 +83,38 @@ impl Module for TabListModule {
             let avg_s15 = tick_times.iter().rev().take(20 * 15).sum::<f32>() / (20.0 * 15.0);
             let avg_s60 = tick_times.iter().sum::<f32>() / tick_times.len() as f32;
 
-            let title = format!(
-                "§b{mode}§r\n§aµ/5s: {avg_s05:.2} ms §r| §eµ/15s: {avg_s15:.2} ms §r| §cµ/1m: \
-                 {avg_s60:.2} ms"
-            );
+            ticks_since_log += 1;
+            if ticks_since_log < TICKS_PER_LOG {
+                return;
+            }
+            ticks_since_log = 0;
 
-            let footer = format!("§d§l{player_count} players online");
-
-            // The components borrow the two strings and the tags borrow the
-            // components, so all four have to outlive the send.
-            let header_text = Component::text(title.as_str());
-            let footer_text = Component::text(footer.as_str());
-            let pkt = TabList {
-                header: header_text.to_tag(),
-                footer: footer_text.to_tag(),
-            };
-
-            compose
-                .broadcast(Clientbound::new(PacketId::TabList.to_raw(), &pkt))
-                .send()
-                .unwrap();
+            // Components and not `§` markup, which is the rule
+            // `hyperion::egress::boss_bar` states and the same `Text` type
+            // carries here: a colour a caller can smuggle in as text is a
+            // colour nothing can check.
+            let header = Text::text("").extend([
+                Text::text(mode).color(NamedColor::Aqua),
+                Text::text("\n"),
+                Text::text(format!("µ/5s: {avg_s05:.2} ms")).color(NamedColor::Green),
+                Text::text(" | "),
+                Text::text(format!("µ/15s: {avg_s15:.2} ms")).color(NamedColor::Yellow),
+                Text::text(" | "),
+                Text::text(format!("µ/1m: {avg_s60:.2} ms")).color(NamedColor::Red),
+            ]);
+            world.get::<&mut TabList>(|list| {
+                if list.header != header {
+                    list.header = header;
+                }
+            });
 
             // The tab list carries this already, but an operator watching the
             // console has no other way to see whether anyone is connected or how
             // the tick budget is holding up.
-            ticks_since_log += 1;
-            if ticks_since_log >= TICKS_PER_LOG {
-                ticks_since_log = 0;
-                info!(
-                    "{player_count} players online | tick µ/5s {avg_s05:.2} ms, µ/15s \
-                     {avg_s15:.2} ms, µ/1m {avg_s60:.2} ms"
-                );
-            }
+            info!(
+                "{player_count} players online | tick µ/5s {avg_s05:.2} ms, µ/15s {avg_s15:.2} \
+                 ms, µ/1m {avg_s60:.2} ms"
+            );
         });
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1687,6 +1687,38 @@
               timeout = 180;
             };
 
+            # The tab list's two new numbers, and the one claim about them that
+            # no Rust test can settle.
+            #
+            # The tick rate half is ordinary: `tab-list-check.py` joins, reads
+            # the `TabList` (id 122) footer back, and checks it carries a
+            # measured rate against the rate the loop is paced to. smash sent no
+            # `TabList` at all before this, so the first assertion is red on an
+            # unpatched tree.
+            #
+            # The ping half is why this is a gate and not a unit test. hyperion
+            # measures round trip time by sending a keep-alive and timing the
+            # answer, and there is a proxy in between. If the proxy answered
+            # keep-alives itself, the game server would be timing the proxy and
+            # the number would look completely plausible -- a lie nothing in the
+            # crate could detect. So the client answers keep-alives, watches a
+            # real latency arrive, then **stops answering** while staying
+            # otherwise busy: the reading has to fall back to -1, which it can
+            # only do if the thing answering was the client. Then it answers
+            # again and the reading comes back, so the fallback is a timeout and
+            # not a dead connection.
+            #
+            # The mute window is `Global::keep_alive_timeout` (20 s) plus room
+            # for a probe to be sent and time out inside it, so this gate is
+            # slower than its neighbours by construction.
+            tab-list-e2e = e2e.mkCheck {
+              name = "hyperion-tab-list-e2e";
+              gameServer = gameBinaries.smash;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "tab-list-check.py";
+              timeout = 300;
+            };
+
             # The dev-profile boot gate. ENG-11000 shipped a singleton that was
             # `world.set` but never registered as a component; a release build
             # compiles the flecs "component is not registered" assert out, so

--- a/tools/packet_monitor.py
+++ b/tools/packet_monitor.py
@@ -103,6 +103,21 @@ SKIN_PART_HAT = 0x40
 ALL_SKIN_PARTS = 0x7F
 
 
+def take_var_int_signed(payload, offset=0):
+    """One VarInt read back as the signed 32-bit value it was written from.
+
+    Minecraft VarInts are two's complement and not zigzag, so `-1` goes on the
+    wire as five bytes and `take_var_int` hands it back as 4294967295. That is
+    the right answer for every count and id in this file and the wrong one for
+    a latency, where `-1` is the "no reading" the client draws its unknown ping
+    sprite for.
+    """
+    value, offset = take_var_int(payload, offset)
+    if value >= 1 << 31:
+        value -= 1 << 32
+    return value, offset
+
+
 def _take_optional_string(payload, offset):
     present = payload[offset]
     offset += 1
@@ -141,7 +156,7 @@ def parse_player_info_update(payload):
             entry["listed"] = bool(payload[offset])
             offset += 1
         if actions & UPDATE_LATENCY:
-            _, offset = take_var_int(payload, offset)
+            entry["latency"], offset = take_var_int_signed(payload, offset)
         if actions & UPDATE_DISPLAY_NAME:
             present = payload[offset]
             offset += 1

--- a/tools/tab-list-check.py
+++ b/tools/tab-list-check.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""The tab list's tick rate and ping, read off the wire by the client that joined.
+
+Two features, and one of them can only be proved by a real client.
+
+# The tick rate
+
+`ClientboundTabListPacket` was sent zero times by smash before this: only
+bedwars built one, and it built both halves itself, every tick, for every
+player. `hyperion::egress::tab_list` now owns the packet and writes the footer
+with the rate the tick loop actually managed, against the rate it is paced to:
+
+    TPS 19.8 / 20.0
+    3 players online
+
+So the first assertion here is fail-then-pass by construction -- an unpatched
+server sends no `TabList` at all -- and the rest read the label back and check
+it says something a loop could have produced.
+
+# The ping, and the one thing only a client can settle
+
+`roster.rs` sent `ping: 0` at join and nothing ever again, which drew five full
+bars for a measurement nobody had taken: the game server routed a serverbound
+`keep_alive` to `Route::Ignore` and never sent a clientbound one.
+
+hyperion now probes with a keep-alive and times the answer. hyperion also puts
+a *proxy* between the client and the game server, and this is the one place the
+design could quietly lie: if the proxy answered keep-alives itself, the game
+server would be timing the proxy, the number would look entirely plausible, and
+nothing in a Rust test could tell the difference.
+
+Reading `crates/hyperion-proxy` says it does not -- there is no keep-alive
+handling in it at all -- but that is an argument, not a measurement. This is the
+measurement, and it is the reason this gate exists rather than a unit test:
+
+  1. join, and read the latency out of the roster: it must be -1, the client's
+     own "no reading" sprite, and not the 0 that used to draw five bars.
+  2. answer keep-alives for a few seconds. A real latency must arrive in an
+     `UPDATE_LATENCY` delta, and on loopback it must be in the top bucket.
+  3. **stop answering, and keep the connection otherwise busy.** After the
+     server's keep-alive timeout the latency must fall back to -1.
+
+Step 3 is the whole argument. If anything between this script and the game
+server were answering keep-alives, the server would go on measuring a healthy
+round trip while this client sat mute, and the reading would never go unknown.
+It only goes unknown if the thing answering is *this process*.
+
+  4. start answering again, and watch a real reading come back, so what step 3
+     proved is a measurement resuming and not a connection that died.
+
+Exits non-zero on the first thing that is not true, after printing what it saw.
+"""
+
+import argparse
+import importlib.util
+import pathlib
+import re
+import struct
+import sys
+import time
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, TOOLS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+match = _load("smash_match", "smash-match.py")
+monitor = _load("packet_monitor", "packet_monitor.py")
+
+take_var_int = match.base.take_var_int
+var_int = match.base.var_int
+take_nbt_string = match.take_nbt_string
+parse_player_info_update = monitor.parse_player_info_update
+
+# crates/hyperion-minecraft-proto/src/generated/packet_id.rs, protocol 776.
+S2C_TAB_LIST = 0x7A
+S2C_PLAYER_INFO_UPDATE = monitor.S2C_PLAYER_INFO_UPDATE
+
+UPDATE_LATENCY = monitor.UPDATE_LATENCY
+ADD_PLAYER = monitor.ADD_PLAYER
+
+# `hyperion::egress::ping::UNKNOWN`, which is the client's own `latency < 0`
+# branch in `PlayerTabOverlay.extractPingIcon` and draws `icon/ping_unknown`.
+UNKNOWN = -1
+
+# `PlayerTabOverlay.extractPingIcon` again: under 150 ms is the five bar
+# sprite. Anything on loopback that is not in this bucket is not a round trip,
+# it is a bug.
+FIVE_BARS_BELOW = 150
+
+# `hyperion::Global::keep_alive_timeout`. How long a probe goes unanswered
+# before the readout gives up on it, plus room for the next probe to be sent,
+# answered nowhere, and time out in turn.
+KEEP_ALIVE_TIMEOUT = 20.0
+MUTE_SECONDS = KEEP_ALIVE_TIMEOUT + 10.0
+
+# `hyperion::egress::tab_list::footer_readout`. Both numbers, because the
+# second is what makes the first checkable: a label carrying only "19.8" could
+# be anything.
+TPS_LABEL = re.compile(r"^TPS (\d+\.\d) / (\d+\.\d)$")
+SAMPLING_LABEL = "TPS sampling"
+PLAYERS_LABEL = re.compile(r"^(\d+) players? online$")
+
+# `hyperion::TICKS_PER_SECOND`, held here as the test's own expectation rather
+# than read from the label being tested.
+TARGET_TPS = 20.0
+
+
+class Watcher(match.MatchClient):
+    """A scripted player that can be told to stop answering keep-alives."""
+
+    def __init__(self, host, port, name, started):
+        super().__init__(host, port, name, started)
+        self.entity_id = None
+        self.joined = False
+        # Whether to answer a keep-alive. Flipping this off is the experiment.
+        self.answer_keep_alives = True
+        # How many arrived, so "the server stopped probing" and "this client
+        # stopped answering" cannot be confused for one another.
+        self.keep_alives = 0
+        # Every tab list, as the two plain strings a player would read.
+        self.tab_lists = []
+        # Every latency this client was told about itself, in arrival order,
+        # tagged with whether it came in the joining roster or a later delta.
+        self.latencies = []
+
+    def absorb(self, packet_id, payload):
+        if packet_id == match.S2C_LOGIN:
+            self.entity_id = struct.unpack(">i", payload[:4])[0]
+            self.joined = True
+            self.log("** in the world ** entity_id=%d" % self.entity_id)
+        elif packet_id == match.S2C_PLAYER_POSITION:
+            teleport_id, offset = take_var_int(payload)
+            x, y, z = struct.unpack(">ddd", payload[offset : offset + 24])
+            self.position = (x, y, z)
+            self.send(match.C2S_ACCEPT_TELEPORTATION, var_int(teleport_id))
+            self.log("<- teleported to (%.1f, %.1f, %.1f)" % (x, y, z))
+        elif packet_id == match.S2C_KEEP_ALIVE:
+            self.keep_alives += 1
+            if self.answer_keep_alives:
+                self.send(match.C2S_KEEP_ALIVE, payload[:8])
+            else:
+                self.log("<- keep-alive #%d, deliberately not answered" % self.keep_alives)
+        elif packet_id == S2C_TAB_LIST:
+            header, offset = take_nbt_string(payload, 0)
+            footer, _ = take_nbt_string(payload, offset)
+            self.tab_lists.append({"header": header, "footer": footer})
+            self.log("<- tab list footer %r" % footer)
+        elif packet_id == S2C_PLAYER_INFO_UPDATE:
+            actions, entries = parse_player_info_update(payload)
+            if not actions & UPDATE_LATENCY:
+                return
+            for entry in entries:
+                self.latencies.append(
+                    {
+                        "uuid": entry["uuid"],
+                        "latency": entry["latency"],
+                        "roster": bool(actions & ADD_PLAYER),
+                        "at": time.monotonic(),
+                    }
+                )
+                self.log(
+                    "<- latency %d ms (%s)"
+                    % (entry["latency"], "roster" if actions & ADD_PLAYER else "delta")
+                )
+        elif packet_id == match.S2C_DISCONNECT:
+            text, _ = match.take_nbt_string(payload, 0)
+            self.log("<- DISCONNECTED: %s" % text)
+            self.alive = False
+
+
+def pump(client, seconds):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if not client.alive:
+            return
+        for packet_id, payload in client.drain():
+            client.absorb(packet_id, payload)
+        if client.joined:
+            # Keeps the connection busy while mute, so a lost reading in step 3
+            # is the keep-alive going unanswered and not the whole client
+            # having gone quiet.
+            client.repeat_position()
+        time.sleep(0.01)
+
+
+def wait_until(client, predicate, seconds, what):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        pump(client, 0.05)
+        if predicate():
+            return True
+    print("TIMEOUT waiting for %s" % what, file=sys.stderr)
+    return False
+
+
+def footer_lines(footer):
+    return footer.split("\n")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=25565)
+    parser.add_argument("--name", default="Tabby")
+    args = parser.parse_args()
+
+    started = time.time()
+    failures = []
+
+    def check(ok, message):
+        print("%s %s" % ("PASS" if ok else "FAIL", message), flush=True)
+        if not ok:
+            failures.append(message)
+
+    client = Watcher(args.host, args.port, args.name, started)
+    client.handshake(args.host, args.port, 2)
+    client.login()
+    client.configuration()
+    client.enter_play()
+
+    if not wait_until(client, lambda: client.joined, 30.0, "the world"):
+        print("RESULT: failure (never joined)", flush=True)
+        return 1
+
+    # --- the tick rate ----------------------------------------------------
+    #
+    # A joining client is unicast the current text, so one arrives without
+    # waiting for anything to change. The measured number needs a full window
+    # first, so allow for the label starting at "sampling".
+    wait_until(
+        client,
+        lambda: any(
+            TPS_LABEL.match(footer_lines(t["footer"])[0]) for t in client.tab_lists
+        ),
+        20.0,
+        "a tab list carrying a measured tick rate",
+    )
+
+    check(
+        bool(client.tab_lists),
+        "a TabList (id 122) arrives at all -- this server sent none before "
+        "(got %d)" % len(client.tab_lists),
+    )
+    if not client.tab_lists:
+        print("RESULT: failure (no tab list)", flush=True)
+        return 1
+
+    measured = [
+        (t, TPS_LABEL.match(footer_lines(t["footer"])[0]))
+        for t in client.tab_lists
+        if TPS_LABEL.match(footer_lines(t["footer"])[0])
+    ]
+    check(
+        bool(measured),
+        "the footer's first line carries a measured rate and the rate it is "
+        "paced to; the footers seen were %r"
+        % [t["footer"] for t in client.tab_lists],
+    )
+    if not measured:
+        print("RESULT: failure (no TPS label)", flush=True)
+        return 1
+
+    last, groups = measured[-1]
+    rate, target = float(groups.group(1)), float(groups.group(2))
+    check(
+        target == TARGET_TPS,
+        "the label prints the ceiling it is drawn against (%.1f, expected "
+        "%.1f)" % (target, TARGET_TPS),
+    )
+    check(
+        0.0 < rate <= target,
+        "the measured rate is a rate this loop could have produced: 0 < %.1f "
+        "<= %.1f" % (rate, target),
+    )
+    players = PLAYERS_LABEL.match(footer_lines(last["footer"])[1])
+    check(
+        players is not None and int(players.group(1)) >= 1,
+        "the footer's second line counts the players actually connected "
+        "(%r)" % footer_lines(last["footer"])[1],
+    )
+
+    # A constant cannot produce this line. If the client got in before the
+    # first measurement window closed, the server said so rather than guessing,
+    # which is the strongest evidence available here that the number is
+    # measured. Not required -- a client that joins later never sees it.
+    sampled = any(
+        footer_lines(t["footer"])[0] == SAMPLING_LABEL for t in client.tab_lists
+    )
+    print(
+        "NOTE  the first window %s observed as %r"
+        % ("was" if sampled else "was not", SAMPLING_LABEL),
+        flush=True,
+    )
+
+    # --- the ping ---------------------------------------------------------
+    roster = [entry for entry in client.latencies if entry["roster"]]
+    check(
+        bool(roster) and all(entry["latency"] == UNKNOWN for entry in roster),
+        "the joining roster carries %d (no reading yet) and not the 0 that "
+        "used to draw five full bars (got %r)"
+        % (UNKNOWN, [entry["latency"] for entry in roster]),
+    )
+
+    wait_until(
+        client,
+        lambda: any(
+            entry["latency"] >= 0 and not entry["roster"] for entry in client.latencies
+        ),
+        20.0,
+        "a measured latency",
+    )
+    real = [
+        entry for entry in client.latencies if entry["latency"] >= 0 and not entry["roster"]
+    ]
+    check(
+        bool(real),
+        "a real round trip arrives as an UPDATE_LATENCY delta once keep-alives "
+        "are being answered (got %r)" % [e["latency"] for e in client.latencies],
+    )
+    if not real:
+        print("RESULT: failure (no latency was ever measured)", flush=True)
+        return 1
+    check(
+        0 <= real[-1]["latency"] < FIVE_BARS_BELOW,
+        "the loopback round trip is in the client's top bucket (%d ms, must "
+        "be under %d)" % (real[-1]["latency"], FIVE_BARS_BELOW),
+    )
+    check(
+        client.keep_alives >= 2,
+        "the server probes repeatedly rather than once (%d keep-alives)"
+        % client.keep_alives,
+    )
+
+    # --- who answers keep-alives ------------------------------------------
+    #
+    # Go mute while staying otherwise busy. Only this process can answer a
+    # keep-alive, so only this process going quiet can take the reading away.
+    print(
+        "NOTE  going mute for %.0f s: not answering keep-alives, still sending "
+        "position" % MUTE_SECONDS,
+        flush=True,
+    )
+    before_mute = len(client.latencies)
+    keep_alives_before = client.keep_alives
+    client.answer_keep_alives = False
+    wait_until(
+        client,
+        lambda: any(
+            entry["latency"] == UNKNOWN for entry in client.latencies[before_mute:]
+        ),
+        MUTE_SECONDS,
+        "the reading to go unknown while nothing answers keep-alives",
+    )
+    went_unknown = [
+        entry for entry in client.latencies[before_mute:] if entry["latency"] == UNKNOWN
+    ]
+    check(
+        bool(went_unknown),
+        "with this client refusing to answer, the reading falls back to %d -- "
+        "so the thing answering keep-alives is the client and not the proxy "
+        "(latencies seen while mute: %r)"
+        % (UNKNOWN, [e["latency"] for e in client.latencies[before_mute:]]),
+    )
+    check(
+        client.keep_alives > keep_alives_before,
+        "keep-alives kept arriving while mute (%d more), so the fallback is a "
+        "timeout and not the server having stopped probing"
+        % (client.keep_alives - keep_alives_before),
+    )
+    check(
+        client.alive,
+        "the connection survives an unanswered keep-alive; hyperion does not "
+        "disconnect over one",
+    )
+
+    # --- and back ---------------------------------------------------------
+    print("NOTE  answering keep-alives again", flush=True)
+    before_resume = len(client.latencies)
+    client.answer_keep_alives = True
+    wait_until(
+        client,
+        lambda: any(
+            entry["latency"] >= 0 for entry in client.latencies[before_resume:]
+        ),
+        30.0,
+        "the reading to come back",
+    )
+    recovered = [
+        entry for entry in client.latencies[before_resume:] if entry["latency"] >= 0
+    ]
+    check(
+        bool(recovered),
+        "the reading comes back once answers resume, so what went unknown was "
+        "a measurement and not a dead connection (got %r)"
+        % [e["latency"] for e in client.latencies[before_resume:]],
+    )
+
+    if failures:
+        print(
+            "RESULT: failure (%d checks failed): %s"
+            % (len(failures), "; ".join(failures)),
+            flush=True,
+        )
+        return 1
+    print(
+        "RESULT: success (tick rate %.1f / %.1f on the wire; ping measured "
+        "against the client, which is the only thing that answers a "
+        "keep-alive)" % (rate, target),
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two numbers the tab list did not have. Both live in `crates/hyperion` rather than an event crate, because server telemetry is not a game concept — the same placement, and the same honesty rule, as `egress::server_load`.

Fixes ENG-12065
Refs ENG-12061, ENG-12062, ENG-12063, ENG-12064

## The tick rate

`egress::tab_list` owns a `TabList` singleton. The event crate writes the header, hyperion writes the footer, and the packet is broadcast **only when the rendered text changes**, with a unicast to catch a joining client up. Before this, bedwars built both halves itself and broadcast them to every player every tick; smash sent no `TabList` at all.

The footer follows `server_load`'s rule, adapted to a surface with no bar to fill — both numbers are printed, the first is what the loop did and the second is what it was paced to:

```
TPS 17.0 / 20.0
1 player online
```

A server keeping up prints them equal, so that is the only way `20.0` can appear: it has to survive `Tps::absorb`, which counts real ticks against a real clock. Before a window has closed it prints `TPS sampling` rather than guessing.

Not flecs's `frame_time_total`, which is time spent *inside* frames and excludes the sleep that holds 20 Hz — a rate derived from it reads near-infinite on an idle server.

## The ping

`roster.rs` sent `ping: 0` at join and nothing after. That was not a stale reading; **nothing had ever taken one**. The game server routed a serverbound `keep_alive` to `Route::Ignore` and never sent a clientbound one, and a vanilla client only ever *answers* a keep-alive, never starts one. Every player drew five full bars for a measurement that did not exist.

`egress::ping` now probes with a keep-alive, one outstanding at a time, and folds the answer in where it is decoded. `UPDATE_LATENCY` deltas go out when the **bar** moves, not when the millisecond does, batched into one packet for everyone who changed. Thresholds are read off the pinned 26.2 client jar (sha1 `2dc72797acbc1b63fc16a11c4ac393605f453754`, the jar `nix/minecraft-version.json` already pins), `PlayerTabOverlay.extractPingIcon`:

```java
Identifier sprite = info.getLatency() < 0 ? PING_UNKNOWN_SPRITE
    : (info.getLatency() < 150 ? PING_5_SPRITE
    : (info.getLatency() < 300 ? PING_4_SPRITE
    : (info.getLatency() < 600 ? PING_3_SPRITE
    : (info.getLatency() < 1000 ? PING_2_SPRITE : PING_1_SPRITE))));
```

Vanilla draws the icon and never the number, so the bar is the whole of what a player can see and the right granularity to resend at. The value on the wire stays the real measurement. A player with no reading yet publishes `-1`, which is the client's own "unknown" sprite — the state they are actually in — rather than the `0` that drew five bars.

## Which side answers keep-alive, and how I know

This is the one place the design could quietly lie. There is a proxy between the client and the game server; a proxy that answered keep-alives itself would leave the game server timing the *proxy*, producing a completely plausible number that measures the wrong thing, and nothing in a Rust test could tell.

**Static:** `crates/hyperion-proxy` contains no keep-alive handling at all. `rg 'keep_alive|KeepAlive' crates/hyperion-proxy/` exits 1. The player-to-server path in `player.rs` reads bytes off the socket and forwards frames without parsing an id.

**Measured**, which is what actually settles it. `tools/tab-list-check.py` answers keep-alives, watches a latency arrive, then **stops answering while continuing to send position**, then answers again:

```
PASS the joining roster carries -1 (no reading yet) and not the 0 that used to draw five full bars (got [-1])
PASS a real round trip arrives as an UPDATE_LATENCY delta once keep-alives are being answered (got [-1, -1, 58])
PASS the loopback round trip is in the client's top bucket (58 ms, must be under 150)
PASS the server probes repeatedly rather than once (2 keep-alives)
NOTE  going mute for 30 s: not answering keep-alives, still sending position
PASS with this client refusing to answer, the reading falls back to -1 -- so the thing answering keep-alives is the client and not the proxy (latencies seen while mute: [-1])
PASS keep-alives kept arriving while mute (2 more), so the fallback is a timeout and not the server having stopped probing
PASS the connection survives an unanswered keep-alive; hyperion does not disconnect over one
NOTE  answering keep-alives again
PASS the reading comes back once answers resume (got [61])
```

Nothing between the client and the game server can produce that transition. What is measured is the player.

## What the number contains, stated rather than hidden

**One whole tick of it is this server.** `recv_data` drains frames once per tick and the probe goes out at the end of one, so an answer cannot be seen before the next tick. That is the floor, not a worst case: measured on loopback, where the true round trip is under a millisecond, the readings were **58 ms and 61 ms**, against a tick of 59 ms on a loop managing 17 tps.

So a displayed ping is the player's round trip plus about a tick, biased one way: a player whose real ping is 100 ms is drawn at four bars rather than five. Never wrong by more than one step. Filed as ENG-12063 with the fix (timestamp a frame on arrival in the packet channel, not at decode); deliberately not corrected for here, since subtracting an estimated tick invents a number and could go negative, which is the client's "unknown" sentinel.

## Two things this turned up

- **ENG-12062:** the loop measures **17.0 tps against its own 20.0 target** on an idle server. That is what a tick-rate readout is for, and it was the first thing it said. Environment-specific until re-measured on Linux; the number is now on the wire, so `tab-list-check.py` prints it anywhere.
- **ENG-12061:** `SimComponentsModule` could not be imported into a bare world — `Prev` and `IgnMap` were registered only by `HyperionCore`. Fixed in the first commit, with `sim_components_module_stands_alone` as the guard.

## A bug my own tests were too clean to catch

The first run of this gate showed `TPS sampling` for twenty seconds while six unit tests passed. Entries older than `WINDOW` are dropped, so the oldest retained is always *inside* the window and the span to now is always a hair short of a whole one — instrumented, `n=83 span=4988ms`. Gating readiness on that span never opens. Except on perfectly regular ticks, where an entry lands exactly on the boundary and survives, which is precisely the 50 ms-multiple fixture every test used.

Fixed by tracking the first tick separately. `a_server_whose_ticks_jitter_still_reports_a_rate` uses deliberately irregular spacing and fails against the old code while the six original tests pass — that asymmetry is the point of the test.

## Verification

- `cargo test --workspace` green; `cargo clippy --all-targets --all-features -- -D warnings` (the args `checks.clippy` uses) green.
- **Every guard added here was watched fail.** Each was broken in place, the test re-run, and restored: `Prev` unregistered → `sim_components_module_stands_alone` red; the `Player`-implies-`Ping` trait removed → red; `Tps` unregistered → registration test red; a bucket threshold moved 150→160 → red; intervals counted as timestamps → red; `changed()` forced true → red; the window fix reverted → the jitter test red.
- `nix build .#checks.<sys>.tab-list-e2e` — the run above.
- `nix build .#checks.<sys>.smash-dev-boot-e2e .#checks.<sys>.bedwars-dev-boot-e2e` green in the **dev profile**, which is not optional here: bedwars aborted on `entity symbol inconsistent: bedwars::module::tab_list::TabListModule (provided) vs. hyperion::egress::tab_list::TabListModule (existing)`. flecs put both at one name; a release build compiles that assert out and silently skips the import instead. Hence `BedwarsTabListModule`. I did not work out flecs's exact scoping rule — a pre-existing `SpawnModule` pair in hyperion and bedwars does *not* collide — so the rename is what I verified, not a theory of why.

## Not done

- The gate asserts the tick rate is delivered, well-formed and in range. It does not prove the number *responds to load* — arranging a slow server inside the sandbox is not something this harness can do. That claim rests on the unit tests, which drive `absorb` directly.
- The one-tick offset above (ENG-12063).
- bedwars' header is now rebuilt once a second rather than every tick, because a two-decimal millisecond average moves on every one and would put the per-tick broadcast straight back. Its player-count line moved into hyperion's footer; nothing else about it changed.

---

Authored by Claude Opus 5 via Claude Code, driven and reviewed by @andrewgazelka.
