### PR TITLE
refactor(proto): delete the hand-written KeepAlive, Ping and Pong (ENG-12064)

### DIFF
--- a/crates/hyperion-minecraft-proto/src/packets/configuration.rs
+++ b/crates/hyperion-minecraft-proto/src/packets/configuration.rs
@@ -604,73 +604,7 @@ impl<'a> Decode<'a> for UpdateTags<'a> {
     }
 }
 
-// --- keep alive, ping, disconnect -----------------------------------------
-
-/// `minecraft:keep_alive`, both directions (`Clientbound`- and
-/// `ServerboundKeepAlivePacket`).
-///
-/// The two classes have the same one-field body, so one type covers both.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct KeepAlive {
-    /// Opaque value the client echoes back.
-    pub id: i64,
-}
-
-impl Encode for KeepAlive {
-    fn encode(&self, writer: &mut Writer) -> Result<()> {
-        writer.i64(self.id);
-        Ok(())
-    }
-}
-
-impl Decode<'_> for KeepAlive {
-    fn decode(reader: &mut Reader<'_>) -> Result<Self> {
-        Ok(Self { id: reader.i64()? })
-    }
-}
-
-/// `minecraft:ping`, clientbound (`ClientboundPingPacket`).
-///
-/// Distinct from the status-state ping: this one is a plain `int`, not the
-/// `long` [`crate::packets::status::PingRequest`] carries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Ping {
-    /// Opaque value returned in the [`Pong`].
-    pub id: i32,
-}
-
-impl Encode for Ping {
-    fn encode(&self, writer: &mut Writer) -> Result<()> {
-        writer.i32(self.id);
-        Ok(())
-    }
-}
-
-impl Decode<'_> for Ping {
-    fn decode(reader: &mut Reader<'_>) -> Result<Self> {
-        Ok(Self { id: reader.i32()? })
-    }
-}
-
-/// `minecraft:pong`, serverbound (`ServerboundPongPacket`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Pong {
-    /// The value from the matching [`Ping`].
-    pub id: i32,
-}
-
-impl Encode for Pong {
-    fn encode(&self, writer: &mut Writer) -> Result<()> {
-        writer.i32(self.id);
-        Ok(())
-    }
-}
-
-impl Decode<'_> for Pong {
-    fn decode(reader: &mut Reader<'_>) -> Result<Self> {
-        Ok(Self { id: reader.i32()? })
-    }
-}
+// --- disconnect -----------------------------------------------------------
 
 /// `minecraft:disconnect`, clientbound (`ClientboundDisconnectPacket`).
 ///

--- a/crates/hyperion-minecraft-proto/tests/configuration.rs
+++ b/crates/hyperion-minecraft-proto/tests/configuration.rs
@@ -21,9 +21,11 @@ use hyperion_minecraft_proto::{
     nbt::{Compound, Tag},
     packets::configuration::{
         AcceptCodeOfConduct, ChatVisiblity, ClientInformation, CodeOfConduct, CustomPayload,
-        Disconnect, FinishConfiguration, FinishConfigurationAck, HumanoidArm, KeepAlive, KnownPack,
-        ParticleStatus, Ping, Pong, RegistryData, RegistryEntry, RegistryTags, ResetChat,
-        SelectKnownPacks, TagEntry, UpdateEnabledFeatures, UpdateTags,
+        Disconnect, FinishConfiguration, FinishConfigurationAck, HumanoidArm, KnownPack,
+        ParticleStatus, RegistryData, RegistryEntry, RegistryTags, ResetChat, SelectKnownPacks,
+        TagEntry, UpdateEnabledFeatures, UpdateTags,
+        clientbound::{KeepAlive as ClientboundKeepAlive, Ping},
+        serverbound::{KeepAlive as ServerboundKeepAlive, Pong},
     },
     text::Component,
 };
@@ -376,23 +378,24 @@ fn empty_update_tags_matches_vanilla() {
 // --- keep alive, ping, disconnect, code of conduct ------------------------
 
 #[test]
-fn keep_alive_matches_vanilla() {
-    // Both ClientboundKeepAlivePacket and ServerboundKeepAlivePacket printed
-    // the same bytes for the same id, which is why one type covers both.
-    round_trip(
-        &KeepAlive {
-            id: 0x0123_4567_89ab_cdef,
-        },
-        &hex("0123456789abcdef"),
-    );
+fn keep_alive_matches_vanilla_in_both_directions() {
+    // Both ClientboundKeepAlivePacket and ServerboundKeepAlivePacket print the
+    // same bytes for the same id. That used to be asserted by *asserting it*:
+    // one hand-written type stood in for both classes, and the claim that they
+    // agree was the comment above it rather than anything a test ran. The
+    // generator emits one type per direction, so both go through the same
+    // fixture and the agreement is checked instead of assumed.
+    let bytes = hex("0123456789abcdef");
+    round_trip(&ClientboundKeepAlive(0x0123_4567_89ab_cdef), &bytes);
+    round_trip(&ServerboundKeepAlive(0x0123_4567_89ab_cdef), &bytes);
 }
 
 #[test]
 fn ping_and_pong_are_ints_not_longs() {
     // The configuration-state ping is an int; the status-state one is a long.
     let bytes = hex("0abcdef1");
-    round_trip(&Ping { id: 0x0abc_def1 }, &bytes);
-    round_trip(&Pong { id: 0x0abc_def1 }, &bytes);
+    round_trip(&Ping(0x0abc_def1), &bytes);
+    round_trip(&Pong(0x0abc_def1), &bytes);
 }
 
 #[test]


### PR DESCRIPTION
`packets/common.rs` states the rule these three broke:

> One Java class is one Rust type here too, re-exported into each state that sends it, so a value built for one state is the same value in another.

`configuration.rs` hand-wrote `KeepAlive { id: i64 }`, `Ping { id: i32 }` and `Pong { id: i32 }` with manual `Encode`/`Decode`, while the generator already emitted `common::{clientbound,serverbound}::KeepAlive(i64)`, `clientbound::Ping(i32)` and `serverbound::Pong(i32)` from `protocol.json` and re-exported them into `configuration::clientbound` and `configuration::serverbound`. Two Rust types per Java class, identical wire layout, the same names inside one crate.

Fixes ENG-12064

## The cost, which is how this was found

Writing `KeepAlive { id }` against a body decoded as `play::serverbound::KeepAlive` fails with

```
error[E0769]: tuple variant `c2s::KeepAlive` written as struct variant
help: use the tuple variant pattern syntax instead
```

which reads as "you got the field name wrong" rather than "there are two of these and you picked the other one". Hit while writing `egress::ping` in #1113.

## The test gets stronger, not weaker

The round trip test's comment claimed the two Java classes print identical bytes, and then tested a single hand-written type standing in for both. So the agreement between the directions was asserted by the comment and by nothing that ran. Both directions now go through the same fixture:

```rust
let bytes = hex("0123456789abcdef");
round_trip(&ClientboundKeepAlive(0x0123_4567_89ab_cdef), &bytes);
round_trip(&ServerboundKeepAlive(0x0123_4567_89ab_cdef), &bytes);
```

Watched fail: flipping one of the two ids by a nibble turns it red.

## Verification

`cargo test --workspace` green (23 pass in `tests/configuration.rs`), `cargo clippy --all-targets --all-features -- -D warnings` green. Nothing outside the proto crate's own tests referenced the deleted types. The proto coverage baseline is unaffected: it tracks what `extract-protocol.py` can recover from the jar, not which Rust types are hand-written.

---

Authored by Claude Opus 5 via Claude Code, driven and reviewed by @andrewgazelka.
