### PR TITLE
fix(hot-reload): one package selection for one flecs_ecs, and stop the engine dylib hiding LMDB (ENG-12053, ENG-12067)

### DIFF
--- a/crates/hyperion/build.rs
+++ b/crates/hyperion/build.rs
@@ -1,0 +1,85 @@
+//! Re-exports LMDB's C symbols from this crate's dylib.
+//!
+//! ## Why this is needed
+//!
+//! rustc links a `dylib` with its own anonymous version script ending in `local: *`, which
+//! demotes every symbol it did not generate. `heed` pulls in `liblmdb.a`, so LMDB's C ends
+//! up absorbed into `libhyperion.so` and hidden -- present and unreachable:
+//!
+//! ```text
+//! $ readelf --dyn-syms libhyperion.so | grep -c mdb_
+//! 0
+//! $ readelf --syms libhyperion.so | grep mdb_env_open
+//!  14356: 0000000000d0df3c   933 FUNC    LOCAL  DEFAULT   13 mdb_env_open
+//! ```
+//!
+//! 133 definitions, none reachable. That is fatal rather than merely wasteful because
+//! `heed`'s API is generic: every consumer monomorphises heed's code into its own rlib and
+//! emits its own calls to `mdb_*`. `hyperion-permission` is such a consumer and is linked
+//! into an event's server binary statically, while rustc suppresses LMDB's own `-llmdb` on
+//! the grounds that an upstream dylib already provides it. The result is a link that fails
+//! only once `hyperion` is built as a dylib, which is to say only under hot reload:
+//!
+//! ```text
+//! rust-lld: error: undefined symbol: mdb_dbi_open
+//! ```
+//!
+//! Re-exporting keeps ONE copy of LMDB in the process. Linking a second `liblmdb.a` into
+//! the executable would also make the link succeed, and would put two copies of a C
+//! library with process-global state in one process -- the same shape
+//! `checks.hot-reload-index-probe` exists to reject for `flecs_ecs`.
+//!
+//! Neither `-Wl,--export-dynamic` nor `-Wl,--export-dynamic-symbol=mdb_*` reverses a
+//! version-script demotion; the latter was measured here leaving the exported count at
+//! zero, independently reproducing what `flecs_ecs/build.rs` documents for `ecs_*`. What
+//! works is a second version script: ld merges them, and an explicit pattern beats a `*`
+//! wildcard, so naming these globs promotes exactly them while leaving rustc's own export
+//! list intact.
+//!
+//! ## The general rule
+//!
+//! Any native static library absorbed into this dylib, whose symbols a downstream
+//! monomorphisation calls, needs its glob here. The signature is an undefined `foo_*` at
+//! an event's final link whose definition is `LOCAL` in `libhyperion.so`'s `.symtab`.
+//! `flecs_ecs` carries its own copy of this build script for `ecs_*`, because a build
+//! script's `rustc-link-arg` applies to its own crate's artifacts and nothing else.
+
+// A build script talks to cargo over stdout and has no other channel, so the
+// workspace-wide `print_stdout = deny` does not apply to this file.
+#![allow(clippy::print_stdout, reason = "the cargo build-script protocol is stdout")]
+
+/// Spelled without the leading underscore Mach-O adds.
+const LMDB_EXPORTS: [&str; 1] = ["mdb_*"];
+
+fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if matches!(target_os.as_str(), "macos" | "ios") {
+        // ld64 unions -exported_symbol with the export list rustc generates, so no second
+        // script is needed and none is available.
+        for pattern in LMDB_EXPORTS {
+            println!("cargo::rustc-link-arg=-Wl,-exported_symbol,_{pattern}");
+        }
+        return;
+    }
+
+    let out_dir = std::env::var("OUT_DIR").expect("cargo always sets OUT_DIR");
+    let script = std::path::Path::new(&out_dir).join("lmdb-exports.map");
+
+    let mut text = String::from("{\n  global:\n");
+    for pattern in LMDB_EXPORTS {
+        text.push_str("    ");
+        text.push_str(pattern);
+        text.push_str(";\n");
+    }
+    // Deliberately no `local:` clause. This script adds to rustc's export list; a
+    // `local: *` here would hide every Rust symbol a consumer resolves through.
+    text.push_str("};\n");
+
+    std::fs::write(&script, text).expect("failed to write the lmdb version script");
+    println!(
+        "cargo::rustc-link-arg=-Wl,--version-script={}",
+        script.display()
+    );
+}

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -773,6 +773,128 @@ wearing a different hat, and every apply restarts. There is a cheap gate for it:
 three derivations, touch a file in the rules crate, rebuild, and assert that exactly one of
 the three paths changed.
 
+### One `flecs_ecs` needs one package selection, not one derivation
+
+Splitting the build across three derivations reintroduced the problem the split exists to
+prevent. Each derivation runs its own `cargo build`, and building `-p hyperion` in one and
+`-p smash-rules` in another put two `flecs_ecs` in one target directory:
+
+```
+libflecs_ecs-a576c74c3728f55c.so    from -p hyperion
+libflecs_ecs-af57d040ba838c15.so    from -p smash-rules
+```
+
+Two `flecs_ecs` is two `INDEX_POOL`s, which is exactly what `checks.hot-reload-index-probe`
+rejects. The first guess was that package *selection* and *source filtering* must differ per
+derivation by design, so no arrangement of inputs could unify them — that fingerprint
+equality across derivations was structurally impossible. That guess was wrong, and
+`cargo build --unit-graph` says why in about a minute.
+
+The `flecs_ecs` unit is **byte-identical** under both selections: same 23 features, same
+profile, same `crate-types = ["dylib", "rlib"]`. What differs is three of its transitive
+dependencies, whose metadata hashes cargo folds into the dependent's:
+
+| crate | `-p hyperion` | `-p smash-rules` |
+| --- | --- | --- |
+| `bitflags` | `serde`, `serde_core`, `std` | (none) |
+| `libc` | `default`, `std` | (none) |
+| `syn` | ..., `fold`, `visit` | (fewer) |
+
+`bitflags` is a direct dependency of `flecs_ecs`. Cargo resolves features over the packages
+named on the command line — `-p hyperion` reaches 473 units and `-p smash-rules` reaches 75 —
+so package selection alone moves the hash.
+
+Which makes the fix cheap and structural rather than clever: **pass the same selection string
+to every derivation.** Feature resolution reads manifests and never source, and `mkSource`
+already puts every workspace member's `Cargo.toml` into every tree, stubbing only the `.rs`
+bodies. So all three invocations resolve over identical inputs by construction. A derivation
+whose source stubs a package still compiles that package's dependency graph — which is
+exactly the seed the others want — and then compiles an empty `lib.rs` for the package
+itself.
+
+The rule that falls out, and the one to keep: the selection may not be narrowed to "the
+packages this derivation ships", and may not be a function of the event being built. Either
+is the source split written out a second time, in a place where its only symptom is a reload
+that silently indexes one world two different ways.
+
+### The seed may only carry artifacts whose source the consumer agrees with
+
+`hyperion-dylibs` tars its target directory so the other two do not recompile the engine, and
+they date everything to 2100 because cargo decides freshness by mtime and everything unpacked
+from the store shares one normalised timestamp. Once the selection was unified, that seed
+also contained a `libsmash.rlib` built from a **stub** — and dated into the future, so the
+consuming derivation never rebuilt it from the real source:
+
+```
+error[E0432]: unresolved import `smash::init_game`
+ --> events/smash/src/main.rs:1:5
+1 | use smash::init_game;
+  |            no `init_game` in the root
+```
+
+`hyperion-dylibs` therefore `cargo clean -p`s every stubbed event member before tarring, with
+a guard that fails the build if a stub artifact survives. Cleaning before the copy is also
+what keeps a stub `libsmash_rules.so` — same filename as the real rules dylib, none of its
+systems — from being shipped beside the engine and landing on every event binary's rpath.
+
+### An engine dylib hides the C libraries it swallows
+
+`smash-server` failed to link with eight undefined LMDB symbols, and the cause is not where
+the error points. `libhyperion.so` contains LMDB's code and hides every byte of it:
+
+```
+$ readelf --dyn-syms libhyperion.so | grep -c mdb_
+0
+$ readelf --syms libhyperion.so | grep mdb_env_open
+ 14356: 0000000000d0df3c   933 FUNC    LOCAL  DEFAULT   13 mdb_env_open
+```
+
+133 definitions, every one `LOCAL`. rustc links a Rust `dylib` with its own anonymous version
+script ending in `local: *`, which demotes every symbol arriving from a native static
+archive. The discriminator is that `ecs_*` (77) and `flecs_*` (22) *are* exported while
+`mdb_`, `AWS_LC` and `deflate` are all at zero — flecs is visible only because `flecs_ecs`
+ships a `build.rs` that adds a second version script for precisely this reason.
+
+That is fatal rather than merely wasteful because `heed`'s API is generic: every consumer
+monomorphises heed's code into its own rlib and emits its own `mdb_*` calls.
+`hyperion-permission` is such a consumer and links into an event's binary statically, while
+rustc suppresses lmdb's own `-llmdb` on the grounds that an upstream dylib already provides
+it.
+
+`-Wl,--export-dynamic-symbol=mdb_*` does not fix it — measured here leaving the exported
+count at zero, independently reproducing what `flecs_ecs/build.rs` documents for `ecs_*`.
+A second version script does, and it has to live in the crate that *is* the dylib, because a
+build script's `rustc-link-arg` applies to its own crate's artifacts and nothing else. That
+is what `crates/hyperion/build.rs` is: 70 exported `mdb_*` after, `mdb_env_open` `GLOBAL`.
+
+This keeps one copy of LMDB in the process. Linking a second `liblmdb.a` into the executable
+would also make the link succeed, and would put two copies of a C library with process-global
+state in one process — the same shape the index probe exists to reject for flecs. The general
+signature, for the next native library that hits this: an undefined `foo_*` at an event's
+final link whose definition is `LOCAL` in `libhyperion.so`'s `.symtab`.
+
+### The boundary, measured rather than asserted
+
+`checks.hot-reload-source-split` compares the source trees. The property it stands in for is
+about derivation inputs, and that is worth checking directly at least once:
+
+```
+                 baseline                          after a rules-only edit
+hyperion-dylibs  b5lxh69r...-hyperion-dylibs.drv   b5lxh69r...  (unchanged)
+smash-server     wz26cwn7...-smash-server.drv      wz26cwn7...  (unchanged)
+smash-rules      4f0rqas7...-smash-rules.drv       hvvb5m74...  (MOVED)
+
+                                                   after a host (component) edit
+hyperion-dylibs                                    b5lxh69r...  (unchanged)
+smash-server                                       aza2i90m...  (MOVED)
+smash-rules                                        www61vnr...  (MOVED)
+```
+
+A rules edit moves the reload trigger and leaves `ExecStart` alone, so systemd reloads. A
+component edit moves `ExecStart`, so systemd restarts — which is the correct outcome, because
+a system compiled against a layout the world no longer holds is memory corruption rather than
+a stale build.
+
 ### Adopting it costs no scheduled restart
 
 Step 1 changes the host binary, so the running game server has to restart once to pick it

--- a/flake.nix
+++ b/flake.nix
@@ -1177,10 +1177,31 @@
           # Kept out of `cargoUnit` because that builder is rlib-only, and split
           # across three derivations because a rules edit has to move exactly
           # one store path. See nix/hot-reload/packaging.nix.
+          # One entry per game. smash is the first consumer, not the shape
+          # (ENG-12067): every hot-reload derivation, check and NixOS option
+          # below is a function of this list rather than of smash.
+          hotReloadEvents = [
+            {
+              name = "smash";
+              hostCrate = "events/smash";
+              rulesCrate = "events/smash-rules";
+            }
+          ];
+
           hotReload = import ./nix/hot-reload/packaging.nix {
             inherit lib pkgs workspace rustToolchain nativeBuildInputs;
             root = ./.;
+            events = hotReloadEvents;
           };
+
+          # One `<event>-server` and `<event>-rules` per event, so adding a game
+          # to `hotReloadEvents` gives it packages without naming it again here.
+          hotReloadPackages = lib.listToAttrs (
+            lib.concatMap (event: [
+              (lib.nameValuePair "${event.name}-server" hotReload.events.${event.name}.server)
+              (lib.nameValuePair "${event.name}-rules" hotReload.events.${event.name}.rules)
+            ]) hotReloadEvents
+          );
 
           # The same game servers, compiled with `debug_assertions` on -- the
           # dev profile `nix run .#smash` runs and the operator actually plays.
@@ -1438,31 +1459,41 @@
             # real file, every rules edit moves `ExecStart` and every apply
             # restarts, dropping every connected player while the pipeline stays
             # green.
-            hot-reload-source-split = pkgs.runCommand "hyperion-hot-reload-source-split" { } ''
-              set -eu
-              server=${hotReload.serverSource}/events/smash-rules/src/lib.rs
-              rules=${hotReload.rulesSource}/events/smash-rules/src/lib.rs
-              engine=${hotReload.dylibSource}/events/smash/src/lib.rs
+            hot-reload-source-split =
+              pkgs.runCommand "hyperion-hot-reload-source-split" { }
+                (
+                  ''
+                    set -eu
+                  ''
+                  + lib.concatMapStrings (event: ''
+                    echo "checking ${event.name}"
+                    server=${hotReload.events.${event.name}.serverSource}/${event.rulesCrate}/src/lib.rs
+                    rules=${hotReload.events.${event.name}.rulesSource}/${event.rulesCrate}/src/lib.rs
+                    engine=${hotReload.dylibSource}/${event.hostCrate}/src/lib.rs
 
-              if [ -s "$server" ]; then
-                echo "smash-server's source carries the real rules crate." >&2
-                echo "Every rules edit would move ExecStart and restart the server." >&2
-                exit 1
-              fi
-              if [ ! -s "$rules" ]; then
-                echo "smash-rules' source carries a stub, not the rules crate." >&2
-                exit 1
-              fi
-              if [ -s "$engine" ]; then
-                echo "hyperion-dylibs' source carries the smash host crate." >&2
-                echo "A host edit would move the engine dylibs and restart." >&2
-                exit 1
-              fi
-              # The real file has to actually be the one in the tree, not merely
-              # non-empty: a stub that grew a comment would pass the size test.
-              cmp "$rules" ${./events/smash-rules/src/lib.rs}
-              touch $out
-            '';
+                    if [ -s "$server" ]; then
+                      echo "${event.name}-server's source carries the real rules crate." >&2
+                      echo "Every rules edit would move ExecStart and restart the server." >&2
+                      exit 1
+                    fi
+                    if [ ! -s "$rules" ]; then
+                      echo "${event.name}-rules' source carries a stub, not the rules crate." >&2
+                      exit 1
+                    fi
+                    if [ -s "$engine" ]; then
+                      echo "hyperion-dylibs' source carries ${event.name}'s host crate." >&2
+                      echo "A host edit would move the engine dylibs and restart." >&2
+                      exit 1
+                    fi
+                    # The real file has to actually be the one in the tree, not
+                    # merely non-empty: a stub that grew a comment would pass
+                    # the size test.
+                    cmp "$rules" ${./. + "/${event.rulesCrate}/src/lib.rs"}
+                  '') hotReloadEvents
+                  + ''
+                    touch $out
+                  ''
+                );
 
             hot-reload-index-probe = pkgs.runCommandCC "hyperion-hot-reload-index-probe" {
               inherit nativeBuildInputs;
@@ -2030,7 +2061,7 @@
               minecraft-encode = minecraft.vanillaEncoder;
             });
 
-          packages = {
+          packages = hotReloadPackages // {
             default = gameBinaries.bedwars;
             # smash is stamped and the other two are not, because smash is the
             # only one that reads the stamp: `nix/modules/game-server.nix`
@@ -2039,7 +2070,7 @@
             smash = stamped gameBinaries.smash;
             inherit (gameBinaries) bedwars hyperion-proxy;
             rust-mc-bot = named "rust-mc-bot" workspace.binaries.rust-mc-bot;
-            inherit (hotReload) hyperion-dylibs smash-server smash-rules;
+            inherit (hotReload) hyperion-dylibs;
 
             minecraft-server-jar = minecraft.serverJar;
             minecraft-data = minecraft.generatedData;

--- a/nix/hot-reload/packaging.nix
+++ b/nix/hot-reload/packaging.nix
@@ -13,21 +13,40 @@
 # A store path is a function of a derivation's inputs, so "which paths move" is
 # decided entirely by which sources reach which derivation:
 #
-#   hyperion-dylibs  crates/*                          an engine change
-#   smash-server     crates/* + events/smash           a component or engine change
-#   smash-rules      crates/* + events/smash + rules   a rules change
+#   hyperion-dylibs   crates/*                       an engine change
+#   <event>-server    crates/* + host crate          a component or engine change
+#   <event>-rules     crates/* + host + rules crate  a rules change
 #
 # Nobody has to remember the rule. A component's layout lives in the host crate
 # and a system's body lives in the rules crate, so the source split is the rule.
 #
+# `smash` is the first consumer, not the shape (ENG-12067). One engine dylib set
+# is shared by every event; each event named in `events` gets its own server and
+# rules pair. Adding an event is one attrset here and one `services.
+# hyperion-game-server` instance, with no smash-shaped path anywhere between.
+#
 # See docs/hot-reload.md, "Packaging: three derivations, because two would
 # restart", for the measurements behind this.
-{ lib, pkgs, workspace, rustToolchain, nativeBuildInputs, root }:
+{
+  lib,
+  pkgs,
+  workspace,
+  rustToolchain,
+  nativeBuildInputs,
+  root,
+  # Each entry is one game: `{ name; hostCrate; rulesCrate; }`, where the two
+  # crates are workspace-member paths. `name` is what the NixOS module keys on
+  # (`/etc/hyperion/<name>-rules.so`) and what the derivations are called.
+  events,
+}:
 let
   # Read from the manifest rather than restated here, so a new member cannot be
   # silently omitted from the stub list and fail one derivation much later.
   members = (lib.importTOML (root + "/Cargo.toml")).workspace.members;
   crateMembers = lib.filter (member: lib.hasPrefix "crates/" member) members;
+  # Package name, not directory basename: `cargo clean -p` takes the former and
+  # the two are only equal by convention.
+  packageNameOf = member: (lib.importTOML (root + "/${member}/Cargo.toml")).package.name;
 
   rootFiles = map (file: root + "/${file}") [
     "Cargo.toml"
@@ -84,23 +103,61 @@ let
       done
     '';
 
+  eventMembers = lib.subtractLists crateMembers members;
+
   dylibSource = mkSource {
     pname = "dylibs";
     realDirs = [ "crates" ];
     realMembers = crateMembers;
   };
-  serverSource = mkSource {
-    pname = "server";
-    realDirs = [ "crates" "events/smash" ];
-    realMembers = crateMembers ++ [ "events/smash" ];
-  };
-  rulesSource = mkSource {
-    pname = "rules";
-    realDirs = [ "crates" "events/smash" "events/smash-rules" ];
-    realMembers = crateMembers ++ [ "events/smash" "events/smash-rules" ];
-  };
+
+  # The engine packages every event links, ahead of the events themselves so
+  # that a one-event workspace produces the selection string this was measured
+  # against.
+  enginePackages = [ "hyperion" "hyperion-hot-reload" ];
+  eventPackages = lib.concatMap (event: [
+    (packageNameOf event.hostCrate)
+    (packageNameOf event.rulesCrate)
+  ]) events;
 
   profile = "release";
+
+  # THE SAME PACKAGE SELECTION IN ALL THREE DERIVATIONS, for the same reason the
+  # RUSTFLAGS string is shared: it decides `flecs_ecs`'s `-C metadata`.
+  #
+  # Cargo resolves features over the packages named on the command line, and it
+  # folds every dependency's metadata hash into the dependent's. So a selection
+  # that reaches a different set of crates gives `flecs_ecs` a different hash
+  # even though nothing about `flecs_ecs` itself changed. Measured with
+  # `cargo build --unit-graph` over the same tree and target directory
+  # (ENG-12053): the `flecs_ecs` unit is byte-identical under `-p hyperion` and
+  # `-p smash-rules` -- same features, same profile, same `crate-types` -- and
+  # three of its transitive dependencies are not.
+  #
+  #     bitflags   -p hyperion: serde, serde_core, std   -p smash-rules: (none)
+  #     libc       -p hyperion: default, std             -p smash-rules: (none)
+  #     syn        -p hyperion: ..., fold, visit         -p smash-rules: (fewer)
+  #
+  # `bitflags` is a direct dependency of `flecs_ecs`, so that alone was the two
+  # hashes the seed failed to reuse: `libflecs_ecs-a576c74c3728f55c.so` from
+  # `-p hyperion` and `libflecs_ecs-af57d040ba838c15.so` from `-p smash-rules`,
+  # both in one target directory.
+  #
+  # Naming every package in every derivation fixes it by construction rather
+  # than by luck, because resolution reads manifests and never source: `mkSource`
+  # puts every member's `Cargo.toml` in every tree and stubs only the `.rs`
+  # bodies, so all three invocations resolve over identical inputs. A derivation
+  # whose source stubs a package still compiles that package's dependency graph
+  # -- which is exactly the seed the other two want -- and then compiles an
+  # empty `lib.rs` for the package itself.
+  #
+  # Do not narrow this to "the packages this derivation ships", and do not make
+  # it a function of the event being built. Either is the split, written out
+  # again: two derivations that disagree get two `flecs_ecs`, and the only
+  # symptom is a reload that silently indexes one world two different ways.
+  selection = lib.concatMapStringsSep " " (package: "-p ${package}") (
+    enginePackages ++ eventPackages
+  );
   sysrootLib = "${rustToolchain}/lib/rustlib/${pkgs.stdenv.hostPlatform.rust.rustcTarget}/lib";
   inherit (pkgs.stdenv.hostPlatform) extensions;
 
@@ -178,14 +235,6 @@ let
 
   # Reuse the engine's artifacts rather than compiling equivalents of them.
   #
-  # THIS DOES NOT YET HOLD; see ENG-12053. Measured on x86_64-linux, the rules
-  # dylib asks for `libflecs_ecs-2c5aa556f4fa166e.so` while this derivation
-  # ships `libflecs_ecs-c4fb60682bf29e00.so`, so the seed was not reused for
-  # that crate and it was recompiled -- most likely because `-p hyperion` and
-  # `-p smash-rules` resolve different features onto it. Two compilations is
-  # two `INDEX_POOL`s, which is what `checks.hot-reload-index-probe` rejects.
-  # The paragraph below is the intent, not yet the fact.
-  #
   # This is not a build-time optimisation, it is what makes the boundary sound.
   # If the server and the rules each compiled their own `hyperion`, each would
   # get its own `-C metadata` hash -- the source ids differ, because the two
@@ -198,6 +247,19 @@ let
   # Artifact mtimes are moved ahead of the sources', because cargo decides
   # freshness by comparing them and everything unpacked from the store shares
   # one normalised timestamp.
+  #
+  # That is also why the seed may only carry artifacts whose SOURCE is identical
+  # in the consuming derivation. `hyperion-dylibs` compiles the event members
+  # from stubs, and dating those artifacts to 2100 told cargo an empty
+  # `libsmash.rlib` was fresher than the real `events/smash` -- so the real
+  # source was never compiled and the binary failed against the stub:
+  #
+  #     error[E0432]: unresolved import `smash::init_game`
+  #      --> events/smash/src/main.rs:1:5
+  #                no `init_game` in the root
+  #
+  # `hyperion-dylibs` therefore drops them before tarring; `crates/*` is real in
+  # all three trees and stays.
   seed = ''
     mkdir -p target
     tar -C target -xf ${hyperion-dylibs}/share/cargo-target.tar
@@ -208,12 +270,32 @@ let
   hyperion-dylibs = pkgs.runCommandCC "hyperion-dylibs" common ''
     ${setup dylibSource}
     export RUSTFLAGS=${lib.escapeShellArg rustFlags}
-    cargo build --profile ${profile} --offline -p hyperion -p hyperion-hot-reload
+    cargo build --profile ${profile} --offline ${selection}
+
+    # The event members were compiled from stubs here; see `seed`. Cleaning
+    # them is what makes the tar safe to unpack over a real source tree.
+    cargo clean --profile ${profile} --offline ${
+      lib.concatMapStringsSep " " (member: "-p ${packageNameOf member}") eventMembers
+    }
+    for package in ${lib.escapeShellArgs (map packageNameOf eventMembers)}; do
+      stale=$(find target -name "lib''${package//-/_}-*" -o -name "''${package//-/_}-*" | head -20)
+      if [ -n "$stale" ]; then
+        echo "cargo clean left stub artifacts for $package:" >&2
+        echo "$stale" >&2
+        exit 1
+      fi
+    done
 
     mkdir -p "$out/lib" "$out/share"
     # `deps/` as well as the profile directory: cargo leaves an unhashed copy of
     # a workspace member's dylib in `target/${profile}`, but a dependency's
     # dylib only in `deps/`, under the metadata hash DT_NEEDED actually names.
+    #
+    # The clean above is what makes this glob correct: the events were compiled
+    # from stubs, so before it ran `target/${profile}` also held a stub
+    # `libsmash_rules.so`, and shipping that beside the engine puts a file with
+    # the real rules dylib's exact name, and none of its systems, on the rpath
+    # of every event binary. Clean first and everything left is the engine.
     cp target/${profile}/*${extensions.sharedLibrary} "$out/lib/"
     cp target/${profile}/deps/libflecs_ecs-*${extensions.sharedLibrary} "$out/lib/"
     ${lib.optionalString pkgs.stdenv.hostPlatform.isElf ''
@@ -226,43 +308,74 @@ let
     tar -C target -cf "$out/share/cargo-target.tar" ${profile}
   '';
 
-  # What `ExecStart` names. Moves on a component or engine change, which is
-  # exactly when a restart is correct: a component's layout is defined here, and
-  # a system compiled against a layout the world no longer holds is memory
-  # corruption rather than a stale build.
-  smash-server = pkgs.runCommandCC "smash-server" (common // { meta.mainProgram = "smash"; }) ''
-    ${setup serverSource}
-    ${seed}
-    export RUSTFLAGS=${lib.escapeShellArg rustFlags}
-    cargo build --profile ${profile} --offline -p smash
+  # One event's pair. The engine dylibs above are shared by all of them; only
+  # these two move when an event's own code does.
+  forEvent =
+    event:
+    let
+      hostPackage = packageNameOf event.hostCrate;
+      rulesPackage = packageNameOf event.rulesCrate;
+      # cargo spells a dylib after the crate name, which is the package name
+      # with dashes folded to underscores.
+      rulesLib = "lib${lib.replaceStrings [ "-" ] [ "_" ] rulesPackage}${extensions.sharedLibrary}";
 
-    mkdir -p "$out/bin"
-    cp target/${profile}/smash "$out/bin/smash"
-    ${setRunPath [ "${hyperion-dylibs}/lib" ] ''"$out/bin/smash"''}
-    ${requireResolved ''"$out/bin/smash"''}
-  '';
+      serverSource = mkSource {
+        pname = "${event.name}-server";
+        realDirs = [ "crates" event.hostCrate ];
+        realMembers = crateMembers ++ [ event.hostCrate ];
+      };
+      rulesSource = mkSource {
+        pname = "${event.name}-rules";
+        realDirs = [ "crates" event.hostCrate event.rulesCrate ];
+        realMembers = crateMembers ++ [ event.hostCrate event.rulesCrate ];
+      };
 
-  # What `X-Reload-Triggers` names, and the only path a rules-only change is
-  # allowed to move.
-  smash-rules = pkgs.runCommandCC "smash-rules" common ''
-    ${setup rulesSource}
-    ${seed}
-    export RUSTFLAGS=${lib.escapeShellArg rustFlags}
-    cargo build --profile ${profile} --offline -p smash-rules
+      # What `ExecStart` names. Moves on a component or engine change, which is
+      # exactly when a restart is correct: a component's layout is defined in the
+      # host crate, and a system compiled against a layout the world no longer
+      # holds is memory corruption rather than a stale build.
+      server =
+        pkgs.runCommandCC "${event.name}-server" (common // { meta.mainProgram = hostPackage; })
+          ''
+            ${setup serverSource}
+            ${seed}
+            export RUSTFLAGS=${lib.escapeShellArg rustFlags}
+            cargo build --profile ${profile} --offline ${selection}
 
-    mkdir -p "$out/lib"
-    cp target/${profile}/libsmash_rules${extensions.sharedLibrary} "$out/lib/"
-    ${setRunPath [ "${hyperion-dylibs}/lib" ] ''"$out/lib/libsmash_rules${extensions.sharedLibrary}"''}
-    ${requireResolved ''"$out/lib/libsmash_rules${extensions.sharedLibrary}"''}
-  '';
+            mkdir -p "$out/bin"
+            cp target/${profile}/${hostPackage} "$out/bin/${hostPackage}"
+            ${setRunPath [ "${hyperion-dylibs}/lib" ] ''"$out/bin/${hostPackage}"''}
+            ${requireResolved ''"$out/bin/${hostPackage}"''}
+          '';
+
+      # What `X-Reload-Triggers` names, and the only path a rules-only change is
+      # allowed to move.
+      rules = pkgs.runCommandCC "${event.name}-rules" common ''
+        ${setup rulesSource}
+        ${seed}
+        export RUSTFLAGS=${lib.escapeShellArg rustFlags}
+        cargo build --profile ${profile} --offline ${selection}
+
+        mkdir -p "$out/lib"
+        cp target/${profile}/${rulesLib} "$out/lib/"
+        ${setRunPath [ "${hyperion-dylibs}/lib" ] ''"$out/lib/${rulesLib}"''}
+        ${requireResolved ''"$out/lib/${rulesLib}"''}
+      '';
+    in
+    {
+      inherit
+        server
+        rules
+        serverSource
+        rulesSource
+        rulesLib
+        ;
+    };
 in
 {
-  inherit
-    hyperion-dylibs
-    smash-server
-    smash-rules
-    dylibSource
-    serverSource
-    rulesSource
-    ;
+  inherit hyperion-dylibs dylibSource;
+  # Keyed by event name so a consumer names the game rather than a path.
+  events = lib.listToAttrs (
+    map (event: lib.nameValuePair event.name (forEvent event)) events
+  );
 }


### PR DESCRIPTION
Closes the two blockers in ENG-12053 and lands the ENG-12067 generalization in the same change, because the fix restructures the same three derivations that would have to be generalized.

## What was wrong, and what the measurements say

**The two `flecs_ecs` hashes are feature unification, not crate-type.** The standing conclusion was that fingerprint equality across derivations was structurally impossible, since selection and source filters must differ per derivation by design. `cargo build --unit-graph` disagrees. The `flecs_ecs` unit is byte-identical under `-p hyperion` and `-p smash-rules` — same 23 features, same profile, same `crate-types = ["dylib", "rlib"]`. Three of its transitive dependencies are not, and cargo folds their metadata hashes into it:

| crate | `-p hyperion` | `-p smash-rules` |
| --- | --- | --- |
| `bitflags` | `serde`, `serde_core`, `std` | (none) |
| `libc` | `default`, `std` | (none) |
| `syn` | ..., `fold`, `visit` | (fewer) |

`bitflags` is a direct dependency of `flecs_ecs`. Cargo resolves features over the packages named on the command line — `-p hyperion` reaches 473 units, `-p smash-rules` reaches 75 — so selection alone moved the hash.

So every derivation now passes the same selection string. This works by construction rather than by luck: resolution reads manifests and never source, and `mkSource` already puts every member's `Cargo.toml` in every tree, stubbing only the `.rs` bodies.

**The seed was serving stub-built artifacts.** With the selection unified, `hyperion-dylibs`' target tarball contained a `libsmash.rlib` compiled from a stub, dated to 2100 like everything else, so consumers never rebuilt from real source (`error[E0432]: unresolved import smash::init_game`). Stubbed event members are now `cargo clean -p`ed before tarring, with a guard that fails if one survives. Doing that before the copy also stops a stub `libsmash_rules.so` — the real dylib's exact filename, none of its systems — shipping beside the engine.

**The LMDB link failure is a version-script demotion.** `libhyperion.so` holds LMDB's code and hides all of it:

```
$ readelf --dyn-syms libhyperion.so | grep -c mdb_
0
$ readelf --syms libhyperion.so | grep mdb_env_open
 14356: 0000000000d0df3c   933 FUNC    LOCAL  DEFAULT   13 mdb_env_open
```

133 definitions, every one `LOCAL`. rustc links a Rust dylib with its own anonymous version script ending `local: *`. The discriminator is that `ecs_*` (77) and `flecs_*` (22) *are* exported while `mdb_`, `AWS_LC` and `deflate` sit at zero — flecs is visible only because `flecs_ecs` ships a `build.rs` doing exactly this. `heed`'s API is generic, so `hyperion-permission` monomorphises heed into its own rlib and emits its own `mdb_*` calls while rustc suppresses `-llmdb`.

`--export-dynamic-symbol=mdb_*` does not reverse it (measured, still zero — independently reproducing what `flecs_ecs/build.rs` documents). `crates/hyperion/build.rs` adds a second version script instead: 70 exported after, `mdb_env_open` `GLOBAL`. That keeps **one** copy of LMDB in the process; linking a second `liblmdb.a` into the executable would also link, and would put two copies of a C library with process-global state in one process.

## Generality (ENG-12067)

`nix/hot-reload/packaging.nix` is now a function of an `events` list — `{ name; hostCrate; rulesCrate; }` — rather than of smash. One shared `hyperion-dylibs`; a `<event>-server` / `<event>-rules` pair per event; `checks.hot-reload-source-split` iterates the same list; `packages` are generated from it. Adding a game is one attrset in `flake.nix`.

## Evidence

All on dev-compute-6 (x86_64-linux). One flecs, one store path:

```
smash-rules   DT_NEEDED  libflecs_ecs-bf77c44af1eeb9f5.so
smash-server  DT_NEEDED  libflecs_ecs-bf77c44af1eeb9f5.so
both -> /nix/store/ya441i6w548yv0ym3py95l1cqy1jdyz1-hyperion-dylibs/lib/
```

The boundary itself, at the derivation level rather than by proxy:

```
                 baseline        rules-only edit    host (component) edit
hyperion-dylibs  b5lxh69r...     unchanged          unchanged
smash-server     wz26cwn7...     unchanged          aza2i90m...  MOVED
smash-rules      4f0rqas7...     hvvb5m74...  MOVED www61vnr...  MOVED
```

A rules edit moves the reload trigger and leaves `ExecStart` alone, so systemd reloads. A component edit moves `ExecStart`, so systemd restarts — correct, because a system compiled against a layout the world no longer holds is memory corruption rather than a stale build.

Green: `packages.{hyperion-dylibs,smash-server,smash-rules}`, `checks.{hot-reload-source-split,hot-reload-index-probe,hot-reload-registry-guard,smash-rules,clippy,fmt,nixos-modules,lint}`.

## What this does NOT do

- No reload IPC, no `ExecReload`, no title. The rules dylib builds and links against the same engine; nothing loads it yet.
- `nix/modules/game-server.nix` is untouched — no `reloadTriggers`, and the `stamped` wrapper that bakes `HYPERION_BUILD_REV` into `ExecStart` is still there, so every apply still restarts. That is the next change.
- The three derivations still each run their own `cargo build` rather than being one `cargoUnit` derivation per crate. `cargoUnit` is rlib-only; filed as ENG-12078 against index. The selection-string discipline this PR relies on is a comment, not something the build system enforces — which is the argument for fixing `cargoUnit` eventually.
- `crates/hyperion/build.rs` was untracked at first, so nix built without it and the symbols stayed hidden with no error anywhere. Filed as ENG-12077.

Authored by Claude Opus via Claude Code.
