### PR TITLE
feat(fleet): declared dev-machine node (hyperion-dev)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -122,6 +122,15 @@
             pkgs.pkg-config
           ];
 
+          # What it takes to build this repository, named once. `devShells.default`
+          # below installs it, and so does the `hyperion-dev` fleet node
+          # (nix/fleet/dev.nix), so a VM built to develop hyperion on cannot come
+          # up with a different compiler than `nix develop` hands a contributor.
+          devEnvironment = {
+            packages = nativeBuildInputs ++ cargoTools ++ [ rustToolchain ];
+            rustSrcPath = "${rustToolchain}/lib/rustlib/src/rust/library";
+          };
+
           # Every dev command carries the tools it needs, so `nix run .#lint`
           # works on a machine with nothing but nix installed.
           mkScript = name: { text, deps ? [ ], toolchain ? rustToolchain }:
@@ -1996,8 +2005,8 @@
         in
         {
           devShells.default = pkgs.mkShell {
-            nativeBuildInputs = nativeBuildInputs ++ cargoTools ++ [ rustToolchain ];
-            RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+            nativeBuildInputs = devEnvironment.packages;
+            RUST_SRC_PATH = devEnvironment.rustSrcPath;
           };
 
           apps = lib.mapAttrs
@@ -2062,6 +2071,10 @@
           # What CI enforces of this set is nix/ci/flake-gate.nix.
           inherit checks;
 
+          # Not a flake output: the fleet reads it to build the dev node, and
+          # `nix build .#devEnvironment` would be a name for something that is
+          # already `nix develop`.
+          inherit devEnvironment;
         };
 
       # The deployed fleet. `nix/fleet/default.nix` says at length why it lives
@@ -2073,11 +2086,16 @@
       # machine evaluates them. Taken from `mkSystem` rather than from
       # `self.packages` so the fleet does not depend on the attribute set it
       # contributes to.
-      fleet = import ./nix/fleet {
-        inherit index;
-        guestPackages = (mkSystem "x86_64-linux").packages;
-        inherit (self) nixosModules;
-      };
+      fleet =
+        let
+          guest = mkSystem "x86_64-linux";
+        in
+        import ./nix/fleet {
+          inherit index;
+          guestPackages = guest.packages;
+          guestDevEnvironment = guest.devEnvironment;
+          inherit (self) nixosModules;
+        };
 
       # Force every fleet node's toplevel and record what it resolved to,
       # WITHOUT building any of them. `unsafeDiscardStringContext` is what buys

--- a/nix/fleet/README.md
+++ b/nix/fleet/README.md
@@ -656,6 +656,157 @@ Treat that as a standing post-apply check, and confirm the rev is one
 `git merge-base --is-ancestor <rev> origin/main` accepts. ENG-11491 tracks
 making the apply refuse an unreachable rev rather than relying on the habit.
 
+## A dev machine in the fleet
+
+`hyperion-dev` is a fifth node and the only one that serves nothing. It exists
+so that the machine hyperion is built on is described in the same evaluation as
+the machines hyperion runs on -- the same argument the header makes for the
+fleet living in this repository at all, one step further back.
+
+```sh
+nix build .#hyperion-dev-system
+ix apply .#hyperion-dev
+ix shell hyperion-dev
+```
+
+Then, inside it, once:
+
+```sh
+cd /work/ix
+git clone https://github.com/hyperion-mc/hyperion
+```
+
+`/work/ix` is the platform's own workspace directory
+(`ix.profiles.base.shellWorkspace.directory`): it is pre-created by a tmpfiles
+rule and login shells land in it, so it is where a checkout is findable by
+somebody who did not make it. **Nothing clones for you, deliberately.** A clone
+is state rather than configuration -- activation would have to pick a revision,
+and every later apply would then either fight your working copy or ignore it,
+which is a worse contract than having no opinion. Reading is public and needs
+no credential; pushing needs yours, forwarded from your own machine, which is
+the point.
+
+The `nix build` line matters here for the same reason it does for the fleet
+(see "Build the fleet once, not once per VM" above) and more so: this node's
+closure carries a Rust toolchain the service nodes do not.
+
+### It is not in the fleet's network segment
+
+Every other node sets `ix.networking.groups = ["hyperion"]`, and that group is
+the only thing keeping an unproxied client off the game server. This one
+replaces it with `hyperion-dev`, so the box whose purpose is running code
+nobody has reviewed yet has no route to the world. The build-and-push loop
+needs none.
+
+Groups are joined at VM create, like `ipv4`, so this is not a property a
+re-apply can change on a VM that already exists: moving this node between
+segments is `ix rm` and apply again.
+
+### What the guest already has, and what it does not
+
+Nearly all of a dev box is answered by the platform, so `nix/fleet/dev.nix`
+adds a compiler and little else. Checkable in one command rather than believed:
+
+```sh
+nix eval --json .#nixosConfigurations.hyperion-dev.config --apply 'c: {
+  workspace = c.ix.profiles.base.shellWorkspace.directory;
+  git = c.programs.git.enable;
+  features = c.nix.settings.experimental-features;
+  substituters = c.nix.settings.substituters;
+}'
+```
+
+which answers `/work/ix`, `true`, a feature list including `flakes` and
+`ca-derivations`, and `cache.ix.dev` ahead of `cache.nixos.org`. That is what
+this flake's `nixConfig` block asks of whatever evaluates it, already true
+inside the guest, so the module restates none of it.
+
+**The `ix` CLI is not in there and cannot be added from this repository.**
+index packages no `ix` binary, and the CLI's repository is private while this
+one is public -- an unauthenticated `GET /repos/indexable-inc/ix` answers 404
+where `indexable-inc/index` answers 200 -- so a flake input naming it would
+break evaluation for every outside contributor and for the gate that runs on
+hosted runners. Type `ix` commands on your own machine against the VM. Anything
+that needs the CLI *inside* the guest, such as an agent creating its own
+sandbox, is out of reach until ENG-12081.
+
+**There is no RAM, CPU or disk knob to set.** A fleet node takes `modules`,
+`deployment`, `tags`, `groups`, `dependsOn`, `replicas` and `updateStrategy`,
+and none of those is a machine size; `ix apply` and `ix new` have no sizing
+flag either. Measured rather than assumed, from a node of this fleet:
+
+```console
+$ ix shell hyperion-game -- sh -c 'grep MemTotal /proc/meminfo; nproc'
+MemTotal:       268435456 kB
+64
+```
+
+So sizing is the platform's answer and not a limit worth designing around here.
+
+### A temporary key, if something on the box needs the API
+
+The loop above needs no ix credential at all: `ix` runs on your machine, and
+git pushes over yours. A key is only wanted when something *on* the box calls
+the ix API directly -- an agent that wants its own sandboxes, say, which today
+means the HTTP API rather than the CLI (ENG-12081 again).
+
+Mint it capped and narrow, store it, and attach it at create:
+
+```sh
+ix keys create hyperion-dev-agent --limit 25 --scope vm:read,create --rate-limit 60
+ix secret set hyperion_dev_ix_key          # reads the value from a hidden prompt
+ix new --name hyperion-dev --group hyperion-dev \
+       --secret-env hyperion_dev_ix_key=IX_API_KEY --no-shell
+ix apply .#hyperion-dev
+```
+
+The order is not a style choice. **`ix apply` cannot attach a secret**: it has
+no `--secret-env`, and this fleet's `deployment.secrets` would be read by the
+deprecated `ix-fleet` alone rather than by the created VM -- the split
+`lib/image/fleet.nix` draws between workflow keys and create-identity keys, and
+the same class of silent drop as ENG-10846. A secret therefore reaches a VM at
+create, which means creating with `ix new` and converging with `ix apply`
+afterwards. Revoke the key when the box goes: `ix keys revoke <id>` is terminal
+and takes every key beneath it with it.
+
+**None of those four commands has been run.** The node was added and evaluated,
+no VM was created, and no key was minted; the sequence follows the CLI's own
+contract (`ix apply` reuses a VM by name, `ix new` is the only path that
+attaches a secret) rather than a run somebody watched. Expect to correct it the
+first time, and correct it here.
+
+**That key is broader than it reads, and this is the reason to keep it
+temporary.** `--scope` parses `RESOURCE:ACTIONS` and nothing else, so there is
+no syntax for naming which VMs it covers; and even a token that carried the ids
+would not be narrowed by them, because the conversion from a token's scopes to
+the permission set the server checks drops `resource_ids` on the floor
+(`crates/ix/server/src/acl/auth.rs`, both `parse_db_scopes` and
+`auth_context_from_validated`). A `vm:read` key therefore reads **every VM the
+account owns**, this fleet's four included, not only the dev box it was minted
+for. ENG-12039. Until that lands, the controls that actually bound the damage
+are the spend cap, the rate limit, and revoking the key when you are done with
+the machine.
+
+### One node, no replicas, applied by name
+
+`replicas` says the proxies are interchangeable. A dev machine is the opposite:
+it holds somebody's working copy, so a second one is a second person's box and
+not another copy of this one. Whoever wants that adds a node with their own
+name on it.
+
+Nothing stacks or scopes these per branch today. A `--stack` that gave each
+branch its own copy of the fleet would change this section; there is no such
+flag, so the fleet is applied by naming targets, and the dev node is applied on
+its own when somebody wants it. Note the consequence of it being declared here:
+a bare `ix apply .` converges every node this repository declares, which now
+includes a dev box. Name your targets, which the commands above and at the top
+of `nix/fleet/default.nix` already do.
+
+Finally, "Apply from a checkout of `main`, not from a branch" above still
+holds, and a dev box makes it easier to get wrong: the checkout in `/work/ix`
+is usually on a branch, and applying the *game* fleet from there stamps an
+unreachable commit onto a boss bar in front of every player.
+
 ## Checking the server answers: `mcping.py` moved
 
 It is `nix/fleet/mcping.py` in this repository. **The old path,

--- a/nix/fleet/default.nix
+++ b/nix/fleet/default.nix
@@ -10,6 +10,12 @@
 #
 # Applied by hand. There is no CI deploy and no automatic apply, deliberately.
 #
+# `hyperion-dev` is declared here too and is not in either line above: it is a
+# machine to build on, not part of serving the game, and it is applied on its
+# own when somebody wants it (README.md, "A dev machine in the fleet"). Naming
+# targets is what keeps those separate -- a bare `ix apply .` converges every
+# node this file declares, which now includes a dev box nobody asked for.
+#
 # ---------------------------------------------------------------------------
 # WHY THIS LIVES HERE, AND WHY IT IS NOT ITS OWN FLAKE
 # ---------------------------------------------------------------------------
@@ -48,6 +54,10 @@
   guestPackages,
   # This repo's own service modules. No input, no pin -- that is the point.
   nixosModules,
+  # What `devShells.default` installs, for the dev node to install too. One
+  # binding rather than two lists, so a VM built to develop hyperion on cannot
+  # end up with a different compiler than `nix develop` hands a contributor.
+  guestDevEnvironment,
 }:
 index.lib.mkFleet {
   # One private segment. A VM outside it has no route to the game server,
@@ -58,6 +68,7 @@ index.lib.mkFleet {
       _module.args = {
         hyperionGameServer = guestPackages.smash;
         hyperionProxy = guestPackages.hyperion-proxy;
+        hyperionDevEnvironment = guestDevEnvironment;
       };
     }
     ./pki.nix
@@ -67,6 +78,17 @@ index.lib.mkFleet {
 
   nodes = {
     "hyperion-game".modules = [./game.nix];
+
+    # One, and no `replicas`. The proxies are interchangeable and a digit says
+    # so; a dev machine is the opposite -- it holds somebody's working copy, so
+    # a second one is a second person's box rather than another copy of this
+    # one. Whoever needs that adds a node with their own name on it.
+    #
+    # It is in the fleet rather than beside it so that one evaluation covers
+    # the machine hyperion is built on and the machines it runs on, which is
+    # the same argument the header makes for the fleet living in this repo at
+    # all. `./dev.nix` says what it deliberately leaves to the platform.
+    "hyperion-dev".modules = [./dev.nix];
 
     # Interchangeable, and `replicas` is how that is said rather than implied:
     # three copy-pasted node entries would let one drift from its siblings.

--- a/nix/fleet/dev.nix
+++ b/nix/fleet/dev.nix
@@ -1,0 +1,118 @@
+# A machine to build hyperion on, declared in the fleet rather than kept beside
+# it. It serves nothing, no player reaches it, and the game does not depend on
+# it -- it exists so that "where do I build this" has the same answer as "where
+# is this deployed", written in one file a reviewer can read.
+#
+# The loop it is for is in README.md ("A dev machine in the fleet"): apply it,
+# `ix shell` in, edit and build on a Linux box that already has the platform's
+# caches, push over your own forwarded credentials.
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS FILE DELIBERATELY DOES NOT DO
+# ---------------------------------------------------------------------------
+#
+# Most of a dev box is already answered by the platform, and restating an
+# answer is how two copies of it start to disagree. Named here so the next
+# reader can check the claim rather than re-derive it, and so nobody adds a
+# second copy believing it was missing:
+#
+#   - Nix is already configured for this repository. `lib/image/platform.nix`
+#     sets `experimental-features` to a list including `flakes`, `nix-command`
+#     and `ca-derivations`, and `modules/profiles/base` puts `cache.ix.dev` in
+#     `substituters` with its `ix-workspace:` key trusted. That is exactly what
+#     this flake's own `nixConfig` block asks of the machine evaluating it, so
+#     a guest copy of those settings would buy nothing and could drift.
+#
+#   - git is already installed, for every user rather than for one profile
+#     (`modules/profiles/base`, which also leaves a fallback identity so a
+#     first `git commit` in a fresh VM does not die on a missing email).
+#
+#   - The working directory is already a convention: `/work/ix`, from
+#     `ix.profiles.base.shellWorkspace.directory`. The platform pre-creates it
+#     with a tmpfiles rule and login shells cd into it, so a second directory
+#     declared here would be one the shell does not land in. The checkout goes
+#     there.
+#
+# NOTHING CLONES THE REPOSITORY INTO IT, and that is a choice rather than an
+# omission. A clone is state, not configuration: activation would have to pick
+# a revision, and every later `ix apply` would then either fight the working
+# copy or silently leave it alone, which is a worse contract than having no
+# opinion at all. Reading this repository needs no credentials -- it is public
+# -- but pushing needs the developer's own, and those are deliberately theirs
+# and not the VM's. So: `git clone` once, by hand, into `/work/ix`.
+#
+# THE `ix` CLI IS NOT HERE, and cannot be added from this repository today.
+# index packages no `ix` binary (its `packages/` tree has `ix-fleet`,
+# `ix-credential`, `ix2nix`, and no CLI), and the CLI's own repository is
+# private: an unauthenticated `GET /repos/indexable-inc/ix` answers 404 while
+# the same call for `indexable-inc/index` answers 200. hyperion is public and
+# its CI installs stock Nix, so a private flake input would break evaluation
+# for every outside contributor and for the gate. The consequence to plan
+# around: `ix` commands are typed on your machine against this VM, never from
+# inside it, so anything needing the CLI in the guest -- a nested VM, an `ix
+# apply` from the dev box -- is out of reach here. ENG-12081.
+#
+# THERE IS NO RAM OR DISK KNOB TO SET, which is why this file sets none. A
+# fleet node takes `modules`, `deployment`, `tags`, `groups`, `dependsOn`,
+# `replicas` and `updateStrategy` (`lib/image/fleet.nix`) and none of those
+# describes a machine size; neither `ix apply` nor `ix new` carries a sizing
+# flag either. Sizing belongs to the platform, and measured from inside a node
+# of this fleet it is not the binding constraint anyway:
+#
+#     $ ix shell hyperion-game -- sh -c 'grep MemTotal /proc/meminfo; nproc'
+#     MemTotal:       268435456 kB
+#     64
+{
+  config,
+  lib,
+  hyperionDevEnvironment,
+  ...
+}: {
+  # Its own east-west segment, NOT the fleet's. `default.nix` puts every node in
+  # `hyperion`, and that group is the only thing keeping an unproxied client off
+  # the game server -- so the one box in this fleet whose purpose is running
+  # code nobody has reviewed yet is the one box that belongs outside it. The
+  # loop this node serves is build-and-push, which needs no route to the game.
+  #
+  # `mkForce` because `groups` is a `listOf str`: without it the fleet default
+  # merges in rather than being replaced. The slug is get-or-created under the
+  # deploying user at create, so it needs no separate setup.
+  #
+  # Groups are joined AT CREATE (`lib/image/platform.nix`), like `ipv4`, so this
+  # is not something a re-apply changes on a VM that already exists: moving this
+  # node between segments is `ix rm` and apply again.
+  ix.networking.groups = lib.mkForce ["hyperion-dev"];
+
+  # `./pki.nix` is a fleet default and gives `serverName` no default, so every
+  # node has to answer it -- including one that runs neither hyperion service.
+  # Answering it and then not minting is the honest pair: the unit exists to
+  # hand the two services their mutual-TLS material, nothing here reads that
+  # material, and the authority is the public throwaway committed next to this
+  # file, so a certificate minted here would attest to nothing.
+  hyperion.pki.serverName = "${config.ix.networking.eastWest.hostName}.ix.internal";
+  systemd.services.hyperion-pki.enable = false;
+
+  # The build environment, taken from the flake's own `devShells.default`
+  # rather than restated: `hyperionDevEnvironment` is the same binding that
+  # shell installs, so `nix develop` on a laptop and a login shell on this VM
+  # cannot disagree about which compiler builds hyperion. The channel under it
+  # is `rust-toolchain.toml`, which is where the version lives for rustup users
+  # and for CI too.
+  #
+  # x86_64-linux for the reason `guestPackages` is: this is a Linux guest
+  # whatever machine types `nix build`, which contributes a builder rather than
+  # an identity.
+  environment = {
+    systemPackages = hyperionDevEnvironment.packages;
+    # What rust-analyzer resolves `std` sources through. The devShell exports
+    # the same string; a shell with the compiler but not this one gives
+    # go-to-definition that lands nowhere.
+    variables.RUST_SRC_PATH = hyperionDevEnvironment.rustSrcPath;
+  };
+
+  # No health check, deliberately. The two service nodes declare theirs because
+  # a process can be running and unable to serve, a distinction only a probe
+  # makes. Nothing here serves: this node is ready when it boots, and a check
+  # re-asking a compiler for its version every interval would be probing a
+  # store path that cannot change without a switch.
+}


### PR DESCRIPTION
## What this adds

A fifth fleet node, `hyperion-dev`, and the only one that serves nothing: a
machine to build hyperion on, described in the same evaluation as the machines
hyperion runs on. That is the same argument the header of `nix/fleet/default.nix`
makes for the fleet living in this repository at all, one step further back.

- `nix/fleet/dev.nix` -- the node. It installs the flake's own
  `devShells.default` inputs rather than a second list of them, puts itself in
  its own east-west group, and answers `hyperion.pki.serverName` while
  disabling the minting unit it does not use.
- `nix/fleet/default.nix` -- registers `"hyperion-dev".modules = [./dev.nix]`,
  with no `replicas`, and threads the dev environment in through `_module.args`
  beside the two service packages.
- `flake.nix` -- names the build environment once as `devEnvironment` and has
  both `devShells.default` and the fleet read it, so a VM built to develop
  hyperion on cannot come up with a different compiler than `nix develop` hands
  a contributor.
- `nix/fleet/README.md` -- a new section, "A dev machine in the fleet".

## The loop it enables

```sh
nix build .#hyperion-dev-system
ix apply .#hyperion-dev
ix shell hyperion-dev
# then, inside, once:
cd /work/ix && git clone https://github.com/hyperion-mc/hyperion
```

`/work/ix` is the platform's own workspace directory
(`ix.profiles.base.shellWorkspace.directory`), pre-created by a tmpfiles rule
with login shells landing in it. **Nothing clones for you.** A clone is state
rather than configuration -- activation would have to pick a revision, and
every later apply would then either fight your working copy or ignore it.
Reading this repository is public; pushing needs the developer's own
credentials, forwarded from their machine, which is the point.

Most of a dev box is already answered by the platform, so the module adds a
compiler and little else. Verified rather than assumed:

```console
$ nix eval --json .#nixosConfigurations.hyperion-dev.config --apply 'c: { ... }'
{
    "experimentalFeatures": ["nix-command","flakes","pipe-operators","fetch-closure",
                             "fetch-tree","ca-derivations","dynamic-derivations",
                             "git-hashing","wasm-builtin"],
    "gameServerEnabled": false,
    "gitEnabled": true,
    "groups": ["hyperion-dev"],
    "healthChecks": [],
    "ipv4": false,
    "pkiUnitEnabled": false,
    "proxyEnabled": false,
    "rustSrcPath": "/nix/store/llw682aha77hf06xzzvr5mf1yym426qc-rust-default-1.99.0-nightly-2026-07-27/lib/rustlib/src/rust/library",
    "substituters": ["https://cache.ix.dev","https://cache.nixos.org/"],
    "workspace": {"directory": "/work/ix","enable": true}
}
```

So flakes, `ca-derivations` and `cache.ix.dev` -- exactly what this flake's
`nixConfig` asks of whatever evaluates it -- are already true inside the guest,
and the module restates none of them.

### It is not in the fleet's network segment

Every other node sets `ix.networking.groups = ["hyperion"]`, and that group is
the only thing keeping an unproxied client off the game server. This node
replaces it with `hyperion-dev`, so the one box in the fleet whose purpose is
running code nobody has reviewed yet has no route to the game. Confirmed above
and cross-checked against the other nodes, which are unchanged:

```json
{"devGroups": ["hyperion-dev"], "gameGroups": ["hyperion"], "proxyGroups": ["hyperion"],
 "gamePki": "hyperion-game.ix.internal",
 "proxyGameServer": {"host": "hyperion-game.ix.internal", "port": 35565},
 "nodes": ["hyperion-dev","hyperion-game","hyperion-proxy-0","hyperion-proxy-1",
           "hyperion-proxy-2","module-smoke-test"]}
```

## Verification

**Ran, passed:**

```console
$ nix eval --raw .#hyperion-dev-system.drvPath
/nix/store/7bj63gk36j0rxgdwjiyvxyqqw16f93wl-nixos-system-hyperion-dev-26.11.20260726.624af66.drv
```

That is the cheap gate: the attribute, not the closure. The two eval outputs
quoted above ran too, and `nix eval .#packages.aarch64-darwin` lists all five
`-system` attrs including `hyperion-dev-system`.

**Attempted, failed for an unrelated reason:**

```console
$ nix build .#hyperion-dev-system
cannot build on 'ssh-ng://root@vc1-nix': error: failed to start SSH connection to 'vc1-nix'
Failed to find a machine for remote build!
error: Cannot build '/nix/store/ih6k5gwr2fz5fffgdfhrh8fgh5ddckiy-etc-hostname.drv'.
       Reason: platform mismatch
       Required system: 'x86_64-linux'  Current system: 'aarch64-darwin'
```

The configured x86_64-linux builder does not resolve and the host behind its
`~/.ssh/config` alias refuses connections, so **the system closure has not been
built and this change is eval-verified only.** ENG-12083.

The same limit blocks the whole-fleet eval that `nix/fleet/README.md` documents
as an 11-second check, and therefore the repository's own `fleet-eval` check on
darwin: forcing `hyperion-game`'s toplevel needs the x86_64-linux IFD
`cargo-unit-planner-file-list`, which is not in `cache.ix.dev`. **That
reproduces on an untouched worktree of `main`**, so it is the builder and not
this change. Consequence to be honest about: I could not produce the
drvPath-equality proof that the four existing nodes are byte-identical. What I
could check is that their configuration is -- groups, PKI server name and the
proxy's resolved game endpoint above -- and that the only wiring this change
adds to them is one lazy `_module.args` entry they never read.

**Not run:** `nix flake check`. This repository's CI does not use it; the gate
is `nix run .#flake-gate`, which builds every `checks` attribute, and that has
the same x86_64-linux problem as above.

**Not done, deliberately:** no VM was created, no `ix apply` was run, no key was
minted. Boot verification belongs to a human or a later step, and until then
nothing here has been shown to come up -- only to evaluate.

## Known holes

- **The `ix` CLI is not in the guest and cannot be added from this repository.**
  index packages no `ix` binary, and the CLI's repository is private while this
  one is public (an unauthenticated `GET /repos/indexable-inc/ix` answers 404
  where `indexable-inc/index` answers 200), so a flake input naming it would
  break evaluation for every outside contributor and for CI on hosted runners.
  `ix` commands are typed on your own machine against the VM. ENG-12081.
- **A temporary API key on the box is broader than it reads.** `ix keys create
  --scope` parses `RESOURCE:ACTIONS` only, and even a token carrying
  `resource_ids` would not be narrowed by them, because the conversion from
  token scopes to the permission set the server checks drops that field
  (`crates/ix/server/src/acl/auth.rs`). A `vm:read` key reads every VM the
  account owns, this fleet's four included. ENG-12039. The README says so and
  leans on the spend cap, the rate limit and prompt revocation instead.
- **`ix apply` cannot attach a secret**, so the README's key recipe creates with
  `ix new --secret-env` and converges with `ix apply` afterwards. That sequence
  follows the CLI's documented contract and has not been exercised end to end;
  the README says that in place.
- **No RAM, CPU or disk knob exists** to size this node with -- not in a fleet
  node's keys, not on `ix apply`, not on `ix new`. Measured from a node of this
  fleet, that is not the binding constraint (`MemTotal: 268435456 kB`, 64 CPUs),
  but it is not something this file can express either way.
- **A bare `ix apply .` now converges a dev box too**, since it converges every
  declared node. The fleet is applied by naming targets, which the README and
  `default.nix` header both do; that is now load-bearing rather than tidy.

## Merging

**Auto-merge deliberately not armed.** `main` here has no enforced
required-status gate (ruleset 566717 carries no `required_status_checks`, and
`branches/main/protection` is 404), so `--auto` would merge this on the spot
rather than wait for anything. Merging is a human's call.

(sent by an AI agent via Claude Code, Claude Opus 5)
