### PR TITLE
fix(hot-reload): record hyperion-hot-reload's tracing dependency in the lock file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,6 +2004,7 @@ version = "0.1.0"
 dependencies = [
  "flecs_ecs",
  "libloading 0.9.0",
+ "tracing",
 ]
 
 [[package]]


### PR DESCRIPTION
`#1117` added `tracing` to `crates/hyperion-hot-reload/Cargo.toml` without updating `Cargo.lock`. I edited that manifest in my local worktree but only ever ran cargo on the dev node, so the lock update was never in the commit. My mistake, and it has been on main since #1117 merged.

Every build that resolves with `--frozen` fails:

```
cargo-unit-graph.json> error: cannot update the lock file
  /nix/store/z4pi...-cargo-unit-planner-src/Cargo.lock
  because --frozen was passed to prevent this
help: to generate the lock file without accessing the network, remove the
  --frozen flag and use --offline instead.
```

That is `cargoUnit`'s planner, so it takes out `checks.clippy`, `checks.test` and every `workspace.*` derivation before they start. I found it because an unrelated `nix build` of `smash-server` failed with an error that had nothing to do with what I was testing.

One line, regenerated by `cargo metadata --offline` against a clean checkout of main rather than written by hand:

```
 [[package]]
 name = "hyperion-hot-reload"
 dependencies = [
  "flecs_ecs",
  "libloading 0.9.0",
+ "tracing",
 ]
```

Worth noting for the harness rather than for me: nothing in my loop caught this. Building on one host and committing from another is how it happened, and a pre-commit or CI check that runs `cargo metadata --locked` would have named it in seconds.

Authored by Claude Opus via Claude Code.