### PR TITLE
feat(smash): make player chat reach players (ENG-12110)

### DIFF
--- a/crates/hyperion/src/simulation/chat.rs
+++ b/crates/hyperion/src/simulation/chat.rs
@@ -1,0 +1,58 @@
+//! Text a player typed, made safe to put inside a component.
+//!
+//! A `SystemChat` payload built from a literal string is rendered by the
+//! client's `StringDecomposer`, which applies legacy section-sign codes as it
+//! reads. That is deliberate and load bearing --
+//! [`crate::net::agnostic::chat`] carries `§c` for exactly this reason -- and
+//! it is why player text cannot be dropped into a component unchanged: to the
+//! client there is no difference between a colour the server chose and one a
+//! player typed.
+
+/// U+00A7, the character the client's legacy formatter looks for.
+///
+/// Spelled as an escape rather than as itself so that this stays greppable and
+/// so that `nix/text.nix` -- which fails the build on a section sign anywhere
+/// in smash's text path or the proto crate -- keeps meaning what it says. That
+/// gate is about *emitting* one; this is the one place whose whole job is
+/// removing them, and it lives here rather than in an event so no event has to
+/// spell the character at all.
+const SECTION_SIGN: char = '\u{a7}';
+
+/// `message` with every formatting escape removed.
+///
+/// Dropped rather than escaped: the legacy scheme has no escape for its own
+/// introducer, and no message a person means to send contains one. What this
+/// prevents is a client painting its own text -- `§k` scrambles the glyphs,
+/// `§0`..`§f` recolours them, and `§4[Server] restarting` is a line that looks
+/// like it came from the server. A vanilla client will not send one, which is
+/// precisely why leaving it in only ever helps a bot.
+#[must_use]
+pub fn strip_formatting(message: &str) -> String {
+    message.replace(SECTION_SIGN, "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_formatting;
+
+    #[test]
+    fn ordinary_text_is_untouched() {
+        assert_eq!(strip_formatting("gg <3 100% !"), "gg <3 100% !");
+    }
+
+    #[test]
+    fn every_sign_goes_and_nothing_else_does() {
+        assert_eq!(
+            strip_formatting("\u{a7}4[Server] restarting \u{a7}kNOW"),
+            "4[Server] restarting kNOW"
+        );
+    }
+
+    #[test]
+    fn a_trailing_sign_with_no_code_after_it_goes_too() {
+        // The client's formatter needs a character after the sign, so a bare
+        // trailing one renders as nothing. Removing it anyway keeps this a
+        // statement about the character rather than about pairs.
+        assert_eq!(strip_formatting("bye\u{a7}"), "bye");
+    }
+}

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -57,6 +57,7 @@ use crate::{
 
 pub mod animation;
 pub mod blocks;
+pub mod chat;
 pub mod command;
 pub mod entity_kind;
 pub mod event;

--- a/events/bedwars/src/module/chat.rs
+++ b/events/bedwars/src/module/chat.rs
@@ -10,7 +10,7 @@ use hyperion::{
         text::{Component, NamedColor, Style, TextColor},
     },
     net::{ConnectionId, protocol::Clientbound},
-    simulation::{Name, Player, Position, event},
+    simulation::{Name, Player, Position, chat::strip_formatting, event},
     storage::EventQueue,
 };
 use tracing::info_span;
@@ -111,7 +111,12 @@ impl Module for ChatModule {
                                     .with_style(colored(TextColor::Rgb(team.rgb()))),
                             )
                             .append(Component::text("> ").with_style(colored(BRACKET_COLOR)))
-                            .append(Component::text(msg));
+                            // Not `msg`. The client renders a literal string
+                            // through its legacy formatter, so a section sign
+                            // a player typed recolours their own text and lets
+                            // them draw something that looks like a server
+                            // notice.
+                            .append(Component::text(strip_formatting(msg)));
 
                         let packet = SystemChat {
                             content: chat.to_tag(),

--- a/events/smash/src/chat.rs
+++ b/events/smash/src/chat.rs
@@ -1,0 +1,128 @@
+//! Player chat.
+//!
+//! hyperion decodes a chat packet into [`event::ChatMessage`] and stops there:
+//! nothing in the engine broadcasts it, because what a chat line looks like is
+//! a game's decision. Until this file existed smash made no decision, so every
+//! message a player typed was decoded, queued, and dropped when the queue was
+//! recycled. Two clients could stand next to each other and neither could say
+//! anything to the other.
+//!
+//! The line is vanilla's: `<Name> message`, undecorated. Vanilla's
+//! `chat.type.text` translation is `<%s> %s` with no style on either half, and
+//! a fighting game has no teams or ranks to colour a name by, so there is
+//! nothing here that vanilla would have coloured.
+//!
+//! # Why this is host-side and not under `src/module/`
+//!
+//! It reads a hyperion event queue. Everything under `src/module/` is the game
+//! half and compiles against the [`crate::server`] seam alone, which is what
+//! lets `tests/` run the whole game with no Minecraft server behind it. The
+//! translation from a hyperion event to a game action is [`crate::input`]'s
+//! job and this is one of those, kept in its own file only so that the chat
+//! decision is somewhere a person can find it.
+
+use flecs_ecs::prelude::*;
+use hyperion::{
+    simulation::{Name, chat::strip_formatting, event},
+    storage::EventQueue,
+};
+
+use crate::server::{Channel, ServerHandle, Text};
+
+/// The chat line for one message, exactly as a client draws it.
+///
+/// Split out from the system so the formatting is testable without a world:
+/// the system's job is to find the speaker's name, and this is the whole of
+/// what the game decides.
+///
+/// [`strip_formatting`] is not optional. The client renders a literal string
+/// through its legacy formatter, so a section sign a player typed is a
+/// formatting instruction and not a character; see that function for what it
+/// buys.
+#[must_use]
+pub fn line(speaker: &str, message: &str) -> Text {
+    Text::text(format!("<{speaker}> {}", strip_formatting(message)))
+}
+
+/// Broadcasting what players type. Behavior only; the components it reads are
+/// registered by the modules it imports.
+#[derive(Component)]
+pub struct SmashChatModule;
+
+impl Module for SmashChatModule {
+    fn module(world: &World) {
+        // `ServerHandle` and every game component below it, and with them the
+        // `hyperion::simulation` registrations that hyperion's own import
+        // brings in. A behavior module imports the registration for everything
+        // it touches even when a parent already did: flecs dedupes the import
+        // and a missing one is a dev-profile abort.
+        world.import::<crate::adapter::SmashAdapterModule>();
+
+        world
+            .system_named::<&mut EventQueue<event::ChatMessage>>("smash_chat")
+            .each_iter(|it, _index, queue| {
+                let world = it.world();
+
+                for event::ChatMessage { msg, by } in queue.drain() {
+                    let speaker = world.entity_from_id(by);
+
+                    // A player who disconnected or died between the packet
+                    // arriving and this tick draining the queue. Their message
+                    // is still theirs, but there is no name to attribute it to.
+                    if !speaker.is_alive() {
+                        continue;
+                    }
+
+                    // Whitespace only. The client will not send an empty
+                    // string, but it will happily send a space.
+                    let msg = msg.as_str();
+                    if msg.trim().is_empty() {
+                        continue;
+                    }
+
+                    let Some(name) = speaker.try_get::<&Name>(ToString::to_string) else {
+                        // Every entity that can send a chat packet is a player
+                        // and hyperion names a player during login, so this is
+                        // a hole in that rather than a message to drop
+                        // quietly.
+                        tracing::warn!("dropping a chat message from an unnamed entity {by:?}");
+                        continue;
+                    };
+
+                    world.get::<&ServerHandle>(|server| {
+                        server.broadcast(Channel::Chat, line(&name, msg));
+                    });
+                }
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::line;
+
+    #[test]
+    fn renders_the_vanilla_shape() {
+        assert_eq!(line("Andrew", "hello").plain(), "<Andrew> hello");
+    }
+
+    #[test]
+    fn a_section_sign_in_the_message_is_dropped() {
+        // Without this the client draws "kbold" scrambled and obfuscated, and
+        // the second line below reads as a server notice rather than as somebody
+        // talking.
+        assert_eq!(line("Andrew", "\u{a7}kbold").plain(), "<Andrew> kbold");
+        assert_eq!(
+            line("Andrew", "\u{a7}4[Server] restarting").plain(),
+            "<Andrew> 4[Server] restarting"
+        );
+    }
+
+    #[test]
+    fn an_ordinary_message_is_untouched() {
+        assert_eq!(
+            line("Andrew", "gg <3 100% !").plain(),
+            "<Andrew> gg <3 100% !"
+        );
+    }
+}

--- a/events/smash/src/lib.rs
+++ b/events/smash/src/lib.rs
@@ -9,6 +9,7 @@
 //! [`adapter`], [`mirror`], [`input`] and [`command`].
 
 pub mod adapter;
+pub mod chat;
 pub mod command;
 pub mod draw;
 pub mod flecs_ext;
@@ -104,6 +105,10 @@ impl Module for SmashHost {
         world.import::<hyperion_item::ItemModule>();
 
         world.import::<crate::adapter::SmashAdapterModule>();
+        // Chat: hyperion decodes it and broadcasts nothing, so without this a
+        // player's message reaches no one. Host-side because it reads a
+        // hyperion event queue; see `crate::chat`.
+        world.import::<crate::chat::SmashChatModule>();
         // After the adapter, because building the maps writes the `Arena`
         // singleton the game half registered.
         world.import::<crate::terrain::MapModule>();

--- a/flake.nix
+++ b/flake.nix
@@ -1718,6 +1718,31 @@
               timeout = 180;
             };
 
+            # Player chat, which smash did not have.
+            #
+            # `PacketId::Chat` was routed, decoded and pushed onto
+            # `EventQueue<event::ChatMessage>`, and nothing drained that queue,
+            # so every message a player typed was thrown away when the queue
+            # was recycled. There was no code to unit-test and no packet to
+            # assert on; the only evidence that separates "wired up" from
+            # "decoded and dropped" is a second connection hearing the first
+            # one, which is what makes this a gate rather than a test.
+            #
+            # `chat-check.py` joins two clients, has one talk, and requires the
+            # line to reach both in vanilla's `<Name> message` shape. It also
+            # sends a message full of section signs: a literal `SystemChat`
+            # string is rendered through the client's `StringDecomposer`, which
+            # applies legacy colour codes as it reads, so `§k` typed by a bot
+            # scrambles its own text and `§4[Server]` paints a fake notice.
+            # Both must arrive with the sign gone.
+            chat-e2e = e2e.mkCheck {
+              name = "hyperion-chat-e2e";
+              gameServer = gameBinaries.smash;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "chat-check.py";
+              timeout = 180;
+            };
+
             # The tab list's two new numbers, and the one claim about them that
             # no Rust test can settle.
             #

--- a/tools/chat-check.py
+++ b/tools/chat-check.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Player chat, proved the only way it can be: two clients, one talking.
+
+smash decoded chat and broadcast nothing. `PacketId::Chat` was routed to a
+handler, the handler pushed `event::ChatMessage`, and no system drained the
+queue, so a message a player typed reached exactly nobody. Nothing in the crate
+could see it -- there was no code to test -- and the only shape of evidence that
+distinguishes "wired up" from "decoded and dropped" is a second connection
+receiving what the first one said.
+
+So this joins two clients and checks four things:
+
+  1. **The speaker hears themselves.** Vanilla echoes your own message back
+     from the server rather than drawing it locally, and a broadcast that
+     skipped the sender would look right to them and be wrong.
+  2. **The other client hears it**, in the vanilla shape `<Name> message`.
+     This is the assertion that is red on an unpatched tree: no `SystemChat`
+     carrying the message arrives at all.
+  3. **A section sign a player typed is not a formatting code.** The client
+     renders a literal `SystemChat` string through `StringDecomposer`, which
+     applies legacy `§` codes as it goes, so `§k` from a bot scrambles the
+     glyphs and `§4[Server]` paints a fake server notice. Both must arrive with
+     the sign gone and the rest of the text intact.
+  4. **A whitespace-only message is dropped**, and dropped rather than
+     broadcast as `<Name>   `.
+
+Assertions 1 to 3 are fail-then-pass by construction and have been watched
+failing: with the module's import removed 1, 2 and 3 go red, and with the
+section sign left in only 3 does. Assertion 4 is not -- a server that
+broadcasts nothing satisfies "nothing was broadcast" -- which is why the
+message after it has to arrive for the run to pass at all.
+
+Exits non-zero on anything that is not true, after printing everything it saw.
+"""
+
+import argparse
+import importlib.util
+import pathlib
+import struct
+import sys
+import time
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, TOOLS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+match = _load("smash_match", "smash-match.py")
+
+var_int = match.base.var_int
+mc_string = match.base.mc_string
+take_nbt_string = match.take_nbt_string
+
+# crates/hyperion-minecraft-proto/src/generated/packet_id.rs, protocol 776:
+# `minecraft:chat` serverbound. Distinct from `chat_command` (7), which is the
+# one every other gate here sends.
+C2S_CHAT = 0x09
+
+# `LastSeenMessagesTracker.window` is 20 wide, so the acknowledged bitset is a
+# fixed three bytes. See `hyperion::simulation::packet::serverbound`.
+LAST_SEEN_ACKNOWLEDGED_BYTES = 3
+
+
+def chat_packet(message):
+    """`ServerboundChatPacket`, unsigned, acknowledging nothing.
+
+    Layout from `ServerboundChatPacket#STREAM_CODEC`: the message, the client's
+    clock, the signature salt, an optional 256-byte signature, then the last
+    seen window. This server does not verify signatures -- `chat_ack` and
+    `chat_session_update` are both routed to `Route::Ignore` -- so the
+    signature is absent and the salt is zero, which is what a client with no
+    chat session sends.
+    """
+    return (
+        mc_string(message)
+        + struct.pack(">qq", int(time.time() * 1000), 0)
+        + b"\x00"
+        + var_int(0)
+        + b"\x00" * LAST_SEEN_ACKNOWLEDGED_BYTES
+        + b"\x00"
+    )
+
+
+class Talker(match.MatchClient):
+    """A scripted player that records every chat line it is sent."""
+
+    def __init__(self, host, port, name, started):
+        super().__init__(host, port, name, started)
+        self.joined = False
+        self.chats = []
+
+    def say(self, message):
+        self.log("-> chat %r" % message)
+        self.send(C2S_CHAT, chat_packet(message))
+
+    def absorb(self, packet_id, payload):
+        if packet_id == match.S2C_LOGIN:
+            self.joined = True
+            self.log("** in the world **")
+        elif packet_id == match.S2C_PLAYER_POSITION:
+            teleport_id, offset = match.base.take_var_int(payload)
+            x, y, z = struct.unpack(">ddd", payload[offset : offset + 24])
+            self.position = (x, y, z)
+            self.send(match.C2S_ACCEPT_TELEPORTATION, var_int(teleport_id))
+        elif packet_id == match.S2C_KEEP_ALIVE:
+            self.send(match.C2S_KEEP_ALIVE, payload[:8])
+        elif packet_id == match.S2C_SYSTEM_CHAT:
+            text, _ = take_nbt_string(payload, 0)
+            self.chats.append(text)
+            self.log("<- chat %r" % text)
+        elif packet_id == match.S2C_DISCONNECT:
+            text, _ = take_nbt_string(payload, 0)
+            self.log("<- DISCONNECTED: %s" % text)
+            self.alive = False
+
+
+def pump(clients, seconds):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        for client in clients:
+            if not client.alive:
+                continue
+            for packet_id, payload in client.drain():
+                client.absorb(packet_id, payload)
+            if client.joined:
+                client.repeat_position()
+        time.sleep(0.01)
+
+
+def wait_until(clients, predicate, seconds, what):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        pump(clients, 0.05)
+        if predicate():
+            return True
+    print("TIMEOUT waiting for %s" % what, file=sys.stderr)
+    return False
+
+
+def connect(host, port, name, started):
+    client = Talker(host, port, name, started)
+    client.handshake(host, port, 2)
+    client.login()
+    client.configuration()
+    client.enter_play()
+    return client
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=25565)
+    parser.add_argument("--speaker", default="Alice")
+    parser.add_argument("--listener", default="Bob")
+    args = parser.parse_args()
+
+    started = time.time()
+    failures = []
+
+    def check(ok, message):
+        print("%s %s" % ("PASS" if ok else "FAIL", message), flush=True)
+        if not ok:
+            failures.append(message)
+
+    speaker = connect(args.host, args.port, args.speaker, started)
+    listener = connect(args.host, args.port, args.listener, started)
+    clients = [speaker, listener]
+
+    if not wait_until(clients, lambda: all(c.joined for c in clients), 60.0, "both clients"):
+        print("RESULT: failure (never joined)", flush=True)
+        return 1
+
+    # Anything the join path says -- the build stamp, the lobby -- lands before
+    # the first message and is not what any assertion below is about.
+    pump(clients, 2.0)
+    for client in clients:
+        client.chats.clear()
+
+    def expect(sent, wanted, note, settle=5.0):
+        """`sent` is typed by the speaker; `wanted` must reach both clients."""
+        speaker.say(sent)
+        arrived = wait_until(
+            clients,
+            lambda: all(wanted in c.chats for c in clients),
+            settle,
+            "%r on both clients" % wanted,
+        )
+        check(
+            arrived,
+            "%s: sent %r, both clients receive %r (speaker saw %r, listener saw %r)"
+            % (note, sent, wanted, speaker.chats, listener.chats),
+        )
+        return arrived
+
+    # The whole feature. An unpatched tree fails here and only here matters.
+    hello = "hello from the other side"
+    expect(
+        hello,
+        "<%s> %s" % (args.speaker, hello),
+        "a message reaches every player in the vanilla shape",
+    )
+
+    # The speaker's own copy, called out separately because a broadcast that
+    # excluded the sender would still pass a listener-only check and would look
+    # wrong to the person typing.
+    check(
+        "<%s> %s" % (args.speaker, hello) in speaker.chats,
+        "the speaker is sent their own message rather than drawing it locally",
+    )
+
+    # Formatting injection. `§k` is the obfuscate code and `§4` is dark red; a
+    # client renders both out of a literal string, so leaving them in lets a bot
+    # scramble its own text and impersonate a server notice.
+    expect(
+        "§4[Server] restarting §kNOW",
+        "<%s> 4[Server] restarting kNOW" % args.speaker,
+        "a section sign a player typed is stripped, and nothing else is",
+    )
+
+    # A message that is only whitespace. Checked by sending a real one after it
+    # and requiring that the real one is the next thing anybody sees, so this
+    # cannot pass by the server simply being slow.
+    before = list(listener.chats)
+    speaker.say("   ")
+    pump(clients, 2.0)
+    blank = [line for line in listener.chats[len(before) :]]
+    check(
+        not any(line.startswith("<%s>" % args.speaker) for line in blank),
+        "a whitespace-only message is dropped rather than broadcast (saw %r)" % blank,
+    )
+    expect(
+        "still here",
+        "<%s> still here" % args.speaker,
+        "chat still works after a dropped message",
+    )
+
+    print(
+        "RESULT: %s" % ("success" if not failures else "failure (%d)" % len(failures)),
+        flush=True,
+    )
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two clients could stand next to each other in smash and neither could say
anything to the other. `PacketId::Chat` was routed, decoded and pushed onto
`EventQueue<event::ChatMessage>`; nothing drained that queue, so the message was
thrown away when the queue was recycled. bedwars has a chat module
(`events/bedwars/src/module/chat.rs`); smash never grew one.

## What this does

`events/smash/src/chat.rs` drains the queue and broadcasts vanilla's
`<Name> message` through the `Server` seam.

Host-side rather than under `src/module/` because it reads a hyperion event
queue. Everything under `src/module/` compiles against the seam alone, which is
what lets `tests/` run the whole game with no Minecraft server behind it;
translating a hyperion event into a game action is `crate::input`'s job and this
is one of those, in its own file only so the chat decision is findable.

Undecorated because that is what vanilla renders. `chat.type.text` is `<%s> %s`
with no style on either half, and a fighting game has no teams or ranks to
colour a name by — bedwars colours the name by team, and there is no smash
equivalent worth inventing.

## The second defect, in both events

A client renders a literal `SystemChat` string through `StringDecomposer`, which
applies legacy section-sign codes as it reads. That is deliberate and load
bearing: it is exactly why `hyperion::net::agnostic::chat` can carry `§c` at
all. It also means a section sign a **player** typed is a formatting
instruction. `§k` scrambles their own glyphs, `§0`..`§f` recolours them, and
`§4[Server] restarting` draws a line that looks like it came from the server. A
vanilla client will not send one, which is precisely why leaving it in only ever
helps a bot.

bedwars appended `Component::text(msg)` straight off the wire and had the same
hole; this fixes it there too, one line.

The strip is `hyperion::simulation::chat::strip_formatting`, in the engine
rather than in either event. Two reasons: any event that echoes player text into
a component has this hazard, and `nix/text.nix` fails the build on a section
sign anywhere in `events/smash/src` or the proto crate. Putting the one function
whose job is *removing* the character in the engine means no event has to spell
it, so that gate keeps meaning what it says. The constant is written `'\u{a7}'`
with a comment saying why, so nobody "cleans it up" into a literal and turns the
gate red.

## Hygiene, and what this deliberately is not

Empty and whitespace-only messages are dropped; the length cap is already
protocol-level (`ServerboundChatPacket.MAX_MESSAGE_LENGTH`, enforced by the
decoder). There is no cooldown, no filter and no moderation here. bedwars has a
15-second cooldown; that is a game's policy and this is not the PR to decide it
for smash.

## The gate

`tools/chat-check.py`, wired as `checks.<system>.chat-e2e`. Two clients join,
one talks, the line has to reach both. This is a gate rather than a unit test
because nothing in the crate could have caught the bug — there was no code to
test — and a second connection hearing the first is the only shape of evidence
that separates "wired up" from "decoded and dropped".

Green on the finished tree, driven against a **dev-profile** server, so the new
flecs module is covered by the debug-assertion path a release e2e gate
structurally cannot see (ENG-11000):

```
$ HYPERION_EVENT=smash HYPERION_E2E_CLIENT="tools/chat-check.py" nix run .#e2e
PASS a message reaches every player in the vanilla shape: sent 'hello from the other side',
     both clients receive '<Alice> hello from the other side'
PASS the speaker is sent their own message rather than drawing it locally
PASS a section sign a player typed is stripped, and nothing else is: sent
     '§4[Server] restarting §kNOW', both clients receive '<Alice> 4[Server] restarting kNOW'
PASS a whitespace-only message is dropped rather than broadcast (saw [])
PASS chat still works after a dropped message: sent 'still here', both clients
     receive '<Alice> still here'
RESULT: success
```

### Watched failing, twice

With `world.import::<crate::chat::SmashChatModule>()` commented out — exit 1:

```
TIMEOUT waiting for '<Alice> hello from the other side' on both clients
FAIL a message reaches every player in the vanilla shape: (speaker saw [], listener saw [])
FAIL the speaker is sent their own message rather than drawing it locally
FAIL a section sign a player typed is stripped, and nothing else is
PASS a whitespace-only message is dropped rather than broadcast (saw [])
FAIL chat still works after a dropped message
RESULT: failure (4)
```

With `strip_formatting` replaced by `message.to_owned()` — exit 1, and only the
one assertion:

```
PASS a message reaches every player in the vanilla shape
PASS the speaker is sent their own message rather than drawing it locally
FAIL a section sign a player typed is stripped, and nothing else is: sent
     '§4[Server] restarting §kNOW', both clients receive '<Alice> 4[Server] restarting kNOW'
     (both saw '<Alice> §4[Server] restarting §kNOW')
RESULT: failure (1)
```

Assertion 4 is **not** fail-then-pass and the script says so: a server that
broadcasts nothing satisfies "nothing was broadcast". That is why a real message
has to arrive after it for the run to pass at all.

## Other gates run locally (aarch64-darwin)

- `checks.clippy` — green (it caught a `redundant_closure_for_method_calls`
  first; fixed).
- `checks.smash-text-no-legacy-formatting` — green, which is the one that would
  have failed had the strip lived in smash.
- `cargo test -p smash` — green, 30 binaries.
- `cargo test -p hyperion --lib chat` — 3 passed.

## One pre-existing failure, not from this branch

`checks.<system>.rustfmt` is **red on `main`** and this PR inherits it.
`crates/hyperion/build.rs:46` is over `max_width`; the file is untouched here
and the long line arrived in a0a0f21 (#1116). Filed as ENG-12111 with the repro.
Fixing it is one line but belongs in its own PR rather than buried in this diff
— say the word if you would rather have it here.

Fixes ENG-12110.

---
Authored by Claude Opus via Claude Code.
