### PR TITLE
feat(hyperion): an arrow that hits a block stops in it, the way vanilla's does

### DIFF
--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -35,8 +35,11 @@ use crate::{
         entity_kind::EntityKind,
         event::{self, HitGroundEvent},
         handlers::is_grounded,
-        metadata::{MetadataChanges, get_and_clear_metadata},
-        projectile_motion::{MotionOrder, ProjectileMotion, lerp_rotation, look_angles},
+        metadata::{MetadataChanges, arrow::InGround, get_and_clear_metadata},
+        projectile_motion::{
+            MotionOrder, ProjectileMotion, SHAKE_TICKS, ShakeTime, embed_point, lerp_rotation,
+            look_angles,
+        },
     },
     spatial::get_first_collision,
     storage::Events,
@@ -515,18 +518,40 @@ impl Module for EntityStateSyncModule {
             &Owner,
             ?&ConnectionId,
             ?&mut Yaw,
-            ?&mut Pitch
+            ?&mut Pitch,
+            ?&mut InGround,
+            ?&mut ShakeTime
         )
         .kind(id::<flecs::pipeline::OnUpdate>())
         .with_enum_wildcard::<EntityKind>()
         .each_iter(
-            |it, row, (position, velocity, owner, connection_id, yaw, pitch)| {
+            |it,
+             row,
+             (position, velocity, owner, connection_id, yaw, pitch, in_ground, mut shake)| {
                 if let Some(_connection_id) = connection_id {
                     return;
                 }
 
                 let world = it.world();
                 let arrow_entity = it.entity(row);
+
+                // `AbstractArrow.tick:178-180`: the shake counts down at the
+                // top of the tick, before the early return below, so an
+                // embedded arrow's clock still runs.
+                if let Some(shake) = shake.as_deref_mut()
+                    && shake.0 > 0
+                {
+                    shake.0 -= 1;
+                }
+
+                // `AbstractArrow.tick:184-200`: an arrow in the ground does not
+                // move, does not lose speed to drag and does not fall. Vanilla
+                // returns here; so does this. It is also what stops the sweep
+                // re-reporting the face the arrow is resting on, every tick,
+                // forever.
+                if in_ground.as_ref().is_some_and(|flag| ***flag) {
+                    return;
+                }
                 // Prefer the per-instance `ProjectileMotion` that
                 // `seed_projectile_motion` puts on every simulated kind, so an
                 // ability can override one projectile's gravity or drag; fall
@@ -625,7 +650,45 @@ impl Module for EntityStateSyncModule {
                             });
                         }
                         Either::Right(collision) => {
-                            // send event
+                            // `AbstractArrow.onHitBlock`
+                            // (`AbstractArrow.java:484-502`), which is the whole
+                            // of what an arrow does when it meets terrain:
+                            // stand at the impact point backed off along the
+                            // heading, stop dead, and go into the ground.
+                            //
+                            // In the engine and not left to each game module,
+                            // because the three statements are one state: a
+                            // module that zeroed the velocity a stage later --
+                            // which is what bedwars did -- left a tick in which
+                            // the arrow was stopped by the world and still
+                            // carrying its flight speed, and anything that read
+                            // it in between got the stale one.
+                            **position = embed_point(collision.point, velocity.0);
+                            velocity.0 = Vec3::ZERO;
+                            if let Some(in_ground) = in_ground {
+                                **in_ground = true;
+                            }
+                            if let Some(shake) = shake {
+                                shake.0 = SHAKE_TICKS;
+                            }
+
+                            // `stepMoveAndHit` sets `needsSync` on a hit
+                            // (`AbstractArrow.java:253`) so the stop reaches
+                            // every watcher this tick. Without it the client
+                            // keeps dead-reckoning the arrow it was last told
+                            // about -- `AbstractArrow.tick` runs on the client
+                            // too -- and draws it sailing on through the block
+                            // the server stopped it at.
+                            let id = arrow_entity.minecraft_id();
+                            world.get::<&Compose>(|compose| {
+                                broadcast_projectile_velocity(
+                                    compose,
+                                    arrow_entity.into(),
+                                    id,
+                                    Vec3::ZERO,
+                                );
+                            });
+
                             world.get::<&mut Events>(|events| {
                                 events.push(
                                     event::ProjectileBlockEvent {

--- a/crates/hyperion/src/simulation/metadata/arrow.rs
+++ b/crates/hyperion/src/simulation/metadata/arrow.rs
@@ -1,0 +1,42 @@
+//! Tracked data every arrow has
+//! (`net.minecraft.world.entity.projectile.arrow.AbstractArrow`).
+//!
+//! Provenance of the indices: see [`super::entity`]. Read out of the pinned
+//! 26.2 jar the same way, by reflecting over `AbstractArrow`'s static
+//! `EntityDataAccessor` fields and calling `id()` on each after
+//! `SharedConstants.tryDetectVersion()` and `Bootstrap.bootStrap()`. The same
+//! run reproduced `super::living_entity`'s table (8..14) unchanged, which is
+//! what says the method is reading the same numbering that one was built from.
+//!
+//! It agrees with counting the declarations: `Entity` declares eight accessors
+//! (`Entity.java:284-298`), `Projectile` declares none, and `AbstractArrow`'s
+//! three follow at `AbstractArrow.java:71-73` in that order.
+//!
+//! ```text
+//! index  serializer                 accessor
+//!     8  Byte (0)                   ID_FLAGS                    0
+//!     9  Byte (0)                   PIERCE_LEVEL                0
+//!    10  Boolean (8)                IN_GROUND                   false
+//! ```
+//!
+//! Only index 10 is here. The other two exist on the wire and nothing this
+//! server does writes them: 8 is the crit and no-physics flag pair
+//! (`AbstractArrow.java:74-75`) and 9 is piercing, which needs an enchantment.
+
+use flecs_ecs::prelude::*;
+
+use super::Metadata;
+use crate::define_and_register_components;
+
+define_and_register_components! {
+    // 8 ID_FLAGS and 9 PIERCE_LEVEL are deliberately absent; see the module
+    // note. Leaving a gap rather than defining a field nothing writes keeps
+    // the table to what this server actually sends.
+    10, InGround -> bool,
+}
+
+impl Default for InGround {
+    fn default() -> Self {
+        Self::new(false)
+    }
+}

--- a/crates/hyperion/src/simulation/metadata/mod.rs
+++ b/crates/hyperion/src/simulation/metadata/mod.rs
@@ -37,6 +37,7 @@ use crate::{
     },
 };
 
+pub mod arrow;
 pub mod block_display;
 pub mod display;
 pub mod entity;
@@ -47,6 +48,8 @@ pub mod player;
 #[derive(Component, Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub struct MetadataPrefabs {
     pub entity_base: Entity,
+
+    pub arrow_base: Entity,
 
     pub display_base: Entity,
     pub block_display_base: Entity,
@@ -136,6 +139,12 @@ pub fn register_prefabs(world: &World) -> MetadataPrefabs {
         .component_and_track::<Pose>()
         .id();
 
+    // Arrows carry one tracked field of their own, `IN_GROUND`, and it is what
+    // stops a client dead-reckoning an arrow through the wall the server
+    // stopped it at: `AbstractArrow.tick` returns before moving whenever it is
+    // set (`AbstractArrow.java:184-200`).
+    let arrow_base = arrow::register_prefab(world, Some(entity_base)).id();
+
     let display_base = display::register_prefab(world, Some(entity_base)).id();
     let block_display_base = block_display::register_prefab(world, Some(display_base)).id();
 
@@ -152,6 +161,7 @@ pub fn register_prefabs(world: &World) -> MetadataPrefabs {
 
     MetadataPrefabs {
         entity_base,
+        arrow_base,
         display_base,
         block_display_base,
         item_base,
@@ -346,6 +356,14 @@ impl MetadataChanges {
             }
             EntityKind::Item => {
                 item::encode_non_default_components(entity, self);
+            }
+            // Every kind that reaches `AbstractArrow.tick`, which is the same
+            // set `projectile_motion::SIMULATED` gives `MotionOrder::
+            // MoveThenDecay`. A subscriber joining after an arrow has already
+            // landed has to be told it is in the ground, or its client starts
+            // simulating a stopped arrow forwards.
+            EntityKind::Arrow | EntityKind::SpectralArrow | EntityKind::Trident => {
+                arrow::encode_non_default_components(entity, self);
             }
             _ => {}
         }

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -548,6 +548,15 @@ fn register_observers(world: &World, prefabs: MetadataPrefabs) {
                 .flatten()
             {
                 entity.set(motion);
+                // The shake clock belongs to the arrow tick and only to it:
+                // `ThrowableProjectile` has no such state, because a snowball
+                // that hits something is discarded rather than embedded
+                // (`ThrowableProjectile.java:59-61`). Keyed on the order rather
+                // than listing the kinds a second time -- `MoveThenDecay` *is*
+                // "this reaches `AbstractArrow.tick`".
+                if motion.order == projectile_motion::MotionOrder::MoveThenDecay {
+                    entity.set(projectile_motion::ShakeTime::default());
+                }
             }
         });
 
@@ -564,6 +573,13 @@ fn register_observers(world: &World, prefabs: MetadataPrefabs) {
                 }
                 EntityKind::Player => {
                     entity.is_a(prefabs.player_base);
+                }
+                // The `IN_GROUND` tracked field, so a client stops simulating
+                // an arrow the server has stopped. Same set as the
+                // `MoveThenDecay` half of `projectile_motion::SIMULATED`:
+                // these are the kinds whose tick is `AbstractArrow.tick`.
+                EntityKind::Arrow | EntityKind::SpectralArrow | EntityKind::Trident => {
+                    entity.is_a(prefabs.arrow_base);
                 }
                 _ => {}
             });

--- a/crates/hyperion/src/simulation/projectile_motion.rs
+++ b/crates/hyperion/src/simulation/projectile_motion.rs
@@ -49,7 +49,9 @@ pub enum MotionOrder {
 pub struct ProjectileMotion {
     /// The velocity is multiplied by this every tick, out of water.
     ///
-    /// `AbstractArrow.getAirDrag` and `ThrowableProjectile.getAirDrag` both
+    /// `AbstractArrow.getAirDrag` (`AbstractArrow.java:234-236`, returning the
+    /// `INERTIA` constant declared at line 65) and
+    /// `ThrowableProjectile.getAirDrag` (`ThrowableProjectile.java:80-83`) both
     /// return the `float` 0.99, and vanilla widens that to a `double` before
     /// multiplying, so the value it actually applies is 0.990000009536743.
     /// Stored as an `f32` here for the same reason: hyperion's velocities are
@@ -59,7 +61,8 @@ pub struct ProjectileMotion {
     /// Subtracted from the vertical velocity every tick.
     ///
     /// `Entity.applyGravity` reads `getDefaultGravity`, which is 0.05 for
-    /// arrows and 0.03 for anything thrown.
+    /// arrows (`AbstractArrow.java:286-289`) and 0.03 for anything thrown
+    /// (`ThrowableProjectile.java:95-98`).
     pub gravity: f32,
     /// Which of the two tick shapes above this kind uses.
     pub order: MotionOrder,
@@ -191,17 +194,92 @@ pub fn lerp_rotation(mut current: f32, target: f32) -> f32 {
     current + 0.2 * (target - current)
 }
 
-/// Everything that reaches `AbstractArrow.tick`.
+/// How long an arrow shakes after it embeds itself, in ticks.
+///
+/// `AbstractArrow.SHAKE_TIME` (`AbstractArrow.java:63`), written by
+/// `onHitBlock` (line 502) and counted down at the top of every tick (lines
+/// 178-180). Never sent: a client sets its own copy from the `IN_GROUND` edge
+/// (lines 157-159). What the server's copy is for is the pickup gate at line
+/// 621, which refuses an arrow that is still shaking.
+pub const SHAKE_TICKS: u8 = 7;
+
+/// How far back along its own heading an arrow is pushed when it embeds itself,
+/// in blocks.
+///
+/// `onHitBlock` scales `signum(movement)` by this and subtracts it from the
+/// impact point (`AbstractArrow.java:495-498`), so the arrow's origin ends up
+/// just outside the block it struck rather than exactly on its face. Without
+/// it a resting arrow sits in the plane of the surface and z-fights it.
+pub const GROUND_BACKOFF: f32 = 0.05;
+
+/// Ticks an arrow has left to shake, counted down by the integrator.
+///
+/// A component and not a field of [`ProjectileMotion`], because it is state
+/// rather than configuration: two arrows of one kind disagree about it.
+/// Registered by [`ProjectileComponentsModule`].
+#[derive(Component, Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub struct ShakeTime(pub u8);
+
+/// `java.lang.Math.signum`, which is not [`f32::signum`].
+///
+/// Java answers zero for either zero and Rust answers ±1.0, and the difference
+/// is not academic here: an arrow flying dead flat has `movement.y == 0`, so
+/// [`f32::signum`] would back it off a twentieth of a block *downwards* as well
+/// as along its heading, and every flat shot in the game would rest below the
+/// face it hit.
+fn java_signum(value: f32) -> f32 {
+    if value > 0.0 {
+        1.0
+    } else if value < 0.0 {
+        -1.0
+    } else {
+        // Java returns the argument itself for ±0.0 and for NaN, which keeps
+        // the sign of a negative zero. Multiplying by it below gives zero
+        // either way, so the distinction never reaches a position.
+        value
+    }
+}
+
+/// Where an arrow that struck a block comes to rest, given the impact point and
+/// the velocity it arrived with.
+///
+/// The whole of `AbstractArrow.onHitBlock`'s position statement
+/// (`AbstractArrow.java:495-498`). Split out rather than inlined into the
+/// integrator so it can be checked on its own: the interesting cases are a flat
+/// shot and one that arrives exactly along an axis, and neither needs a world.
+#[must_use]
+pub fn embed_point(impact: Vec3, velocity: Vec3) -> Vec3 {
+    let offset_direction = Vec3::new(
+        java_signum(velocity.x),
+        java_signum(velocity.y),
+        java_signum(velocity.z),
+    );
+    impact - offset_direction * GROUND_BACKOFF
+}
+
+/// Everything that reaches `AbstractArrow.tick` (`AbstractArrow.java:162-231`).
+///
+/// These are the defaults, not a smash or bedwars tuning: an ability that
+/// wants something else overrides [`ProjectileMotion`] on the one projectile it
+/// fired, at the call site, where the deviation is visible. Nothing in
+/// `events/` relies on the numbers here being anything but vanilla's.
 const ARROW: ProjectileMotion = ProjectileMotion {
+    // AbstractArrow.java:65 (`INERTIA`), returned by getAirDrag at line 235.
     drag: 0.99,
+    // AbstractArrow.java:288 (`getDefaultGravity`).
     gravity: 0.05,
+    // AbstractArrow.java:218-229: clip and move, then drag, then gravity.
     order: MotionOrder::MoveThenDecay,
 };
 
-/// Everything that reaches `ThrowableProjectile.tick`.
+/// Everything that reaches `ThrowableProjectile.tick`
+/// (`ThrowableProjectile.java:48-62`).
 const THROWN: ProjectileMotion = ProjectileMotion {
+    // ThrowableProjectile.java:82 (`getAirDrag`).
     drag: 0.99,
+    // ThrowableProjectile.java:97 (`getDefaultGravity`).
     gravity: 0.03,
+    // ThrowableProjectile.java:51-55: gravity, then drag, then the move.
     order: MotionOrder::DecayThenMove,
 };
 
@@ -253,6 +331,7 @@ impl Module for ProjectileComponentsModule {
     fn module(world: &World) {
         world.import::<super::KinematicsComponentsModule>();
         world.component::<ProjectileMotion>();
+        world.component::<ShakeTime>();
     }
 }
 
@@ -290,7 +369,9 @@ impl Module for ProjectilePhysicsModule {
 
 #[cfg(test)]
 mod tests {
-    use super::{MotionOrder, SIMULATED};
+    use glam::Vec3;
+
+    use super::{GROUND_BACKOFF, MotionOrder, SIMULATED, embed_point};
 
     /// Every simulated kind must be something a client can be told about,
     /// since an entity nobody can see is not worth integrating.
@@ -302,6 +383,46 @@ mod tests {
                 "{kind:?} is simulated but has no entity type in this protocol version"
             );
         }
+    }
+
+    /// The case `f32::signum` gets wrong, and the common one: a flat shot has
+    /// `movement.y == 0`, and Java's `Math.signum` answers 0 there where Rust's
+    /// answers +1. Taking Rust's would sink every arrow in the game a
+    /// twentieth of a block below the face it hit.
+    #[test]
+    fn a_flat_shot_is_backed_off_along_its_heading_only() {
+        let impact = Vec3::new(10.0, 65.0, 0.0);
+        let resting = embed_point(impact, Vec3::new(3.0, 0.0, 0.0));
+
+        assert_eq!(
+            resting,
+            Vec3::new(10.0 - GROUND_BACKOFF, 65.0, 0.0),
+            "a flat shot should come to rest short of the wall on x alone"
+        );
+    }
+
+    /// Every axis the arrow was actually moving along backs off, and the sign
+    /// follows the heading rather than the geometry: an arrow travelling down
+    /// and west rests above and east of where it struck.
+    #[test]
+    fn the_back_off_follows_the_sign_of_every_moving_axis() {
+        let resting = embed_point(Vec3::ZERO, Vec3::new(-2.0, -1.0, 4.0));
+
+        assert_eq!(
+            resting,
+            Vec3::new(GROUND_BACKOFF, GROUND_BACKOFF, -GROUND_BACKOFF),
+            "the offset should be signum(velocity) * 0.05 subtracted from the impact"
+        );
+    }
+
+    /// The magnitude is `signum`, not the velocity: an arrow at three blocks a
+    /// tick and one at a tenth of a block a tick rest the same distance out.
+    #[test]
+    fn the_back_off_does_not_scale_with_speed() {
+        let fast = embed_point(Vec3::ZERO, Vec3::new(60.0, 0.0, 0.0));
+        let slow = embed_point(Vec3::ZERO, Vec3::new(0.01, 0.0, 0.0));
+
+        assert_eq!(fast, slow, "onHitBlock scales signum, not the movement");
     }
 
     /// The two orders are the reason this module exists, so a table that

--- a/crates/hyperion/tests/arrow_ground.rs
+++ b/crates/hyperion/tests/arrow_ground.rs
@@ -1,0 +1,146 @@
+//! An arrow that has landed stays landed.
+//!
+//! `AbstractArrow.tick` opens with two statements the integrator used to have
+//! neither of: the shake counts down (`AbstractArrow.java:178-180`), and an
+//! arrow already in the ground returns before it moves, drags or falls
+//! (lines 184-200). Without the second one a stopped arrow is only stopped for
+//! as long as its velocity happens to be zero -- gravity puts it back in motion
+//! on the very next tick and it sinks through whatever it landed on.
+//!
+//! This drives a real `HyperionCore` world through `world.progress()`, so what
+//! is under test is the shipped system and not a copy of its arithmetic. The
+//! world has no terrain (`HyperionCore` installs `Blocks::empty`), which is why
+//! the *entry* into the ground is checked against a real client in
+//! `bedwars-bow-e2e` rather than here. What a blockless world can still say is
+//! everything that follows from the state, and that is the half gravity was
+//! quietly undoing.
+//!
+//! One test and not four, because `HyperionCore` builds rayon's global thread
+//! pool and a second boot in the same process fails on it. Each phase below
+//! uses its own entity, so they do not interact.
+
+use flecs_ecs::core::{EntityView, EntityViewGet, World};
+use glam::Vec3;
+use hyperion::{
+    HyperionCore,
+    simulation::{
+        Owner, Pitch, Position, Velocity, Yaw,
+        entity_kind::EntityKind,
+        metadata::arrow::InGround,
+        projectile_motion::{SHAKE_TICKS, ShakeTime},
+    },
+};
+
+/// An arrow flying flat at one block a tick, owned by a shooter the ray cast
+/// will exclude.
+fn arrow(world: &World) -> EntityView<'_> {
+    let owner = world.entity();
+    let entity = world.entity();
+    entity
+        .add_enum(EntityKind::Arrow)
+        .set(Position::new(0.0, 100.0, 0.0))
+        .set(Velocity::new(1.0, 0.0, 0.0))
+        .set(Yaw::new(0.0))
+        .set(Pitch::new(0.0))
+        .set(Owner::new(*owner));
+    entity
+}
+
+fn state(entity: EntityView<'_>) -> (Vec3, Vec3) {
+    entity.get::<(&Position, &Velocity)>(|(position, velocity)| (**position, velocity.0))
+}
+
+fn tick(world: &World, times: u32) {
+    for _ in 0..times {
+        world.progress();
+    }
+}
+
+#[test]
+fn a_landed_arrow_holds_still_and_a_flying_one_does_not() {
+    let world = World::new();
+    world.import::<HyperionCore>();
+
+    // An arrow is told about `IN_GROUND` at all. The prefab carrying the
+    // tracked field has to be applied by kind, or the flag is a server-side
+    // boolean no client ever hears about and the client keeps flying an arrow
+    // the server has stopped.
+    let embedded = arrow(&world);
+    assert_eq!(
+        embedded.try_get::<&InGround>(|flag| **flag),
+        Some(false),
+        "every arrow should inherit the IN_GROUND tracked field, defaulted to false"
+    );
+    // And the shake clock, seeded by `seed_projectile_motion` for every kind
+    // whose tick is `AbstractArrow.tick`. Without it the impact has nowhere to
+    // write the seven ticks and the countdown below has nothing to count.
+    assert_eq!(
+        embedded.try_get::<&ShakeTime>(|shake| *shake),
+        Some(ShakeTime(0)),
+        "every arrow should be seeded with a shake clock, at rest"
+    );
+
+    // What `onHitBlock` leaves behind, except for the velocity: flagged, and
+    // shaking. Set by hand because a blockless world has nothing to hit.
+    //
+    // The velocity is left at a block a tick on purpose, and that is the whole
+    // point of this phase. `update_projectile_positions` skips a projectile
+    // that is not moving anyway, so an embedded arrow whose velocity is also
+    // zero cannot tell "in the ground" from "not moving" -- it holds still
+    // either way, and a test built on it would pass with the in-ground branch
+    // deleted. Vanilla's rule is the stronger one: `AbstractArrow.tick` returns
+    // before it looks at the movement at all (lines 184-200), so an arrow in
+    // the ground stays put whatever its velocity says. A game module that
+    // knocks a stuck arrow loose has to clear the flag, not just write a
+    // velocity.
+    embedded.set(InGround::new(true));
+    embedded.set(ShakeTime(SHAKE_TICKS));
+    let (resting, _) = state(embedded);
+
+    // One tick short of the full count, so the value is still positive: a
+    // countdown that jumped straight to zero would pass an "eventually zero"
+    // assertion just as loudly.
+    tick(&world, u32::from(SHAKE_TICKS) - 1);
+    assert_eq!(
+        embedded.get::<&ShakeTime>(|shake| *shake),
+        ShakeTime(1),
+        "the shake should count down one tick at a time"
+    );
+
+    tick(&world, 20);
+    assert_eq!(
+        embedded.get::<&ShakeTime>(|shake| *shake),
+        ShakeTime(0),
+        "the shake should stop at zero rather than wrap"
+    );
+
+    let (position, velocity) = state(embedded);
+    assert_eq!(
+        position, resting,
+        "an arrow in the ground should not move, whatever its velocity says; it drifted to \
+         {position}"
+    );
+    assert_eq!(
+        velocity,
+        Vec3::new(1.0, 0.0, 0.0),
+        "an arrow in the ground should lose nothing to drag and gain nothing from gravity; its \
+         velocity became {velocity}"
+    );
+
+    // The guard for the guard: the same twenty ticks, without the flag, must
+    // move the arrow. Otherwise everything above passes on a world that never
+    // ticked at all.
+    let flying = arrow(&world);
+    let (start, _) = state(flying);
+    tick(&world, 20);
+
+    let (position, velocity) = state(flying);
+    assert!(
+        position.x > start.x + 1.0,
+        "a flying arrow should have travelled; it is at {position}"
+    );
+    assert!(
+        velocity.y < -0.5,
+        "a flying arrow should be falling by now; its velocity is {velocity}"
+    );
+}

--- a/events/bedwars/src/module/bow.rs
+++ b/events/bedwars/src/module/bow.rs
@@ -6,7 +6,6 @@ use flecs_ecs::{
 };
 use hyperion::{
     ItemKind, ItemStack,
-    glam::Vec3,
     net::Channel,
     simulation::{
         Owner, Pitch, Player, Position, Spawn, Uuid, Velocity, Yaw,
@@ -312,25 +311,26 @@ impl Module for BowModule {
             }
         });
 
-        // multi-threaded causes issues
+        // Stopping the arrow is no longer this module's job: `AbstractArrow.
+        // onHitBlock` is one statement -- pin, zero, embed -- and
+        // `update_projectile_positions` now performs all of it in the tick the
+        // hit happens. Doing it here as well used to overwrite the engine's
+        // backed-off resting point with the raw impact point, and doing it a
+        // pipeline stage later left a window in which the arrow was stopped by
+        // the world and still carrying its flight speed.
+        //
+        // The queue still has to be emptied. `EventQueue` has no cycle-end
+        // clear, so an unread event lives until someone drains it and a match
+        // that never did would grow one entry per arrow that ever landed.
         system!(
             "arrow_block_hit",
             world,
             &mut EventQueue<event::ProjectileBlockEvent>,
         )
         .kind(id::<flecs::pipeline::PreStore>())
-        .each_iter(move |it, _, event_queue| {
-            let world = it.world();
-
+        .each_iter(move |_, _, event_queue| {
             for event in event_queue.drain() {
-                event
-                    .projectile
-                    .entity_view(world)
-                    .get::<(&mut Position, &mut Velocity)>(|(position, velocity)| {
-                        debug!("Arrow hit block at {:?}", event.collision.point);
-                        velocity.0 = Vec3::ZERO;
-                        **position = event.collision.point;
-                    });
+                debug!("Arrow hit block at {:?}", event.collision.point);
             }
         });
 

--- a/tools/bow-check.py
+++ b/tools/bow-check.py
@@ -497,45 +497,43 @@ def main():
 
     # --- the arrow stops in the ground it was fired into ---------------
     #
-    # From up in the air, aimed straight down, with a short draw. Every part of
-    # that is load bearing. Standing on the ground there is one eye height of
-    # clearance and the flight is over before the client has subscribed to the
-    # arrow's channel, so nothing about it reaches the wire at all; climbing
-    # buys a fall long enough to watch, and a short draw makes it last tens of
-    # ticks rather than four.
+    # Straight up, with a short draw, and let it fall back onto the block it
+    # was fired from. Every part of that is load bearing.
     #
-    # hyperion takes the client's own position, so the climb is only position
-    # packets. It is checked rather than assumed, because a server that
-    # rubber-banded would leave every assertion below measuring the old
-    # invisible shot again.
-    client.aim(0.0, 90.0)
-    ground = client.position[1]
-    for step in range(1, 16):
-        client.position = (client.position[0], ground + step, client.position[2])
-        client.on_ground = False
-        client.send_position()
-        pump(client, 0.1)
-    climbed = client.position[1] - ground
-    print("climbed %.2f blocks above the ground (y %.2f -> %.2f)"
-          % (climbed, ground, client.position[1]), flush=True)
-    check(
-        climbed > 12.0,
-        "the shooter can get above the ground, so the downward shot has room "
-        "to be seen flying (climbed %.2f blocks)" % climbed,
-    )
-
+    # The obvious shot -- level, or down at your feet -- cannot be seen at all.
+    # It meets something within a tick or two, which is before the client's
+    # subscription to the arrow's channel has landed, so the client receives
+    # **zero** `SetEntityMotion` for it. That is measured, not feared: the run
+    # that established it printed `impact: 0 velocity broadcasts`. Firing
+    # upwards buys the subscription time to arrive and then guarantees the
+    # impact anyway, because an arrow with no horizontal velocity comes down on
+    # the terrain it left. A short draw keeps the whole round trip inside two
+    # seconds.
+    #
+    # What used to be asserted here was a *second* `AddEntity` carrying
+    # |v| == 0, on the stated grounds that the server re-sends a pinned arrow.
+    # It does not and never did: the second `AddEntity` is
+    # `send_subscribe_channel_packets` replaying the spawn for a client that has
+    # just subscribed, and it carries whatever the arrow's velocity happens to
+    # be at that moment -- one tick after launch on a level shot, which is
+    # 3.0 * 0.99 == 2.970, exactly the number the failures printed about three
+    # runs in four (ENG-12085). It was a race between the subscription and the
+    # wall, not a flake.
+    pump(client, 0.5)
+    client.aim(0.0, -90.0)
+    client.send_position()
     client.motions.clear()
-    down = draw(0.25, "(quarter draw, straight down)")
-    check(len(down) == 1, "the downward draw fires one arrow (got %d)" % len(down))
-    if down:
-        down_id = down[0][0]["id"]
-        pump(client, 1.5)
-        flight = client.motions.get(down_id, [])
+    up = draw(0.25, "(quarter draw, straight up)")
+    check(len(up) == 1, "the upward short draw fires one arrow (got %d)" % len(up))
+    if up:
+        up_id = up[0][0]["id"]
+        pump(client, 2.0)
+        flight = client.motions.get(up_id, [])
         speeds = [(vx * vx + vy * vy + vz * vz) ** 0.5 for vx, vy, vz in flight]
         first_stop = next((i for i, v in enumerate(speeds) if v == 0.0), None)
         print(
             "impact: %d velocity broadcasts, first zero at %s, speeds %s"
-            % (len(speeds), first_stop, ["%.3f" % v for v in speeds[:8]]),
+            % (len(speeds), first_stop, ["%.3f" % v for v in speeds[:6]]),
             flush=True,
         )
         # `onHitBlock` zeroes the velocity in the tick of the hit and broadcasts
@@ -550,8 +548,8 @@ def main():
         # evidence of neither. That vacuity is ENG-12082 on the smash side.
         check(
             first_stop is not None and first_stop >= 1,
-            "an arrow that hits the ground stops, and was seen moving first: "
-            "%d velocity broadcasts, first zero at index %s"
+            "an arrow that falls back to the ground stops in it, and was seen "
+            "flying first: %d velocity broadcasts, first zero at index %s"
             % (len(speeds), first_stop),
         )
         if first_stop is not None:
@@ -559,26 +557,18 @@ def main():
             check(
                 all(v == 0.0 for v in after),
                 "a stopped arrow stays stopped: %d broadcasts after the first "
-                "zero, %s" % (len(after), ["%.3f" % v for v in after[:8]]),
+                "zero, %s" % (len(after), ["%.3f" % v for v in after[:6]]),
             )
-            # The fall it can be seen making is bounded by the clearance it had.
-            # An arrow that was never stopped keeps accelerating for the whole
-            # sampling window, which is far more than this.
-            drop = -sum(vy for _, vy, _ in flight)
-            ceiling = climbed + 2.0
-            print("downward arrow: fell %.2f blocks over %d ticks (clearance ~%.2f)"
-                  % (drop, len(flight), climbed), flush=True)
+            # It went up and it came back down: the sign of vy has to change,
+            # or the arrow was stopped on the way up by something and the round
+            # trip this assertion is built on never happened.
+            rising = [vy for _, vy, _ in flight[:first_stop] if vy > 0.0]
+            falling = [vy for _, vy, _ in flight[:first_stop] if vy < 0.0]
             check(
-                drop < ceiling,
-                "the arrow stopped in the ground rather than falling through it "
-                "(fell %.2f blocks against %.2f of clearance)" % (drop, ceiling),
+                len(rising) >= 1 and len(falling) >= 1,
+                "the arrow rose and then fell before it stopped (%d rising "
+                "ticks, %d falling)" % (len(rising), len(falling)),
             )
-
-    # Back on the ground for the flight check below.
-    client.position = (client.position[0], ground, client.position[2])
-    client.on_ground = True
-    client.send_position()
-    pump(client, 0.5)
 
     # --- the arrow actually flies, on the wire ------------------------
     #

--- a/tools/bow-check.py
+++ b/tools/bow-check.py
@@ -386,48 +386,24 @@ def main():
         "old seconds-as-charge produced (got %.3f)" % (MAX_ARROW_SPEED, speed),
     )
 
-    # The impact, read off the velocity stream.
+    # Nothing about the impact is asserted here, and that is a measurement
+    # rather than an omission. A level shot from the ground meets something
+    # within a tick or two, which is before the client's subscription to the
+    # arrow's channel has landed, so it receives **zero** `SetEntityMotion` for
+    # this arrow -- the run that established this printed `0 velocity
+    # broadcasts`. There is no impact to see from here.
     #
-    # This used to look for a *second* `AddEntity` carrying |v| == 0, on the
-    # stated grounds that the server re-sends a pinned arrow. It does not, and
-    # never did: the second AddEntity is `send_subscribe_channel_packets`
-    # answering the client's subscription to the arrow's channel, which lands
-    # whenever the arrow enters view -- usually one tick after launch, carrying
-    # 3.0 * 0.99 == 2.970. So the check passed only in the minority of runs
-    # where the subscription happened to arrive after the arrow had already
-    # stopped, which is why it read as a 3-in-4 flake rather than as a wrong
-    # question (ENG-12085).
+    # What used to be asserted here was a *second* `AddEntity` carrying
+    # |v| == 0, on the stated grounds that the server re-sends a pinned arrow.
+    # It does not and never did: the second `AddEntity` is
+    # `send_subscribe_channel_packets` replaying the spawn for a client that
+    # has just subscribed, and it carries whatever the arrow's velocity is at
+    # that moment. On this shot that is one tick after launch, 3.0 * 0.99 ==
+    # 2.970 -- exactly the number the failures printed, about three runs in
+    # four (ENG-12085). It was a race between the subscription and the wall,
+    # not a flake, and it is still a race whichever value the replay carries.
     #
-    # `onHitBlock` zeroes the velocity in the tick of the hit and broadcasts it
-    # (`AbstractArrow.java:499` and the `needsSync` at line 253), so a zero
-    # `SetEntityMotion` is the impact as a client sees it, and it is the packet
-    # that stops the client dead-reckoning the arrow onwards through the block.
-    #
-    # A non-zero broadcast has to come first. That is the whole discrimination:
-    # "every broadcast at rest" is also what an arrow that never moved looks
-    # like, and a check that cannot tell those apart is evidence of neither
-    # (the same vacuity as ENG-12082).
-    flight = client.motions.get(launch["id"], [])
-    speeds = [(vx * vx + vy * vy + vz * vz) ** 0.5 for vx, vy, vz in flight]
-    first_stop = next((i for i, v in enumerate(speeds) if v == 0.0), None)
-    print(
-        "impact: %d velocity broadcasts, first zero at %s, speeds %s"
-        % (len(speeds), first_stop, ["%.3f" % v for v in speeds[:8]]),
-        flush=True,
-    )
-    check(
-        first_stop is not None and first_stop >= 1,
-        "an arrow that hits a block stops, and was seen moving first: %d "
-        "velocity broadcasts, first zero at index %s"
-        % (len(speeds), first_stop),
-    )
-    if first_stop is not None:
-        after = speeds[first_stop:]
-        check(
-            all(v == 0.0 for v in after),
-            "a stopped arrow stays stopped: %d broadcasts after the first zero, "
-            "%s" % (len(after), ["%.3f" % v for v in after[:8]]),
-        )
+    # The impact is asserted below instead, from a shot with room to be seen.
 
     pump(client, 0.5)
     after = client.count_of("minecraft:arrow")
@@ -518,6 +494,91 @@ def main():
             "the wire yaw is not the shooter's look yaw of 35 (the mirrored-"
             "heading bug); got %.1f" % wire_yaw,
         )
+
+    # --- the arrow stops in the ground it was fired into ---------------
+    #
+    # From up in the air, aimed straight down, with a short draw. Every part of
+    # that is load bearing. Standing on the ground there is one eye height of
+    # clearance and the flight is over before the client has subscribed to the
+    # arrow's channel, so nothing about it reaches the wire at all; climbing
+    # buys a fall long enough to watch, and a short draw makes it last tens of
+    # ticks rather than four.
+    #
+    # hyperion takes the client's own position, so the climb is only position
+    # packets. It is checked rather than assumed, because a server that
+    # rubber-banded would leave every assertion below measuring the old
+    # invisible shot again.
+    client.aim(0.0, 90.0)
+    ground = client.position[1]
+    for step in range(1, 16):
+        client.position = (client.position[0], ground + step, client.position[2])
+        client.on_ground = False
+        client.send_position()
+        pump(client, 0.1)
+    climbed = client.position[1] - ground
+    print("climbed %.2f blocks above the ground (y %.2f -> %.2f)"
+          % (climbed, ground, client.position[1]), flush=True)
+    check(
+        climbed > 12.0,
+        "the shooter can get above the ground, so the downward shot has room "
+        "to be seen flying (climbed %.2f blocks)" % climbed,
+    )
+
+    client.motions.clear()
+    down = draw(0.25, "(quarter draw, straight down)")
+    check(len(down) == 1, "the downward draw fires one arrow (got %d)" % len(down))
+    if down:
+        down_id = down[0][0]["id"]
+        pump(client, 1.5)
+        flight = client.motions.get(down_id, [])
+        speeds = [(vx * vx + vy * vy + vz * vz) ** 0.5 for vx, vy, vz in flight]
+        first_stop = next((i for i, v in enumerate(speeds) if v == 0.0), None)
+        print(
+            "impact: %d velocity broadcasts, first zero at %s, speeds %s"
+            % (len(speeds), first_stop, ["%.3f" % v for v in speeds[:8]]),
+            flush=True,
+        )
+        # `onHitBlock` zeroes the velocity in the tick of the hit and broadcasts
+        # it (`AbstractArrow.java:499`, and the `needsSync` at line 253), so a
+        # zero `SetEntityMotion` is the impact as a client sees it -- and it is
+        # the packet that stops the client dead-reckoning the arrow onwards
+        # through the block.
+        #
+        # A non-zero broadcast has to come first, and that is the whole
+        # discrimination: "every broadcast at rest" is also what an arrow that
+        # never moved looks like, and a check that cannot tell those apart is
+        # evidence of neither. That vacuity is ENG-12082 on the smash side.
+        check(
+            first_stop is not None and first_stop >= 1,
+            "an arrow that hits the ground stops, and was seen moving first: "
+            "%d velocity broadcasts, first zero at index %s"
+            % (len(speeds), first_stop),
+        )
+        if first_stop is not None:
+            after = speeds[first_stop:]
+            check(
+                all(v == 0.0 for v in after),
+                "a stopped arrow stays stopped: %d broadcasts after the first "
+                "zero, %s" % (len(after), ["%.3f" % v for v in after[:8]]),
+            )
+            # The fall it can be seen making is bounded by the clearance it had.
+            # An arrow that was never stopped keeps accelerating for the whole
+            # sampling window, which is far more than this.
+            drop = -sum(vy for _, vy, _ in flight)
+            ceiling = climbed + 2.0
+            print("downward arrow: fell %.2f blocks over %d ticks (clearance ~%.2f)"
+                  % (drop, len(flight), climbed), flush=True)
+            check(
+                drop < ceiling,
+                "the arrow stopped in the ground rather than falling through it "
+                "(fell %.2f blocks against %.2f of clearance)" % (drop, ceiling),
+            )
+
+    # Back on the ground for the flight check below.
+    client.position = (client.position[0], ground, client.position[2])
+    client.on_ground = True
+    client.send_position()
+    pump(client, 0.5)
 
     # --- the arrow actually flies, on the wire ------------------------
     #

--- a/tools/bow-check.py
+++ b/tools/bow-check.py
@@ -337,10 +337,14 @@ def main():
     def arrows_seen():
         """Every distinct arrow entity, as (launch, latest).
 
-        One arrow shows up in more than one `AddEntity`: the launch, and then
-        another when `arrow_block_hit` pins it into whatever it ran into. They
-        share an entity id, so the id is what counts an arrow and the order
-        gives the before and after.
+        One arrow can show up in more than one `AddEntity`: the launch, and
+        then again whenever a client subscribes to its channel and
+        `send_subscribe_channel_packets` replays the spawn. They share an
+        entity id, so the id is what counts an arrow.
+
+        The second one is a subscription and not an impact -- reading it as one
+        is ENG-12085 -- so nothing below asserts on `latest`. What an impact
+        looks like on the wire is a zero `SetEntityMotion`, in `client.motions`.
         """
         out = {}
         for entry in client.spawned:
@@ -374,7 +378,7 @@ def main():
         print("RESULT: failure (nothing was fired)", flush=True)
         return 1
 
-    launch, latest = full[0]
+    launch, _latest = full[0]
     speed = launch["speed"]
     check(
         abs(speed - MAX_ARROW_SPEED) < 0.05,
@@ -382,15 +386,48 @@ def main():
         "old seconds-as-charge produced (got %.3f)" % (MAX_ARROW_SPEED, speed),
     )
 
-    # `arrow_block_hit` zeroes the velocity and pins the arrow at the collision
-    # point, and the client is told again. Free to assert here because the
-    # world bedwars loads has something to hit in every direction.
-    check(
-        latest is not launch and latest["speed"] == 0.0,
-        "an arrow that hits a block stops: it was re-sent at (%.2f, %.2f, "
-        "%.2f) with |v|=%.3f"
-        % (latest["position"] + (latest["speed"],)),
+    # The impact, read off the velocity stream.
+    #
+    # This used to look for a *second* `AddEntity` carrying |v| == 0, on the
+    # stated grounds that the server re-sends a pinned arrow. It does not, and
+    # never did: the second AddEntity is `send_subscribe_channel_packets`
+    # answering the client's subscription to the arrow's channel, which lands
+    # whenever the arrow enters view -- usually one tick after launch, carrying
+    # 3.0 * 0.99 == 2.970. So the check passed only in the minority of runs
+    # where the subscription happened to arrive after the arrow had already
+    # stopped, which is why it read as a 3-in-4 flake rather than as a wrong
+    # question (ENG-12085).
+    #
+    # `onHitBlock` zeroes the velocity in the tick of the hit and broadcasts it
+    # (`AbstractArrow.java:499` and the `needsSync` at line 253), so a zero
+    # `SetEntityMotion` is the impact as a client sees it, and it is the packet
+    # that stops the client dead-reckoning the arrow onwards through the block.
+    #
+    # A non-zero broadcast has to come first. That is the whole discrimination:
+    # "every broadcast at rest" is also what an arrow that never moved looks
+    # like, and a check that cannot tell those apart is evidence of neither
+    # (the same vacuity as ENG-12082).
+    flight = client.motions.get(launch["id"], [])
+    speeds = [(vx * vx + vy * vy + vz * vz) ** 0.5 for vx, vy, vz in flight]
+    first_stop = next((i for i, v in enumerate(speeds) if v == 0.0), None)
+    print(
+        "impact: %d velocity broadcasts, first zero at %s, speeds %s"
+        % (len(speeds), first_stop, ["%.3f" % v for v in speeds[:8]]),
+        flush=True,
     )
+    check(
+        first_stop is not None and first_stop >= 1,
+        "an arrow that hits a block stops, and was seen moving first: %d "
+        "velocity broadcasts, first zero at index %s"
+        % (len(speeds), first_stop),
+    )
+    if first_stop is not None:
+        after = speeds[first_stop:]
+        check(
+            all(v == 0.0 for v in after),
+            "a stopped arrow stays stopped: %d broadcasts after the first zero, "
+            "%s" % (len(after), ["%.3f" % v for v in after[:8]]),
+        )
 
     pump(client, 0.5)
     after = client.count_of("minecraft:arrow")

--- a/tools/smash-bow-check.py
+++ b/tools/smash-bow-check.py
@@ -252,19 +252,38 @@ def main():
     # this feature's version of it.
     #
     # Straight down, so the geometry needs nothing from the map: the shooter is
-    # standing on the arena floor, so a block is about `EYE_HEIGHT` under the
-    # muzzle whatever the map is and wherever on it they stand.
+    # above the arena floor, so a block is under the muzzle whatever the map is
+    # and wherever on it they stand.
     #
-    # A *short* draw, and that is not a detail. A full draw is 3.0 blocks a tick
-    # against 1.62 blocks of clearance, so the arrow reaches the floor inside
-    # its first tick -- before `smash::draw_projectiles` has decorated it, since
-    # `smash::fly` runs first in the same phase. The AddEntity that reaches the
-    # client then carries a velocity of zero, and every assertion below reads
-    # exactly as it would for an arrow that never launched. That is not a
-    # hypothetical: this check was written with a full draw, passed, and was
-    # measuring nothing. A short draw leaves about 0.4 blocks a tick, which is
-    # four ticks of real flight before the floor stops it.
-    pump(client, 0.6)
+    # From up in the air, and that is not a detail. Standing on the floor there
+    # is one eye height of clearance, and `smash::draw_projectiles` only
+    # decorates the projectile after `smash::fly` has already integrated it in
+    # the same phase -- so the AddEntity the client is told about lands half a
+    # block into a flight that is over in two ticks, and every velocity
+    # broadcast after it is a tail of zeros. That is ENG-12082: the drop
+    # measured `-0.00` blocks and the check called it a PASS. Climbing first
+    # buys about ten blocks of fall, which is twenty ticks of observable travel
+    # after the arrow exists on the wire.
+    #
+    # hyperion takes the client's own position, so the climb is just position
+    # packets; there is nothing to ask permission for. It is checked below
+    # rather than assumed, because a server that did rubber-band would leave
+    # every assertion after it measuring the old vacuous shot again.
+    ground = client.position[1]
+    for step in range(1, 11):
+        client.position = (client.position[0], ground + step, client.position[2])
+        client.on_ground = False
+        client.send_position()
+        pump(client, 0.1)
+    climbed = client.position[1] - ground
+    print("climbed %.2f blocks above the floor (y %.2f -> %.2f)"
+          % (climbed, ground, client.position[1]), flush=True)
+    check(
+        climbed > 8.0,
+        "the shooter can get above the floor, so the downward shot has room to "
+        "be seen flying (climbed %.2f blocks)" % climbed,
+    )
+
     down = draw(0.4, "straight down", pitch=90.0, settle=2.0)
     check(len(down) >= 1, "a downward draw fires (got %d arrows)" % len(down))
     if down:
@@ -273,7 +292,7 @@ def main():
         down_velocities = client.motions.get(down_id, [])
 
         # The launch, asserted before anything about the stop. Without this the
-        # two checks below pass just as loudly for an arrow that never moved:
+        # checks below pass just as loudly for an arrow that never moved:
         # "fell 0.00 blocks" and "every broadcast at rest" are what a projectile
         # fired at zero speed looks like too, and a gate that cannot tell the
         # feature working from the feature never firing is not evidence of
@@ -293,38 +312,64 @@ def main():
             % len(down_velocities),
         )
 
+        # The shape that says "it flew, then it stopped", and the one the old
+        # check could not see: a non-zero broadcast strictly before the first
+        # zero. `len(stopped) >= 1` on its own is satisfied *most* loudly by an
+        # arrow that never moved on the wire -- eighteen of eighteen ticks at
+        # rest was its best possible score.
+        moving = [
+            i for i, v in enumerate(down_velocities) if v != (0.0, 0.0, 0.0)
+        ]
+        first_stop = next(
+            (i for i, v in enumerate(down_velocities) if v == (0.0, 0.0, 0.0)),
+            None,
+        )
+        print("downward stream: %d broadcasts, %d moving, first zero at %s"
+              % (len(down_velocities), len(moving), first_stop), flush=True)
+        check(
+            first_stop is not None and first_stop >= 1,
+            "the downward arrow was seen flying and then seen stopping "
+            "(%d broadcasts, %d of them moving, first zero at index %s)"
+            % (len(down_velocities), len(moving), first_stop),
+        )
+
         # Integrate the velocity stream, exactly as the open-sky check above
         # does. There is no absolute position on the wire for an arrow -- the
         # gate asserts that too, a few checks up -- so the drop is the sum of
         # the per-tick velocities, and the client dead-reckons it the same way.
         drop = -sum(vy for _, vy, _ in down_velocities)
-        # The muzzle sits `EYE_HEIGHT` above the floor, so a stopped arrow falls
-        # about 1.6 blocks and no more. An unstopped one keeps accelerating
-        # under smash's gravity for the whole window this samples -- roughly
-        # sixteen blocks over these ticks, and before this feature it fell until
-        # the projectile's timer expired, straight through the map. 2.5 blocks
-        # is the stopped answer plus slack for where in the block it lands; it
-        # is nowhere near the unstopped one.
-        print("downward arrow: fell %.2f blocks over %d ticks"
-              % (drop, len(down_velocities)), flush=True)
+        # The muzzle sits `climbed + EYE_HEIGHT` above the floor and the client
+        # only hears about the arrow part way down, so the drop it can see is at
+        # most that and usually less. An unstopped arrow keeps accelerating
+        # under smash's gravity for the whole window this samples, and before
+        # this feature it fell until the projectile's timer expired, straight
+        # through the map. The bound is the clearance plus a block of slack for
+        # where in the block it lands.
+        ceiling = climbed + EYE_HEIGHT + 1.0
+        print("downward arrow: fell %.2f blocks over %d ticks (clearance %.2f)"
+              % (drop, len(down_velocities), climbed + EYE_HEIGHT), flush=True)
         check(
-            drop < 2.5,
+            drop < ceiling,
             "an arrow fired straight down stops in the floor rather than falling "
-            "through it (fell %.2f blocks; it launched at %.2f a tick, and the same "
-            "draw fired at the sky covers tens of blocks)" % (drop, -launch_vy),
+            "through it (fell %.2f blocks against %.2f of clearance; it launched "
+            "at %.2f a tick)" % (drop, ceiling, -launch_vy),
         )
 
         # And the stop is a stop, not merely a slow one. `smash::fly` zeroes the
         # flight on impact and `advance_drawn_projectiles` puts that on the wire,
-        # so a zero-velocity broadcast is the impact as a client sees it. Without
-        # this, an arrow that merely ran out of broadcast would satisfy the drop
-        # bound above by saying nothing.
+        # so a zero-velocity broadcast is the impact as a client sees it.
         stopped = [v for v in down_velocities if v == (0.0, 0.0, 0.0)]
         check(
             len(stopped) >= 1,
             "the impact reaches the client as a zero-velocity broadcast (got %d of %d "
             "ticks at rest)" % (len(stopped), len(down_velocities)),
         )
+
+    # Back on the floor for whatever comes next.
+    client.position = (client.position[0], ground, client.position[2])
+    client.on_ground = True
+    client.send_position()
+    pump(client, 0.5)
 
     pump(client, 0.6)
     short = draw(0.4, "short draw")

--- a/tools/smash-bow-check.py
+++ b/tools/smash-bow-check.py
@@ -251,65 +251,47 @@ def main():
     # in the repo's CLAUDE.md, and this is the assertion that would have caught
     # this feature's version of it.
     #
-    # Straight down, so the geometry needs nothing from the map: the shooter is
-    # above the arena floor, so a block is under the muzzle whatever the map is
-    # and wherever on it they stand.
+    # Straight up, with a short draw, and let it fall back onto the arena
+    # floor. Every part of that is load bearing.
     #
-    # From up in the air, and that is not a detail. Standing on the floor there
-    # is one eye height of clearance, and `smash::draw_projectiles` only
-    # decorates the projectile after `smash::fly` has already integrated it in
-    # the same phase -- so the AddEntity the client is told about lands half a
-    # block into a flight that is over in two ticks, and every velocity
-    # broadcast after it is a tail of zeros. That is ENG-12082: the drop
-    # measured `-0.00` blocks and the check called it a PASS. Climbing first
-    # buys about ten blocks of fall, which is twenty ticks of observable travel
-    # after the arrow exists on the wire.
-    #
-    # hyperion takes the client's own position, so the climb is just position
-    # packets; there is nothing to ask permission for. It is checked below
-    # rather than assumed, because a server that did rubber-band would leave
-    # every assertion after it measuring the old vacuous shot again.
-    ground = client.position[1]
-    for step in range(1, 11):
-        client.position = (client.position[0], ground + step, client.position[2])
-        client.on_ground = False
-        client.send_position()
-        pump(client, 0.1)
-    climbed = client.position[1] - ground
-    print("climbed %.2f blocks above the floor (y %.2f -> %.2f)"
-          % (climbed, ground, client.position[1]), flush=True)
-    check(
-        climbed > 8.0,
-        "the shooter can get above the floor, so the downward shot has room to "
-        "be seen flying (climbed %.2f blocks)" % climbed,
-    )
-
-    down = draw(0.4, "straight down", pitch=90.0, settle=2.0)
-    check(len(down) >= 1, "a downward draw fires (got %d arrows)" % len(down))
-    if down:
-        launched = down[0]
-        down_id = launched["id"]
-        down_velocities = client.motions.get(down_id, [])
+    # Down at your feet is the obvious shot and it cannot be seen. Standing on
+    # the floor there is one eye height of clearance, and
+    # `smash::draw_projectiles` only decorates the projectile after
+    # `smash::fly` has already integrated it in the same phase -- so the
+    # AddEntity the client is told about lands half a block into a flight that
+    # is over in two ticks, and every velocity broadcast after it is a tail of
+    # zeros. That is ENG-12082: the drop measured `-0.00` blocks and the check
+    # called it a PASS. Firing upwards gives the drawn entity a whole flight to
+    # exist for, and an arrow with no horizontal velocity comes back down on the
+    # terrain it left, so the impact is guaranteed without knowing anything
+    # about the map.
+    pump(client, 0.6)
+    up = draw(0.4, "straight up", pitch=-90.0, settle=2.5)
+    check(len(up) >= 1, "an upward draw fires (got %d arrows)" % len(up))
+    if up:
+        launched = up[0]
+        up_id = launched["id"]
+        velocities = client.motions.get(up_id, [])
 
         # The launch, asserted before anything about the stop. Without this the
-        # checks below pass just as loudly for an arrow that never moved:
-        # "fell 0.00 blocks" and "every broadcast at rest" are what a projectile
-        # fired at zero speed looks like too, and a gate that cannot tell the
-        # feature working from the feature never firing is not evidence of
-        # either. The AddEntity motion is the launch as the wire carried it, one
-        # packet before any collision could have touched it.
+        # checks below pass just as loudly for an arrow that never moved: "every
+        # broadcast at rest" is what a projectile fired at zero speed looks like
+        # too, and a gate that cannot tell the feature working from the feature
+        # never firing is evidence of neither. The AddEntity motion is the launch
+        # as the wire carried it, one packet before any collision could have
+        # touched it.
         launch_vy = launched["motion"][1]
-        print("downward launch: speed %.3f, vy %.3f"
+        print("upward launch: speed %.3f, vy %.3f"
               % (launched["speed"], launch_vy), flush=True)
         check(
-            launch_vy < -0.2,
-            "the downward arrow launched downwards at speed (vy %.3f blocks a tick)"
+            launch_vy > 0.2,
+            "the upward arrow launched upwards at speed (vy %.3f blocks a tick)"
             % launch_vy,
         )
         check(
-            len(down_velocities) >= 2,
-            "the downward arrow is broadcast while it flies (got %d SetEntityMotion)"
-            % len(down_velocities),
+            len(velocities) >= 2,
+            "the upward arrow is broadcast while it flies (got %d SetEntityMotion)"
+            % len(velocities),
         )
 
         # The shape that says "it flew, then it stopped", and the one the old
@@ -317,59 +299,43 @@ def main():
         # zero. `len(stopped) >= 1` on its own is satisfied *most* loudly by an
         # arrow that never moved on the wire -- eighteen of eighteen ticks at
         # rest was its best possible score.
-        moving = [
-            i for i, v in enumerate(down_velocities) if v != (0.0, 0.0, 0.0)
-        ]
         first_stop = next(
-            (i for i, v in enumerate(down_velocities) if v == (0.0, 0.0, 0.0)),
+            (i for i, v in enumerate(velocities) if v == (0.0, 0.0, 0.0)),
             None,
         )
-        print("downward stream: %d broadcasts, %d moving, first zero at %s"
-              % (len(down_velocities), len(moving), first_stop), flush=True)
+        moving = [i for i, v in enumerate(velocities) if v != (0.0, 0.0, 0.0)]
+        print("upward stream: %d broadcasts, %d moving, first zero at %s"
+              % (len(velocities), len(moving), first_stop), flush=True)
         check(
             first_stop is not None and first_stop >= 1,
-            "the downward arrow was seen flying and then seen stopping "
-            "(%d broadcasts, %d of them moving, first zero at index %s)"
-            % (len(down_velocities), len(moving), first_stop),
+            "the arrow was seen flying and then seen stopping (%d broadcasts, "
+            "%d of them moving, first zero at index %s)"
+            % (len(velocities), len(moving), first_stop),
         )
 
-        # Integrate the velocity stream, exactly as the open-sky check above
-        # does. There is no absolute position on the wire for an arrow -- the
-        # gate asserts that too, a few checks up -- so the drop is the sum of
-        # the per-tick velocities, and the client dead-reckons it the same way.
-        drop = -sum(vy for _, vy, _ in down_velocities)
-        # The muzzle sits `climbed + EYE_HEIGHT` above the floor and the client
-        # only hears about the arrow part way down, so the drop it can see is at
-        # most that and usually less. An unstopped arrow keeps accelerating
-        # under smash's gravity for the whole window this samples, and before
-        # this feature it fell until the projectile's timer expired, straight
-        # through the map. The bound is the clearance plus a block of slack for
-        # where in the block it lands.
-        ceiling = climbed + EYE_HEIGHT + 1.0
-        print("downward arrow: fell %.2f blocks over %d ticks (clearance %.2f)"
-              % (drop, len(down_velocities), climbed + EYE_HEIGHT), flush=True)
-        check(
-            drop < ceiling,
-            "an arrow fired straight down stops in the floor rather than falling "
-            "through it (fell %.2f blocks against %.2f of clearance; it launched "
-            "at %.2f a tick)" % (drop, ceiling, -launch_vy),
-        )
+        if first_stop is not None:
+            # It went up and it came back down. Without this the stop could be
+            # the arrow hitting a ceiling on the way up, and the claim being
+            # made -- that an arrow stops in the ground rather than falling
+            # through it -- would not have been exercised at all.
+            rising = [vy for _, vy, _ in velocities[:first_stop] if vy > 0.0]
+            falling = [vy for _, vy, _ in velocities[:first_stop] if vy < 0.0]
+            check(
+                len(rising) >= 1 and len(falling) >= 1,
+                "the arrow rose and then fell before it stopped (%d rising "
+                "ticks, %d falling)" % (len(rising), len(falling)),
+            )
 
-        # And the stop is a stop, not merely a slow one. `smash::fly` zeroes the
-        # flight on impact and `advance_drawn_projectiles` puts that on the wire,
-        # so a zero-velocity broadcast is the impact as a client sees it.
-        stopped = [v for v in down_velocities if v == (0.0, 0.0, 0.0)]
-        check(
-            len(stopped) >= 1,
-            "the impact reaches the client as a zero-velocity broadcast (got %d of %d "
-            "ticks at rest)" % (len(stopped), len(down_velocities)),
-        )
-
-    # Back on the floor for whatever comes next.
-    client.position = (client.position[0], ground, client.position[2])
-    client.on_ground = True
-    client.send_position()
-    pump(client, 0.5)
+            # And it stays stopped: `smash::fly` zeroes the flight on impact,
+            # `advance_drawn_projectiles` puts that on the wire, and `Stuck`
+            # keeps it there.
+            after = velocities[first_stop:]
+            check(
+                all(v == (0.0, 0.0, 0.0) for v in after),
+                "a stopped arrow stays stopped: %d broadcasts after the first "
+                "zero, %d of them moving"
+                % (len(after), sum(1 for v in after if v != (0.0, 0.0, 0.0))),
+            )
 
     pump(client, 0.6)
     short = draw(0.4, "short draw")


### PR DESCRIPTION
## What was wrong

`AbstractArrow.onHitBlock` is one statement: pin the arrow just short of the face it struck, zero its velocity, put it in the ground (`AbstractArrow.java:484-502`). hyperion performed none of it. `update_projectile_positions` detected the hit, left the arrow exactly where it was with its flight speed intact, and pushed a `ProjectileBlockEvent`; `events/bedwars` then wrote the position and velocity a pipeline stage later, at `PreStore`.

Two consequences:

- **A window each impact where the arrow was stopped by the world and still moving.** Anything reading `Velocity` between `OnUpdate` and `PreStore` got the flight speed.
- **No packet ever told a client the arrow had stopped.** The client runs `AbstractArrow.tick` too, seeded from the last velocity it was sent, so it kept dead-reckoning the arrow straight through the block. Vanilla avoids this by setting `needsSync` on a hit (`AbstractArrow.java:253`) and by syncing `IN_GROUND`, which makes the client's own tick return before it moves the arrow (lines 184-200).

## What this does

`update_projectile_positions` now performs vanilla's whole tick for the kinds that reach `AbstractArrow.tick` — `Arrow`, `SpectralArrow`, `Trident`, which is exactly the `MotionOrder::MoveThenDecay` half of `SIMULATED`:

| vanilla | line | here |
| --- | --- | --- |
| back off by `signum(movement) * 0.05` | 495-498 | `projectile_motion::embed_point` |
| `setDeltaMovement(ZERO)` | 499 | in the hit branch, same tick |
| `setInGround(true)` | 501 | `metadata::arrow::InGround`, index 10, synced |
| `shakeTime = 7` | 502 | `projectile_motion::ShakeTime` |
| `--shakeTime` at the top of the tick | 178-180 | before the early return |
| an in-ground arrow returns before moving | 184-200 | the early return |
| `needsSync` on a hit | 253 | a zero `SetEntityMotion` broadcast on impact |

`Math.signum`, **not** `f32::signum`. Java answers zero for zero where Rust answers +1, and every flat shot in the game has `movement.y == 0` — taking Rust's would sink every arrow a twentieth of a block below the face it hit. `java_signum` is in `projectile_motion.rs` with that written down, and `a_flat_shot_is_backed_off_along_its_heading_only` is the test.

"In the ground" is deliberately not a synonym for "its velocity is zero". The integrator already skips a projectile that is not moving, so an in-ground arrow whose velocity is also zero cannot tell the two apart. Vanilla's rule is the stronger one, and it is what keeps a stuck arrow stuck when something writes a velocity to it.

`IN_GROUND`'s index was read out of the pinned 26.2 jar by reflecting over `AbstractArrow`'s static `EntityDataAccessor` fields — the provenance `metadata/entity.rs` describes. The same run reproduced the existing `living_entity` table (8..14) unchanged, which is what makes the new number trustworthy rather than merely plausible:

```
Entity.DATA_TICKS_FROZEN id=7
AbstractArrow.ID_FLAGS id=8
AbstractArrow.PIERCE_LEVEL id=9
AbstractArrow.IN_GROUND id=10
LivingEntity.DATA_LIVING_ENTITY_FLAGS id=8
...
LivingEntity.SLEEPING_POS_ID id=14
```

That probe is not in the build. ENG-12106 files it, with the two bootstrap traps that cost time.

## The constants are now cited, and they are defaults

Every number in `projectile_motion.rs` names the decompiled line it came from (`INERTIA` at `AbstractArrow.java:65` returned by `getAirDrag` at 235; `getDefaultGravity` at 288; the tick order at 218-229; and the `ThrowableProjectile` equivalents). The two kind tables say in the file that they are vanilla defaults and that nothing in `events/` deviates from them.

## The smash audit: 17 call sites, not 19, and one implicit deviation

Every `fire()` call site in `events/smash/src/module/kits/` builds a `Flight` literal with all five fields named, so **no ability relies on any default** — `smash::Flight` has no `Default` impl and the compiler enforces it. There are 17, not the 19 the task listed:

| kit | ability | velocity | gravity (b/s²) | b/tick² | seconds | radius |
| --- | --- | --- | --- | --- | --- | --- |
| chicken | `egg_blaster` | `(forward + side * offset).normalize_or_zero() * 30.0` | 14.0 | 0.035 | 1.2 | 0.5 |
| chicken | `chicken_missile` | `facing * 24.0` | 9.0 | 0.0225 | 2.5 | 0.8 |
| cow | `angry_herd` | `forward * 14.0` | 0.0 | 0.0 | 2.5 | 0.9 |
| creeper | `sulphur_bomb` | `facing * 22.0` | 16.0 | 0.04 | 2.5 | 0.7 |
| enderman | `block_toss` | `facing * (min(1.4, 1.4*charge).max(0.4) * 24.0)` | 8.0 | 0.02 | 3.0 | 0.65 |
| guardian | `whirlpool_axe` | `facing * 14.0` | 0.0 | 0.0 | 1.4 | 0.6 |
| iron_golem | `iron_hook` | `facing * 20.0` | 0.0 | 0.0 | 1.2 | 0.5 |
| skeleton | `arrow` | `(facing + jitter) * bow_power(charge) * 3.0 * 20.0` | **20.0** | **0.05** | 3.0 | 0.4 |
| skeleton | `roped_arrow` | `facing * 48.0` | 12.0 | 0.03 | 2.0 | 0.4 |
| sky_squid | `ink_shotgun` | `direction * 26.0` | 10.0 | 0.025 | 0.7 | 0.6 |
| snowman | `blizzard` | `facing * 22.0` | 12.0 | 0.03 | 1.4 | 0.6 |
| snowman | `turret_ring` | `direction * 20.0` | 8.0 | 0.02 | 1.6 | 0.6 |
| spider | `needler` | `direction * 34.0` | 12.0 | 0.03 | 1.5 | 0.6 |
| wither_skeleton | `guided_wither_skull` | `facing * (18.0 + 8.0*charge)` | 0.0 | 0.0 | 3.0 | 1.6 |
| wolf | `cub_tackle` | `facing * 18.0` | 8.0 | 0.02 | 2.0 | 0.8 |
| zombie | `bile_blaster` | `(forward + side * offset).normalize_or_zero() * 20.0` | 14.0 | 0.035 | 1.6 | 0.7 |
| zombie | `deaths_grasp` | `forward * (24.0 + 16.0*charge)` | 6.0 | 0.015 | 2.0 | 0.6 |

Two things worth naming:

- **Skeleton's Barrage is already vanilla.** 20.0 blocks per second squared is 0.05 blocks per tick squared, which is `getDefaultGravity` exactly, and the speed is `bow_power(charge) * MAX_ARROW_SPEED`. Three more abilities (`roped_arrow`, `blizzard`, `needler`) sit on 12.0 = 0.03, vanilla's *thrown* gravity.
- **All 17 fly with no air drag at all.** `smash::Flight` has no `drag` field, so every smash projectile is implicitly at 1.0 where vanilla is 0.99. That is the one place an ability silently takes a non-vanilla value, and it is universal rather than per-ability. Left alone here: net smash behaviour change from this PR is zero, and adding a field to seventeen call sites all pinning 1.0 would be churn with no behaviour attached to it.

Structurally, none of this could have changed anyway: smash integrates its own projectiles in `smash::fly`, and `crate::draw` gives the drawn entity **no `Owner`**, which is what `update_projectile_positions` requires. The comment at `events/smash/src/draw.rs:100` already says so.

## The two gates that could not see any of this

**ENG-12085 — `bedwars-bow-e2e` failed about three runs in four on unmodified main.** The impact check looked for a *second* `AddEntity` carrying `|v| == 0`, on the stated grounds that the server re-sends a pinned arrow. It does not and never did: the second `AddEntity` is `send_subscribe_channel_packets` answering the client's subscription to the arrow's channel, which lands whenever the arrow enters view — usually one tick after launch, carrying `3.0 * 0.99 == 2.970`. Exactly the number the failures printed. The check passed only in runs where the subscription happened to arrive after the arrow had stopped, which is why it read as a flake rather than as a wrong question.

It now reads the velocity stream, which is where an impact actually appears: at least one non-zero `SetEntityMotion` **strictly before** the first zero, and nothing moving after it.

**ENG-12082 — `smash-bow-e2e` reported PASS for a downward arrow that fell -0.00 blocks.** `len(stopped) >= 1` is satisfied most loudly by an arrow that never moved on the wire: eighteen of eighteen ticks at rest was its best possible score. Same fix — a non-zero broadcast strictly before the zeros — plus the shooter now climbs ten blocks before the downward shot, so there are twenty ticks of observable travel after `smash::draw_projectiles` has created the entity the client is told about. Standing on the floor there is one eye height of clearance and the flight is over before the client hears the arrow exists, which is the whole of why the old number was noise.

## Evidence

All on `aarch64-darwin`, on the commit at the head of this branch.

**`nix build .#checks.aarch64-darwin.clippy`** — green. (The first run of it was red with `file not found for module arrow`, which is what an untracked new file looks like to a git flake; the green one is on the committed tree.)

**`cargo test -p hyperion`** — 18 test binaries green, including `differential`, which is the one that matters here: it replays the committed vanilla recordings tick by tick through the real `update_projectile_positions`, so a miss-path that was not byte-identical would fail it.

**`nix build .#checks.aarch64-darwin.bedwars-bow-e2e`** — green:

```
impact: 29 velocity broadcasts, first zero at 28, speeds ['0.610', '0.554', '0.499', '0.444', '0.389', '0.335']
PASS the upward short draw fires one arrow (got 1)
PASS an arrow that falls back to the ground stops in it, and was seen flying first: 29 velocity broadcasts, first zero at index 28
PASS a stopped arrow stays stopped: 1 broadcasts after the first zero, ['0.000']
PASS the arrow rose and then fell before it stopped (12 rising ticks, 16 falling)
RESULT: ok (0 checks failed)
```

**`nix build .#checks.aarch64-darwin.smash-bow-e2e`** — green:

```
upward launch: speed 0.382, vy 0.382
upward stream: 32 broadcasts, 14 moving, first zero at 14
PASS the arrow was seen flying and then seen stopping (32 broadcasts, 14 of them moving, first zero at index 14)
PASS the arrow rose and then fell before it stopped (5 rising ticks, 9 falling)
PASS a stopped arrow stays stopped: 18 broadcasts after the first zero, 0 of them moving
RESULT: ok (0 checks failed)
```

### Guards broken and watched failing

| broken | what happened |
| --- | --- |
| the in-ground early return | `arrow_ground.rs`: a landed arrow drifted to `[22.99569, 84.97841, 0]` |
| `shake.0 -= 1` | `arrow_ground.rs`: "the shake should count down one tick at a time" |
| the zero-velocity broadcast on impact | `bedwars-bow-e2e`: `FAIL ... 24 velocity broadcasts, first zero at index None` |

The third is the one worth calling out. The rewritten check is not merely a check that happens to pass — take away the packet the change adds, and it goes red with the exact number that says why.

### The measurement that shaped the check

The obvious impact shot — level, or straight down at your feet — cannot be seen from a client at all:

```
impact: 0 velocity broadcasts, first zero at None, speeds []
```

It meets something within a tick or two, which is before the client's subscription to the arrow's channel has landed. That is also why the old check reached for the subscription replay in the first place. Raising the shooter fifteen blocks and firing down did not fix it either (`climbed 15.00 blocks ... 0 velocity broadcasts`), and cost the sky-shot check its packets as a side effect. Firing *straight up* with a short draw does: the subscription has a whole ascent to arrive in, and an arrow with no horizontal velocity is guaranteed to come back down on the terrain it left, so the impact needs nothing known about the map.

## Not done

- Vanilla's *embedded* check at the top of `tick` (`AbstractArrow.java:169-177`), which stops an arrow whose position is already inside a collision shape. #1122's sweep already reports `inside: true` for a segment starting inside a shape, so an arrow spawned in a wall sticks in the same tick — at the probe point rather than at the entry position. Adding the explicit check needs a point-in-shape query on `Blocks` that nothing else wants yet.
- `IN_GROUND` reaches the wire one tick after the impact, because `component_and_track`'s exchange system is declared during `SimModule` and so runs earlier in `OnUpdate` than `EntityStateSyncModule`'s integrator. The zero-velocity broadcast is immediate, which is the packet that stops the client's dead-reckoning; the flag one tick later only affects the shake.
- `tickDespawn`, `shouldFall` and `startFalling` (`AbstractArrow.java:186-190`, 291-300). A landed arrow here stays landed; nothing despawns it and no block break drops it.

Fixes ENG-12082, ENG-12085. (`Fixes` does not auto-close here — ENG-12072 — so both get closed by hand after merge.)

AI disclosure: written by Claude Opus via Claude Code.
