### PR TITLE
style(hyperion): fix the rustfmt red on main from #1116 (ENG-12111)

### DIFF
--- a/crates/hyperion/build.rs
+++ b/crates/hyperion/build.rs
@@ -46,7 +46,10 @@
 
 // A build script talks to cargo over stdout and has no other channel, so the
 // workspace-wide `print_stdout = deny` does not apply to this file.
-#![allow(clippy::print_stdout, reason = "the cargo build-script protocol is stdout")]
+#![allow(
+    clippy::print_stdout,
+    reason = "the cargo build-script protocol is stdout"
+)]
 
 /// Spelled without the leading underscore Mach-O adds.
 const LMDB_EXPORTS: [&str; 1] = ["mdb_*"];


### PR DESCRIPTION
One attribute in crates/hyperion/build.rs exceeded max_width when #1116 landed (a0a0f21), turning checks.rustfmt red on main and blocking every PR gate since. This is `cargo fmt`'s own output, no hand edits. Verified: `cargo fmt --all --check` rc=0 on this branch.

Found by the chat agent while its PR #1124 went red on an untouched file; filed as ENG-12111.

(authored by Claude Fable 5 via Claude Code)