### PR TITLE
feat(console): an engine-level operator web console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "hyperion-item",
  "hyperion-permission",
  "hyperion-utils",
+ "hyperion-web-console",
  "rayon",
  "roaring",
  "rustc-hash 2.1.3",
@@ -1765,6 +1766,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1794,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1972,6 +1980,7 @@ dependencies = [
  "dotenvy",
  "envy",
  "hyperion",
+ "hyperion-web-console",
  "serde",
  "tracing",
  "tracing-subscriber",
@@ -2176,6 +2185,24 @@ dependencies = [
  "tokio-util",
  "tracing",
  "valence_protocol",
+]
+
+[[package]]
+name = "hyperion-web-console"
+version = "0.1.0"
+dependencies = [
+ "flecs_ecs",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "hyperion",
+ "hyperion-command",
+ "hyperion-minecraft-proto",
+ "hyperion-permission",
+ "serde_json",
+ "serial_test",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3903,6 +3930,7 @@ dependencies = [
  "hyperion-minecraft-proto",
  "hyperion-permission",
  "hyperion-utils",
+ "hyperion-web-console",
  "proptest",
  "tracing",
  "valence_nbt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     'crates/hyperion-proxy-proto',
     'crates/hyperion-reload-client',
     'crates/hyperion-utils',
+    'crates/hyperion-web-console',
     'crates/packet-channel',
     'events/bedwars',
     'events/smash',
@@ -92,6 +93,13 @@ heapless = "0.9.3"
 heed = "0.22.1"
 hex = '0.4.3'
 humantime = "2.4.0"
+# The console's web server. hyper and its two helper crates are already
+# in the lock through reqwest, so naming them here adds no new tree --
+# axum would have. Nothing here needs routing or extractors: five paths
+# matched on a string is the whole surface.
+http-body-util = "0.1.4"
+hyper = "1.11.0"
+hyper-util = "0.1.20"
 hyperion-proxy = { path = "crates/hyperion-proxy" }
 itertools = "0.15.0"
 kanal = '0.1.1'
@@ -254,6 +262,9 @@ path = 'crates/hyperion-proxy-proto'
 
 [workspace.dependencies.hyperion-utils]
 path = 'crates/hyperion-utils'
+
+[workspace.dependencies.hyperion-web-console]
+path = 'crates/hyperion-web-console'
 
 [workspace.dependencies.packet-channel]
 path = 'crates/packet-channel'

--- a/crates/hyperion-event-runner/Cargo.toml
+++ b/crates/hyperion-event-runner/Cargo.toml
@@ -4,6 +4,7 @@ clap = { workspace = true }
 dotenvy = { workspace = true }
 envy = "0.4"
 hyperion = { workspace = true }
+hyperion-web-console = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/hyperion-event-runner/src/lib.rs
+++ b/crates/hyperion-event-runner/src/lib.rs
@@ -18,9 +18,10 @@ use std::{
     path::PathBuf,
 };
 
-use anyhow::bail;
+use anyhow::{Context, bail};
 use clap::Parser;
 use hyperion::Crypto;
+use hyperion_web_console::Config as ConsoleConfig;
 use serde::Deserialize;
 use tracing_subscriber::{EnvFilter, Registry, filter::LevelFilter, layer::SubscriberExt};
 
@@ -76,6 +77,30 @@ pub struct Args {
     #[clap(long, requires_all = ["rules", "reload_socket"])]
     #[serde(default)]
     pub build_stamp: Option<PathBuf>,
+
+    /// Where to serve the operator console, or nowhere.
+    ///
+    /// Absent means no console at all: no socket is opened and nothing is
+    /// spent. An address here is an admin surface, so the value an operator
+    /// should reach for is a loopback or an internal one; see
+    /// [`hyperion_web_console`] for what it exposes.
+    ///
+    /// `requires` runs this way round and not the other because only one
+    /// direction is dangerous. A token file with no bind address is a console
+    /// that is simply off; a bind address with no token file is an open admin
+    /// port that looks configured.
+    #[clap(long, requires = "console_token_file")]
+    #[serde(default)]
+    pub console_bind: Option<SocketAddr>,
+
+    /// The file holding the console's bearer token.
+    ///
+    /// A file rather than an argument or an environment variable, because both
+    /// of those are readable by anything that can list processes. A systemd
+    /// `LoadCredential` puts one here.
+    #[clap(long)]
+    #[serde(default)]
+    pub console_token_file: Option<PathBuf>,
 }
 
 /// The paths a packaged deployment hands the server.
@@ -131,6 +156,46 @@ impl Args {
                 bail!("a partial deployment: {} not set", missing.join(", "))
             }
         }
+    }
+
+    /// How to run the operator console, or `None` when it was not asked for.
+    ///
+    /// # Errors
+    /// Fails when a bind address was given without a token file, when the file
+    /// cannot be read, or when it is empty once trimmed. All three are refused
+    /// at startup rather than warned about: every one of them ends in a console
+    /// that either is not there or has no password, and an operator finding
+    /// that out later finds it out the wrong way.
+    pub fn console(&self) -> anyhow::Result<Option<ConsoleConfig>> {
+        let Some(address) = self.console_bind else {
+            return Ok(None);
+        };
+
+        // `clap` already refuses this on the command line; the environment path
+        // does not go through clap at all, so this is the check that covers
+        // `SMASH_CONSOLE_BIND` set without its token. Same shape, and same
+        // reason, as `deployment` above.
+        let Some(path) = self.console_token_file.as_ref() else {
+            bail!(
+                "the console was asked for at {address} with no --console-token-file, which would \
+                 be an admin port with no password"
+            );
+        };
+
+        let token = std::fs::read_to_string(path)
+            .with_context(|| format!("reading the console token from {}", path.display()))?;
+        // Trimmed because a token file written by a person, or by systemd's
+        // credential machinery, ends in a newline that is not part of the
+        // secret. A token compared with the newline still on it fails every
+        // request and looks like a wrong password.
+        let token = token.trim().to_owned();
+        anyhow::ensure!(
+            !token.is_empty(),
+            "the console token file {} is empty",
+            path.display()
+        );
+
+        Ok(Some(ConsoleConfig { address, token }))
     }
 }
 

--- a/crates/hyperion-web-console/Cargo.toml
+++ b/crates/hyperion-web-console/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+license.workspace = true
+publish = false
+name = "hyperion-web-console"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+flecs_ecs = { workspace = true }
+http-body-util = { workspace = true }
+hyper = { workspace = true, features = ["http1", "server"] }
+hyper-util = { workspace = true, features = ["tokio"] }
+hyperion = { workspace = true }
+hyperion-command = { workspace = true }
+hyperion-minecraft-proto = { workspace = true }
+hyperion-permission = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt", "net", "sync", "macros", "io-util", "time"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+serial_test = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/hyperion-web-console/assets/console.html
+++ b/crates/hyperion-web-console/assets/console.html
@@ -1,0 +1,325 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>hyperion console</title>
+<!--
+  One file, hand written, no build step. A console that needs `npm install`
+  before anyone can look at it is a console that has stopped working by the
+  time somebody needs it.
+
+  It looks like the game because what it shows is the game: the same dark
+  translucent backdrop the chat box draws on, the same sixteen colours, and
+  section-sign codes rendered rather than stripped. A line reads here the way
+  it reads in the chat box, which is the point.
+-->
+<style>
+  :root {
+    /* Minecraft's chat backdrop: black at 50%, over whatever is behind it.
+       There is nothing behind a browser tab, so this is the flat result. */
+    --backdrop: #101010;
+    --panel: #1c1c1c;
+    --edge: #2f2f2f;
+    --dim: #7f7f7f;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    background: var(--backdrop);
+    color: #fff;
+    /* Minecraft's own font is not ours to ship, so this asks for the
+       closest thing already on the machine and falls back to any monospace
+       rather than to a proportional face, which would make the columns
+       below stop lining up. */
+    font-family: "Minecraft", "Monocraft", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 14px;
+    line-height: 1.45;
+    display: grid;
+    grid-template-columns: 1fr 260px;
+    grid-template-rows: auto 1fr auto;
+    grid-template-areas: "head side" "log side" "input side";
+    height: 100vh;
+  }
+  header {
+    grid-area: head;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--edge);
+    display: flex;
+    gap: 16px;
+    align-items: baseline;
+  }
+  header b { font-weight: normal; color: #55ff55; }
+  #log {
+    grid-area: log;
+    overflow-y: auto;
+    padding: 10px 12px;
+    /* Pre-wrap, because chat is whitespace and a long line must wrap rather
+       than scroll sideways away from the operator. */
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  #log div { padding: 1px 0; }
+  #log .system { color: var(--dim); }
+  #log .reply { border-left: 2px solid #3f3f3f; padding-left: 8px; }
+  #log time { color: #4a4a4a; margin-right: 8px; font-size: 12px; }
+  form {
+    grid-area: input;
+    display: flex;
+    gap: 8px;
+    padding: 10px 12px;
+    border-top: 1px solid var(--edge);
+  }
+  input, button, select {
+    font: inherit;
+    background: var(--panel);
+    color: #fff;
+    border: 1px solid var(--edge);
+    padding: 6px 10px;
+  }
+  #line { flex: 1; }
+  button { cursor: pointer; }
+  button:hover { background: #2a2a2a; }
+  aside {
+    grid-area: side;
+    border-left: 1px solid var(--edge);
+    padding: 10px 12px;
+    overflow-y: auto;
+  }
+  aside h2 { font-size: 12px; color: var(--dim); font-weight: normal; margin: 12px 0 6px; text-transform: uppercase; }
+  aside h2:first-child { margin-top: 0; }
+  .player { display: flex; justify-content: space-between; gap: 8px; }
+  .ping-good { color: #55ff55; }
+  .ping-ok { color: #ffff55; }
+  .ping-bad { color: #ff5555; }
+  .ping-unknown { color: var(--dim); }
+  #gate {
+    position: fixed; inset: 0; background: rgba(0,0,0,.85);
+    display: grid; place-items: center; gap: 10px; grid-auto-flow: row;
+  }
+  #gate[hidden] { display: none; }
+</style>
+
+<header>
+  <span>hyperion console</span>
+  <span>tps <b id="tps">—</b></span>
+  <span>build <b id="build">—</b></span>
+  <span id="link" class="ping-unknown">connecting…</span>
+</header>
+
+<div id="log"></div>
+
+<form id="send">
+  <select id="mode">
+    <option value="say">say</option>
+    <option value="command">command</option>
+  </select>
+  <input id="line" autocomplete="off" placeholder="a message every player sees">
+  <button>send</button>
+</form>
+
+<aside>
+  <h2>players</h2>
+  <div id="players" class="ping-unknown">—</div>
+</aside>
+
+<div id="gate">
+  <div>this console needs its bearer token</div>
+  <input id="token" type="password" autocomplete="off" placeholder="token">
+  <button id="unlock">open</button>
+</div>
+
+<script>
+  // Minecraft's legacy formatter, which is what the server writes and what a
+  // client renders out of a literal string. Kept as a table rather than as
+  // CSS classes so that a code with no meaning falls through visibly instead
+  // of silently doing nothing.
+  const COLOURS = {
+    '0': '#000000', '1': '#0000aa', '2': '#00aa00', '3': '#00aaaa',
+    '4': '#aa0000', '5': '#aa00aa', '6': '#ffaa00', '7': '#aaaaaa',
+    '8': '#555555', '9': '#5555ff', a: '#55ff55', b: '#55ffff',
+    c: '#ff5555', d: '#ff55ff', e: '#ffff55', f: '#ffffff',
+  };
+
+  // Renders one line into an element, applying section-sign codes as it goes.
+  // Deliberately builds text nodes rather than assigning innerHTML: every
+  // string here came off the wire from a player, and the one thing this page
+  // must never do is let somebody type markup into chat and have a browser
+  // run it.
+  function render(text) {
+    const out = document.createDocumentFragment();
+    let style = {};
+    let buffer = '';
+
+    const flush = () => {
+      if (!buffer) return;
+      const span = document.createElement('span');
+      span.textContent = buffer;
+      if (style.colour) span.style.color = style.colour;
+      if (style.bold) span.style.fontWeight = 'bold';
+      if (style.italic) span.style.fontStyle = 'italic';
+      if (style.underline) span.style.textDecoration = 'underline';
+      if (style.strike) span.style.textDecoration = 'line-through';
+      if (style.obfuscated) span.classList.add('obf');
+      out.appendChild(span);
+      buffer = '';
+    };
+
+    for (let index = 0; index < text.length; index += 1) {
+      const character = text[index];
+      if (character !== '§' || index + 1 >= text.length) {
+        buffer += character;
+        continue;
+      }
+      const code = text[index + 1].toLowerCase();
+      index += 1;
+      flush();
+      if (COLOURS[code]) {
+        // A colour resets every decoration, exactly as the client's own
+        // formatter does. Getting this wrong makes bold leak down a line.
+        style = { colour: COLOURS[code] };
+      } else if (code === 'l') style.bold = true;
+      else if (code === 'o') style.italic = true;
+      else if (code === 'n') style.underline = true;
+      else if (code === 'm') style.strike = true;
+      else if (code === 'k') style.obfuscated = true;
+      else if (code === 'r') style = {};
+      else buffer += '§' + text[index];
+    }
+    flush();
+    return out;
+  }
+
+  const log = document.getElementById('log');
+  const seen = new Set();
+
+  function append(line) {
+    // The stream replays a backlog and then goes live, and a line pushed
+    // between those two can arrive twice. Dropping by sequence is why that is
+    // safe; the alternative (subscribe after fetching) loses lines instead.
+    if (line.seq && seen.has(line.seq)) return;
+    if (line.seq) seen.add(line.seq);
+
+    const atBottom = log.scrollHeight - log.scrollTop - log.clientHeight < 40;
+    const row = document.createElement('div');
+    row.className = line.source;
+    const when = document.createElement('time');
+    when.textContent = new Date(line.at || Date.now())
+      .toTimeString()
+      .slice(0, 8);
+    row.appendChild(when);
+    row.appendChild(render(line.text));
+    log.appendChild(row);
+    // Only follow the tail if the operator was already at it. Yanking the
+    // view down while somebody is reading history is the single most annoying
+    // thing a live log can do.
+    if (atBottom) log.scrollTop = log.scrollHeight;
+  }
+
+  let token = sessionStorage.getItem('hyperion-console-token') || '';
+  const gate = document.getElementById('gate');
+  const link = document.getElementById('link');
+
+  function open() {
+    gate.hidden = true;
+    const stream = new EventSource('/events?token=' + encodeURIComponent(token));
+    stream.onopen = () => {
+      link.textContent = 'live';
+      link.className = 'ping-good';
+    };
+    stream.onmessage = (event) => append(JSON.parse(event.data));
+    stream.onerror = () => {
+      // EventSource reconnects on its own, which is most of why this is not a
+      // WebSocket. Say so rather than leaving a stale "live".
+      link.textContent = 'reconnecting…';
+      link.className = 'ping-bad';
+    };
+    poll();
+  }
+
+  document.getElementById('unlock').onclick = () => {
+    token = document.getElementById('token').value.trim();
+    sessionStorage.setItem('hyperion-console-token', token);
+    open();
+  };
+
+  if (token) open();
+
+  document.getElementById('mode').onchange = (event) => {
+    document.getElementById('line').placeholder =
+      event.target.value === 'say'
+        ? 'a message every player sees'
+        : 'a command, with or without the leading slash';
+  };
+
+  document.getElementById('send').onsubmit = async (event) => {
+    event.preventDefault();
+    const input = document.getElementById('line');
+    const body = input.value;
+    if (!body.trim()) return;
+    input.value = '';
+    const path = document.getElementById('mode').value === 'say' ? '/say' : '/command';
+    const response = await fetch(path, {
+      method: 'POST',
+      headers: { authorization: 'Bearer ' + token },
+      body,
+    });
+    if (!response.ok) {
+      append({
+        at: Date.now(),
+        source: 'system',
+        text: '§cthe server refused that: ' + response.status + ' ' + (await response.text()),
+      });
+    }
+  };
+
+  async function poll() {
+    try {
+      const response = await fetch('/state', {
+        headers: { authorization: 'Bearer ' + token },
+      });
+      if (response.ok) draw(await response.json());
+    } catch (error) {
+      // A failed poll is the same condition the stream already reports, so
+      // this stays quiet rather than saying it twice.
+    }
+    setTimeout(poll, 2000);
+  }
+
+  function draw(state) {
+    document.getElementById('tps').textContent =
+      state.tps === null || state.tps === undefined
+        ? 'sampling'
+        : state.tps.toFixed(1) + ' / ' + state.targetTps.toFixed(1);
+
+    document.getElementById('build').textContent = state.buildRev
+      ? state.buildRev + (state.buildDirty ? ' (dirty)' : '')
+      : 'unknown';
+
+    const players = document.getElementById('players');
+    players.textContent = '';
+    if (!state.players.length) {
+      players.textContent = 'nobody online';
+      players.className = 'ping-unknown';
+      return;
+    }
+    players.className = '';
+    for (const player of state.players) {
+      const row = document.createElement('div');
+      row.className = 'player';
+      const name = document.createElement('span');
+      name.textContent = player.name;
+      const ping = document.createElement('span');
+      // Null is "nothing has been measured", which is not the same as fast.
+      // The engine is careful about this distinction and so is the page.
+      if (player.latency === null || player.latency === undefined) {
+        ping.textContent = '—';
+        ping.className = 'ping-unknown';
+      } else {
+        ping.textContent = player.latency + 'ms';
+        ping.className =
+          player.latency < 150 ? 'ping-good' : player.latency < 300 ? 'ping-ok' : 'ping-bad';
+      }
+      row.append(name, ping);
+      players.appendChild(row);
+    }
+  }
+</script>

--- a/crates/hyperion-web-console/src/feed.rs
+++ b/crates/hyperion-web-console/src/feed.rs
@@ -1,0 +1,186 @@
+//! What the console has seen, and everyone watching it.
+
+use std::{
+    collections::VecDeque,
+    sync::{
+        Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use tokio::sync::broadcast;
+
+/// How many lines a browser is handed when it connects.
+///
+/// A console opened after something went wrong is the normal case, so the
+/// backlog is what makes the page useful at all rather than a nicety. Bounded
+/// because this is a live server's memory: two hundred lines is a screenful
+/// several times over and costs a few tens of kilobytes.
+pub const BACKLOG: usize = 200;
+
+/// How many lines a slow browser may fall behind before it is cut loose.
+///
+/// A dropped subscriber is told how many it missed rather than silently handed
+/// a gap; see [`Feed::subscribe`].
+const CHANNEL_CAPACITY: usize = 512;
+
+/// Where a line came from, which is the only thing the page styles on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    /// A player typed it.
+    Chat,
+    /// The console typed it, and every player saw it.
+    Console,
+    /// A reply addressed to the console: the output of a command it ran.
+    Reply,
+    /// The server saying something about itself. A join, a leave, a refusal.
+    System,
+}
+
+impl Source {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Chat => "chat",
+            Self::Console => "console",
+            Self::Reply => "reply",
+            Self::System => "system",
+        }
+    }
+}
+
+/// One line, as the page will draw it.
+///
+/// The text keeps its section-sign codes. Rendering them is the browser's job
+/// -- it is the only place that knows what a colour looks like -- and stripping
+/// them here would throw away the thing that makes the page look like the game.
+#[derive(Debug, Clone)]
+pub struct Line {
+    /// Monotonic within a process, so a page can tell it has the whole story.
+    /// Not a timestamp: two lines in one tick share a millisecond.
+    pub seq: u64,
+    /// Unix milliseconds, for the clock the page draws.
+    pub at: u64,
+    pub source: Source,
+    pub text: String,
+}
+
+impl Line {
+    /// This line as one SSE `data:` payload.
+    #[must_use]
+    pub fn to_json(&self) -> String {
+        serde_json::json!({
+            "seq": self.seq,
+            "at": self.at,
+            "source": self.source.as_str(),
+            "text": self.text,
+        })
+        .to_string()
+    }
+}
+
+/// Every line the console has, and a tap for anyone watching.
+#[derive(Debug)]
+pub struct Feed {
+    next_seq: AtomicU64,
+    backlog: Mutex<VecDeque<Line>>,
+    live: broadcast::Sender<Line>,
+}
+
+impl Default for Feed {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Feed {
+    #[must_use]
+    pub fn new() -> Self {
+        let (live, _) = broadcast::channel(CHANNEL_CAPACITY);
+        Self {
+            next_seq: AtomicU64::new(1),
+            backlog: Mutex::new(VecDeque::with_capacity(BACKLOG)),
+            live,
+        }
+    }
+
+    /// Record a line and hand it to everyone watching.
+    pub fn push(&self, source: Source, text: impl Into<String>) {
+        let line = Line {
+            seq: self.next_seq.fetch_add(1, Ordering::Relaxed),
+            at: now_ms(),
+            source,
+            text: text.into(),
+        };
+
+        if let Ok(mut backlog) = self.backlog.lock() {
+            if backlog.len() == BACKLOG {
+                backlog.pop_front();
+            }
+            backlog.push_back(line.clone());
+        }
+
+        // `Err` means nobody is watching, which is the usual state of an
+        // operator console and not a problem.
+        let _unused = self.live.send(line);
+    }
+
+    /// The lines a page gets before the live ones start.
+    #[must_use]
+    pub fn backlog(&self) -> Vec<Line> {
+        self.backlog
+            .lock()
+            .map(|backlog| backlog.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// A live tap. Every subscriber gets every line pushed after this call.
+    #[must_use]
+    pub fn subscribe(&self) -> broadcast::Receiver<Line> {
+        self.live.subscribe()
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |since| u64::try_from(since.as_millis()).unwrap_or(0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BACKLOG, Feed, Source};
+
+    #[test]
+    fn the_backlog_is_bounded_and_keeps_the_newest() {
+        let feed = Feed::new();
+        for index in 0..(BACKLOG + 10) {
+            feed.push(Source::System, format!("line {index}"));
+        }
+
+        let backlog = feed.backlog();
+        assert_eq!(backlog.len(), BACKLOG);
+        assert_eq!(backlog[0].text, "line 10");
+        assert_eq!(backlog[BACKLOG - 1].text, format!("line {}", BACKLOG + 9));
+    }
+
+    #[test]
+    fn sequence_numbers_are_dense_and_increasing() {
+        let feed = Feed::new();
+        feed.push(Source::Chat, "one");
+        feed.push(Source::Chat, "two");
+
+        let backlog = feed.backlog();
+        assert_eq!(backlog[1].seq, backlog[0].seq + 1);
+    }
+
+    #[test]
+    fn a_section_sign_survives_into_the_feed() {
+        // The browser renders these. Stripping them here would be the console
+        // quietly deciding the page should look like a terminal.
+        let feed = Feed::new();
+        feed.push(Source::Console, "\u{a7}cred");
+        assert_eq!(feed.backlog()[0].text, "\u{a7}cred");
+    }
+}

--- a/crates/hyperion-web-console/src/http.rs
+++ b/crates/hyperion-web-console/src/http.rs
@@ -1,0 +1,401 @@
+//! The web server, and the whole of what it will answer.
+//!
+//! Five paths matched on a string. That is why this is hyper and not axum:
+//! there is no routing to do, no extractors to derive, and hyper plus its two
+//! helper crates are already in the lock through `reqwest`, so the console
+//! costs no new dependency tree at all.
+//!
+//! # Authentication
+//!
+//! One shared secret, read from a file the server never writes and compared in
+//! constant time. There are no accounts and no sessions on purpose: this is one
+//! operator's window onto their own server, and everything an accounts system
+//! would add is a second thing to get wrong.
+//!
+//! `POST` requests carry it as `Authorization: Bearer <token>`. The event
+//! stream carries it as `?token=` instead, because `EventSource` cannot set a
+//! header -- the browser API simply has no argument for it. So the token
+//! reaches the server's own access log, if it has one, and the browser's
+//! history. That is stated rather than hidden, and it is why the bind address
+//! defaults to loopback: this is not a port to put on the internet.
+
+use std::{
+    convert::Infallible,
+    net::SocketAddr,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use http_body_util::{BodyExt, combinators::BoxBody};
+use hyper::{
+    Method, Request as HttpRequest, Response, StatusCode,
+    body::{Body as HttpBody, Bytes, Frame, Incoming},
+    server::conn::http1,
+    service::service_fn,
+};
+use hyper_util::rt::TokioIo;
+use tokio::{
+    net::TcpListener,
+    sync::{broadcast::error::RecvError, mpsc},
+};
+
+use crate::{
+    Console,
+    feed::{Line, Source},
+    state::Request,
+};
+
+/// The page itself, compiled in.
+///
+/// One file, hand written, no build step. A console that needs `npm` before it
+/// can be looked at is a console that stops working the first time nobody has
+/// run `npm` recently.
+const PAGE: &str = include_str!("../assets/console.html");
+
+/// The largest body this will read.
+///
+/// A chat line is 256 bytes at the protocol level and a command is not much
+/// more, so anything past this is not an operator typing.
+const MAX_BODY: usize = 8 * 1024;
+
+type Body = BoxBody<Bytes, Infallible>;
+
+/// Serve on an already bound listener until the process ends.
+///
+/// Takes the listener rather than an address because the bind is the one
+/// failure a caller can still do something about, and it has to happen before
+/// the thread this runs on is spawned. See [`crate::spawn`].
+pub async fn serve(console: Arc<Console>, listener: TcpListener) {
+    match listener.local_addr() {
+        Ok(address) => tracing::info!("console listening on http://{address}/"),
+        Err(error) => tracing::warn!("console listening, but on what: {error}"),
+    }
+
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(accepted) => accepted,
+            Err(error) => {
+                // One connection failing to come up is not the listener
+                // failing, so this must not end the loop.
+                tracing::warn!("console accept failed: {error}");
+                continue;
+            }
+        };
+
+        let console = Arc::clone(&console);
+        tokio::spawn(async move {
+            let service = service_fn(move |request| route(Arc::clone(&console), request, peer));
+            if let Err(error) = http1::Builder::new()
+                .serve_connection(TokioIo::new(stream), service)
+                .await
+            {
+                tracing::debug!("console connection from {peer} ended: {error}");
+            }
+        });
+    }
+}
+
+async fn route(
+    console: Arc<Console>,
+    request: HttpRequest<Incoming>,
+    peer: SocketAddr,
+) -> Result<Response<Body>, Infallible> {
+    // Owned, because the body is read by value further down and a borrow of
+    // the request cannot outlive that.
+    let (path, query) = {
+        let (path, query) =
+            split_query(request.uri().path_and_query().map_or("/", |pq| pq.as_str()));
+        (path.to_owned(), query.to_owned())
+    };
+
+    Ok(match (request.method(), path.as_str()) {
+        // The page is not behind the token. It has nothing in it: it is markup
+        // that asks for a token and then goes and gets the data. Gating it
+        // would mean an operator could not reach the box that asks for the
+        // secret without already having sent the secret.
+        (&Method::GET, "/") => html(PAGE),
+
+        (&Method::GET, "/events") => {
+            if console.authorises(query_token(&query).unwrap_or_default().as_bytes()) {
+                events(&console)
+            } else {
+                refuse(peer, "/events")
+            }
+        }
+
+        (&Method::GET, "/state") => {
+            if authorised_header(&console, &request) {
+                json(&console.snapshot())
+            } else {
+                refuse(peer, "/state")
+            }
+        }
+
+        (&Method::POST, "/say" | "/command") => {
+            if authorised_header(&console, &request) {
+                match read_body(request).await {
+                    Err(message) => text(StatusCode::PAYLOAD_TOO_LARGE, message),
+                    Ok(body) if body.trim().is_empty() => {
+                        text(StatusCode::BAD_REQUEST, "nothing to send")
+                    }
+                    Ok(body) => {
+                        console.submit(if path == "/say" {
+                            Request::Say(body.trim().to_owned())
+                        } else {
+                            Request::Command(body.trim().to_owned())
+                        });
+                        text(StatusCode::ACCEPTED, "queued")
+                    }
+                }
+            } else {
+                refuse(peer, &path)
+            }
+        }
+
+        _ => text(StatusCode::NOT_FOUND, "no such path"),
+    })
+}
+
+/// A refusal, said once per attempt at a real severity.
+///
+/// `warn` and not `debug`: somebody probing an admin port is the thing an
+/// operator wants to find in a journal, and a line below `info` is invisible to
+/// every query that filters on severity.
+fn refuse(peer: SocketAddr, path: &str) -> Response<Body> {
+    tracing::warn!("console rejected an unauthenticated {path} from {peer}");
+    text(StatusCode::UNAUTHORIZED, "a bearer token is required")
+}
+
+fn authorised_header(console: &Console, request: &HttpRequest<Incoming>) -> bool {
+    let offered = request
+        .headers()
+        .get(hyper::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .unwrap_or_default();
+    console.authorises(offered.as_bytes())
+}
+
+/// The live stream: the backlog first, then everything as it happens.
+///
+/// The backlog is taken *after* subscribing, so a line pushed between the two
+/// can be sent twice but can never be lost. Duplicates the page can see and
+/// drop by sequence number; a hole it cannot.
+fn events(console: &Console) -> Response<Body> {
+    let mut live = console.feed.subscribe();
+    let backlog = console.feed.backlog();
+
+    let (sender, receiver) = mpsc::channel::<Bytes>(64);
+
+    tokio::spawn(async move {
+        for line in backlog {
+            if sender.send(sse(&line)).await.is_err() {
+                return;
+            }
+        }
+
+        loop {
+            let chunk = match live.recv().await {
+                Ok(entry) => sse(&entry),
+                // The browser fell behind far enough to lose lines. Saying so
+                // is the point: a gap the page does not know about is a page
+                // that has quietly stopped being the truth.
+                Err(RecvError::Lagged(missed)) => Bytes::from(format!(
+                    "data: {}\n\n",
+                    Line {
+                        seq: 0,
+                        at: 0,
+                        source: Source::System,
+                        text: format!("\u{a7}8[{missed} lines dropped: this browser fell behind]"),
+                    }
+                    .to_json()
+                )),
+                Err(RecvError::Closed) => return,
+            };
+
+            if sender.send(chunk).await.is_err() {
+                return;
+            }
+        }
+    });
+
+    Response::builder()
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-store")
+        // Any reverse proxy in front of this must not buffer, or a live stream
+        // arrives in silent bursts and looks like a hang.
+        .header("x-accel-buffering", "no")
+        .body(BodyExt::boxed(EventStream { receiver }))
+        .expect("a response with only static headers cannot fail to build")
+}
+
+/// The SSE body: whatever the sender above puts on the channel.
+///
+/// Hand written rather than reached for through a stream adapter crate,
+/// because the whole of it is "forward one channel" and the alternative is a
+/// dependency for eleven lines.
+struct EventStream {
+    receiver: mpsc::Receiver<Bytes>,
+}
+
+impl HttpBody for EventStream {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Bytes>, Infallible>>> {
+        self.receiver
+            .poll_recv(context)
+            .map(|chunk| chunk.map(|bytes| Ok(Frame::data(bytes))))
+    }
+}
+
+fn sse(line: &Line) -> Bytes {
+    Bytes::from(format!("data: {}\n\n", line.to_json()))
+}
+
+async fn read_body(request: HttpRequest<Incoming>) -> Result<String, &'static str> {
+    let collected = request
+        .into_body()
+        .collect()
+        .await
+        .map_err(|_unused| "could not read the body")?;
+    let bytes = collected.to_bytes();
+    if bytes.len() > MAX_BODY {
+        return Err("body too large");
+    }
+    String::from_utf8(bytes.to_vec()).map_err(|_unused| "body was not utf-8")
+}
+
+fn split_query(path_and_query: &str) -> (&str, &str) {
+    path_and_query
+        .split_once('?')
+        .map_or((path_and_query, ""), |(path, query)| (path, query))
+}
+
+fn query_token(query: &str) -> Option<String> {
+    query
+        .split('&')
+        .find_map(|pair| pair.strip_prefix("token=").map(percent_decode))
+}
+
+/// Enough of percent decoding for a token.
+///
+/// `%XX` and nothing else. A `+` decodes to a literal plus rather than to a
+/// space: the page sends the token through `encodeURIComponent`, which spells
+/// a space `%20` and leaves `+` untouched, so the form-encoding rule can never
+/// recover a space anyone sent and can only corrupt a token that contains a
+/// plus. Standard base64 emits `+` and `/`, so the obvious way to generate a
+/// token produces exactly the value that rule breaks, and it breaks it as a
+/// 401 with nothing in the log to say why. That is not hypothetical: it is
+/// what `tools/console-check.py` hit on its first run against a live server.
+fn percent_decode(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'%' if index + 2 < bytes.len() => {
+                let hex = std::str::from_utf8(&bytes[index + 1..index + 3]).unwrap_or("");
+                match u8::from_str_radix(hex, 16) {
+                    Ok(byte) => {
+                        out.push(byte);
+                        index += 3;
+                    }
+                    Err(_unused) => {
+                        out.push(b'%');
+                        index += 1;
+                    }
+                }
+            }
+            byte => {
+                out.push(byte);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8(out).unwrap_or_default()
+}
+
+fn html(body: &'static str) -> Response<Body> {
+    Response::builder()
+        .header("content-type", "text/html; charset=utf-8")
+        .body(full(Bytes::from_static(body.as_bytes())))
+        .expect("a response with only static headers cannot fail to build")
+}
+
+fn json(body: &str) -> Response<Body> {
+    Response::builder()
+        .header("content-type", "application/json")
+        .header("cache-control", "no-store")
+        .body(full(Bytes::from(body.to_owned())))
+        .expect("a response with only static headers cannot fail to build")
+}
+
+fn text(status: StatusCode, body: &str) -> Response<Body> {
+    Response::builder()
+        .status(status)
+        .header("content-type", "text/plain; charset=utf-8")
+        .body(full(Bytes::from(body.to_owned())))
+        .expect("a response with only static headers cannot fail to build")
+}
+
+fn full(bytes: Bytes) -> Body {
+    BodyExt::boxed(http_body_util::Full::new(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{percent_decode, query_token};
+
+    /// What `head -c 24 /dev/urandom | base64` produces: standard base64,
+    /// which uses `+` and `/`. The console reads its token from a file an
+    /// operator generated, so this is the ordinary case rather than an edge.
+    const BASE64_TOKEN: &str = "z/qKP4ZL2WfCDIGq8Sh0+dt1i96XQRq1";
+
+    /// The bug this pins. Treating `+` as a space -- the form-encoding rule --
+    /// turned a token a browser had sent correctly into a 401 that said
+    /// nothing about why.
+    #[test]
+    fn a_plus_is_a_plus_and_not_a_space() {
+        assert_eq!(percent_decode("a+b"), "a+b");
+        assert_eq!(percent_decode(BASE64_TOKEN), BASE64_TOKEN);
+    }
+
+    /// What the page actually sends: `encodeURIComponent` escapes both of
+    /// base64's awkward characters, and the decode has to give the token back
+    /// unchanged or the page cannot open its own event stream.
+    #[test]
+    fn the_encoding_the_page_uses_round_trips() {
+        let encoded = "z%2FqKP4ZL2WfCDIGq8Sh0%2Bdt1i96XQRq1";
+        assert_eq!(percent_decode(encoded), BASE64_TOKEN);
+        assert_eq!(
+            query_token(&format!("token={encoded}")).as_deref(),
+            Some(BASE64_TOKEN)
+        );
+    }
+
+    /// A space still arrives when somebody really sent one: dropping the `+`
+    /// rule costs nothing, because `encodeURIComponent(' ')` is `%20`.
+    #[test]
+    fn a_percent_twenty_is_still_a_space() {
+        assert_eq!(percent_decode("a%20b"), "a b");
+    }
+
+    /// A `%` that does not begin an escape is a `%`, rather than eating the
+    /// bytes after it and silently shortening the token.
+    #[test]
+    fn a_stray_percent_is_literal() {
+        assert_eq!(percent_decode("100%"), "100%");
+        assert_eq!(percent_decode("a%zzb"), "a%zzb");
+    }
+
+    #[test]
+    fn a_token_is_found_among_other_parameters() {
+        assert_eq!(query_token("since=4&token=abc").as_deref(), Some("abc"));
+        assert_eq!(query_token("since=4"), None);
+    }
+}

--- a/crates/hyperion-web-console/src/legacy.rs
+++ b/crates/hyperion-web-console/src/legacy.rs
@@ -1,0 +1,200 @@
+//! A component, written back out as the section-sign codes a page renders.
+//!
+//! The console reads replies off the wire as `SystemChat`, which carries a
+//! component: a tree with colour and decoration as *fields*. The page renders
+//! section signs. So something has to bridge the two, and
+//! [`Component::plain`](hyperion::hyperion_minecraft_proto::text::Component::plain)
+//! is not it -- it throws every field away, which turns a red refusal into a
+//! sentence in the same colour as everything else and loses the one thing that
+//! made it read as a refusal.
+//!
+//! Most replies survive `plain` by accident, because
+//! [`hyperion::net::agnostic::chat`] builds its component from a string that
+//! already has `§c` inside it. The ones that do not are exactly the ones a
+//! game built properly, through a typed seam, which is the direction the
+//! workspace is moving in.
+//!
+//! This is lossy in the other direction and deliberately so. Hover text, click
+//! actions, fonts and true-colour RGB have no legacy spelling; RGB is mapped to
+//! its nearest named colour rather than dropped, because a wrong-ish red reads
+//! far closer to the intent than no colour at all.
+
+use hyperion::hyperion_minecraft_proto::text::{Component, NamedColor, Rgb24, TextColor};
+
+/// The character the client's legacy formatter looks for. Spelled as an escape
+/// for the same reason `hyperion::simulation::chat` spells it that way.
+const SECTION_SIGN: char = '\u{a7}';
+
+/// `component`, flattened into text with legacy codes.
+#[must_use]
+pub fn render(component: &Component<'_>) -> String {
+    let mut out = String::new();
+
+    // `runs` is the component already flattened with inheritance applied, so
+    // this never walks the tree itself. Walking it was the first version and
+    // it got nesting wrong at depth three: a child inherits its parent's
+    // style, a sibling must not, and re-deriving that by hand is exactly the
+    // work `runs` has already done correctly.
+    for run in component.runs() {
+        // A colour code resets every decoration in the legacy scheme, so the
+        // colour is written first and the decorations after it. The other
+        // order silently drops the decorations, which renders as "nearly
+        // right".
+        //
+        // `§r` first, because a run carries its whole resolved style and the
+        // previous run's codes are still in force at this point.
+        out.push(SECTION_SIGN);
+        out.push('r');
+
+        if let Some(colour) = run.style.color.map(code_for) {
+            out.push(SECTION_SIGN);
+            out.push(colour);
+        }
+        for (enabled, code) in [
+            (run.style.bold, 'l'),
+            (run.style.italic, 'o'),
+            (run.style.underlined, 'n'),
+            (run.style.strikethrough, 'm'),
+            (run.style.obfuscated, 'k'),
+        ] {
+            if enabled == Some(true) {
+                out.push(SECTION_SIGN);
+                out.push(code);
+            }
+        }
+
+        out.push_str(&run.text);
+    }
+
+    out
+}
+
+/// The legacy code for a colour.
+///
+/// Total, because every colour has an answer: a named one has its own code and
+/// a true-colour one has its nearest swatch. There is deliberately no `None`
+/// here -- an `Option` would invite a caller to drop the colour, and dropping
+/// it renders as "this line was never coloured", which is a worse lie than a
+/// slightly wrong red.
+fn code_for(colour: TextColor) -> char {
+    let named = match colour {
+        TextColor::Named(named) => named,
+        // No legacy code exists, so the nearest named one is the closest
+        // truthful answer. The alternative is dropping the colour, which reads
+        // as "this line was never coloured".
+        TextColor::Rgb(rgb) => nearest_named(rgb),
+    };
+
+    match named {
+        NamedColor::Black => '0',
+        NamedColor::DarkBlue => '1',
+        NamedColor::DarkGreen => '2',
+        NamedColor::DarkAqua => '3',
+        NamedColor::DarkRed => '4',
+        NamedColor::DarkPurple => '5',
+        NamedColor::Gold => '6',
+        NamedColor::Gray => '7',
+        NamedColor::DarkGray => '8',
+        NamedColor::Blue => '9',
+        NamedColor::Green => 'a',
+        NamedColor::Aqua => 'b',
+        NamedColor::Red => 'c',
+        NamedColor::LightPurple => 'd',
+        NamedColor::Yellow => 'e',
+        NamedColor::White => 'f',
+    }
+}
+
+/// The named colour closest to `rgb`, by squared distance in plain RGB.
+///
+/// Not a perceptual space. This is picking one of sixteen swatches for a
+/// console pane, and the difference between a plain and a perceptual metric at
+/// that resolution is not something a person reading chat can see.
+fn nearest_named(rgb: Rgb24) -> NamedColor {
+    const SWATCHES: [(NamedColor, [i32; 3]); 16] = [
+        (NamedColor::Black, [0x00, 0x00, 0x00]),
+        (NamedColor::DarkBlue, [0x00, 0x00, 0xaa]),
+        (NamedColor::DarkGreen, [0x00, 0xaa, 0x00]),
+        (NamedColor::DarkAqua, [0x00, 0xaa, 0xaa]),
+        (NamedColor::DarkRed, [0xaa, 0x00, 0x00]),
+        (NamedColor::DarkPurple, [0xaa, 0x00, 0xaa]),
+        (NamedColor::Gold, [0xff, 0xaa, 0x00]),
+        (NamedColor::Gray, [0xaa, 0xaa, 0xaa]),
+        (NamedColor::DarkGray, [0x55, 0x55, 0x55]),
+        (NamedColor::Blue, [0x55, 0x55, 0xff]),
+        (NamedColor::Green, [0x55, 0xff, 0x55]),
+        (NamedColor::Aqua, [0x55, 0xff, 0xff]),
+        (NamedColor::Red, [0xff, 0x55, 0x55]),
+        (NamedColor::LightPurple, [0xff, 0x55, 0xff]),
+        (NamedColor::Yellow, [0xff, 0xff, 0x55]),
+        (NamedColor::White, [0xff, 0xff, 0xff]),
+    ];
+
+    let channels = rgb.channels();
+    let want = [
+        i32::from(channels[0]),
+        i32::from(channels[1]),
+        i32::from(channels[2]),
+    ];
+    SWATCHES
+        .into_iter()
+        .min_by_key(|(_named, swatch)| {
+            (0..3)
+                .map(|axis| (swatch[axis] - want[axis]).pow(2))
+                .sum::<i32>()
+        })
+        .map_or(NamedColor::White, |(named, _swatch)| named)
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperion::hyperion_minecraft_proto::text::{
+        Component, NamedColor, Rgb24, Style, TextColor,
+    };
+
+    use super::render;
+
+    fn coloured(colour: TextColor) -> Style<'static> {
+        Style {
+            color: Some(colour),
+            ..Style::new()
+        }
+    }
+
+    #[test]
+    fn plain_text_gets_one_reset_and_nothing_else() {
+        assert_eq!(render(&Component::text("hello")), "\u{a7}rhello");
+    }
+
+    #[test]
+    fn a_colour_becomes_its_legacy_code() {
+        let component =
+            Component::text("nope").with_style(coloured(TextColor::Named(NamedColor::Red)));
+        assert_eq!(render(&component), "\u{a7}r\u{a7}cnope");
+    }
+
+    #[test]
+    fn a_sibling_does_not_inherit_the_previous_run() {
+        // The bug this exists to prevent: without the reset per run, "after"
+        // is drawn red because "before" was.
+        let component = Component::text("")
+            .append(
+                Component::text("before").with_style(coloured(TextColor::Named(NamedColor::Red))),
+            )
+            .append(Component::text("after"));
+        // One reset, not two: the empty root carries no text, and `runs`
+        // only emits a run for a non-empty `Contents::Text`, so the root
+        // contributes nothing to render. Asserting two was this test's own
+        // authoring error and it is the only thing that was ever red here.
+        assert_eq!(render(&component), "\u{a7}r\u{a7}cbefore\u{a7}rafter");
+    }
+
+    #[test]
+    fn true_colour_falls_back_to_the_nearest_swatch() {
+        // Dropping it would render as "this line was never coloured", which is
+        // a worse lie than a slightly wrong red.
+        let component = Component::text("close enough")
+            .with_style(coloured(TextColor::Rgb(Rgb24::new(0xf0, 0x50, 0x50))));
+        assert_eq!(render(&component), "\u{a7}r\u{a7}cclose enough");
+    }
+}

--- a/crates/hyperion-web-console/src/lib.rs
+++ b/crates/hyperion-web-console/src/lib.rs
@@ -1,0 +1,207 @@
+//! An operator's window onto a running hyperion server, in a browser.
+//!
+//! Watch chat as it happens, say something back, and run any command a player
+//! could run -- as an operator, from outside the game, without a Minecraft
+//! client. The page is styled like the game because that is what the thing it
+//! shows looks like: section-sign colours are rendered rather than stripped, so
+//! a line reads on the web the way it reads in the chat box.
+//!
+//! # Why this is engine-level
+//!
+//! Watching and administering a server is not a game concept. `smash` and
+//! `bedwars` are two games on one engine and an operator's question --- who is
+//! on, is it keeping up, what build is this, say something to everybody --- is
+//! the same question for both. So nothing here knows what game is running:
+//! chat is taken at the point hyperion decodes it, the roster is hyperion's own
+//! [`Ping`](hyperion::egress::ping::Ping) and [`Name`], and commands go through
+//! the registry every event already registers into. The precedent is
+//! `hyperion::egress::server_load`, which is telemetry in the engine for the
+//! same reason.
+//!
+//! # Commands run through the same dispatch players use
+//!
+//! There is no admin API here. A command typed on the web becomes
+//! [`event::Command`], the same event a `chat_command` packet produces, and is
+//! executed by `hyperion_command`'s own system against the same
+//! [`CommandRegistry`](hyperion_command::CommandRegistry). One implementation
+//! of `/perms`, not two.
+//!
+//! What that costs is the console needing an identity, because a command reads
+//! its caller's permission group and answers to its caller's connection. So the
+//! module makes one entity --- named `Console`, group `Admin` --- and gives it a
+//! [`ConnectionId`](hyperion::net::ConnectionId) with no socket behind it,
+//! registered through [`hyperion::net::VirtualConnection`]. Replies addressed
+//! to it are intercepted before the proxy and decoded back into text for the
+//! page, using the same [`FrameDecoder`](hyperion_minecraft_proto::framing::FrameDecoder)
+//! a client would. Every command in the workspace answers
+//! `caller.get::<&ConnectionId>()`; teaching all of them a second kind of reply
+//! would have been the alternative, and it would have been a worse one.
+//!
+//! # Authentication, and what it is not
+//!
+//! One bearer token, read from a file at startup, compared in constant time.
+//! No accounts, no sessions, no login page. The bind address defaults to
+//! loopback and the NixOS option that exposes it is off by default, because a
+//! console is an admin surface and the honest default for an admin surface is
+//! "reachable from the box it runs on". See [`http`] for where the token
+//! travels and the one place it is not in a header.
+
+pub mod feed;
+pub mod http;
+pub mod legacy;
+pub mod module;
+pub mod state;
+mod virtual_connection;
+
+use std::{
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+
+pub use module::{ConsoleComponentsModule, ConsoleModule, install};
+
+use crate::{
+    feed::Feed,
+    state::{Inbox, Request, Snapshot},
+};
+
+/// How the console was told to run.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Where to listen. Loopback unless an operator says otherwise.
+    pub address: SocketAddr,
+    /// The shared secret every request must carry.
+    pub token: String,
+}
+
+/// Everything the web server and the tick loop share.
+///
+/// One `Arc`, handed to both. The web server never touches the world and the
+/// tick loop never touches a socket; [`Inbox`] and [`Snapshot`] are the two
+/// places they meet, and both are plain mutexes over small values written once
+/// a tick at most.
+#[derive(Debug)]
+pub struct Console {
+    pub feed: Feed,
+    inbox: Inbox,
+    snapshot: Mutex<Snapshot>,
+    token: String,
+}
+
+impl Console {
+    #[must_use]
+    pub fn new(token: String) -> Self {
+        Self {
+            feed: Feed::new(),
+            inbox: Inbox::default(),
+            snapshot: Mutex::new(Snapshot::default()),
+            token,
+        }
+    }
+
+    /// Whether `offered` is the configured token.
+    ///
+    /// Constant time in the length of the token, so a caller cannot learn it
+    /// one byte at a time from how long the comparison took. An empty token is
+    /// refused outright rather than matching an empty configuration, because
+    /// the failure mode of the other choice is a console with no password that
+    /// looks like it has one.
+    #[must_use]
+    pub fn authorises(&self, offered: &[u8]) -> bool {
+        if self.token.is_empty() || offered.is_empty() {
+            return false;
+        }
+        let expected = self.token.as_bytes();
+        if expected.len() != offered.len() {
+            return false;
+        }
+        let mut difference = 0_u8;
+        for (left, right) in expected.iter().zip(offered) {
+            difference |= left ^ right;
+        }
+        difference == 0
+    }
+
+    /// Queue something for the next tick to carry out.
+    pub fn submit(&self, request: Request) {
+        self.inbox.push(request);
+    }
+
+    /// Everything queued since the last tick.
+    #[must_use]
+    pub fn take_requests(&self) -> Vec<Request> {
+        self.inbox.drain()
+    }
+
+    /// The state the page draws, as JSON.
+    #[must_use]
+    pub fn snapshot(&self) -> String {
+        self.snapshot
+            .lock()
+            .map_or_else(|_unused| "{}".to_owned(), |snapshot| snapshot.to_json())
+    }
+
+    /// Replace the state the page draws.
+    pub fn publish(&self, snapshot: Snapshot) {
+        if let Ok(mut held) = self.snapshot.lock() {
+            *held = snapshot;
+        }
+    }
+}
+
+/// Start the web server on its own runtime.
+///
+/// Its own, rather than the one hyperion runs the proxy connection on: an
+/// operator console must not be able to starve the tick loop's I/O, and a
+/// single worker thread is more than a page of text needs.
+///
+/// # Errors
+/// Fails if the runtime cannot be built or the address cannot be bound. Both
+/// are startup failures an operator has to hear about: a console that silently
+/// did not come up is indistinguishable from one nobody opened. Everything
+/// after the bind is a per-connection failure and is logged rather than
+/// returned, because there is nobody left to return it to.
+pub fn spawn(console: Arc<Console>, address: SocketAddr) -> std::io::Result<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
+    // Bound here and handed over, rather than bound here and bound again in
+    // the thread. Binding twice was the first version of this and it is two
+    // bugs: the port is released between the two calls, so something else can
+    // take it and the second bind fails for a reason the first one proved was
+    // not true; and on a platform with `SO_REUSEADDR` semantics that permit it,
+    // both binds succeed and the console serves on a socket nobody checked.
+    let listener = runtime.block_on(async { tokio::net::TcpListener::bind(address).await })?;
+
+    std::thread::Builder::new()
+        .name("hyperion-console".to_owned())
+        .spawn(move || {
+            runtime.block_on(async move {
+                http::serve(console, listener).await;
+            });
+        })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Console;
+
+    #[test]
+    fn the_right_token_is_accepted_and_a_wrong_one_is_not() {
+        let console = Console::new("s3cret".to_owned());
+        assert!(console.authorises(b"s3cret"));
+        assert!(!console.authorises(b"s3cres"));
+        assert!(!console.authorises(b"s3cret "));
+    }
+
+    #[test]
+    fn an_empty_token_never_matches() {
+        // The dangerous shape: a console started with no token configured,
+        // answering every request that also sent nothing.
+        assert!(!Console::new(String::new()).authorises(b""));
+        assert!(!Console::new("s3cret".to_owned()).authorises(b""));
+    }
+}

--- a/crates/hyperion-web-console/src/module.rs
+++ b/crates/hyperion-web-console/src/module.rs
@@ -1,0 +1,291 @@
+//! Wiring: the console entity, the tap, the web server, and one system a tick.
+
+use std::sync::Arc;
+
+use flecs_ecs::{macros::system, prelude::*};
+use hyperion::{
+    console::{ChatObserver, ChatObservers},
+    egress::{ping::Ping, tab_list::Tps},
+    hyperion_minecraft_proto::{
+        generated::packet_id::play::clientbound::PacketId,
+        packets::play::clientbound::SystemChat,
+        text::{Component, NamedColor},
+    },
+    net::{Compose, ConnectionId, protocol::Clientbound},
+    simulation::{Name, PacketState, chat::strip_formatting, event},
+    storage::Events,
+};
+use hyperion_permission::Group;
+
+use crate::{
+    Config, Console,
+    feed::Source,
+    state::{PlayerRow, Request, Snapshot},
+    virtual_connection::ConsoleConnection,
+};
+
+/// How the console appears in chat, and to any command that names its caller.
+pub const CONSOLE_NAME: &str = "Console";
+
+/// How often the roster and the tick rate are rebuilt, in ticks.
+///
+/// A second. The page is a person watching, and a person cannot read twenty
+/// updates a second; rebuilding the roster every tick would cost a query per
+/// tick to redraw something that has not changed.
+const SNAPSHOT_EVERY: i64 = 20;
+
+/// The console, as an ECS singleton.
+///
+/// A newtype rather than storing the `Arc` bare, because a bare `Arc<Console>`
+/// is not a component and flecs keys on the type.
+#[derive(Component)]
+pub struct ConsoleHandle(pub Arc<Console>);
+
+/// The entity commands run as.
+#[derive(Component)]
+pub struct ConsoleCaller(pub Entity);
+
+/// Registration: the components this crate owns, and nothing else.
+#[derive(Component)]
+pub struct ConsoleComponentsModule;
+
+impl Module for ConsoleComponentsModule {
+    fn module(world: &World) {
+        world
+            .component::<ConsoleHandle>()
+            .add_trait::<flecs::Singleton>();
+        world
+            .component::<ConsoleCaller>()
+            .add_trait::<flecs::Singleton>();
+    }
+}
+
+/// Behaviour: the web server, the chat tap, and the tick that carries out what
+/// the operator asked for.
+///
+/// Imported explicitly by a deployment rather than by `HyperionCore`, because a
+/// console is a thing an operator turns on. Import it and pass a [`Config`];
+/// leave it out and nothing here costs anything.
+#[derive(Component)]
+pub struct ConsoleModule;
+
+impl Module for ConsoleModule {
+    fn module(world: &World) {
+        world.import::<ConsoleComponentsModule>();
+        // Every component this module's systems read, registered by the module
+        // that owns it. `HyperionCore` is not optional and not implied by the
+        // event having imported it already: flecs dedupes the import, and the
+        // failure mode of leaving it out is a use-before-register that a
+        // release build compiles the assert out of and a dev build aborts on
+        // (ENG-11000). `Compose`, `Events`, `Name`, `ConnectionId`,
+        // `ChatObservers`, `Ping` and `Tps` all come from here.
+        world.import::<hyperion::HyperionCore>();
+        // The registry commands are looked up in, and the `Group` a command's
+        // permission check reads off the caller.
+        world.import::<hyperion_command::CommandModule>();
+        world.import::<hyperion_permission::PermissionModule>();
+    }
+}
+
+/// Turn the console on.
+///
+/// Separate from [`ConsoleModule`] because a flecs module takes no arguments
+/// and the address and the token are not compile-time facts. Import the module,
+/// then call this.
+///
+/// # Errors
+/// Fails if the web server cannot bind. Deliberately fatal to the caller rather
+/// than logged: an operator who asked for a console and did not get one has to
+/// find out at startup.
+pub fn install(world: &World, config: &Config) -> std::io::Result<()> {
+    let console = Arc::new(Console::new(config.token.clone()));
+
+    // Leaked on purpose, and exactly once. The tap and the virtual connection
+    // are called from the packet path and from `IoBuf`, neither of which can
+    // hold a world reference, and the console lives as long as the process
+    // anyway. A leak with a bounded, known size beats threading a lifetime
+    // through the engine's hot path.
+    let shared: &'static Console = Box::leak(Box::new(Arc::clone(&console)));
+
+    let caller = spawn_caller(world);
+    world.set(ConsoleCaller(caller));
+
+    world.get::<&mut ChatObservers>(|observers| {
+        observers.watch(Arc::new(ChatToFeed {
+            console: Arc::clone(&console),
+        }));
+    });
+
+    world.get::<&mut Compose>(|compose| {
+        // The server's own threshold, handed over as it is: turning it into
+        // what a decoder wants is `ConsoleConnection`'s job, next to the tests
+        // that pin the rule.
+        let threshold = compose.global().shared.compression_threshold;
+        compose
+            .io_buf_mut()
+            .attach_virtual_connection(Arc::new(ConsoleConnection::new(&shared.feed, threshold)));
+    });
+
+    crate::spawn(Arc::clone(&console), config.address)?;
+    console.feed.push(
+        Source::System,
+        format!("\u{a7}8console listening on http://{}/", config.address),
+    );
+
+    world.set(ConsoleHandle(console));
+    install_systems(world);
+    Ok(())
+}
+
+/// The entity commands run as.
+///
+/// It is not a player and must never be mistaken for one: no
+/// [`PacketState::Play`], which is what events key "this is somebody who
+/// joined" on, so no game promotes it, counts it in a lobby, or writes a
+/// sidebar to it. What it does carry is exactly what a command reads --- a
+/// name, a group, and a connection to answer.
+fn spawn_caller(world: &World) -> Entity {
+    let caller = world
+        .entity_named(CONSOLE_NAME)
+        .set(Name::from(std::sync::Arc::<str>::from(CONSOLE_NAME)))
+        .set(Group::Admin)
+        .set(ConnectionId::new(
+            crate::virtual_connection::CONSOLE_STREAM,
+            hyperion::net::ProxyId::new(crate::virtual_connection::CONSOLE_PROXY),
+        ));
+
+    debug_assert!(
+        !caller.has_enum(PacketState::Play),
+        "the console caller must not look like a joined player"
+    );
+
+    caller.id()
+}
+
+/// Player chat, on its way to the page.
+struct ChatToFeed {
+    console: Arc<Console>,
+}
+
+impl ChatObserver for ChatToFeed {
+    fn player_said(&self, _speaker: Entity, name: &str, message: &str) {
+        // Vanilla's shape, so a line reads on the page the way it reads in the
+        // chat box. Not the line the game broadcast, which this cannot see:
+        // see `hyperion::console` for why the tap is before the queue and what
+        // that trades away.
+        //
+        // The message keeps its section signs and the page renders them, which
+        // is a decision with a hazard attached: a player typing `\u{a7}c` paints
+        // their own text here. That is the same hazard the game has and the
+        // same answer -- the engine's `strip_formatting` -- applied at the one
+        // place that knows this text came off a wire.
+        self.console.feed.push(
+            Source::Chat,
+            format!("<{name}> {}", strip_formatting(message)),
+        );
+    }
+}
+
+fn install_systems(world: &World) {
+    system!(
+        "console_requests",
+        world,
+        &ConsoleHandle,
+        &ConsoleCaller,
+        &Compose,
+        &Events
+    )
+    .each_iter(|it, _index, (handle, caller, compose, events)| {
+        let world = it.world();
+        for request in handle.0.take_requests() {
+            match request {
+                Request::Say(message) => {
+                    // Built as a component with the colour as a field,
+                    // rather than as a string with `\u{a7}d` inside it.
+                    // Both render the same on a client, and `nix/text.nix`
+                    // exists because only one of them survives contact
+                    // with anything that reads the text: the legacy codes
+                    // are invisible to `Component::plain`, say nothing
+                    // outside the sixteen named colours, and are a
+                    // formatter kept alive for 1.8 servers. That gate does
+                    // not reach this crate today (ENG-10796 tracks
+                    // widening it), which is a reason to hold the line
+                    // here rather than to relax it.
+                    //
+                    // The operator's own text is a child with no style of
+                    // its own, so it cannot be styled by the prefix, and
+                    // the feed gets the same component rendered back down
+                    // to the codes the page draws.
+                    let component = Component::text(format!("[{CONSOLE_NAME}]"))
+                        .color(NamedColor::LightPurple)
+                        .append(Component::text(format!(" {message}")).color(NamedColor::White));
+                    let line = crate::legacy::render(&component);
+                    let packet = SystemChat {
+                        content: component.to_tag(),
+                        overlay: false,
+                    };
+                    match compose
+                        .broadcast(Clientbound::new(PacketId::SystemChat.to_raw(), &packet))
+                        .send()
+                    {
+                        Ok(()) => handle.0.feed.push(Source::Console, line),
+                        Err(error) => {
+                            // The operator pressed send and nothing
+                            // happened, so the page has to say so rather
+                            // than the journal alone.
+                            handle.0.feed.push(
+                                Source::System,
+                                format!("\u{a7}cthe message was not sent: {error}"),
+                            );
+                        }
+                    }
+                }
+                Request::Command(raw) => {
+                    let raw = raw.strip_prefix('/').unwrap_or(&raw).to_owned();
+                    handle
+                        .0
+                        .feed
+                        .push(Source::Console, format!("\u{a7}8> /{raw}"));
+                    events.push(
+                        event::Command {
+                            raw: raw.into(),
+                            by: caller.0,
+                        },
+                        &world,
+                    );
+                }
+            }
+        }
+    });
+
+    system!("console_snapshot", world, &ConsoleHandle, &Compose, &Tps).each_iter(
+        |it, _index, (handle, compose, tps)| {
+            if compose.global().tick % SNAPSHOT_EVERY != 0 {
+                return;
+            }
+
+            let mut players = Vec::new();
+            it.world()
+                .query::<(&Name, &Ping)>()
+                .build()
+                .each(|(name, ping)| {
+                    players.push(PlayerRow {
+                        name: name.to_string(),
+                        // `latency` reports the engine's own "no reading"
+                        // sentinel as a negative, which the page must not draw
+                        // as a fast connection.
+                        latency_ms: Some(ping.latency()).filter(|latency| *latency >= 0),
+                    });
+                });
+            players.sort_by(|left, right| left.name.cmp(&right.name));
+
+            handle.0.publish(Snapshot {
+                players,
+                tps: tps.rate,
+                target_tps: hyperion::TICKS_PER_SECOND,
+                build_rev: std::env::var("HYPERION_BUILD_REV").ok(),
+                build_dirty: std::env::var("HYPERION_BUILD_DIRTY").as_deref() == Ok("1"),
+            });
+        },
+    );
+}

--- a/crates/hyperion-web-console/src/state.rs
+++ b/crates/hyperion-web-console/src/state.rs
@@ -1,0 +1,131 @@
+//! What the console shows besides chat, and what it sends back into the world.
+
+use std::sync::Mutex;
+
+/// One player, as the console's roster draws them.
+#[derive(Debug, Clone)]
+pub struct PlayerRow {
+    pub name: String,
+    /// Round trip in milliseconds, or `None` when nothing has been measured.
+    ///
+    /// `None` rather than a zero, for the same reason
+    /// [`hyperion::egress::ping::UNKNOWN`] exists: a zero draws a healthy
+    /// connection for a client nobody has timed.
+    pub latency_ms: Option<i32>,
+}
+
+/// Everything the page shows that is not a line of chat.
+///
+/// Rebuilt whole once a second by a flecs system and read by the web server on
+/// whatever thread it happens to be on, so it crosses a mutex rather than
+/// being queried live: a query needs the world, and the world belongs to the
+/// tick loop.
+#[derive(Debug, Default, Clone)]
+pub struct Snapshot {
+    pub players: Vec<PlayerRow>,
+    /// Ticks per second over the engine's own window, or `None` while it is
+    /// still sampling. Not defaulted to twenty: a number nobody has measured
+    /// is exactly what an operator is checking for.
+    pub tps: Option<f32>,
+    /// What the tick loop is paced to, so the rate above has a denominator.
+    pub target_tps: f32,
+    /// The commit this server was built from, `None` when nothing said.
+    pub build_rev: Option<String>,
+    /// The working tree had uncommitted changes at build time.
+    pub build_dirty: bool,
+}
+
+impl Snapshot {
+    /// This snapshot as the JSON the page reads.
+    #[must_use]
+    pub fn to_json(&self) -> String {
+        let players: Vec<_> = self
+            .players
+            .iter()
+            .map(|player| serde_json::json!({ "name": player.name, "latency": player.latency_ms }))
+            .collect();
+
+        serde_json::json!({
+            "players": players,
+            "tps": self.tps,
+            "targetTps": self.target_tps,
+            "buildRev": self.build_rev,
+            "buildDirty": self.build_dirty,
+        })
+        .to_string()
+    }
+}
+
+/// What the operator asked for, waiting for a tick to carry it out.
+///
+/// A web request arrives on a tokio thread and everything it wants to do needs
+/// the world, which only the tick loop may touch. So a request lands here and
+/// the next tick drains it. The operator's own latency is one tick, 50 ms,
+/// which is under what a click can perceive.
+#[derive(Debug, Clone)]
+pub enum Request {
+    /// Say something to every player, as the console.
+    Say(String),
+    /// Run a command, as the console operator.
+    Command(String),
+}
+
+/// The queue those requests wait in.
+#[derive(Debug, Default)]
+pub struct Inbox {
+    pending: Mutex<Vec<Request>>,
+}
+
+impl Inbox {
+    pub fn push(&self, request: Request) {
+        if let Ok(mut pending) = self.pending.lock() {
+            pending.push(request);
+        }
+    }
+
+    /// Everything queued since the last call.
+    #[must_use]
+    pub fn drain(&self) -> Vec<Request> {
+        self.pending
+            .lock()
+            .map(|mut pending| std::mem::take(&mut *pending))
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Inbox, PlayerRow, Request, Snapshot};
+
+    #[test]
+    fn draining_leaves_the_queue_empty() {
+        let inbox = Inbox::default();
+        inbox.push(Request::Say("hello".to_owned()));
+        assert_eq!(inbox.drain().len(), 1);
+        assert!(inbox.drain().is_empty());
+    }
+
+    #[test]
+    fn an_unmeasured_ping_is_null_and_not_zero() {
+        // A zero here draws five bars for a client nobody has timed, which is
+        // the bug ENG-11113 fixed on the tab list. The console must not
+        // reintroduce it in a second place.
+        let snapshot = Snapshot {
+            players: vec![PlayerRow {
+                name: "Andrew".to_owned(),
+                latency_ms: None,
+            }],
+            ..Snapshot::default()
+        };
+        assert!(snapshot.to_json().contains(r#""latency":null"#));
+    }
+
+    #[test]
+    fn a_tps_still_sampling_is_null_and_not_twenty() {
+        let snapshot = Snapshot {
+            target_tps: 20.0,
+            ..Snapshot::default()
+        };
+        assert!(snapshot.to_json().contains(r#""tps":null"#));
+    }
+}

--- a/crates/hyperion-web-console/src/virtual_connection.rs
+++ b/crates/hyperion-web-console/src/virtual_connection.rs
@@ -1,0 +1,169 @@
+//! The console's end of a connection that has no socket.
+//!
+//! Every command in the workspace answers its caller by reading the caller's
+//! [`ConnectionId`] and unicasting to it. So the console has one, and this is
+//! what is on the other side of it: frames arrive exactly as the proxy would
+//! have received them, go through the same decoder a client uses, and any
+//! `SystemChat` among them becomes a line on the page.
+//!
+//! Anything that is not chat is dropped. A command that answers by moving a
+//! boss bar or opening an inventory has said something the console cannot
+//! draw, and inventing a rendering for it would be worse than being quiet.
+
+use std::sync::Mutex;
+
+use hyperion::{
+    hyperion_minecraft_proto::{
+        framing::FrameDecoder, generated::packet_id::play::clientbound::PacketId,
+        packets::play::clientbound::SystemChat, text::Component,
+    },
+    net::{ConnectionId, VirtualConnection},
+    valence_protocol::CompressionThreshold,
+};
+
+use crate::feed::{Feed, Source};
+
+/// The stream id the console answers to.
+///
+/// Far above anything the proxy hands out --- ids come from a counter that
+/// starts at zero and one server would need to outlive the heat death of
+/// several suns to reach this --- so a real player can never be given it.
+pub const CONSOLE_STREAM: u64 = u64::MAX - 1;
+
+/// The proxy the console pretends to be behind.
+///
+/// Never used to route anything: the interception in
+/// [`hyperion::net::IoBuf::unicast_raw`] happens before a proxy is chosen. It
+/// exists because a [`ConnectionId`] has two halves and both are compared.
+pub const CONSOLE_PROXY: u64 = u64::MAX - 1;
+
+/// Turns frames addressed to the console into lines on the page.
+pub struct ConsoleConnection {
+    stream: ConnectionId,
+    /// The decoder carries state across frames --- a packet can be split over
+    /// several writes --- so it is one decoder for the life of the console
+    /// rather than one per frame.
+    decoder: Mutex<FrameDecoder>,
+    feed: &'static Feed,
+}
+
+impl ConsoleConnection {
+    /// A connection delivering into `feed`.
+    ///
+    /// Takes the server's own [`CompressionThreshold`] rather than a
+    /// `Option<usize>` a caller worked out, because working it out is the one
+    /// step here that can be silently wrong. See [`decoder_threshold`].
+    #[must_use]
+    pub fn new(feed: &'static Feed, compression_threshold: CompressionThreshold) -> Self {
+        let mut decoder = FrameDecoder::new();
+        decoder.set_compression_threshold(decoder_threshold(compression_threshold));
+
+        Self {
+            stream: ConnectionId::new(CONSOLE_STREAM, hyperion::net::ProxyId::new(CONSOLE_PROXY)),
+            decoder: Mutex::new(decoder),
+            feed,
+        }
+    }
+}
+
+/// What to tell a [`FrameDecoder`] given the threshold the encoder holds.
+///
+/// The two are not the same type and the mapping is not obvious.
+/// `PacketEncoder::append_packet` switches on `threshold.0 >= 0`, so a
+/// negative threshold means no compression at all and every other value --
+/// including zero -- means every frame carries a `data_len` varint, whether or
+/// not that particular frame was deflated. `usize::try_from` is exactly that
+/// predicate: `None` for the negative case, `Some` for the rest.
+///
+/// This is a named function with tests rather than an expression at the call
+/// site because getting it wrong is invisible. A decoder told there is no
+/// compression reads the `data_len` varint as the packet id, decides the frame
+/// is not a `SystemChat`, and drops it -- no error, no log line, an operator
+/// console that shows a command being sent and never shows a reply. That state
+/// was reproduced deliberately against a live server: every command reply
+/// vanished and the server said nothing at any log level.
+fn decoder_threshold(threshold: CompressionThreshold) -> Option<usize> {
+    usize::try_from(threshold.0).ok()
+}
+
+impl VirtualConnection for ConsoleConnection {
+    fn stream(&self) -> ConnectionId {
+        self.stream
+    }
+
+    fn deliver(&self, frame: &[u8]) {
+        let Ok(mut decoder) = self.decoder.lock() else {
+            return;
+        };
+
+        decoder.queue(frame);
+
+        loop {
+            match decoder.next_packet() {
+                Ok(Some(packet)) => {
+                    if packet.id != PacketId::SystemChat.to_raw() {
+                        continue;
+                    }
+                    match packet.decode_body::<SystemChat<'_>>() {
+                        // The page renders section signs, so the text goes on
+                        // with its own formatting intact.
+                        Ok(chat) => match Component::from_tag(&chat.content) {
+                            // `legacy::render` and not `plain`: a component
+                            // carries its colour as a field, the page renders
+                            // section signs, and `plain` throws the field away
+                            // -- which turns a red refusal into a sentence the
+                            // same colour as everything else.
+                            Ok(component) => {
+                                self.feed
+                                    .push(Source::Reply, crate::legacy::render(&component));
+                            }
+                            Err(error) => {
+                                tracing::warn!("console could not read a reply component: {error}");
+                            }
+                        },
+                        Err(error) => {
+                            tracing::warn!("console could not decode a chat reply: {error}");
+                        }
+                    }
+                }
+                Ok(None) => return,
+                // The stream position is no longer known, so every later frame
+                // would be read at the wrong offset. Saying so once and
+                // stopping beats a page filling with garbage.
+                Err(error) => {
+                    tracing::error!("console reply stream is unreadable, giving up: {error}");
+                    return;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperion::valence_protocol::CompressionThreshold;
+
+    use super::decoder_threshold;
+
+    /// The server's own default, from `crates/hyperion/src/lib.rs`. Frames
+    /// carry a `data_len`, so the decoder has to expect one.
+    #[test]
+    fn the_shipping_threshold_turns_compression_on() {
+        assert_eq!(decoder_threshold(CompressionThreshold(256)), Some(256));
+    }
+
+    /// `PacketEncoder::append_packet` treats `>= 0` as compression enabled, so
+    /// zero is on -- every frame framed with a `data_len`, and every one of
+    /// them deflated, since the encoder compresses when `data_len > 0`.
+    /// Reading zero as "off" is the plausible mistake this pins.
+    #[test]
+    fn zero_is_compression_on_and_not_off() {
+        assert_eq!(decoder_threshold(CompressionThreshold(0)), Some(0));
+    }
+
+    /// The only value that means off.
+    #[test]
+    fn a_negative_threshold_is_the_one_that_disables_it() {
+        assert_eq!(decoder_threshold(CompressionThreshold(-1)), None);
+    }
+}

--- a/crates/hyperion-web-console/tests/registration_modules.rs
+++ b/crates/hyperion-web-console/tests/registration_modules.rs
@@ -1,0 +1,86 @@
+//! Dev-profile guard: the console's registration module stands on its own.
+//!
+//! The same property `crates/hyperion/tests/registration_modules.rs` asserts
+//! for the engine's modules, asserted for this crate's. It has to live here
+//! rather than beside those: `hyperion` cannot depend on a crate that depends
+//! on `hyperion`.
+//!
+//! This is the only shape of test that can see ENG-11000's class. flecs builds
+//! with `flecs_manual_registration`, so using a component before registering it
+//! aborts with `ECS_INVALID_OPERATION` -- but that guard is an `ecs_assert`,
+//! which release builds compile out. Every e2e gate in this repo builds a
+//! release binary and is therefore structurally blind to it. `cargo test` is
+//! not.
+
+use flecs_ecs::core::{ComponentId, World, id};
+use hyperion_web_console::{
+    ConsoleComponentsModule,
+    module::{ConsoleCaller, ConsoleHandle},
+};
+use serial_test::serial;
+
+/// Asserts `T` is registered without registering it as a side effect, which is
+/// what a plain `id::<T>()` or a `set` would do.
+fn assert_registered<T: ComponentId>(world: &World) {
+    assert!(
+        world.get_component_id::<T>().is_some(),
+        "{} should be registered by its registration module alone",
+        core::any::type_name::<T>()
+    );
+}
+
+#[test]
+#[serial]
+fn the_registration_module_registers_both_singletons_standalone() {
+    let world = World::new();
+    world.import::<ConsoleComponentsModule>();
+
+    assert_registered::<ConsoleHandle>(&world);
+    assert_registered::<ConsoleCaller>(&world);
+}
+
+#[test]
+#[serial]
+fn registration_carries_no_behaviour() {
+    // The other half of the convention in the root `CLAUDE.md`: a consumer can
+    // import the types without importing the systems. If these ever appear
+    // here, "give me the components but not the behaviour" has stopped being
+    // expressible and the smash mock loses the seam it depends on.
+    let world = World::new();
+    world.import::<ConsoleComponentsModule>();
+
+    assert!(
+        world.try_lookup("console_requests").is_none(),
+        "the registration module must install no systems"
+    );
+    assert!(
+        world.try_lookup("console_snapshot").is_none(),
+        "the registration module must install no systems"
+    );
+}
+
+/// The singletons are registered, but deliberately not *set*.
+///
+/// Unlike `SpatialIndex` or `WorldTime`, neither of these has a meaningful
+/// default: a `ConsoleHandle` is an `Arc<Console>` that only exists once an
+/// operator has asked for a console and a port has been bound, and a
+/// `ConsoleCaller` names an entity that `install` creates. So the registration
+/// module registers the types and `install` sets the values, and that split is
+/// the thing this asserts -- a future edit that "helpfully" adds a `Default`
+/// and sets it here would give every server a console handle pointing at
+/// nothing.
+#[test]
+#[serial]
+fn the_singletons_are_registered_but_not_set() {
+    let world = World::new();
+    world.import::<ConsoleComponentsModule>();
+
+    assert!(
+        !world.has(id::<ConsoleHandle>()),
+        "a handle must not exist until `install` has bound a port"
+    );
+    assert!(
+        !world.has(id::<ConsoleCaller>()),
+        "a caller must not exist until `install` has spawned the entity"
+    );
+}

--- a/crates/hyperion/src/console.rs
+++ b/crates/hyperion/src/console.rs
@@ -1,0 +1,67 @@
+//! The engine's side of an operator console.
+//!
+//! A console needs to see chat, and chat is a single-consumer queue: whichever
+//! system calls [`EventQueue::drain`](crate::storage::EventQueue::drain) first
+//! takes every message, and the game is that system. A second reader is not
+//! expressible, and making the queue multi-consumer to give one watcher a copy
+//! would change how every event in the engine is delivered.
+//!
+//! So the tap is here, at the point the packet is decoded, before the queue.
+//! What an observer sees is what the player typed, which is also the more
+//! useful thing for an operator: the rendered line is a game's decision --
+//! bedwars colours the name by team, smash does not -- and a game that refuses
+//! a message on a cooldown still leaves the operator wanting to know somebody
+//! tried.
+//!
+//! Nothing in the engine installs an observer. With none installed this costs
+//! one singleton read and an empty iteration per chat packet.
+
+use std::sync::Arc;
+
+use flecs_ecs::prelude::*;
+
+/// Something watching what players type.
+///
+/// Called from the packet handler, on the tick thread, before the message
+/// reaches any game. An implementation must not block: a slow observer is a
+/// slow tick.
+pub trait ChatObserver: Send + Sync {
+    /// `speaker`, whose username is `name`, said `message`.
+    ///
+    /// The name is passed rather than looked up because an observer is called
+    /// from the packet path and has no world to look it up in. Resolving it
+    /// there and handing over an entity id was the first shape of this and it
+    /// was useless: a chat pane reading `1234: hello` names nobody.
+    ///
+    /// `message` is unsanitised on purpose. What is safe to put in a component
+    /// is a question about a Minecraft client, and an observer that is not one
+    /// -- a web page, a log, a bridge -- has its own answer.
+    fn player_said(&self, speaker: Entity, name: &str, message: &str);
+}
+
+/// Everyone watching. A singleton, empty unless something registers.
+#[derive(Component, Default)]
+pub struct ChatObservers {
+    observers: Vec<Arc<dyn ChatObserver>>,
+}
+
+impl ChatObservers {
+    /// Start watching. There is no way to stop: an observer lives as long as
+    /// the process, which is what every caller so far wants and is one less
+    /// piece of state than a handle nobody would return.
+    pub fn watch(&mut self, observer: Arc<dyn ChatObserver>) {
+        self.observers.push(observer);
+    }
+
+    /// Tell everyone watching.
+    pub fn player_said(&self, speaker: Entity, name: &str, message: &str) {
+        for observer in &self.observers {
+            observer.player_said(speaker, name, message);
+        }
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.observers.is_empty()
+    }
+}

--- a/crates/hyperion/src/lib.rs
+++ b/crates/hyperion/src/lib.rs
@@ -73,6 +73,7 @@ use crate::{
     util::mojang::ApiProvider,
 };
 
+pub mod console;
 pub mod effects;
 pub mod egress;
 pub mod ingress;
@@ -302,6 +303,13 @@ impl HyperionCore {
             .component::<MojangClient>()
             .add_trait::<flecs::Singleton>();
         world.component::<Events>().add_trait::<flecs::Singleton>();
+        // Empty unless an operator console registers. Registered here rather
+        // than in whatever installs an observer, so the packet handler can
+        // read it on a server that has no console at all.
+        world
+            .component::<console::ChatObservers>()
+            .add_trait::<flecs::Singleton>();
+        world.set(console::ChatObservers::default());
         world.component::<Comms>().add_trait::<flecs::Singleton>();
         world
             .component::<EgressComm>()

--- a/crates/hyperion/src/net/mod.rs
+++ b/crates/hyperion/src/net/mod.rs
@@ -1,6 +1,6 @@
 //! All the networking related code.
 
-use std::{cell::RefCell, fmt::Debug};
+use std::{cell::RefCell, fmt::Debug, sync::Arc};
 
 use byteorder::WriteBytesExt;
 use bytes::{Bytes, BytesMut};
@@ -12,7 +12,7 @@ use hyperion_utils::EntityExt;
 use libdeflater::CompressionLvl;
 use rustc_hash::FxHashMap;
 use thread_local::ThreadLocal;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::{
     Global, PacketBundle, Scratch,
@@ -387,6 +387,33 @@ impl Compose {
     }
 }
 
+/// A [`ConnectionId`] with no socket behind it.
+///
+/// Everything that answers a player -- a command's reply, a permission
+/// refusal, a parse error -- is written as `caller.get::<&ConnectionId>()` and
+/// a `unicast`, in dozens of places across `hyperion-clap` and both events. So
+/// a caller that is not a player has exactly two options: teach every one of
+/// those call sites about a second kind of reply, or give it a connection id
+/// and answer to that. This is the second one.
+///
+/// The frames arrive here already framed, exactly as the proxy would have
+/// received them, because that is the last point where a packet is still one
+/// contiguous thing. Whoever installs this is expected to run them back
+/// through a [`hyperion_minecraft_proto::framing::FrameDecoder`], which is the
+/// same code a client uses and so cannot drift from what was sent.
+///
+/// Without this the id belongs to nobody and the proxy says so, once per
+/// packet: `Player not found for id ...`, a warning that names the wrong
+/// cause.
+pub trait VirtualConnection: Send + Sync {
+    /// The id that means "me". Compared against every unicast, so this must be
+    /// cheap and must not change.
+    fn stream(&self) -> ConnectionId;
+
+    /// One whole framed packet addressed to [`stream`](Self::stream).
+    fn deliver(&self, frame: &[u8]);
+}
+
 /// This is useful for the ECS, so we can use Single<&mut Broadcast> instead of having to use a marker struct
 #[derive(Component, Default)]
 pub struct IoBuf {
@@ -394,9 +421,25 @@ pub struct IoBuf {
     // broadcast_buffer: ThreadLocal<RefCell<BytesMut>>,
     temp_buffer: ThreadLocal<RefCell<BytesMut>>,
     egress_comms: FxHashMap<ProxyId, EgressComm>,
+    /// Installed by an operator console and absent otherwise, which is what
+    /// keeps this off the cost of a server nobody is watching: one
+    /// `Option::is_none` per unicast and nothing at all per broadcast.
+    virtual_connection: Option<Arc<dyn VirtualConnection>>,
 }
 
 impl IoBuf {
+    /// Route every unicast addressed to `connection.stream()` to it rather
+    /// than to a proxy.
+    ///
+    /// Replaces any previous one: there is one console per server, and two
+    /// silently sharing a stream id would each see half the traffic.
+    pub fn attach_virtual_connection(&mut self, connection: Arc<dyn VirtualConnection>) {
+        if self.virtual_connection.is_some() {
+            warn!("replacing an already attached virtual connection");
+        }
+        self.virtual_connection = Some(connection);
+    }
+
     pub(crate) fn add_proxy(&mut self, proxy_id: ProxyId, egress_comm: EgressComm) {
         let already_exists = self.egress_comms.insert(proxy_id, egress_comm).is_some();
 
@@ -674,6 +717,16 @@ impl IoBuf {
     }
 
     pub(crate) fn unicast_raw(&self, data: &[u8], stream: ConnectionId) {
+        // Before the proxy, because a virtual connection has none: an id with
+        // no socket behind it makes the proxy warn once per packet about a
+        // player that was never going to be there.
+        if let Some(virtual_connection) = self.virtual_connection.as_ref()
+            && virtual_connection.stream() == stream
+        {
+            virtual_connection.deliver(data);
+            return;
+        }
+
         self.add_proxy_message(&IntermediateServerToProxyMessage::Unicast(
             intermediate::Unicast { stream, data },
         ));

--- a/crates/hyperion/src/simulation/handlers.rs
+++ b/crates/hyperion/src/simulation/handlers.rs
@@ -25,7 +25,7 @@
 #![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use anyhow::bail;
-use flecs_ecs::core::{Entity, EntityView, EntityViewGet, World, id};
+use flecs_ecs::core::{Entity, EntityView, EntityViewGet, World, WorldGet, id};
 use geometry::aabb::Aabb;
 use glam::{DVec3, IVec3, Vec3};
 use hyperion_minecraft_proto::{
@@ -62,7 +62,7 @@ use crate::{
         protocol::{decode_body, frame_body, send},
     },
     simulation::{
-        Pitch, Yaw, aabb,
+        Name, Pitch, Yaw, aabb,
         blocks::translate,
         event, gamemode,
         metadata::{
@@ -293,6 +293,22 @@ fn interact(body: &[u8], query: &mut PacketSwitchQuery<'_>) -> anyhow::Result<()
 
 fn chat(body: &[u8], query: &mut PacketSwitchQuery<'_>) -> anyhow::Result<()> {
     let packet: serverbound::Chat<'_> = decode_body(body)?;
+
+    // Before the queue, because the queue has one consumer and the game is it.
+    // See `crate::console`. The name is resolved here because this is the last
+    // place that has a world; an observer does not.
+    query
+        .world
+        .get::<&crate::console::ChatObservers>(|observers| {
+            if observers.is_empty() {
+                return;
+            }
+            let speaker = query.id.entity_view(query.world);
+            let name = speaker
+                .try_get::<&Name>(ToString::to_string)
+                .unwrap_or_else(|| query.id.to_string());
+            observers.player_said(query.id, &name, packet.message);
+        });
 
     query.events.push(
         event::ChatMessage {

--- a/events/bedwars/Cargo.toml
+++ b/events/bedwars/Cargo.toml
@@ -14,6 +14,7 @@ hyperion-inventory = { workspace = true }
 hyperion-item = { workspace = true }
 hyperion-permission = { workspace = true }
 hyperion-utils = { workspace = true }
+hyperion-web-console = { workspace = true }
 rayon = { workspace = true }
 roaring = { workspace = true }
 rustc-hash = { workspace = true }

--- a/events/bedwars/src/lib.rs
+++ b/events/bedwars/src/lib.rs
@@ -154,7 +154,11 @@ impl Module for BedwarsModule {
     }
 }
 
-pub fn init_game(address: SocketAddr, crypto: Crypto) -> anyhow::Result<()> {
+pub fn init_game(
+    address: SocketAddr,
+    crypto: Crypto,
+    console: Option<hyperion_web_console::Config>,
+) -> anyhow::Result<()> {
     let world = World::new();
 
     world.import::<HyperionCore>();
@@ -162,6 +166,15 @@ pub fn init_game(address: SocketAddr, crypto: Crypto) -> anyhow::Result<()> {
 
     world.set(crypto);
     world.set(GameServerEndpoint::from(address));
+
+    // After the game's own modules, so a command registered by the event is
+    // already in the registry the console's caller will be dispatched
+    // against, and after `GameServerEndpoint`, so the first line on the page
+    // is a server that has finished coming up.
+    if let Some(config) = console {
+        world.import::<hyperion_web_console::ConsoleModule>();
+        hyperion_web_console::install(&world, &config)?;
+    }
 
     let mut app = world.app();
 

--- a/events/bedwars/src/main.rs
+++ b/events/bedwars/src/main.rs
@@ -10,7 +10,10 @@
 use bedwars::init_game;
 
 fn main() -> anyhow::Result<()> {
-    // bedwars takes the address and nothing else: it has no reloadable rules,
-    // so the deployment paths on `Args` are none of its business.
-    hyperion_event_runner::run("BEDWARS_", |args, crypto| init_game(args.address(), crypto))
+    // bedwars takes no deployment paths: it has no reloadable rules, so that
+    // part of `Args` is none of its business. It does take a console, which is
+    // engine-level and asks the same operator questions of either game.
+    hyperion_event_runner::run("BEDWARS_", |args, crypto| {
+        init_game(args.address(), crypto, args.console()?)
+    })
 }

--- a/events/smash/Cargo.toml
+++ b/events/smash/Cargo.toml
@@ -21,6 +21,7 @@ hyperion-item = { workspace = true }
 hyperion-minecraft-proto = { workspace = true }
 hyperion-permission = { workspace = true }
 hyperion-utils = { workspace = true }
+hyperion-web-console = { workspace = true }
 tracing = { workspace = true }
 valence_nbt = { workspace = true }
 valence_protocol = { workspace = true }

--- a/events/smash/src/lib.rs
+++ b/events/smash/src/lib.rs
@@ -276,6 +276,7 @@ pub fn init_game(
     address: SocketAddr,
     crypto: Crypto,
     deployment: Option<Deployment>,
+    console: Option<hyperion_web_console::Config>,
 ) -> anyhow::Result<()> {
     let world = World::new();
 
@@ -284,6 +285,15 @@ pub fn init_game(
 
     world.set(crypto);
     world.set(GameServerEndpoint::from(address));
+
+    // After the game's own modules, so a command registered by the event is
+    // already in the registry the console's caller will be dispatched against,
+    // and after `GameServerEndpoint`, so the first line on the page is a server
+    // that has finished coming up.
+    if let Some(config) = console {
+        world.import::<hyperion_web_console::ConsoleModule>();
+        hyperion_web_console::install(&world, &config)?;
+    }
 
     let mut rules = deployment.map(|it| Rules::open(&world, it)).transpose()?;
 

--- a/events/smash/src/main.rs
+++ b/events/smash/src/main.rs
@@ -40,6 +40,6 @@ use smash::init_game;
 
 fn main() -> anyhow::Result<()> {
     hyperion_event_runner::run("SMASH_", |args, crypto| {
-        init_game(args.address(), crypto, args.deployment()?)
+        init_game(args.address(), crypto, args.deployment()?, args.console()?)
     })
 }

--- a/flake.nix
+++ b/flake.nix
@@ -852,7 +852,11 @@
                 # code in their working tree, rebuilt incrementally. The check
                 # of the same name hands the same driver two store paths, and
                 # that is the only difference between them.
-                export HYPERION_E2E_GAME_SERVER="cargo run --profile $profile -p $event --"
+                # `HYPERION_E2E_GAME_SERVER_ARGS` is the `nix run` twin of
+                # `mkCheck`'s `gameServerArgs`: extra flags for the server,
+                # for trying a gate's configuration by hand before writing it
+                # down.
+                export HYPERION_E2E_GAME_SERVER="cargo run --profile $profile -p $event -- ''${HYPERION_E2E_GAME_SERVER_ARGS:-}"
                 export HYPERION_E2E_PROXY="cargo run --profile $profile --bin hyperion-proxy --"
                 export HYPERION_E2E_CLIENT="''${HYPERION_E2E_CLIENT:-tools/client-26.2.py --name e2e}"
                 # Certificates from the store rather than `nix run .#certs`, so
@@ -1937,6 +1941,47 @@
               timeout = 180;
             };
 
+            # The operator console, which needs a server and a browser at once
+            # and so cannot be tested from inside its own crate.
+            #
+            # `hyperion-web-console` has unit tests for everything that is a
+            # function of its inputs -- the token comparison, the backlog
+            # bound, the legacy colour rendering, the threshold rule. None of
+            # them can see the three things the console actually claims, all of
+            # which are about two processes agreeing:
+            #
+            #   * a line a player types reaching a browser, with the section
+            #     signs they typed stripped on the way. The stripping is
+            #     per-source and the game's own path already does it, so a
+            #     mirror of that path would look right and paint the operator's
+            #     console anyway.
+            #   * a command typed on the web running through the same registry
+            #     a player's command runs through, and its reply coming back
+            #     over a `ConnectionId` with no socket behind it. Nothing short
+            #     of a real unicast exercises that.
+            #   * that reply surviving both branches of the frame decoder. A
+            #     short reply is framed with `data_len` zero and a long one is
+            #     deflated, and a decoder told the wrong threshold reads the
+            #     length as a packet id and silently drops every frame -- no
+            #     error, no log line, an operator console that shows commands
+            #     going out and nothing coming back. That state was reproduced
+            #     deliberately, and this gate is the only thing that saw it.
+            #
+            # `console = true` has the driver pick a third port beside the
+            # other two and hand the same address and token file to the server
+            # and the client. No `e2eOffsets` entry, for the same reason
+            # `chat-e2e` has none: the offsets exist for the gates that also
+            # run as host apps, and a sandboxed check gets free ports from the
+            # driver instead.
+            console-e2e = e2e.mkCheck {
+              name = "hyperion-console-e2e";
+              gameServer = gameBinaries.smash;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "console-check.py";
+              console = true;
+              timeout = 180;
+            };
+
             # The tab list's two new numbers, and the one claim about them that
             # no Rust test can settle.
             #
@@ -1998,6 +2043,32 @@
                 "--name"
                 "smashdevboot"
               ];
+              timeout = 300;
+            };
+
+            # The same boot, with the console turned on.
+            #
+            # `console-e2e` runs the release binary, because that is what
+            # ships, and a release build has the flecs assert compiled out. So
+            # everything `install` does -- registering two singletons, setting
+            # both, spawning the caller entity, attaching the virtual
+            # connection -- is reached by no gate that can see a
+            # use-before-register. That is the ENG-11000 shape exactly: a
+            # console that aborts `nix run .#smash` on boot while every gate
+            # above stays green.
+            #
+            # It runs the whole console client rather than a bare join, because
+            # the assert fires wherever the unregistered component is first
+            # used, and for the console that is as likely to be a command reply
+            # or a snapshot as it is the boot itself.
+            console-dev-boot-e2e = e2e.mkCheck {
+              name = "hyperion-console-dev-boot-e2e";
+              gameServer = devGameBinaries.smash;
+              proxy = gameBinaries.hyperion-proxy;
+              client = "console-check.py";
+              console = true;
+              # A dev build is unoptimised, so it gets the same generous
+              # deadline as the boot gate above rather than `console-e2e`'s.
               timeout = 300;
             };
 

--- a/nix/e2e.nix
+++ b/nix/e2e.nix
@@ -142,19 +142,27 @@ let
       : "''${HYPERION_E2E_CLIENT:?the client script and its arguments}"
       : "''${HYPERION_E2E_CERTS:?a directory holding root_ca.crt and the two leaf pairs}"
 
-      # Unset means "find a free pair". A check has no reason to care which
+      # Unset means "find a free set". A check has no reason to care which
       # ports it uses and every reason not to collide: on Linux the sandbox
       # has its own network namespace, but on darwin there is no such thing
       # and a build shares the host's loopback with everything else on the
       # machine. A fixed 47565 lost that race to an unrelated server the first
-      # time this ran. Both sockets are held open until both numbers are read,
-      # so the pair cannot come back equal.
+      # time this ran. Every socket is held open until all the numbers are
+      # read, so no two can come back equal.
+      #
+      # Three and not two because a gate may ask for an operator console, which
+      # listens on a port of its own. Picked here rather than derived from one
+      # of the others -- `server_port + 1` is a free number right up until the
+      # run that finds it taken -- and picked whether or not this run wants
+      # one, so the held-open guarantee covers the same set every time.
       picked_player=""
       picked_server=""
-      if [ -z "''${HYPERION_PLAYER_PORT:-}" ] || [ -z "''${HYPERION_SERVER_PORT:-}" ]; then
-        read -r picked_player picked_server < <(python3 -c "
+      picked_console=""
+      if [ -z "''${HYPERION_PLAYER_PORT:-}" ] || [ -z "''${HYPERION_SERVER_PORT:-}" ] \
+        || [ -z "''${HYPERION_CONSOLE_PORT:-}" ]; then
+        read -r picked_player picked_server picked_console < <(python3 -c "
       import socket
-      held = [socket.socket() for _ in range(2)]
+      held = [socket.socket() for _ in range(3)]
       for sock in held:
           sock.bind(('127.0.0.1', 0))
       print(' '.join(str(sock.getsockname()[1]) for sock in held))
@@ -162,6 +170,7 @@ let
       fi
       player_port="''${HYPERION_PLAYER_PORT:-$picked_player}"
       server_port="''${HYPERION_SERVER_PORT:-$picked_server}"
+      console_port="''${HYPERION_CONSOLE_PORT:-$picked_console}"
       bind="''${HYPERION_E2E_BIND:-127.0.0.1}"
       certs="$HYPERION_E2E_CERTS"
       log="''${HYPERION_E2E_LOG:-$(mktemp -t hyperion-e2e.XXXXXX)}"
@@ -174,6 +183,30 @@ let
       read -ra proxy <<< "$HYPERION_E2E_PROXY"
       read -ra client <<< "$HYPERION_E2E_CLIENT"
 
+      # An operator console, for the one gate whose question is about it. Off
+      # otherwise: a console is an admin port, and opening one on every gate
+      # would be a surface nothing else here needs.
+      #
+      # The server and the client are handed the same two facts from one place,
+      # because an address written down twice is the pair most likely to drift.
+      # Arrays rather than strings, so the absent case expands to no arguments
+      # at all rather than to one empty one.
+      game_server_console=()
+      client_console=()
+      if [ -n "''${HYPERION_E2E_CONSOLE:-}" ]; then
+        token_file="''${HYPERION_E2E_TOKEN_FILE:-$(mktemp -t hyperion-console-token.XXXXXX)}"
+        # Deliberately a token carrying `+` and `/`. Standard base64 emits
+        # both, an operator who generates one with `base64` gets them, and `+`
+        # in a query used to come back 401 because the decoder read it as a
+        # space. A token without them leaves that fix untested.
+        python3 -c "
+      import base64, os, sys
+      sys.stdout.write('+/' + base64.b64encode(os.urandom(18)).decode())
+      " > "$token_file"
+        game_server_console=(--console-bind "$bind:$console_port" --console-token-file "$token_file")
+        client_console=(--console "$bind:$console_port" --token-file "$token_file")
+      fi
+
       echo "stack log: $log"
 
       "''${game_server[@]}" \
@@ -181,6 +214,7 @@ let
         --root-ca-cert "$certs/root_ca.crt" \
         --cert "$certs/server.crt" \
         --private-key "$certs/server_private_key.pem" \
+        ''${game_server_console[@]+"''${game_server_console[@]}"} \
         < /dev/null >> "$log" 2>&1 &
       game_pid=$!
 
@@ -258,6 +292,13 @@ let
       # rather than at once; a check has both already built.
       await_port "$server_port" "game server" "$game_pid"
 
+      # The console binds inside `init_game`, so a client that reaches for it
+      # before the server gets there sees connection refused and reports it as
+      # the console being broken. Waiting names the right thing instead.
+      if [ -n "''${HYPERION_E2E_CONSOLE:-}" ]; then
+        await_port "$console_port" "console" "$game_pid"
+      fi
+
       # Best effort: a sandbox can hold a hard limit below this, and these
       # gates drive four clients rather than the few thousand bots it is for.
       ulimit -Sn ${fileDescriptors} || true
@@ -279,7 +320,8 @@ let
       # both processes, and the next run would die on "address already in use".
       rc=0
       client_log="$(mktemp -t hyperion-e2e-client.XXXXXX)"
-      python3 "''${client[@]}" --host 127.0.0.1 --port "$player_port" "$@" \
+      python3 "''${client[@]}" --host 127.0.0.1 --port "$player_port" \
+        ''${client_console[@]+"''${client_console[@]}"} "$@" \
         2>&1 | tee "$client_log" || rc=$?
 
       # A client that finished its checks proves nothing if the server died
@@ -326,10 +368,21 @@ let
       proxy,
       client,
       clientArgs ? [ ],
+      # Extra arguments for the game server, after the five the driver always
+      # passes. For a gate whose question is about a server configured a
+      # particular way; `serverEnv` cannot answer it, because
+      # `hyperion_event_runner` reads the environment all-or-nothing and falls
+      # back to the command line the moment one variable is missing.
+      gameServerArgs ? [ ],
       # Environment for the game server process. A gate whose question needs a
       # server configured differently from the one the product ships says so
       # here, rather than the client inferring it.
       serverEnv ? { },
+      # Start the game server with an operator console and tell the client
+      # where to find it. A boolean and not a number: the driver picks the port
+      # beside the other two, and a gate naming its own would be the fixed-port
+      # race this file already learned about once.
+      console ? false,
       needsGenMap ? false,
       timeout ? 300,
     }:
@@ -365,7 +418,7 @@ let
             name: value: "export ${name}=${lib.escapeShellArg (toString value)}"
           ) serverEnv
         )}
-        export HYPERION_E2E_GAME_SERVER="${lib.getExe gameServer}"
+        export HYPERION_E2E_GAME_SERVER="${lib.getExe gameServer} ${lib.escapeShellArgs gameServerArgs}"
         export HYPERION_E2E_PROXY="${lib.getExe proxy}"
         export HYPERION_E2E_CLIENT="${clients}/tools/${client} ${lib.escapeShellArgs clientArgs}"
         export HYPERION_E2E_CERTS="${certs}"
@@ -373,6 +426,12 @@ let
         # The binaries are already built, so anything past this is a hang
         # rather than a slow compile.
         export HYPERION_E2E_TIMEOUT=120
+        ${lib.optionalString console ''
+          export HYPERION_E2E_CONSOLE=1
+          # Named rather than left to `mktemp`, so a run that fails leaves
+          # the token beside the rest of the build's evidence.
+          export HYPERION_E2E_TOKEN_FILE="$NIX_BUILD_TOP/console-token"
+        ''}
 
         timeout ${toString timeout} hyperion-e2e-driver
         touch "$out"

--- a/tools/console-check.py
+++ b/tools/console-check.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""The operator console, driven the way an operator drives it.
+
+Everything the console claims needs both halves present at once: a real client
+in the world and a real HTTP client on the port. Nothing in the crate can test
+that pairing, because the crate has neither.
+
+So this joins one scripted player, then talks to the console over HTTP and
+checks the two directions meet:
+
+  1. **The page is served and the port is not open.** `GET /` answers, and
+     every path that carries data refuses a request with no bearer token. This
+     is the assertion an operator's safety rests on, so it is first.
+  2. **What a player types reaches the web.** The client sends a chat packet
+     and the line has to arrive on `/events` in vanilla's `<Name> message`
+     shape.
+  3. **What the console says reaches the game.** `POST /say` has to arrive at
+     the client as a `SystemChat`, attributed to the console, and has to appear
+     on the feed too, so the operator sees their own message land.
+  4. **A command runs through the real dispatch and answers back.** `POST
+     /command` with a command nobody registered has to come back on the feed as
+     `hyperion_command`'s own "Available commands" reply. That reply is written
+     by the engine, unicast to the caller's connection, and the caller here has
+     no socket -- so it arriving at all is the whole of the virtual-connection
+     mechanism working end to end. A second command asks for a reply too big to
+     fit under the compression threshold, because the short one and the long
+     one take different branches of the console's decoder and only one of them
+     is otherwise exercised.
+  5. **The live state is live.** `/state` names the joined player and carries a
+     tick rate.
+
+Every assertion here has been watched failing against a live server, which is
+the only reason to believe any of them. What was broken, and what went red:
+
+  * the decoder handed the wrong compression threshold -- all three reply
+    assertions, and nothing else. Worth stating plainly: that failure is
+    **silent**. The decoder reads the `data_len` varint as a packet id, decides
+    the frame is not chat, and drops it; the server logs nothing at any level.
+    No unit test can see it either, because the crate has no server to unicast
+    through. This file is the only thing between that bug and an operator.
+  * `strip_formatting` removed from the chat tap -- both spoof assertions, with
+    `<Name> \u00a74[Server] restarting` arriving on the feed exactly as the
+    attack intends. The in-game line stayed clean, which is the point: the two
+    paths trust the text differently.
+  * `id="log"` renamed in `console.html` -- the page assertion, naming the
+    marker it could not find. A title-substring check stayed green through the
+    same edit, which is why this one keys on the ids the page's own script
+    looks up.
+  * the right token offered where a refusal is demanded -- every refusal
+    assertion. `/events` needed the token in the query rather than a header to
+    go red at all, since that is the only way it authenticates.
+
+Exits non-zero on anything that is not true, after printing everything it saw.
+"""
+
+import argparse
+import importlib.util
+import json
+import pathlib
+import struct
+import sys
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, TOOLS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+match = _load("smash_match", "smash-match.py")
+chat_check = _load("chat_check", "chat-check.py")
+
+take_nbt_string = match.take_nbt_string
+var_int = match.base.var_int
+
+# `hyperion_web_console::module::CONSOLE_NAME`, as the console prefixes its own
+# messages in game.
+CONSOLE_PREFIX = "[Console]"
+
+# `hyperion::Global`'s own, set in `crates/hyperion/src/lib.rs`. The encoder
+# compresses a packet whose body is longer than this and writes a `data_len` of
+# zero otherwise, so a reply either side of it takes a different branch of the
+# console's decoder.
+COMPRESSION_THRESHOLD = 256
+
+
+class Watcher(chat_check.Talker):
+    """The scripted player, reused from the chat gate: it already knows how to
+    send a serverbound chat packet and record every `SystemChat` it is sent."""
+
+
+class Feed(threading.Thread):
+    """`/events`, read the way a browser reads it.
+
+    A thread because SSE is a response that never ends: the read blocks, and
+    the rest of this file has a client to pump in the meantime.
+    """
+
+    def __init__(self, base, token):
+        super().__init__(daemon=True)
+        # Encoded the way the page encodes it. `console.html` builds this URL
+        # with `encodeURIComponent`, and a gate that interpolates the raw token
+        # is not driving the console the way an operator drives it: a standard
+        # base64 token contains `+` and `/`, and sending those raw asks the
+        # server a different question than the browser ever asks.
+        self.url = "%s/events?token=%s" % (base, urllib.parse.quote(token, safe=""))
+        self.lines = []
+        self.error = None
+        self.connected = threading.Event()
+
+    def run(self):
+        try:
+            with urllib.request.urlopen(self.url, timeout=60) as response:
+                self.connected.set()
+                for raw in response:
+                    text = raw.decode("utf-8", "replace").strip()
+                    if not text.startswith("data:"):
+                        continue
+                    self.lines.append(json.loads(text[5:].strip()))
+        except Exception as error:  # noqa: BLE001 - reported, not handled
+            self.error = error
+            self.connected.set()
+
+    def texts(self, source=None):
+        return [
+            line["text"]
+            for line in list(self.lines)
+            if source is None or line["source"] == source
+        ]
+
+
+def request(base, path, token=None, body=None, method=None):
+    """One HTTP request, returning (status, body). A refusal is a result here,
+    not an exception: half the assertions below are about refusals."""
+    url = "%s%s" % (base, path)
+    data = body.encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    if token:
+        req.add_header("Authorization", "Bearer %s" % token)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as response:
+            return response.status, response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as error:
+        return error.code, error.read().decode("utf-8", "replace")
+    except urllib.error.URLError as error:
+        return 0, str(error)
+    # A read that never finishes is the shape `/events` has -- it is a stream,
+    # and a body that ends is the abnormal case. Reaching it here means a path
+    # that should have answered and closed did not, and that has to arrive as a
+    # status this file can assert on. Uncaught, it ends the run in a traceback
+    # partway down, which reports nothing about the checks that never ran.
+    except (TimeoutError, OSError) as error:
+        return 0, "no complete response: %r" % (error,)
+
+
+def pump(client, seconds):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if not client.alive:
+            return
+        for packet_id, payload in client.drain():
+            client.absorb(packet_id, payload)
+        if client.joined:
+            client.repeat_position()
+        time.sleep(0.01)
+
+
+def wait_until(client, predicate, seconds, what):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        pump(client, 0.05)
+        if predicate():
+            return True
+    print("TIMEOUT waiting for %s" % what, file=sys.stderr)
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=25565)
+    parser.add_argument("--console", default="127.0.0.1:8791")
+    parser.add_argument("--token-file", required=True)
+    parser.add_argument("--name", default="Watcher")
+    args = parser.parse_args()
+
+    token = pathlib.Path(args.token_file).read_text().strip()
+    base = "http://%s" % args.console
+    started = time.time()
+    failures = []
+
+    def check(ok, message):
+        print("%s %s" % ("PASS" if ok else "FAIL", message), flush=True)
+        if not ok:
+            failures.append(message)
+
+    # --- 1. the port is not open -----------------------------------------
+    #
+    # First, because everything after it assumes a console that is reachable,
+    # and a console reachable *without* the token is worse than one that does
+    # not work at all.
+    status, body = request(base, "/")
+    # The ids the page's own script looks up, and the URL it builds. A title
+    # or a heading is prose and can be reworded without anything breaking; if
+    # any of these three goes missing the page is served and does not work,
+    # which is the failure worth catching. See `assets/console.html`.
+    missing = [
+        marker
+        for marker in ('id="log"', 'id="token"', "/events?token=")
+        if marker not in body
+    ]
+    check(
+        status == 200 and not missing,
+        "GET / serves a page the script can drive (%s, missing %r)" % (status, missing),
+    )
+
+    for path, method, payload in (
+        ("/events", None, None),
+        ("/state", None, None),
+        ("/say", "POST", "hello"),
+        ("/command", "POST", "perms"),
+    ):
+        status, _ = request(base, path, body=payload, method=method)
+        check(status == 401, "%s without a token is refused (%s)" % (path, status))
+
+    status, _ = request(base, "/state", token="not-the-token")
+    check(status == 401, "a wrong token is refused (%s)" % status)
+
+    # --- the world ---------------------------------------------------------
+    client = Watcher(args.host, args.port, args.name, started)
+    client.handshake(args.host, args.port, 2)
+    client.login()
+    client.configuration()
+    client.enter_play()
+
+    if not wait_until(client, lambda: client.joined, 60.0, "the client to join"):
+        print("RESULT: failure (never joined)", flush=True)
+        return 1
+
+    feed = Feed(base, token)
+    feed.start()
+    feed.connected.wait(timeout=10)
+    if feed.error is not None:
+        print("FAIL /events with a token did not open: %r" % feed.error, flush=True)
+        print("RESULT: failure (no event stream)", flush=True)
+        return 1
+    print("PASS /events with a token opens", flush=True)
+
+    pump(client, 2.0)
+    client.chats.clear()
+
+    # --- 2. the game reaches the web --------------------------------------
+    spoken = "console gate is watching"
+    client.say(spoken)
+    wanted = "<%s> %s" % (args.name, spoken)
+    arrived = wait_until(
+        client,
+        lambda: wanted in feed.texts("chat"),
+        10.0,
+        "%r on the console feed" % wanted,
+    )
+    check(arrived, "a player's message reaches the web feed as %r (saw %r)" % (wanted, feed.texts("chat")))
+
+    # --- 2b. a player cannot paint their own line -------------------------
+    #
+    # The page renders section signs, so a message carrying them is a player
+    # writing colour into an operator's console: `\u00a74[Server] restarting`
+    # arrives looking like the server said it. The engine's own
+    # `strip_formatting` runs on the way to the feed, and it takes the sign and
+    # leaves everything else, so the code letter stays as an ordinary
+    # character. Same rule, and same expected shape, as `chat-check.py`'s third
+    # assertion.
+    spoof = "\u00a74[Server] restarting \u00a7kNOW"
+    client.say(spoof)
+    stripped = "<%s> 4[Server] restarting kNOW" % args.name
+    spoofed = wait_until(
+        client,
+        lambda: any("[Server] restarting" in line for line in feed.texts("chat")),
+        10.0,
+        "the spoof attempt on the console feed",
+    )
+    painted = [line for line in feed.texts("chat") if "[Server] restarting" in line]
+    check(
+        spoofed and painted == [stripped],
+        "a player's section signs are stripped before the web feed "
+        "(wanted %r, saw %r)" % (stripped, painted),
+    )
+    check(
+        all("\u00a7" not in line for line in painted),
+        "no section sign a player typed survives onto the feed (saw %r)" % painted,
+    )
+
+    # --- 3. the web reaches the game --------------------------------------
+    announcement = "the console can talk"
+    status, body = request(base, "/say", token=token, body=announcement, method="POST")
+    check(status == 202, "POST /say is accepted (%s %s)" % (status, body))
+
+    heard = wait_until(
+        client,
+        lambda: any(
+            CONSOLE_PREFIX in line and announcement in line for line in client.chats
+        ),
+        10.0,
+        "the announcement at the client",
+    )
+    check(
+        heard,
+        "a console announcement reaches a real client attributed to the console (saw %r)"
+        % client.chats,
+    )
+    check(
+        any(announcement in line for line in feed.texts("console")),
+        "the operator sees their own announcement on the feed (saw %r)"
+        % feed.texts("console"),
+    )
+
+    # --- 4. a command runs, and answers back ------------------------------
+    #
+    # A command nobody registered, so the reply is `hyperion_command`'s own and
+    # does not depend on which event is running. It is unicast to the caller's
+    # connection, and the caller is the console, which has no socket -- so this
+    # arriving is the virtual connection working.
+    status, body = request(
+        base, "/command", token=token, body="notacommand", method="POST"
+    )
+    check(status == 202, "POST /command is accepted (%s %s)" % (status, body))
+
+    replied = wait_until(
+        client,
+        lambda: any("Available commands" in line for line in feed.texts("reply")),
+        10.0,
+        "a command reply on the feed",
+    )
+    check(
+        replied,
+        "a command's reply comes back to the console over its virtual "
+        "connection (replies seen: %r)" % feed.texts("reply"),
+    )
+
+    # --- 4b. a reply the encoder compressed --------------------------------
+    #
+    # The reply above is under two hundred bytes, so the encoder writes it with
+    # a `data_len` of zero and the decoder takes it verbatim. That leaves the
+    # other half of `FrameDecoder` -- the branch that inflates -- unproven, and
+    # a decoder told the wrong threshold reads a compressed frame as a raw one
+    # and produces nonsense rather than an error. So this asks for a reply that
+    # cannot fit under the threshold and checks it arrives whole.
+    #
+    # `perms --help` and not a smash command, because the console is engine
+    # level and this gate should not depend on which event is running.
+    status, body = request(
+        base, "/command", token=token, body="perms --help", method="POST"
+    )
+    check(status == 202, "POST /command (a long one) is accepted (%s %s)" % (status, body))
+
+    long_replies = []
+
+    def long_reply():
+        long_replies[:] = [
+            text
+            for text in feed.texts("reply")
+            if len(text.encode("utf-8")) > COMPRESSION_THRESHOLD
+        ]
+        return bool(long_replies)
+
+    inflated = wait_until(client, long_reply, 10.0, "a reply past the compression threshold")
+    check(
+        inflated,
+        "a reply larger than the %d byte compression threshold reaches the "
+        "console, so the decoder's inflate branch works (longest seen: %d bytes)"
+        % (
+            COMPRESSION_THRESHOLD,
+            max((len(text.encode("utf-8")) for text in feed.texts("reply")), default=0),
+        ),
+    )
+    check(
+        any("perms" in text for text in long_replies),
+        "that reply is the one asked for rather than any long line (saw %r)"
+        % [text[:60] for text in long_replies],
+    )
+
+    # --- 5. live state -----------------------------------------------------
+    status, body = request(base, "/state", token=token)
+    check(status == 200, "GET /state with a token answers (%s)" % status)
+    state = json.loads(body) if status == 200 else {}
+    check(
+        any(player["name"] == args.name for player in state.get("players", [])),
+        "the roster names the joined player (%r)" % state.get("players"),
+    )
+    check(
+        "tps" in state and "targetTps" in state,
+        "the state carries a tick rate against the rate it is paced to (%r)" % state,
+    )
+    check(
+        state.get("targetTps") == 20.0,
+        "the target tick rate is the engine's own (%r)" % state.get("targetTps"),
+    )
+
+    print(
+        "RESULT: %s" % ("success" if not failures else "failure (%d)" % len(failures)),
+        flush=True,
+    )
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## An operator's window onto a running server, in a browser

Watching or administering a hyperion server currently means joining it with a
Minecraft client. This adds `crates/hyperion-web-console`: a Minecraft-styled
page that shows chat as it happens, lists who is on with their ping and the
server's tick rate, says something to everybody, and runs any command a player
could run.

It is off unless asked for. No `--console-bind` means no socket is opened and
nothing is spent.

```
smash --console-bind 127.0.0.1:8791 --console-token-file /run/credentials/console-token
```

## Why this is in the engine and not in an event

Watching a server is not a game concept. `smash` and `bedwars` are two games on
one engine, and an operator's questions — who is on, is it keeping up, what
build is this, say something to everybody — are the same for both. So nothing
here knows what game is running: chat is taken where hyperion decodes it, the
roster is hyperion's own `Ping` and `Name`, and commands go through the registry
every event already registers into. The precedent is `egress::server_load`,
which is telemetry in the engine for the same reason.

## Three design decisions worth reviewing

**The chat tap is before the queue, not after.** `EventQueue::drain` is
single-consumer and the game is that consumer; a second reader is not
expressible without changing how every event in the engine is delivered. So
`hyperion::console::ChatObservers` is called at the point the packet is decoded.
What an observer sees is what the player typed, which is also the more useful
thing: the rendered line is a game's decision, and a game that refuses a message
on a cooldown still leaves an operator wanting to know somebody tried. The cost
on a server with no console is one singleton read and an empty iteration per
chat packet.

**Commands run through the same dispatch players use, so the console needs an
identity.** Every reply in the workspace is written as
`caller.get::<&ConnectionId>()` and a unicast, in dozens of places. A caller
that is not a player has two options: teach all of them about a second kind of
reply, or give it a connection id. This is the second. `hyperion::net::VirtualConnection`
is a `ConnectionId` with no socket; `IoBuf::unicast_raw` intercepts frames
addressed to it before a proxy is chosen and runs them back through the same
`FrameDecoder` a client uses. The console entity deliberately carries no
`PacketState::Play`, so no game promotes it, counts it in a lobby, or writes a
sidebar to it.

**One bearer token, loopback by default, and one place it is not in a header.**
No accounts and no sessions: this is one operator's window onto their own
server. `EventSource` cannot set a header — the browser API has no argument for
it — so `/events` takes the token in the query, which puts it in any access log
and in browser history. That is stated in the module docs rather than hidden,
and it is why the bind address defaults to loopback.

## Two gates, because one profile cannot answer both questions

`console-e2e` boots the release binary — what actually ships — and drives both
halves with a scripted client. The crate's 20 unit tests cover everything that
is a function of its inputs; none of them can reach the three things the console
claims, because the crate has neither a server nor a browser.

`console-dev-boot-e2e` runs the same client against `devGameBinaries.smash`,
where flecs's registration assert is still compiled in. Everything `install`
does — two singletons registered and set, a caller entity spawned, a virtual
connection attached — is otherwise reached by no gate that can see a
use-before-register, which is ENG-11000 exactly. The claim was demonstrated
rather than asserted: dropping `ConsoleHandle`'s registration killed the dev
gate with

```
ECS_INVALID_OPERATION: Component hyperion_web_console::module::ConsoleHandle
is not registered with the world before usage
```

while the release gate passed all 22 assertions with the same break in place.

Each assertion family was broken and watched failing against a live server
before being trusted. `tools/console-check.py`'s docstring records which break
produced which red line:

| broken | what went red |
| --- | --- |
| decoder handed the wrong compression threshold | all three reply assertions |
| `strip_formatting` removed from the chat tap | both spoof assertions |
| `id="log"` renamed in `console.html` | the page assertion, naming the marker |
| the right token offered where a refusal is demanded | every refusal assertion |

And the gate's own wiring, twice: with `console = false` the run fails because
the client is asked for a console that is not there, and with one assertion
changed to expect a tick rate the engine does not have, `nix build` fails
printing that FAIL line. The second matters because "a client verdict reaches
the derivation" is exactly the kind of thing that is easy to have backwards.

**One failure here is silent, which is the reason this is a gate.** Handed the
wrong compression threshold, the decoder reads the `data_len` varint as a packet
id, decides the frame is not chat, and drops it. Reproduced deliberately: every
command reply vanished from the console and the server logged nothing at any
level, including under `RUST_LOG=info`. The threshold rule now lives in one
named, tested function rather than in an expression at the call site, because
`PacketEncoder::append_packet` switches on `threshold.0 >= 0` — so zero means
compression *on*, which is the plausible misreading.

## A bug the first live run found

`head -c 24 /dev/urandom | base64` produces standard base64, which contains `+`.
The console's query decoder applied the form-encoding rule that turns `+` into a
space, so a token generated that way came back 401 with nothing in the log. The
rule bought nothing to begin with: the page builds its URL with
`encodeURIComponent`, which spells a space `%20` and leaves `+` alone, so
`+`-as-space could only ever corrupt a token and could never recover a space
anybody sent. Dropped, with tests either side. The gate's token now deliberately
carries `+` and `/` so the fix stays covered.

## Verification

All of the below was re-run after rebasing onto `main`, which had meanwhile
landed the hot-reload deployment work and changed `run` to hand the event
`&Args`. The console no longer threads through `run` at all: each event's
`main.rs` calls `args.console()?` beside `args.deployment()?`.

- `nix build .#checks.aarch64-darwin.console-e2e` — 22 assertions, `RESULT: success`
- `nix build .#checks.aarch64-darwin.console-dev-boot-e2e` — the same 22 under
  `debug_assertions`
- `nix build .#checks.aarch64-darwin.clippy` and `.rustfmt` — green
- `cargo test -p hyperion-web-console` — 20 unit + 3 registration tests
- Live, against a real client through the proxy: a player's chat reached
  `/events`; `POST /say` arrived at the client as `[Console] the console can
  talk`; `POST /command` ran through the real registry and answered back over
  the virtual connection, with colours intact, on both sides of the compression
  threshold — `notacommand` at 88 bytes (uncompressed, `data_len` zero) and
  `perms --help` at 912 bytes (deflated and inflated back).

## What I did not do

- No NixOS module, as above.
- No `e2eOffsets` entry. The offsets exist for gates that also run as host apps
  (`nix run .#smash-e2e`); a sandboxed check takes free ports from the driver,
  which now picks three instead of two. `chat-e2e` and `tab-list-e2e` are in the
  same position.
- The console has not been run on a dev node or against a real Minecraft client
  — only against the scripted one. The page's own JavaScript is therefore
  covered by the structural markers the gate asserts and by nothing else; no
  browser has loaded it in this work.

## Deliberately not included

**NixOS module wiring.** There is no `services.hyperion.console` option in this
change. It belongs on top of a separate wiring change that has not landed, and
adding it here would mean shipping an option nothing has booted. The flags and
the token-file contract are what a module would consume, and they are stable.

Tracked as ENG-12123.

---

Written by Claude Opus via Claude Code.
