### PR TITLE
feat(hot-reload): a rules deploy that reloads instead of restarting (ENG-12067)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,6 @@ dependencies = [
  "rayon",
  "roaring",
  "rustc-hash 2.1.3",
- "tikv-jemallocator",
  "tracing",
  "uuid",
  "valence_protocol",
@@ -2004,7 +2003,6 @@ version = "0.1.0"
 dependencies = [
  "flecs_ecs",
  "libloading 0.9.0",
- "tracing",
 ]
 
 [[package]]
@@ -2155,6 +2153,10 @@ dependencies = [
  "glam",
  "rkyv",
 ]
+
+[[package]]
+name = "hyperion-reload-client"
+version = "0.1.0"
 
 [[package]]
 name = "hyperion-utils"
@@ -3895,14 +3897,13 @@ dependencies = [
  "hyperion",
  "hyperion-clap",
  "hyperion-event-runner",
+ "hyperion-hot-reload",
  "hyperion-inventory",
  "hyperion-item",
  "hyperion-minecraft-proto",
  "hyperion-permission",
  "hyperion-utils",
  "proptest",
- "rayon",
- "tikv-jemallocator",
  "tracing",
  "valence_nbt",
  "valence_protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     'crates/hyperion-permission',
     'crates/hyperion-proxy',
     'crates/hyperion-proxy-proto',
+    'crates/hyperion-reload-client',
     'crates/hyperion-utils',
     'crates/packet-channel',
     'events/bedwars',

--- a/crates/hyperion-event-runner/src/lib.rs
+++ b/crates/hyperion-event-runner/src/lib.rs
@@ -13,14 +13,16 @@
 //! which cannot be spelled wrong.
 
 use std::{
+    io::IsTerminal,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
 };
 
+use anyhow::bail;
 use clap::Parser;
 use hyperion::Crypto;
 use serde::Deserialize;
-use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt};
+use tracing_subscriber::{EnvFilter, Registry, filter::LevelFilter, layer::SubscriberExt};
 
 /// What every event binary takes.
 #[derive(Parser, Deserialize, Debug)]
@@ -46,6 +48,50 @@ pub struct Args {
     /// The file path to the game server's private key.
     #[clap(long)]
     pub private_key: PathBuf,
+
+    /// The reloadable rules dylib: loaded once at startup, and again on every
+    /// reload request.
+    ///
+    /// A stable path outside the store, so that deploying a new build of the
+    /// rules does not change this string and therefore does not change the
+    /// unit's `[Service]` section -- which is the condition under which systemd
+    /// reloads rather than restarts. See `nix/modules/game-server.nix`.
+    #[clap(long, requires_all = ["reload_socket", "build_stamp"])]
+    #[serde(default)]
+    pub rules: Option<PathBuf>,
+
+    /// Where to listen for reload requests. `ExecReload` runs a client that
+    /// connects here; see `hyperion-reload-client`.
+    #[clap(long, requires_all = ["rules", "build_stamp"])]
+    #[serde(default)]
+    pub reload_socket: Option<PathBuf>,
+
+    /// Directory holding the build stamp files the deploy writes.
+    ///
+    /// A directory read at runtime rather than three variables in the
+    /// environment, because a process's environment is fixed at `exec` and a
+    /// hot reload's entire point is that there is no new `exec` to fix it. A
+    /// server that reloaded would otherwise report the build it started as,
+    /// forever.
+    #[clap(long, requires_all = ["rules", "reload_socket"])]
+    #[serde(default)]
+    pub build_stamp: Option<PathBuf>,
+}
+
+/// The paths a packaged deployment hands the server.
+///
+/// All three or none of them. They are separate options rather than one
+/// directory because the deployment, not the event, decides where each lives,
+/// and an event that derived `<dir>/<its own name>-rules.so` would be a second
+/// place that has to agree with the NixOS module about a filename.
+#[derive(Debug, Clone)]
+pub struct Deployment {
+    /// The rules dylib to load, and to reload.
+    pub rules: PathBuf,
+    /// The socket a reload is asked for on.
+    pub reload_socket: PathBuf,
+    /// The directory the build stamp files are in.
+    pub build_stamp: PathBuf,
 }
 
 impl Args {
@@ -53,6 +99,38 @@ impl Args {
     #[must_use]
     pub const fn address(&self) -> SocketAddr {
         SocketAddr::new(self.ip, self.port)
+    }
+
+    /// The deployment paths, when this process was started by one.
+    ///
+    /// Clap enforces all-or-nothing on the command line; this is the same rule
+    /// for the environment, which `envy` deserializes without consulting clap
+    /// at all. Refusing a partial set rather than degrading to "no reload" is
+    /// deliberate: a deploy that passed two of the three and silently lost the
+    /// ability to reload would look exactly like one that never asked for it.
+    ///
+    /// # Errors
+    /// If some of the three are set and some are not, naming which are missing.
+    pub fn deployment(&self) -> anyhow::Result<Option<Deployment>> {
+        match (&self.rules, &self.reload_socket, &self.build_stamp) {
+            (None, None, None) => Ok(None),
+            (Some(rules), Some(reload_socket), Some(build_stamp)) => Ok(Some(Deployment {
+                rules: rules.clone(),
+                reload_socket: reload_socket.clone(),
+                build_stamp: build_stamp.clone(),
+            })),
+            (rules, socket, stamp) => {
+                let missing: Vec<&str> = [
+                    ("--rules", rules.is_none()),
+                    ("--reload-socket", socket.is_none()),
+                    ("--build-stamp", stamp.is_none()),
+                ]
+                .into_iter()
+                .filter_map(|(name, absent)| absent.then_some(name))
+                .collect();
+                bail!("a partial deployment: {} not set", missing.join(", "))
+            }
+        }
     }
 }
 
@@ -64,17 +142,39 @@ const fn default_port() -> u16 {
     35565
 }
 
+/// Logging, at a level and in a form that survives the trip to a journal.
+///
+/// # `info` by default, rather than whatever `RUST_LOG` happens to say
+///
+/// `EnvFilter::from_default_env()` with `RUST_LOG` unset builds a filter with no directives
+/// at all, which passes nothing. A deployed unit sets no `RUST_LOG`, so the server was
+/// silent: not quiet, silent -- no startup line, no map built, and no `hot reload accepted`
+/// either, which is the one line an operator needs after a deploy that is supposed to be
+/// invisible. Measured on dev-compute-6: the same server, same unit, with and without
+/// `RUST_LOG`, is zero journal lines versus every line below.
+///
+/// `RUST_LOG` still wins when it is set, so narrowing or widening is a variable away.
+///
+/// # No ANSI unless something is there to render it
+///
+/// `fmt::layer()` colours its output whatever it is writing to, so a service wrote
+/// `\x1b[32m INFO\x1b[0m` into the journal and every `grep 'INFO'` over it matched
+/// nothing. The escapes are dropped when stdout is not a terminal, which is exactly the
+/// case where nobody can see them and something is probably grepping.
 fn setup_logging() {
+    let filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
     tracing::subscriber::set_global_default(
-        Registry::default()
-            .with(EnvFilter::from_default_env())
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .with_target(false)
-                    .with_thread_ids(false)
-                    .with_file(true)
-                    .with_line_number(true),
-            ),
+        Registry::default().with(filter).with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(std::io::stdout().is_terminal())
+                .with_target(false)
+                .with_thread_ids(false)
+                .with_file(true)
+                .with_line_number(true),
+        ),
     )
     .expect("setup tracing subscribers");
 }
@@ -90,7 +190,7 @@ fn setup_logging() {
 /// Returns whatever `init_game` returns, or an error reading the TLS material.
 pub fn run(
     env_prefix: &str,
-    init_game: impl FnOnce(SocketAddr, Crypto) -> anyhow::Result<()>,
+    init_game: impl FnOnce(&Args, Crypto) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
@@ -109,11 +209,13 @@ pub fn run(
 
     let crypto = Crypto::new(&args.root_ca_cert, &args.cert, &args.private_key)?;
 
-    init_game(args.address(), crypto)
+    init_game(&args, crypto)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use clap::Parser;
 
     use super::Args;
@@ -138,6 +240,55 @@ mod tests {
     #[test]
     fn an_ipv6_listen_address_survives_reaching_the_socket() {
         assert_eq!(args_from("::").address().to_string(), "[::]:35565");
+    }
+
+    /// Nothing set is the developer's server, and it is not a misconfiguration.
+    #[test]
+    fn a_server_with_no_deployment_paths_has_no_deployment() {
+        assert!(
+            args_from("::")
+                .deployment()
+                .expect("all three absent is legal")
+                .is_none()
+        );
+    }
+
+    /// Two of three has to fail, and has to say which one is missing.
+    ///
+    /// Clap refuses this on the command line -- `requires_all` -- so the way it
+    /// reaches a running server is `envy`, which reads the environment and
+    /// knows nothing about clap's argument groups. That is the path the
+    /// deployed server takes.
+    #[test]
+    fn a_partial_deployment_is_refused_by_name() {
+        let mut args = args_from("::");
+        args.rules = Some(PathBuf::from("/etc/hyperion/smash-rules.so"));
+        args.reload_socket = Some(PathBuf::from("/run/hyperion/reload.sock"));
+
+        let error = args
+            .deployment()
+            .expect_err("two of three must not read as a working deployment")
+            .to_string();
+        assert!(error.contains("--build-stamp"), "{error}");
+        assert!(!error.contains("--rules"), "{error}");
+    }
+
+    #[test]
+    fn all_three_together_are_a_deployment() {
+        let mut args = args_from("::");
+        args.rules = Some(PathBuf::from("/etc/hyperion/smash-rules.so"));
+        args.reload_socket = Some(PathBuf::from("/run/hyperion/reload.sock"));
+        args.build_stamp = Some(PathBuf::from("/etc/hyperion"));
+
+        let deployment = args
+            .deployment()
+            .expect("all three set")
+            .expect("all three set");
+        assert_eq!(
+            deployment.rules,
+            PathBuf::from("/etc/hyperion/smash-rules.so")
+        );
+        assert_eq!(deployment.build_stamp, PathBuf::from("/etc/hyperion"));
     }
 
     #[test]

--- a/crates/hyperion-hot-reload/Cargo.toml
+++ b/crates/hyperion-hot-reload/Cargo.toml
@@ -18,10 +18,31 @@ version.workspace = true
 [lib]
 crate-type = ["dylib", "rlib"]
 
+# NO `tracing`, AND NOTHING ELSE THAT `hyperion` ALSO STATICALLY LINKS.
+#
+# This crate and `crates/hyperion` are both dylibs, and under the packaged build's
+# `-C prefer-dynamic` they are SIBLINGS in the graph: neither depends on the other, so
+# each statically includes its own copy of every rlib it uses. A binary linking both is
+# then refused outright, naming the shared crates:
+#
+#     error: cannot satisfy dependencies so `tracing` only shows up once
+#     error: cannot satisfy dependencies so `tracing_core` only shows up once
+#     error: cannot satisfy dependencies so `once_cell` only shows up once
+#     error: cannot satisfy dependencies so `pin_project_lite` only shows up once
+#
+# Those four are `tracing` and its dependencies, and they were the entire list --
+# everything else this crate uses arrives inside `libflecs_ecs.so`, which is a dylib and
+# therefore one copy. So this crate reports rather than logs: `service::Outcome` carries
+# what happened to the host, and the host writes it wherever hosts write things.
+#
+# The obvious alternative -- making `hyperion` depend on this crate, which turns the
+# siblings into a chain -- was tried and reverted. It fixes the packaged link and breaks
+# a plain one: `cargo test -p hyperion-hot-reload -p smash` then builds `libhyperion.so`
+# against `libhyperion_hot_reload.so`, neither with `prefer-dynamic`, and `std` is
+# duplicated instead.
 [dependencies]
 flecs_ecs.workspace = true
 libloading = "0.9.0"
-tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/hyperion-hot-reload/src/host.rs
+++ b/crates/hyperion-hot-reload/src/host.rs
@@ -30,6 +30,14 @@ struct Loaded {
 /// Why a load could not even be attempted.
 #[derive(Debug)]
 pub enum LoadError {
+    /// The candidate could not be copied somewhere `dlopen` has not seen before.
+    ///
+    /// Carries the path because `std::fs::copy`'s error does not: "No such file or
+    /// directory" with no name in it is the least useful thing a failed deploy can say.
+    Stage {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
     Dlopen(libloading::Error),
     MissingEntry(libloading::Error),
     /// The module and the host disagree about the runtime they share.
@@ -47,6 +55,13 @@ fn platform_detail(e: &libloading::Error) -> String {
 impl core::fmt::Display for LoadError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            Self::Stage { path, source } => {
+                write!(
+                    f,
+                    "could not read the module at {}: {source}",
+                    path.display()
+                )
+            }
             Self::Dlopen(e) => write!(f, "could not open module: {}", platform_detail(e)),
             Self::MissingEntry(e) => {
                 write!(
@@ -64,6 +79,7 @@ impl core::fmt::Display for LoadError {
 impl std::error::Error for LoadError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            Self::Stage { source, .. } => Some(source),
             Self::Dlopen(e) | Self::MissingEntry(e) => Some(e),
             Self::Abi(_) | Self::Refused(_) => None,
         }
@@ -95,6 +111,45 @@ pub struct HotReloader {
     /// So the handles are forgotten rather than stored. The cost is address-space growth
     /// proportional to the number of reloads.
     retained: Vec<std::path::PathBuf>,
+}
+
+/// Copies `candidate` to a path `dlopen` has never been given before, and returns it.
+///
+/// # Why a copy, and not the path the caller asked for
+///
+/// **`dlopen` dedupes on the name it is handed, before it ever looks at the file.** glibc
+/// searches its list of loaded objects by name first; a match returns the existing image
+/// and the file on disk is never opened. So a host that loads its module through a stable
+/// path -- which is exactly what `nix/modules/game-server.nix` arranges, because a path
+/// that moves is a `[Service]` that moves and a restart instead of a reload -- would
+/// `dlopen` `/etc/hyperion/smash-rules.so`, get back the image it loaded at startup, run
+/// the OLD entry point, and report success.
+///
+/// That is not hypothetical and it is not visible from anything but a running server. On
+/// dev-compute-6 the reload answered `accepted smash-rules bbbbbbb`, `MainPID` and
+/// `NRestarts` were unchanged, the journal said `hot reload accepted` -- and
+/// `/proc/<pid>/maps` still showed only the first build, with the old code still logging
+/// its old string. Every signal said the deploy landed.
+///
+/// Resolving the symlink instead of copying would work in this deployment, because the nix
+/// store gives every build its own path. It would keep the bug for anybody rebuilding to a
+/// fixed path outside the store, which is what a developer's inner loop looks like, and the
+/// symptom would again be silence. A copy is a hundred kilobytes and has no such case.
+///
+/// The copies are never removed, for the same reason the libraries are never `dlclose`d
+/// (see [`HotReloader::retained`]). Under the deployed unit they live in the private `/tmp`
+/// systemd tears down with the service.
+fn stage(candidate: &Path, generation: usize) -> std::io::Result<std::path::PathBuf> {
+    let name = candidate
+        .file_name()
+        .unwrap_or_else(|| std::ffi::OsStr::new("module"));
+    // The pid, because two servers on one machine share `/tmp` unless something gives them
+    // private ones, and a collision here would hand one of them the other's module.
+    let dir = std::env::temp_dir().join(format!("hyperion-hot-reload-{}", std::process::id()));
+    std::fs::create_dir_all(&dir)?;
+    let staged = dir.join(format!("{generation}-{}", name.to_string_lossy()));
+    std::fs::copy(candidate, &staged)?;
+    Ok(staged)
 }
 
 impl Default for HotReloader {
@@ -129,7 +184,13 @@ impl HotReloader {
     /// # Panics
     /// Panics if the module's registration panics.
     pub fn load(&mut self, world: &World, path: &Path) -> Result<Applied, LoadError> {
-        let lib = unsafe { libloading::Library::new(path) }.map_err(LoadError::Dlopen)?;
+        // Never the caller's path: see `stage`, which is the difference between a reload
+        // and a reload-shaped no-op that reports success.
+        let staged = stage(path, self.retained.len()).map_err(|source| LoadError::Stage {
+            path: path.to_owned(),
+            source,
+        })?;
+        let lib = unsafe { libloading::Library::new(&staged) }.map_err(LoadError::Dlopen)?;
         let descriptor = {
             let entry: libloading::Symbol<'_, ModuleEntry> =
                 unsafe { lib.get(ENTRY_SYMBOL) }.map_err(LoadError::MissingEntry)?;
@@ -139,7 +200,7 @@ impl HotReloader {
         // Leaked before any of its code runs, so an early return still leaves the mapping
         // alive for whatever already holds a pointer into it.
         core::mem::forget(lib);
-        self.retained.push(path.to_owned());
+        self.retained.push(staged);
 
         if let Some(reason) = descriptor.token.incompatibility() {
             return Err(LoadError::Abi(reason));
@@ -365,5 +426,58 @@ pub fn read_raw(world: &World, entity: EntityView<'_>, component: &str) -> Optio
             return None;
         }
         Some(std::slice::from_raw_parts(ptr.cast::<u8>(), size).to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property the deployment rests on: one path, handed to the loader twice, is two
+    /// different names by the time `dlopen` sees it.
+    ///
+    /// Watched failing. Returning `candidate.to_owned()` from `stage` makes this report the
+    /// same path twice, which is precisely the state in which a reload runs the old build
+    /// and answers `accepted`.
+    #[test]
+    fn one_path_loaded_twice_becomes_two_names() {
+        let dir = std::env::temp_dir().join("hyperion-hot-reload-stage-test");
+        drop(std::fs::remove_dir_all(&dir));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let stable = dir.join("rules.so");
+
+        std::fs::write(&stable, b"first build").expect("write");
+        let first = stage(&stable, 0).expect("stage the first build");
+
+        // What a deploy does: the same path, different bytes behind it.
+        std::fs::write(&stable, b"second build").expect("rewrite");
+        let second = stage(&stable, 1).expect("stage the second build");
+
+        assert_ne!(
+            first, second,
+            "both builds would reach dlopen under one name, and the second would be ignored"
+        );
+        assert_eq!(std::fs::read(&first).expect("read"), b"first build");
+        assert_eq!(std::fs::read(&second).expect("read"), b"second build");
+
+        drop(std::fs::remove_dir_all(&dir));
+    }
+
+    /// A path that is not there fails here rather than at `dlopen`, and says which path.
+    #[test]
+    fn a_path_that_is_not_there_is_named_in_the_error() {
+        let mut reloader = HotReloader::new();
+        let world = World::new();
+        let error = reloader
+            .load(&world, Path::new("/nonexistent/hyperion-no-such-module.so"))
+            .expect_err("a module that is not there cannot load");
+        assert!(
+            matches!(error, LoadError::Stage { .. }),
+            "expected a staging failure, got {error:?}"
+        );
+        assert!(
+            error.to_string().contains("hyperion-no-such-module"),
+            "the message does not name the path: {error}"
+        );
     }
 }

--- a/crates/hyperion-hot-reload/src/service.rs
+++ b/crates/hyperion-hot-reload/src/service.rs
@@ -64,6 +64,22 @@ const VERB_TIMEOUT: Duration = Duration::from_millis(100);
 /// The only thing a client may ask for.
 const VERB: &str = "reload";
 
+/// What answering one request did.
+///
+/// Returned rather than logged, because this crate cannot depend on `tracing`: it and
+/// `hyperion` are sibling dylibs and every rlib they both use is a duplicate the final
+/// link refuses. See `Cargo.toml`. The host writes these wherever it writes things, at
+/// whatever severity it thinks a failed deploy deserves.
+#[derive(Debug, Clone)]
+pub enum Outcome {
+    /// A new build is live in the world.
+    Applied(Reloaded),
+    /// Nothing changed, and this is why -- the same words the client was told, so an
+    /// operator reading `systemctl reload` and an operator reading the journal see one
+    /// message rather than two accounts of one event.
+    Refused(String),
+}
+
 /// A reload that was applied to the running world.
 #[derive(Debug, Clone)]
 pub struct Reloaded {
@@ -137,72 +153,65 @@ impl ReloadService {
 
     /// Answers every request waiting on the socket, applying each to `world`.
     ///
-    /// Returns one entry per reload that was applied. A refused reload leaves the world
-    /// exactly as it was and produces no entry, because the caller's job -- telling players
-    /// what they are now running -- has nothing to say about a build that was rejected.
-    pub fn poll(&mut self, world: &World) -> Vec<Reloaded> {
-        let mut applied = Vec::new();
+    /// One entry per request answered, refusals included: a refused reload means the
+    /// deploy did not take, and something has to say so at a severity an operator queries.
+    pub fn poll(&mut self, world: &World) -> Vec<Outcome> {
+        let mut answered = Vec::new();
         loop {
             let stream = match self.listener.accept() {
                 Ok((stream, _)) => stream,
                 // Nothing waiting: the normal exit from this loop, once per tick.
-                Err(e) if e.kind() == ErrorKind::WouldBlock => return applied,
+                Err(e) if e.kind() == ErrorKind::WouldBlock => return answered,
+                // Nobody is waiting on a reply this can be written to, so it goes back
+                // with the rest -- a reload was asked for and did not happen.
                 Err(e) => {
-                    tracing::warn!("reload socket accept failed: {e}");
-                    return applied;
+                    answered.push(Outcome::Refused(format!(
+                        "could not accept a reload request: {e}"
+                    )));
+                    return answered;
                 }
             };
-            if let Some(reloaded) = self.serve(world, stream) {
-                applied.push(reloaded);
-            }
+            answered.push(self.serve(world, stream));
         }
     }
 
     /// One request, start to finish.
-    fn serve(&mut self, world: &World, mut stream: UnixStream) -> Option<Reloaded> {
-        let reply = match read_verb(&mut stream) {
+    fn serve(&mut self, world: &World, mut stream: UnixStream) -> Outcome {
+        let outcome = match read_verb(&mut stream) {
             Ok(verb) if verb == VERB => match self.reloader.load(world, &self.module) {
-                Ok(applied) => {
-                    let revision = self.revision();
-                    let reloaded = Reloaded {
-                        module: applied.module.clone(),
-                        revision: revision.clone(),
-                        migrated_instances: applied.migrated_instances,
-                    };
-                    let label = revision.as_deref().unwrap_or("unknown");
-                    tracing::info!(
-                        module = %applied.module,
-                        revision = label,
-                        migrated_instances = applied.migrated_instances,
-                        "hot reload accepted"
-                    );
-                    let line = format!("accepted {} {label}", applied.module);
-                    respond(&mut stream, &line);
-                    return Some(reloaded);
-                }
-                // Deliberately `error`, not `warn`: a refused reload means the deploy did
-                // not take, and the operator has to see it in a query filtered by severity.
-                Err(e) => {
-                    tracing::error!("hot reload refused: {e}");
-                    format!("refused {e}")
-                }
+                Ok(applied) => Outcome::Applied(Reloaded {
+                    module: applied.module,
+                    revision: self.revision(),
+                    migrated_instances: applied.migrated_instances,
+                }),
+                Err(e) => Outcome::Refused(e.to_string()),
             },
-            Ok(verb) => format!("refused unknown request `{verb}`"),
-            Err(e) => format!("refused could not read request: {e}"),
+            Ok(verb) => Outcome::Refused(format!("unknown request `{verb}`")),
+            Err(e) => Outcome::Refused(format!("could not read request: {e}")),
         };
-        respond(&mut stream, &reply);
-        None
+
+        // The reply is one line and its first word is the client's exit status.
+        let line = match &outcome {
+            Outcome::Applied(reloaded) => format!(
+                "accepted {} {}",
+                reloaded.module,
+                reloaded.revision.as_deref().unwrap_or("unknown")
+            ),
+            Outcome::Refused(reason) => format!("refused {reason}"),
+        };
+        respond(&mut stream, &line);
+        outcome
     }
 }
 
-/// Writes one line back, or says why it could not.
+/// Writes one line back.
 ///
 /// A client that hung up before reading is not a reload failure -- the reload already
-/// happened -- so this reports and returns rather than propagating.
+/// happened, and the world does not care whether anybody read the receipt -- so the error
+/// is dropped rather than propagated or reported. This is the one thing in here that is
+/// deliberately silent.
 fn respond(stream: &mut UnixStream, line: &str) {
-    if let Err(e) = writeln!(stream, "{line}").and_then(|()| stream.flush()) {
-        tracing::warn!("could not answer a reload request: {e}");
-    }
+    drop(writeln!(stream, "{line}").and_then(|()| stream.flush()));
 }
 
 /// Reads the client's verb, giving up after [`VERB_TIMEOUT`].
@@ -219,17 +228,24 @@ fn read_verb(stream: &mut UnixStream) -> std::io::Result<String> {
 
 /// Ticks the world until it stops, answering reload requests between frames.
 ///
-/// `on_reload` is the seam an event uses to tell its players what just happened; it is
-/// called once per applied reload, with a world that is between frames and safe to write
-/// to. It is deliberately a callback on the loop rather than a flecs observer, because a
+/// `on_reload` is the seam an event uses to tell its players -- and its journal -- what
+/// just happened. It is called once per request answered, refusals included, with a world
+/// that is between frames and safe to write to. It is deliberately a callback on the loop rather than a flecs observer, because a
 /// reload is not a world event -- it is the thing that just replaced every observer.
-pub fn run<F>(world: &World, service: &mut ReloadService, mut on_reload: F)
+///
+/// `service` is optional because a server started without a rules dylib -- a developer's
+/// `nix run`, an end-to-end gate -- still needs a tick loop, and it must be *this* loop.
+/// Two loops, one that can reload and one that cannot, is two things that have to agree
+/// about how a frame is run, and the one nobody deploys is the one that would drift.
+pub fn run<F>(world: &World, mut service: Option<&mut ReloadService>, mut on_reload: F)
 where
-    F: FnMut(&World, &Reloaded),
+    F: FnMut(&World, &Outcome),
 {
     while world.progress() {
-        for reloaded in service.poll(world) {
-            on_reload(world, &reloaded);
+        if let Some(service) = service.as_deref_mut() {
+            for outcome in service.poll(world) {
+                on_reload(world, &outcome);
+            }
         }
     }
 }
@@ -332,6 +348,10 @@ mod tests {
 
     /// The refusal carries the loader's own words. An operator reading `systemctl reload`
     /// output needs the reason, not a generic failure.
+    ///
+    /// A module that is not there fails while being staged rather than at `dlopen` -- see
+    /// `host::stage`, which copies every candidate to a name `dlopen` has not seen -- so
+    /// the words are the read's, and the path is in them.
     #[test]
     fn a_refused_load_answers_with_the_loaders_reason() {
         let fixture = Fixture::new("bad-module");
@@ -339,8 +359,12 @@ mod tests {
         let mut service = fixture.service();
         let reply = fixture.ask(&mut service, &world, Some(b"reload"));
         assert!(
-            reply.starts_with("refused could not open module"),
-            "expected the dlopen refusal, got `{reply}`"
+            reply.starts_with("refused could not read the module at "),
+            "expected the staging refusal, got `{reply}`"
+        );
+        assert!(
+            reply.contains("no-such-module.so"),
+            "the refusal does not name the module: `{reply}`"
         );
     }
 

--- a/crates/hyperion-hot-reload/tests/load_errors.rs
+++ b/crates/hyperion-hot-reload/tests/load_errors.rs
@@ -21,9 +21,11 @@ fn a_missing_dylib_names_the_path_the_loader_tried() {
         .load(&world, path)
         .expect_err("loading a path that does not exist must fail");
 
+    // Staging, not `dlopen`: every candidate is copied to a name `dlopen` has never
+    // been given (see `host::stage`), so a path that is not there fails on the read.
     assert!(
-        matches!(error, LoadError::Dlopen(_)),
-        "expected a dlopen failure, got {error:?}"
+        matches!(error, LoadError::Stage { .. }),
+        "expected a staging failure, got {error:?}"
     );
 
     let message = error.to_string();

--- a/crates/hyperion-reload-client/Cargo.toml
+++ b/crates/hyperion-reload-client/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+edition.workspace = true
+license.workspace = true
+name = "hyperion-reload-client"
+publish = false
+repository.workspace = true
+version.workspace = true
+
+# NO DEPENDENCIES, AND THAT IS THE POINT OF A SEPARATE CRATE.
+#
+# This is what `ExecReload` runs, so it is the process that has to start in
+# order for a reload to be attempted at all. Linking it against `flecs_ecs`
+# -- directly, or through `hyperion-hot-reload` -- would make a mismatched
+# engine dylib turn "the reload was refused, here is why" into "the client
+# could not start", which is the one failure mode a reload client must not
+# have. It speaks the protocol over a socket and knows nothing else.
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/hyperion-reload-client/src/main.rs
+++ b/crates/hyperion-reload-client/src/main.rs
@@ -1,0 +1,157 @@
+//! `ExecReload`: ask a running game server to reload its rules, and report what it said.
+//!
+//! # Why this is its own binary rather than a flag on the server
+//!
+//! `systemctl reload` runs a *new process*, and its exit status is the reload's exit
+//! status. So the thing systemd runs has to be something that can always start: this crate
+//! has no dependencies at all, which means a rules dylib built against the wrong engine
+//! cannot turn "the reload was refused, and here is the reason" into "the client failed to
+//! start". The refusal has to survive to be read.
+//!
+//! # What it says, and what it exits with
+//!
+//! One verb out, one line back, straight from `hyperion_hot_reload::service`:
+//!
+//! ```text
+//! accepted <module> <revision>   -> printed, exit 0
+//! refused <reason>               -> printed, exit 1
+//! ```
+//!
+//! The reply is printed either way, because the reason is the only part of a refused
+//! deploy anybody can act on and `systemctl reload` shows it to whoever asked.
+
+// This program's entire output contract is one line on stdout -- the server's own answer,
+// which a person or a deploy script reads. The workspace denies `print_stdout` because a
+// library or a game server writing to stdout is a bug; for a one-shot CLI it is the API.
+#![allow(clippy::print_stdout)]
+
+use std::{
+    io::{BufRead, BufReader, Write},
+    os::unix::net::UnixStream,
+    path::Path,
+    process::ExitCode,
+    time::Duration,
+};
+
+/// The only thing the server answers.
+const VERB: &[u8] = b"reload";
+
+/// How long to wait for the answer.
+///
+/// The server polls the socket between two ticks, so the floor is one tick -- 50ms -- plus
+/// however long the `dlopen`, the schema diff and any component migration take. Thirty
+/// seconds is far above every measurement in `docs/hot-reload.md` and far below systemd's
+/// default `TimeoutSec`, which is what would otherwise decide this: a client that hangs
+/// forever turns a wedged server into a wedged `ix apply` with no message anywhere.
+const REPLY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Whether a reply means the reload happened.
+///
+/// The first word and not a substring search: "refused could not open module" contains the
+/// word "accepted" in no reading, but a reason quoted back from a build could contain
+/// anything, and a status derived from a `contains` would be a status that can be talked
+/// into lying.
+fn accepted(reply: &str) -> bool {
+    reply.split_whitespace().next() == Some("accepted")
+}
+
+/// Sends the verb and returns the single line the server answered with.
+fn ask(socket: &Path) -> std::io::Result<String> {
+    let mut stream = UnixStream::connect(socket)?;
+    stream.set_read_timeout(Some(REPLY_TIMEOUT))?;
+    stream.write_all(VERB)?;
+    stream.flush()?;
+
+    let mut reply = String::new();
+    BufReader::new(stream).read_line(&mut reply)?;
+    Ok(reply.trim_end().to_owned())
+}
+
+fn main() -> ExitCode {
+    let mut args = std::env::args_os().skip(1);
+    let Some(socket) = args.next() else {
+        eprintln!("usage: hyperion-reload-client <socket>");
+        return ExitCode::FAILURE;
+    };
+
+    match ask(Path::new(&socket)) {
+        Ok(reply) if accepted(&reply) => {
+            println!("{reply}");
+            ExitCode::SUCCESS
+        }
+        // A refusal is the server working: it looked at the build and said no. Printed the
+        // same way, because the words are the gate's own and they name the component.
+        Ok(reply) => {
+            println!("{reply}");
+            ExitCode::FAILURE
+        }
+        // Nothing answered. `ECONNREFUSED` on an existing path is the interesting one --
+        // the socket file outlived the process that bound it -- so the path is named.
+        Err(e) => {
+            eprintln!(
+                "could not reach the game server on {}: {e}",
+                socket.display()
+            );
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io::Read, os::unix::net::UnixListener, thread};
+
+    use super::*;
+
+    /// A socket that answers one request with `reply` and then stops.
+    fn server_saying(
+        name: &str,
+        reply: &'static str,
+    ) -> (std::path::PathBuf, thread::JoinHandle<Vec<u8>>) {
+        let path = std::env::temp_dir().join(format!("hyperion-reload-client-{name}.sock"));
+        drop(std::fs::remove_file(&path));
+        let listener = UnixListener::bind(&path).expect("bind");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            // One `read`, exactly like `hyperion_hot_reload::service::read_verb`. Reading
+            // to EOF instead would test a server this client never talks to.
+            let mut buffer = [0u8; 64];
+            let read = stream.read(&mut buffer).expect("read");
+            writeln!(stream, "{reply}").expect("write");
+            buffer[..read].to_vec()
+        });
+        (path, handle)
+    }
+
+    /// The verb reaches the server and the answer comes back whole.
+    #[test]
+    fn the_server_hears_the_verb_and_its_answer_comes_back() {
+        let (path, handle) = server_saying("round-trip", "accepted smash-rules abc1234");
+        let reply = ask(&path).expect("ask");
+        assert_eq!(reply, "accepted smash-rules abc1234");
+        assert_eq!(handle.join().expect("join"), VERB);
+        drop(std::fs::remove_file(&path));
+    }
+
+    /// A socket file with nothing behind it is what a killed server leaves. It has to read
+    /// as a failed reload rather than as a hang or a success.
+    #[test]
+    fn a_socket_nobody_is_listening_on_is_an_error() {
+        let path = std::env::temp_dir().join("hyperion-reload-client-dead.sock");
+        drop(std::fs::remove_file(&path));
+        drop(UnixListener::bind(&path).expect("bind"));
+        assert!(ask(&path).is_err());
+        drop(std::fs::remove_file(&path));
+    }
+
+    /// The exit status comes from the first word, and only from the first word.
+    #[test]
+    fn only_an_accepted_first_word_is_a_success() {
+        assert!(accepted("accepted smash-rules abc1234"));
+        assert!(accepted("accepted smash-rules unknown"));
+        assert!(!accepted("refused component smash::Health changed layout"));
+        assert!(!accepted(""));
+        // A refusal whose reason quotes a build cannot talk its way into a zero exit.
+        assert!(!accepted("refused unknown request `accepted`"));
+    }
+}

--- a/crates/hyperion/src/lib.rs
+++ b/crates/hyperion/src/lib.rs
@@ -80,6 +80,7 @@ pub mod net;
 pub mod simulation;
 pub mod spatial;
 pub mod storage;
+pub mod tick_loop;
 
 /// Relationship for previous values
 #[derive(Component)]

--- a/crates/hyperion/src/tick_loop.rs
+++ b/crates/hyperion/src/tick_loop.rs
@@ -1,0 +1,67 @@
+//! Everything flecs's own `ecs_app_run` does to a world before it starts ticking, for a
+//! host that ticks the world itself.
+//!
+//! # Why a host would want its own loop
+//!
+//! `App::run` is `ecs_app_run`, and it does not return until the world quits. A host that
+//! has to do anything at all between two frames -- hot reload is the case this exists for,
+//! because a module swap mid-frame rebuilds a system table underneath an iterator -- cannot
+//! use it. See `hyperion_hot_reload::service::run`, which is that loop.
+//!
+//! # What `ecs_app_run` actually does, and what is left here
+//!
+//! Read from flecs's `addons/app.c` at the pinned `flecs_ecs_sys` version, in order:
+//!
+//! | `ecs_app_run` | here |
+//! | --- | --- |
+//! | `ecs_set_target_fps(world, desc->target_fps)` | [`prepare`] refuses a world with none |
+//! | `ecs_set_threads(world, desc->threads)` | [`HyperionCore`](crate::HyperionCore) |
+//! | `ECS_IMPORT(FlecsRest)` + `ecs_set(EcsWorld, EcsRest, {port})` | [`prepare`] |
+//! | `ECS_IMPORT(FlecsStats)` | [`prepare`] |
+//! | `while (ecs_progress(world, 0)) {}` | the host's loop |
+//!
+//! The two rows that are not here are not omissions:
+//!
+//! **Threads.** `HyperionCore` already calls `world.set_threads(rayon::current_num_threads())`
+//! while it is being imported, which is before any event's `init_game` reaches its loop.
+//! flecs's `flecs_set_threads_internal` returns without doing anything when the stage count
+//! already equals the requested thread count, so the `App::set_threads(...)` every event
+//! used to call with the same expression was provably a second no-op call rather than the
+//! one that mattered.
+//!
+//! **Target frame rate.** `HyperionCore` sets it to `TICKS_PER_SECOND`. `App::new` would
+//! have read that same value back out of the world and set it again -- and, had nothing set
+//! one, would have quietly substituted 60. That substitution is the reason [`prepare`]
+//! refuses instead of defaulting: a game server whose target rate is zero does not run
+//! slowly or quickly, it spins a core per stage as fast as `ecs_progress` will return, and
+//! the only outward symptom is a host that is hot.
+
+use anyhow::ensure;
+use flecs_ecs::{addons::stats::Stats, core::World, prelude::*};
+
+/// Bring the world to the state `App::enable_rest(0).enable_stats(true).run()` left it in,
+/// short of the loop itself.
+///
+/// The REST port is flecs's own default (27750) rather than a number chosen here, which is
+/// what `enable_rest(0)` meant: `desc.port = 0` reaches `EcsRest` as zero, and flecs reads
+/// zero as "unset".
+///
+/// # Errors
+/// If no target frame rate has been set on the world -- see the module docs for why that is
+/// worth failing over rather than filling in.
+pub fn prepare(world: &World) -> anyhow::Result<()> {
+    let target_fps = world.info().target_fps;
+    ensure!(
+        target_fps > 0.0,
+        "no target frame rate on this world: import HyperionCore before preparing the tick loop, \
+         or the server will spin instead of tick"
+    );
+
+    // Both of these are what the flecs Explorer connects to. `FlecsRest` itself is already
+    // imported by `ecs_init`, so setting the singleton is the whole of `enable_rest`;
+    // `FlecsStats` is not, and is the whole of `enable_stats`.
+    world.set(flecs::rest::Rest::default());
+    world.import::<Stats>();
+
+    Ok(())
+}

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -618,9 +618,152 @@ Three pieces make that hold:
   A refused reload then surfaces as a failed activation with the reason in the deploy
   output, rather than as a silent no-op, and the world keeps running on the old build.
 
-Not built. `app.run()` in an event's `init_game` is flecs's own main loop and offers no
-per-tick Rust hook; it would become an explicit `while world.progress()` so reloads land
-between ticks, which is also what the "reloads must happen between ticks" gap above needs.
+All three are built. `nix/modules/game-server.nix` is the unit,
+`crates/hyperion-reload-client` is the client, and `events/smash`'s `init_game` no longer
+calls `app.run()` — see below.
+
+### What replaced `app.run()`, and what had to be reproduced by hand
+
+`App::run` is flecs's `ecs_app_run`, which does not return until the world quits and offers
+no per-tick Rust hook. The host therefore calls `world.progress()` itself, which means
+everything `ecs_app_run` does to a world *before* its loop has to be done by somebody. Read
+out of flecs's own `addons/app.c` at the pinned `flecs_ecs_sys`, in order:
+
+| `ecs_app_run` | where it lives now |
+| --- | --- |
+| `ecs_set_target_fps(world, desc->target_fps)` | `hyperion::tick_loop::prepare` refuses a world with none |
+| `ecs_set_threads(world, desc->threads)` | `HyperionCore`, which already did it |
+| `ECS_IMPORT(FlecsRest)` + `ecs_set(EcsWorld, EcsRest, {port})` | `hyperion::tick_loop::prepare` |
+| `ECS_IMPORT(FlecsStats)` | `hyperion::tick_loop::prepare` |
+| `while (ecs_progress(world, 0)) {}` | `hyperion_hot_reload::service::run` |
+
+Two rows deserve a note, because both look like omissions and neither is.
+
+**Threads.** `HyperionCore` calls `world.set_threads(rayon::current_num_threads())` while it
+is being imported. Every event's `init_game` then called `App::set_threads` with the *same
+expression*, and flecs's `flecs_set_threads_internal` returns without doing anything when
+the stage count already equals the request — so that second call was provably a no-op, and
+deleting it changes nothing.
+
+**Target frame rate.** `HyperionCore` sets it to `TICKS_PER_SECOND`. `App::new` read that
+same value back out of the world and set it again; what it *also* did was substitute 60
+when nothing had set one. `prepare` refuses instead of substituting, because a world with a
+target rate of zero does not run slowly — it spins a core per stage as fast as
+`ecs_progress` returns, and the only outward symptom is a host that is hot.
+
+The one thing a release gate cannot check here is the flecs registration asserts, which are
+compiled out of release builds (CLAUDE.md, ENG-11000). `checks.smash-dev-boot-e2e` boots the
+dev-profile binary for that reason, and it covers this loop.
+
+### The unit, as deployed
+
+```ini
+[Unit]
+X-Reload-Triggers=/nix/store/...-X-Reload-Triggers-hyperion-game-server
+
+[Service]
+ExecStart=/nix/store/...-smash-server/bin/smash --ip :: --port 35565 \
+  --root-ca-cert ... --cert ... --private-key ... \
+  --rules /etc/hyperion/smash-rules.so \
+  --reload-socket /run/hyperion-game-server/reload.sock \
+  --build-stamp /etc/hyperion
+ExecReload=/nix/store/...-hyperion-dylibs/bin/hyperion-reload-client /run/hyperion-game-server/reload.sock
+RuntimeDirectory=hyperion-game-server
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+```
+
+Four things in there are load bearing and none of them is obvious:
+
+- **Every path on `ExecStart` is stable.** The rules dylib's store path is in
+  `X-Reload-Triggers` and nowhere else — and note that nixpkgs does not inline the triggers,
+  it hashes them into a file of their own and names *that*. So "is the dylib in the right
+  line" is not a checkable property; "does changing the dylib move exactly one line" is, and
+  that is what `checks.hot-reload-unit-split` asserts, by rendering the unit twice.
+- **`AF_UNIX` had to be granted.** `nix/modules/common.nix` hardens both services down to
+  `AF_INET` and `AF_INET6`. The reload socket is a unix socket, so without this the server
+  dies at startup on `Address family not supported by protocol` — on a real host, and
+  nowhere else, because nothing in a test or a gate runs under that filter.
+- **`ExecReload` ships with the engine, not with the event.** It is part of `[Service]`, so a
+  client whose path moved when the rules moved would restart the server on exactly the
+  deploys this exists to make invisible. `hyperion-dylibs` moves only on an engine change,
+  which restarts anyway.
+- **The build stamp is a reload trigger too.** A commit that changes nothing the server
+  links still changes `/etc/hyperion/build-rev`, and without a reload the bar would go on
+  naming the previous commit — the one question it exists to answer. That reload re-opens a
+  byte-identical dylib and cannot be refused, because a schema can only move when the dylib
+  does.
+
+### Three things only a running server said, and one gate each
+
+The deployment was built against static evidence -- store paths, `readelf`, `ldd`, rendered
+unit files -- and all of it was green. Starting the thing on dev-compute-6 found three
+defects in an afternoon, every one of them silent and two of them already shipped.
+
+**The packaged binary segfaulted on startup, in every build ever made of it.** Not under
+load: `smash-server/bin/smash --help` exited 139. `#[global_allocator]` and
+`-C prefer-dynamic` cannot coexist, because rustc gives each Rust dylib a version script
+ending `local: *` -- the same fact this document already records about LMDB -- so each
+dylib's `__rust_alloc` is local and uninterposable, and the process runs the system
+allocator inside the dylibs and jemalloc inside the binary. The first pointer to cross
+takes it out, inside clap, before `main`. Nothing caught it because the fourteen end-to-end
+gates boot `gameBinaries.smash`, a `cargoUnit` build with no dylibs at all; the packaged
+binary was inspected and never executed. `checks.hot-reload-server-starts` now runs
+`--help` on it, which costs milliseconds and needs no certificates, no world and no
+network. ENG-12112.
+
+**The reload loaded nothing and said `accepted`.** `dlopen` searches its list of loaded
+objects by name before it stats the file, and the loader deliberately never `dlclose`s, so
+a second load through `/etc/hyperion/<event>-rules.so` returned the image from the first
+and re-ran the old entry point. `MainPID` unchanged, `NRestarts` unchanged, the journal
+saying `hot reload accepted`, the client printing `accepted smash-rules bbbbbbb`, the `/etc`
+symlink pointing at the new build -- and `/proc/<pid>/maps` naming only the old one. The
+trigger is the very thing that makes reload-not-restart work: the path has to be stable,
+so the deployed configuration is exactly the one `dlopen` dedupes. `HotReloader::load` now
+copies each candidate to a fresh name first. ENG-12113.
+
+**The deployed server logged nothing at all.** `EnvFilter::from_default_env()` with
+`RUST_LOG` unset builds a filter with no directives, which passes nothing, and a unit sets
+no `RUST_LOG`. So `hot reload accepted` -- the one line that says an invisible deploy
+landed -- would never have reached the journal. Measured both ways on the same binary and
+unit: zero lines against every line. The default is now `info`, and ANSI is dropped when
+stdout is not a terminal, because a service was writing `\x1b[32m INFO\x1b[0m` into the
+journal and every severity grep over it matched nothing.
+
+The shape they share is worth more than any of them: **a derivation that is only ever
+inspected is not a derivation that is known to work.** Two of the three were introduced by
+changes whose evidence sections were entirely static analysis, and static analysis is what
+they were correct about.
+
+### Two sibling dylibs may not share an rlib
+
+`crates/hyperion` and `crates/hyperion-hot-reload` are both dylibs and neither depends on
+the other, so under `prefer-dynamic` each statically includes its own copy of every rlib it
+uses, and a binary linking both is refused:
+
+```
+error: cannot satisfy dependencies so `tracing` only shows up once
+error: cannot satisfy dependencies so `tracing_core` only shows up once
+error: cannot satisfy dependencies so `once_cell` only shows up once
+error: cannot satisfy dependencies so `pin_project_lite` only shows up once
+```
+
+Those four are `tracing` and its dependencies, and they were the whole list: everything else
+`hyperion-hot-reload` uses arrives inside `libflecs_ecs.so`, which is a dylib and therefore
+one copy. Three ways out, and only one of them is right here:
+
+- **Make one depend on the other.** Tried and reverted. It fixes the packaged link and
+  breaks a plain one -- `cargo test -p hyperion-hot-reload -p smash` then builds
+  `libhyperion.so` against `libhyperion_hot_reload.so`, neither with `prefer-dynamic`, and
+  duplicates `std` instead.
+- **Make the shared crate a dylib.** Not available for a crate we do not own.
+- **Stop sharing it.** `hyperion-hot-reload` gave up `tracing` and now returns
+  `service::Outcome::{Applied, Refused}` for the host to log. Better layering anyway: a
+  library that logs has decided your format, and the severities belong to whoever runs the
+  query.
+
+So: before adding a dependency to `hyperion-hot-reload`, check whether `hyperion` has it
+too. `cargo tree -p hyperion-hot-reload` intersected with `cargo tree -p hyperion`, minus
+whatever `libflecs_ecs.so` already carries, is the list that must stay empty.
 
 ### What a reload costs
 
@@ -678,9 +821,10 @@ above.
 **2. Package it.** No longer the unknown it was; see "Packaging: three derivations, because
 two would restart" below, which replaces the guesswork with a measured design.
 
-**3. Wire the NixOS module and the fleet spec.** Designed in "Deploying a reload" above:
-`reloadTriggers`, the stable `/etc` path, and an `ExecReload` client that exits non-zero on
-a refusal. Small, and the design is settled.
+**Done: wire the NixOS module and the fleet spec.** `reloadTriggers`, the stable `/etc`
+path, and an `ExecReload` client that exits non-zero on a refusal, all as designed in
+"Deploying a reload" above. `checks.hot-reload-unit-split` renders the unit for two builds
+of the rules and asserts that the only line which moved is `X-Reload-Triggers`.
 
 ### Do the deployment half first, against a module with nothing in it
 
@@ -691,8 +835,8 @@ build them in. Reversed:
   calls and 30 system declarations, moved across a crate boundary. Large, mechanical, and
   nothing about it can surprise anyone.
 - **The deployment half has all of them.** systemd's reload-versus-restart decision, the
-  `/etc` indirection, rpaths that resolve in the store, the `stamped` wrapper that puts a
-  per-commit path inside `[Service]`, and whether a title reaches a connected player at
+  `/etc` indirection, rpaths that resolve in the store, the `makeWrapper` that used to put
+  a per-commit path inside `[Service]`, and whether a title reaches a connected player at
   all. Every one of those is a fact about a running host.
 
 So build the loader, the socket, the `ExecReload` client, the title and the NixOS wiring
@@ -768,7 +912,7 @@ it is the source split.
 Each derivation needs a `src` narrow enough that an unrelated commit does not move it, and
 wide enough that cargo can resolve the workspace: the root `Cargo.toml`, `Cargo.lock`, and
 the member directories in that crate's dependency graph. Get it wrong in the loose
-direction and `smash-server` moves on every commit, which is the `stamped` wrapper's bug
+direction and `smash-server` moves on every commit, which is the build-stamp wrapper's bug
 wearing a different hat, and every apply restarts. There is a cheap gate for it: build the
 three derivations, touch a file in the rules crate, rebuild, and assert that exactly one of
 the three paths changed.

--- a/events/bedwars/Cargo.toml
+++ b/events/bedwars/Cargo.toml
@@ -36,6 +36,3 @@ name = "bedwars"
 publish = false
 readme = "README.md"
 version.workspace = true
-
-[target.'cfg(not(target_os = "windows"))'.dependencies]
-tikv-jemallocator.workspace = true

--- a/events/bedwars/src/main.rs
+++ b/events/bedwars/src/main.rs
@@ -1,9 +1,16 @@
+//! bedwars' entry point.
+//!
+//! No `#[global_allocator]`, for the reason written out in full in
+//! `events/smash/src/main.rs`: a Rust global allocator and the `-C
+//! prefer-dynamic` dylib split put two allocators in one process, and the first
+//! pointer that crosses between them segfaults. bedwars is not packaged that way
+//! yet, and adding an event to `hotReloadEvents` is meant to be one attrset --
+//! so the landmine is removed here rather than left for whoever does it.
+
 use bedwars::init_game;
 
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
 fn main() -> anyhow::Result<()> {
-    hyperion_event_runner::run("BEDWARS_", init_game)
+    // bedwars takes the address and nothing else: it has no reloadable rules,
+    // so the deployment paths on `Args` are none of its business.
+    hyperion_event_runner::run("BEDWARS_", |args, crypto| init_game(args.address(), crypto))
 }

--- a/events/smash/Cargo.toml
+++ b/events/smash/Cargo.toml
@@ -14,13 +14,13 @@ geometry = { workspace = true }
 glam = { workspace = true }
 hyperion = { workspace = true }
 hyperion-event-runner = { workspace = true }
+hyperion-hot-reload = { workspace = true }
 hyperion-clap = { workspace = true }
 hyperion-inventory = { workspace = true }
 hyperion-item = { workspace = true }
 hyperion-minecraft-proto = { workspace = true }
 hyperion-permission = { workspace = true }
 hyperion-utils = { workspace = true }
-rayon = { workspace = true }
 tracing = { workspace = true }
 valence_nbt = { workspace = true }
 valence_protocol = { workspace = true }
@@ -37,6 +37,3 @@ proptest = { workspace = true }
 
 [lints]
 workspace = true
-
-[target.'cfg(not(target_os = "windows"))'.dependencies]
-tikv-jemallocator.workspace = true

--- a/events/smash/src/lib.rs
+++ b/events/smash/src/lib.rs
@@ -21,18 +21,40 @@ pub mod server;
 pub mod terrain;
 pub mod terrain_seam;
 
-use std::net::SocketAddr;
+use std::{
+    net::SocketAddr,
+    path::{Path, PathBuf},
+};
 
+use anyhow::Context;
 use flecs_ecs::prelude::*;
 use hyperion::{Crypto, GameServerEndpoint, HyperionCore};
 use hyperion_clap::hyperion_command::CommandRegistry;
+use hyperion_event_runner::Deployment;
+use hyperion_hot_reload::service::{self, Outcome, ReloadService};
 
-use crate::module::{
-    ability::AbilityModule, arena::ArenaModule, build_stamp::BuildStampModule,
-    damage::DamageModule, effect::EffectModule, hud::HudModule, jump::JumpModule, kit::KitModule,
-    kits::StockKits, knockback::KnockbackModule, lives::LivesModule, lobby::LobbyModule,
-    player::PlayerModule, projectile::ProjectileModule, scoreboard::ScoreboardModule,
-    selector::SelectorModule, sound::SoundModule, vitals::VitalsModule,
+use crate::{
+    module::{
+        ability::AbilityModule,
+        arena::ArenaModule,
+        build_stamp::{self, BuildStamp, BuildStampModule},
+        damage::DamageModule,
+        effect::EffectModule,
+        hud::HudModule,
+        jump::JumpModule,
+        kit::KitModule,
+        kits::StockKits,
+        knockback::KnockbackModule,
+        lives::LivesModule,
+        lobby::LobbyModule,
+        player::PlayerModule,
+        projectile::ProjectileModule,
+        scoreboard::ScoreboardModule,
+        selector::SelectorModule,
+        sound::SoundModule,
+        vitals::VitalsModule,
+    },
+    server::{NamedColor, Text, Title},
 };
 
 /// The whole game.
@@ -127,17 +149,134 @@ impl Module for SmashHost {
     }
 }
 
+/// Say what the reload did, in the journal and on every player's screen.
+///
+/// # Why the host does the logging
+///
+/// `hyperion-hot-reload` reports rather than logs, because it cannot depend on `tracing`
+/// without duplicating it against `hyperion`'s copy -- see that crate's `Cargo.toml`. So
+/// the severities are chosen here, and they are not the same for the two arms. **A refusal
+/// is an `error`**: it means the deploy did not take, and the operator has to find it in a
+/// query filtered by severity rather than by reading a log. An accepted reload is `info`,
+/// which is what `hyperion-event-runner` defaults to precisely so this line arrives.
+///
+/// # Why the players are told at all
+///
+/// A reload is invisible from a client: nothing disconnects, nothing respawns, and the
+/// only outward sign is that a rule behaves differently than it did a second ago. Somebody
+/// in a match who is about to lose to a number that just changed deserves to know it
+/// changed, and somebody watching their own deploy land needs the confirmation that it
+/// landed. A title is the one channel that reaches a player looking at the middle of their
+/// screen, which in a fighting game is everyone.
+///
+/// The build bar underneath is not a duplicate of it: the title is gone in a few seconds
+/// and says "something just changed", the bar stays and says "to what".
+///
+/// # Why this is a callback and not an observer
+///
+/// A reload deletes and re-creates every system and observer the module registered, so an
+/// observer is exactly the wrong shape -- the thing that would react to the event is the
+/// thing the event just replaced. See `hyperion_hot_reload::service::run`, which calls this
+/// between two frames.
+fn announce_reload(world: &World, outcome: &Outcome, build_stamp: &Path) {
+    let reloaded = match outcome {
+        Outcome::Applied(reloaded) => reloaded,
+        Outcome::Refused(reason) => {
+            tracing::error!("hot reload refused, the world is unchanged: {reason}");
+            return;
+        }
+    };
+
+    // Re-read, because the deploy that carried these rules rewrote these files and there is
+    // no new `exec` to pick them up. This is the whole reason the stamp is files rather
+    // than the environment it used to be.
+    world.set(BuildStamp::read(build_stamp));
+
+    // `reloaded.revision` is `<build_stamp>/build-rev` read by the service on the same
+    // reload, so the title and the bar cannot name different builds.
+    let label = reloaded.revision.as_deref().unwrap_or("an unknown build");
+
+    tracing::info!(
+        module = %reloaded.module,
+        revision = label,
+        migrated_instances = reloaded.migrated_instances,
+        "hot reload accepted"
+    );
+
+    world.get::<&ServerHandle>(|server| {
+        server.broadcast_title(Title::new(
+            Text::text(format!("Reloading to build {label}")).color(NamedColor::Yellow),
+        ));
+    });
+}
+
+/// The reload half of a deployment, bound and loaded.
+///
+/// The two travel together because [`announce_reload`] needs the stamp
+/// directory and only a server that has a service can ever reach it.
+struct Rules {
+    service: ReloadService,
+    build_stamp: PathBuf,
+}
+
+impl Rules {
+    /// Bind the socket and load the rules for the first time.
+    ///
+    /// A first load that fails is fatal, unlike a reload that is refused: the
+    /// running world has nothing to protect yet, and a server that came up
+    /// silently missing every one of its rules is worse than one that did not
+    /// come up.
+    fn open(world: &World, deployment: Deployment) -> anyhow::Result<Self> {
+        world.set(BuildStamp::read(&deployment.build_stamp));
+
+        let mut service = ReloadService::bind(
+            &deployment.reload_socket,
+            deployment.rules.clone(),
+            deployment.build_stamp.join(build_stamp::REV_FILE),
+        )
+        .with_context(|| format!("binding {}", deployment.reload_socket.display()))?;
+
+        let applied = service
+            .load_initial(world)
+            // `LoadError` is not `Send + Sync`, which `anyhow::Error` wants:
+            // it carries a `libloading::Error`. The text is the whole value.
+            .map_err(|e| anyhow::anyhow!("loading {}: {e}", deployment.rules.display()))?;
+        tracing::info!(module = %applied.module, "rules loaded");
+
+        Ok(Self {
+            service,
+            build_stamp: deployment.build_stamp,
+        })
+    }
+}
+
 /// Build the world and run it. The entry point `main.rs` calls.
 ///
-/// `embedded_proxy` asks for a proxy inside this process, listening on that
-/// address. Running one is the shortest path to a playable server, but it is
-/// optional because the deployed shape is proxies on their own machines --
-/// and because two proxies racing for one port is the sort of thing that
-/// leaves a dev stack half up with no obvious reason why.
+/// `deployment` is the packaged shape: a rules dylib to load, a socket to be
+/// asked to load it again on, and the directory the build stamp is written to.
+/// `None` is a developer's server or an end-to-end gate -- same world, same
+/// loop, no reloadable rules.
+///
+/// # Why this does not call `App::run`
+///
+/// It used to. `App::run` is flecs's `ecs_app_run`, which does not return until
+/// the world quits, and a reload has to happen between two frames: swapping a
+/// module mid-frame rebuilds a system table underneath an iterator. So the host
+/// ticks the world itself. [`hyperion::tick_loop::prepare`] is what
+/// `ecs_app_run` did to the world before its own loop, and
+/// [`hyperion_hot_reload::service::run`] is the loop.
 ///
 /// # Errors
-/// If the thread count does not fit in the `i32` flecs wants.
-pub fn init_game(address: SocketAddr, crypto: Crypto) -> anyhow::Result<()> {
+/// If the world has no target frame rate, if the reload socket cannot be bound,
+/// or if the rules dylib is refused on the first load. A rules dylib that
+/// cannot be loaded at startup is fatal, unlike one refused later: the running
+/// world has nothing to protect yet, and a server that came up silently missing
+/// every one of its rules is worse than one that did not come up.
+pub fn init_game(
+    address: SocketAddr,
+    crypto: Crypto,
+    deployment: Option<Deployment>,
+) -> anyhow::Result<()> {
     let world = World::new();
 
     world.import::<HyperionCore>();
@@ -146,13 +285,22 @@ pub fn init_game(address: SocketAddr, crypto: Crypto) -> anyhow::Result<()> {
     world.set(crypto);
     world.set(GameServerEndpoint::from(address));
 
-    let mut app = world.app();
+    let mut rules = deployment.map(|it| Rules::open(&world, it)).transpose()?;
 
-    app.enable_rest(0)
-        .enable_stats(true)
-        .set_threads(i32::try_from(rayon::current_num_threads())?);
+    hyperion::tick_loop::prepare(&world)?;
 
-    app.run();
+    match rules.as_mut() {
+        // A developer's server or an end-to-end gate: the same world and the
+        // same loop, with nothing to reload. The callback cannot be reached
+        // without a service, so it has nothing to do.
+        None => service::run(&world, None, |_, _| {}),
+        Some(rules) => {
+            let build_stamp = rules.build_stamp.clone();
+            service::run(&world, Some(&mut rules.service), |world, outcome| {
+                announce_reload(world, outcome, &build_stamp);
+            });
+        }
+    }
 
     Ok(())
 }

--- a/events/smash/src/main.rs
+++ b/events/smash/src/main.rs
@@ -1,9 +1,45 @@
+//! smash's entry point.
+//!
+//! # There is no `#[global_allocator]` here, and that is not an oversight
+//!
+//! There was: `tikv_jemallocator::Jemalloc`. It cannot coexist with the dylib
+//! split this server is packaged with, and the failure is a segfault before
+//! `main` gets anywhere.
+//!
+//! `nix/hot-reload/packaging.nix` builds with `-C prefer-dynamic` so that the
+//! server and the rules dylib resolve `hyperion`, and through it the one
+//! `flecs_ecs` that owns the component index pool, to a shared image. That also
+//! makes `std` a shared image, and rustc gives every Rust dylib an anonymous
+//! version script ending `local: *` -- so each dylib's `__rust_alloc` is LOCAL
+//! and cannot be interposed by the executable's. The process ends up with the
+//! system allocator inside the dylibs and jemalloc inside the binary, and the
+//! first pointer that crosses between them takes the process out:
+//!
+//! ```text
+//! $ smash-server/bin/smash --help
+//! Segmentation fault (core dumped)
+//!
+//! #0  _rjem_je_rtree_leaf_elm_lookup_hard ()
+//! #1  do_rallocx ()
+//! #2  <alloc::raw_vec::RawVecInner>::finish_grow ()
+//! #4  <clap_builder::builder::arg_group::ArgGroup>::args ()
+//! #5  <hyperion_event_runner::Args as clap_builder::derive::Args>::augment_args ()
+//! ```
+//!
+//! Every `smash-server` built before this comment existed crashed that way, and
+//! nothing caught it: the end-to-end gates run `gameBinaries.smash`, which is a
+//! `cargoUnit` build with no `-C prefer-dynamic`, so the packaged binary had
+//! never been executed by anything. It was found by starting it on a dev node.
+//!
+//! Keeping jemalloc would mean loading it as an `LD_PRELOAD` malloc replacement
+//! rather than as a Rust global allocator, so that one allocator serves the
+//! whole process including the dylibs. That is a deployment change with its own
+//! measurements to take; ENG-12112 carries it.
+
 use smash::init_game;
 
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
 fn main() -> anyhow::Result<()> {
-    hyperion_event_runner::run("SMASH_", init_game)
+    hyperion_event_runner::run("SMASH_", |args, crypto| {
+        init_game(args.address(), crypto, args.deployment()?)
+    })
 }

--- a/events/smash/src/module/build_stamp.rs
+++ b/events/smash/src/module/build_stamp.rs
@@ -1,48 +1,74 @@
 //! What build the server is running, on the player's screen.
 //!
 //! There is a live server that is redeployed as main moves, and until this
-//! existed the only way to tell whether a change had reached it was to guess
-//! at deploy timing from outside the game. The commit and the time it was made
+//! existed the only way to tell whether a change had reached it was to guess at
+//! deploy timing from outside the game. The commit and how long ago it was made
 //! are the two facts that answer it, so they go where a player is already
 //! looking.
 //!
 //! # Why a second bar and not the lobby's
 //!
 //! The other candidate was [`crate::module::hud::boss_bar`]'s `Phase::Waiting`
-//! arm -- the "Waiting for players 1/2" strip -- and it was rejected for two
-//! reasons that point the same way.
-//!
-//! It is **not always there.** The bar becomes a countdown, then a percentage,
+//! arm -- the "Waiting for players 1/2" strip -- and it was rejected because
+//! that bar is **not always there**. It becomes a countdown, then a percentage,
 //! the moment a match starts, so a stamp folded into it answers the question
 //! only for somebody who happens to arrive between matches. The question is
 //! asked at arbitrary times, including by a person who joined a running match
 //! to check, and half the time the lobby bar is a bar about something else.
 //!
-//! It **changes.** That title is a function of the player count, so a stamp
-//! carried inside it is re-sent every time anybody joins or leaves -- as a
-//! whole `Add`, because the title and the fill move together and
-//! `hyperion::egress::boss_bar` collapses two moved fields into one. A build
-//! stamp is constant for the life of a process and should cost exactly one
-//! packet per viewer. Its own bar is the only shape that does.
+//! What its own bar gives up is a permanent strip of screen in a fighting game,
+//! which is a real cost. It is paid down as far as it goes: the fill is left
+//! empty so it draws no coloured length, and it is pushed after the match bar
+//! so it sits under it rather than above.
 //!
-//! What that gives up is a permanent strip of screen in a fighting game, which
-//! is a real cost. It is paid down as far as it goes: the bar is written once
-//! per player and never again, its fill is left empty so it draws no coloured
-//! length, and it is pushed after the match bar so it sits under it rather
-//! than above.
+//! # The age is relative now, and here is what that costs
+//!
+//! This bar used to read `build 8f3a21c · 2026-07-29 18:04 UTC` and was sent
+//! exactly once per player, on the argument that a build stamp is constant for
+//! the life of a process and should cost exactly one packet per viewer.
+//!
+//! Two things ended that argument. The absolute form does not answer the
+//! question the bar is on screen for -- "is my change live yet" is a question
+//! about elapsed time, and a UTC minute has to be subtracted from a clock the
+//! reader goes and finds, in a fighting game, mid-match. And the process is no
+//! longer the unit anyway: a hot reload replaces the rules without restarting,
+//! so "constant for the life of a process" stopped being true the moment
+//! [`crate::init_game`] started re-reading this stamp on every accepted reload.
+//!
+//! So the wording moved to `build 8f3a21c · 2h ago`, and a relative age changes
+//! on its own. The cost is bounded by coarsening the wording as the build ages,
+//! which is [`relative_age`]'s whole job: a string reading to the minute changes
+//! once a minute, `2h ago` changes once an hour, `3d ago` changes once a day.
+//! One build therefore costs at most 60 packets per viewer in its first hour,
+//! 23 more across the rest of its first day, and one a day after that. The
+//! steady state a deployed server sits in is **one packet per viewer per hour**.
+//!
+//! `show_build_stamp` is what turns that bound into behaviour rather than
+//! arithmetic: it sends only when the rendered string differs from the one that
+//! player was last sent, so the packet count is a function of the wording and
+//! not of the tick rate.
 //!
 //! # Where the values come from
 //!
-//! Three environment variables, set by a wrapper the Nix build puts around the
-//! server binary (see `flake.nix`). Not `env!` in a build script: baking a
-//! commit hash into a crate makes every commit a full workspace recompile, and
-//! the compile is already the floor on the pipeline. A wrapper is a symlink
-//! and three assignments, so a new commit rebuilds that and nothing else.
+//! Three files in a directory the deployment names on the command line
+//! (`--build-stamp`), written by `nix/modules/game-server.nix`.
 //!
-//! A `cargo run` build has none of them set and says so, rather than claiming
-//! a commit it was not built from.
+//! **Files and not environment variables**, which is what they were until hot
+//! reload existed. A process's environment is fixed at `exec`, so a server that
+//! reloaded its rules without restarting would go on reporting the build it
+//! started as, forever -- and not restarting is the entire point.
+//!
+//! Not `env!` in a build script either: baking a commit hash into a crate makes
+//! every commit a full workspace recompile, and the compile is already the floor
+//! on the pipeline.
+//!
+//! A `cargo run` build is handed no directory at all and says so, rather than
+//! claiming a commit it was not built from.
 
-use std::env;
+use std::{
+    path::Path,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use flecs_ecs::prelude::*;
 
@@ -51,22 +77,27 @@ use crate::{
     server::{BarColour, BarSlot, BossBar, NamedColor, PlayerId, ServerHandle, Text},
 };
 
-/// The short commit hash the server was built from, with no dirty marker on
-/// it. That marker is [`DIRTY_VAR`]'s job.
-pub const REV_VAR: &str = "HYPERION_BUILD_REV";
+/// The short commit hash the server was built from, with no dirty marker on it.
+/// That marker is [`DIRTY_FILE`]'s job.
+///
+/// Public because `hyperion_hot_reload::ReloadService` reads this same file to
+/// name the build in its `accepted <module> <revision>` reply. One filename with
+/// two spellings is one deploy away from a reload reporting a revision nobody
+/// wrote.
+pub const REV_FILE: &str = "build-rev";
 
 /// When that commit was made, in whole seconds since the unix epoch.
-pub const TIME_VAR: &str = "HYPERION_BUILD_TIME";
+pub const TIME_FILE: &str = "build-time";
 
 /// `1` when the working tree had uncommitted changes at build time.
-pub const DIRTY_VAR: &str = "HYPERION_BUILD_DIRTY";
+pub const DIRTY_FILE: &str = "build-dirty";
 
-/// What build this process is.
+/// What build this process is currently running.
 ///
-/// Every field is optional because the honest answer for a `cargo run` build
-/// is that nobody said. A missing field reads as "unknown" on screen rather
-/// than as a default that would be a lie -- a stamp that says `0000000` is
-/// worse than one that says it does not know.
+/// Every field is optional because the honest answer for a `cargo run` build is
+/// that nobody said. A missing field reads as "unknown" on screen rather than
+/// as a default that would be a lie -- a stamp that says `0000000` is worse
+/// than one that says it does not know.
 #[derive(Component, Debug, Clone, PartialEq, Eq, Default)]
 pub struct BuildStamp {
     /// The short commit hash, `None` when nothing said.
@@ -79,26 +110,30 @@ pub struct BuildStamp {
 }
 
 impl BuildStamp {
-    /// What the environment says this build is.
+    /// What the files in `dir` say this build is.
+    ///
+    /// A directory that is not there, or a file that cannot be read, is the
+    /// unpackaged case rather than an error. This is a label; a server that
+    /// refused to start over one would be trading a running game for a string.
     #[must_use]
-    pub fn from_env() -> Self {
+    pub fn read(dir: &Path) -> Self {
+        let field = |name: &str| std::fs::read_to_string(dir.join(name)).ok();
         Self::parse(
-            env::var(REV_VAR).ok().as_deref(),
-            env::var(TIME_VAR).ok().as_deref(),
-            env::var(DIRTY_VAR).ok().as_deref(),
+            field(REV_FILE).as_deref(),
+            field(TIME_FILE).as_deref(),
+            field(DIRTY_FILE).as_deref(),
         )
     }
 
     /// The same, from three strings.
     ///
-    /// Split out from [`Self::from_env`] because `std::env::set_var` is unsafe
-    /// in edition 2024 and racy in a test binary that runs its tests on
-    /// threads. Everything worth pinning is in here, and it is reachable
-    /// without touching the process environment at all.
+    /// Split out from [`Self::read`] so that every wording case is reachable
+    /// without a filesystem.
     ///
-    /// A field that is present but unusable -- an empty rev, a time that is
-    /// not a number -- is treated as absent. The bar is a readout and half of
-    /// one is better than none.
+    /// A field that is present but unusable -- an empty rev, a time that is not
+    /// a number -- is treated as absent. The bar is a readout and half of one is
+    /// better than none. Everything is trimmed, because `environment.etc` ends
+    /// each of these files with a newline.
     #[must_use]
     pub fn parse(rev: Option<&str>, committed_at: Option<&str>, dirty: Option<&str>) -> Self {
         Self {
@@ -112,6 +147,62 @@ impl BuildStamp {
     }
 }
 
+/// How long ago `committed_at` was, seen from `now`, in as few characters as it
+/// can be said in.
+///
+/// # The granularity is the packet budget
+///
+/// Each unit is chosen so the string is stable for one whole unit of it, which
+/// is what bounds how often the bar is redrawn. Minutes for the first hour,
+/// because that is the window somebody watching their own deploy land is
+/// actually in; hours for the first day; days after that. Nothing finer than a
+/// minute, because a bar that changed every second would cost twenty times more
+/// than the whole rest of this module and tell a reader nothing they did not
+/// already know.
+///
+/// A build that has not yet aged a minute reads `just now`, and so does one
+/// whose timestamp is in the future. The future case is not hypothetical -- a
+/// host whose clock is behind the machine that made the commit produces it --
+/// and `in -3m` on a boss bar is a worse answer than a slightly early `just
+/// now`.
+#[must_use]
+pub fn relative_age(committed_at: i64, now: i64) -> String {
+    const MINUTE: i64 = 60;
+    const HOUR: i64 = 60 * MINUTE;
+    const DAY: i64 = 24 * HOUR;
+
+    let age = now.saturating_sub(committed_at).max(0);
+    if age < MINUTE {
+        "just now".to_owned()
+    } else if age < HOUR {
+        format!("{}m ago", age / MINUTE)
+    } else if age < DAY {
+        format!("{}h ago", age / HOUR)
+    } else {
+        format!("{}d ago", age / DAY)
+    }
+}
+
+/// The line across the top of the screen, as plain text.
+///
+/// Split from [`stamp_bar`] because the colours are a function of one boolean
+/// and the wording is the part worth pinning in a test.
+#[must_use]
+pub fn stamp_title(stamp: &BuildStamp, now: i64) -> String {
+    let rev = match (stamp.rev.as_deref(), stamp.dirty) {
+        (Some(rev), true) => format!("{rev} + uncommitted changes"),
+        (Some(rev), false) => rev.to_owned(),
+        // Not "unknown" alone: the reason it is unknown is the useful half,
+        // because it tells a developer looking at their own `cargo run` that
+        // nothing is broken.
+        (None, _) => "unpackaged build".to_owned(),
+    };
+    stamp.committed_at.map_or_else(
+        || format!("build {rev}"),
+        |at| format!("build {rev} \u{b7} {}", relative_age(at, now)),
+    )
+}
+
 /// The bar a build stamp draws.
 ///
 /// **Empty, and that is deliberate.** A boss bar's fill is a fraction of
@@ -123,21 +214,9 @@ impl BuildStamp {
 /// and the whole value of a stamp is that it can be trusted, so the one case
 /// where it cannot be is the one case that is impossible to skim past.
 #[must_use]
-pub fn stamp_bar(stamp: &BuildStamp) -> BossBar {
-    let rev = match (stamp.rev.as_deref(), stamp.dirty) {
-        (Some(rev), true) => format!("{rev} + uncommitted changes"),
-        (Some(rev), false) => rev.to_owned(),
-        // Not "unknown" alone: the reason it is unknown is the useful half,
-        // because it tells a developer looking at their own `cargo run` that
-        // nothing is broken.
-        (None, _) => "unpackaged build".to_owned(),
-    };
-    let title = stamp.committed_at.map_or_else(
-        || format!("build {rev}"),
-        |at| format!("build {rev} \u{b7} {}", utc_minute(at)),
-    );
+pub fn stamp_bar(stamp: &BuildStamp, now: i64) -> BossBar {
     BossBar {
-        title: Text::text(title).color(if stamp.dirty {
+        title: Text::text(stamp_title(stamp, now)).color(if stamp.dirty {
             NamedColor::Red
         } else {
             NamedColor::Gray
@@ -151,65 +230,40 @@ pub fn stamp_bar(stamp: &BuildStamp) -> BossBar {
     }
 }
 
-/// `seconds` since the unix epoch as `YYYY-MM-DD HH:MM UTC`.
+/// Wall-clock seconds since the unix epoch.
 ///
-/// **Absolute and not "two hours ago".** A relative age is the friendlier
-/// thing to read and it is the one thing this bar cannot say: it would change
-/// every minute, and a bar that changes is a packet per viewer per change
-/// forever, which is exactly the cost this whole design is built to avoid.
-///
-/// UTC and to the minute, because the reader is comparing it against a deploy
-/// they watched and a commit timestamp they can read out of git, and both of
-/// those are in UTC.
-///
-/// The date arithmetic is Howard Hinnant's `civil_from_days`, from
-/// <https://howardhinnant.github.io/date_algorithms.html>, which is exact for
-/// every year this will ever be handed and needs no table. There are no leap
-/// seconds in unix time, so a day is 86,400 seconds and the split is a
-/// division.
-#[must_use]
-pub fn utc_minute(seconds: i64) -> String {
-    const SECONDS_PER_DAY: i64 = 86_400;
-
-    let days = seconds.div_euclid(SECONDS_PER_DAY);
-    let within = seconds.rem_euclid(SECONDS_PER_DAY);
-    let (hour, minute) = (within / 3600, (within % 3600) / 60);
-
-    // Shift the epoch to 0000-03-01, which puts the leap day at the end of the
-    // 400 year era and makes every month length a straight line.
-    let shifted = days + 719_468;
-    let era = shifted.div_euclid(146_097);
-    let day_of_era = shifted.rem_euclid(146_097);
-    let year_of_era =
-        (day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
-    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
-    let march_month = (5 * day_of_year + 2) / 153;
-    let day = day_of_year - (153 * march_month + 2) / 5 + 1;
-    let month = if march_month < 10 {
-        march_month + 3
-    } else {
-        march_month - 9
-    };
-    let year = year_of_era + era * 400 + i64::from(month <= 2);
-
-    format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02} UTC")
+/// Wall clock and not the world's own tick counter, because the number this is
+/// compared against is a git commit's timestamp, which lives on the same clock.
+/// A host whose clock is wrong renders an age that is wrong by the same amount,
+/// which is the honest failure for a readout of somebody else's timestamp.
+fn now_epoch() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |since| {
+            i64::try_from(since.as_secs()).unwrap_or(i64::MAX)
+        })
 }
 
-/// Marks a player who has already been sent the stamp, so it is sent once.
+/// The last thing this player was told about the build.
 ///
-/// A tag and not a flag inside a record, because it is the query itself that
-/// has to stop matching: once every connected player carries this, the system
-/// below iterates nothing at all rather than iterating everybody to decide
-/// there is nothing to do.
+/// It holds the rendered string rather than a tag, and that is what makes the
+/// system idempotent instead of edge-triggered: "have they been told" is a
+/// question with a stale answer the moment the wording changes, and the wording
+/// now changes on its own. Comparing against what was actually sent means a
+/// player who joined ten seconds ago and a player who has been standing there
+/// since the deploy are handled by one branch.
 #[derive(Component, Debug)]
-pub struct StampShown;
+pub struct StampShown {
+    /// Exactly the text of the bar this player last received.
+    pub text: String,
+}
 
-/// Registration: the types this file owns, and the stamp itself.
+/// Registration: the types this file owns.
 ///
-/// The environment is read here, once, where [`BuildStamp`] is registered. A
-/// test that wants a particular build overwrites the singleton after importing
-/// the game, which is why nothing else in this file ever looks at the
-/// environment again.
+/// The stamp singleton is registered here and left at its default. Filling it in
+/// is [`crate::init_game`]'s job, because only the host knows whether it was
+/// handed a `--build-stamp` directory -- and it re-fills it on every accepted
+/// reload, which is a thing a registration module could not do.
 #[derive(Component)]
 pub struct BuildStampComponentsModule;
 
@@ -221,11 +275,12 @@ impl Module for BuildStampComponentsModule {
         world
             .component::<BuildStamp>()
             .add_trait::<flecs::Singleton>();
-        world.set(BuildStamp::from_env());
+        world.set(BuildStamp::default());
     }
 }
 
-/// Behaviour: put the stamp on each player's screen, exactly once.
+/// Behaviour: keep each player's build bar equal to what the stamp currently
+/// says.
 #[derive(Component)]
 pub struct BuildStampModule;
 
@@ -238,7 +293,9 @@ impl Module for BuildStampModule {
         // reason `smash::draw_projectiles` is one: a player is assembled over
         // several `set` calls and an observer on the first of them sees an
         // entity that has no `PlayerId` yet. Matching on what is needed and
-        // skipping what is done sees a whole player or none of one.
+        // skipping what is done sees a whole player or none of one. It is also
+        // the only shape that can notice the wording changing under it, which
+        // an observer on the player could not.
         //
         // Declared after `HudModule`'s `update_hud` -- `SmashModule` imports
         // this module last -- so on the tick a player joins, the match bar's
@@ -248,14 +305,23 @@ impl Module for BuildStampModule {
         world
             .system_named::<&PlayerId>("show_build_stamp")
             .with(Player::id())
-            .without(StampShown::id())
             .each_iter(|it, row, id| {
                 let world = it.world();
-                let bar = world.get::<&BuildStamp>(stamp_bar);
+                let bar = world.get::<&BuildStamp>(|stamp| stamp_bar(stamp, now_epoch()));
+                let text = bar.title.plain();
+
+                let entity = it.entity(row);
+                let unchanged = entity
+                    .try_get::<&StampShown>(|shown| shown.text == text)
+                    .unwrap_or(false);
+                if unchanged {
+                    return;
+                }
+
                 world.get::<&ServerHandle>(|server| {
                     server.set_boss_bar(*id, BarSlot::Build, bar.clone());
                 });
-                it.entity(row).add(StampShown::id());
+                entity.set(StampShown { text });
             });
     }
 }

--- a/events/smash/tests/build_stamp.rs
+++ b/events/smash/tests/build_stamp.rs
@@ -1,15 +1,19 @@
-//! The build stamp: what it says, and that it is said exactly once.
+//! The build stamp: what it says, how often it says it, and that a reload
+//! changes it.
 //!
-//! Two halves, and the second one is the whole reason this file exists. The
-//! wording is a pure function of a small struct and is pinned character for
-//! character. The delivery is a whole world, run for hundreds of ticks through
-//! every phase change a lobby has, asserting that the number of times a player
-//! is told what build this is stays at one.
+//! Three halves, and the middle one is the reason this file is as long as it
+//! is. The wording is a pure function of a small struct and a clock, and is
+//! pinned character for character. The *rate* is pinned too, because the bar
+//! now says `2h ago` rather than a UTC minute and a relative age changes on its
+//! own: `hyperion::egress::boss_bar` turns one `set_boss_bar` whose contents
+//! moved into one packet per viewer, so an age that read to the second would be
+//! a packet per player per second forever. And the delivery is a whole world,
+//! run for hundreds of ticks through every phase change a lobby has.
 //!
-//! That second claim is not a micro-optimisation. `hyperion::egress::boss_bar`
-//! turns one `set_boss_bar` whose contents moved into one packet per viewer,
-//! and a stamp that were pushed per tick would be twenty packets a second per
-//! player carrying a string that cannot change until the process exits.
+//! Where a test is about delivery rather than wording it uses a stamp with no
+//! commit time, whose rendering is therefore constant. The alternative is
+//! asserting a string that depends on how long ago 2026-07-29 was when the test
+//! ran, which passes today and fails tomorrow.
 
 mod harness;
 
@@ -17,7 +21,7 @@ use glam::Vec3;
 use harness::Game;
 use smash::{
     module::{
-        build_stamp::{BuildStamp, stamp_bar, utc_minute},
+        build_stamp::{BuildStamp, relative_age, stamp_bar},
         lobby::{Lobby, LobbyConfig, Phase},
     },
     server::{BarColour, BarSlot, NamedColor, PlayerId, TextColor, mock::Call},
@@ -27,23 +31,38 @@ use smash::{
 fn clean() -> BuildStamp {
     BuildStamp {
         rev: Some("8f3a21c".to_owned()),
-        committed_at: Some(1_785_348_240),
+        committed_at: Some(COMMITTED_AT),
         dirty: false,
     }
 }
+
+/// The same build with nothing said about when it was made, so its bar reads
+/// the same string whenever the test happens to run.
+fn timeless() -> BuildStamp {
+    BuildStamp {
+        committed_at: None,
+        ..clean()
+    }
+}
+
+const COMMITTED_AT: i64 = 1_785_348_240;
+
+/// Two hours and five minutes after [`COMMITTED_AT`].
+const TWO_HOURS_LATER: i64 = COMMITTED_AT + 2 * 3600 + 5 * 60;
+
+const MINUTE: i64 = 60;
+const HOUR: i64 = 60 * MINUTE;
+const DAY: i64 = 24 * HOUR;
 
 // ---------------------------------------------------------------------------
 // what it says
 // ---------------------------------------------------------------------------
 
-/// The commit and the minute it was made, in that order, on one line.
+/// The commit and how long ago it was made, in that order, on one line.
 #[test]
-fn the_stamp_names_the_commit_and_when_it_was_made() {
-    let bar = stamp_bar(&clean());
-    assert_eq!(
-        bar.title.plain(),
-        "build 8f3a21c \u{b7} 2026-07-29 18:04 UTC"
-    );
+fn the_stamp_names_the_commit_and_how_old_it_is() {
+    let bar = stamp_bar(&clean(), TWO_HOURS_LATER);
+    assert_eq!(bar.title.plain(), "build 8f3a21c \u{b7} 2h ago");
     assert_eq!(
         bar.title.runs()[0].color(),
         Some(TextColor::Named(NamedColor::Gray))
@@ -61,13 +80,16 @@ fn the_stamp_names_the_commit_and_when_it_was_made() {
 /// whole strip rather than adding a word to the end of a line.
 #[test]
 fn a_dirty_build_says_so_and_turns_the_bar_red() {
-    let bar = stamp_bar(&BuildStamp {
-        dirty: true,
-        ..clean()
-    });
+    let bar = stamp_bar(
+        &BuildStamp {
+            dirty: true,
+            ..clean()
+        },
+        TWO_HOURS_LATER,
+    );
     assert_eq!(
         bar.title.plain(),
-        "build 8f3a21c + uncommitted changes \u{b7} 2026-07-29 18:04 UTC"
+        "build 8f3a21c + uncommitted changes \u{b7} 2h ago"
     );
     assert_eq!(
         bar.title.runs()[0].color(),
@@ -79,12 +101,13 @@ fn a_dirty_build_says_so_and_turns_the_bar_red() {
 
 /// A build nobody stamped says that, rather than a commit it does not have.
 ///
-/// This is the `cargo run` case, and the wording is aimed at the person who
-/// will meet it: a developer on their own machine, who needs to know that the
-/// blank is expected and not a broken deploy.
+/// This is the `cargo run` case -- no `--build-stamp` directory on the command
+/// line -- and the wording is aimed at the person who will meet it: a developer
+/// on their own machine, who needs to know that the blank is expected and not a
+/// broken deploy.
 #[test]
 fn an_unstamped_build_says_it_is_unpackaged() {
-    let bar = stamp_bar(&BuildStamp::default());
+    let bar = stamp_bar(&BuildStamp::default(), TWO_HOURS_LATER);
     assert_eq!(bar.title.plain(), "build unpackaged build");
     assert_eq!(bar.colour, BarColour::Blue);
 }
@@ -93,14 +116,13 @@ fn an_unstamped_build_says_it_is_unpackaged() {
 /// after it.
 #[test]
 fn half_a_stamp_is_shown_rather_than_none_of_one() {
-    let bar = stamp_bar(&BuildStamp {
-        committed_at: None,
-        ..clean()
-    });
-    assert_eq!(bar.title.plain(), "build 8f3a21c");
+    assert_eq!(
+        stamp_bar(&timeless(), TWO_HOURS_LATER).title.plain(),
+        "build 8f3a21c"
+    );
 }
 
-/// The environment is parsed the way the wrapper writes it, and a field that
+/// The three files are parsed the way the deploy writes them, and a field that
 /// cannot be used is dropped rather than shown as itself.
 #[test]
 fn a_field_that_is_not_usable_reads_as_absent() {
@@ -108,52 +130,104 @@ fn a_field_that_is_not_usable_reads_as_absent() {
         BuildStamp::parse(Some("8f3a21c"), Some("1785348240"), Some("1")),
         BuildStamp {
             rev: Some("8f3a21c".to_owned()),
-            committed_at: Some(1_785_348_240),
+            committed_at: Some(COMMITTED_AT),
             dirty: true,
         }
     );
-    // An empty rev is what an unset variable looks like when something exports
-    // it anyway, and a time that is not a number is what a broken wrapper
+    // `environment.etc` ends every file it writes with a newline, so the
+    // trimming is not defensive -- it is the format.
+    assert_eq!(
+        BuildStamp::parse(Some("8f3a21c\n"), Some("1785348240\n"), Some("0\n")),
+        clean()
+    );
+    // An empty rev is what an unset value looks like when something writes the
+    // file anyway, and a time that is not a number is what a broken deploy
     // produces. Neither is worth putting on a screen.
     assert_eq!(
         BuildStamp::parse(Some("   "), Some("not-a-time"), Some("0")),
         BuildStamp::default()
     );
     assert_eq!(BuildStamp::parse(None, None, None), BuildStamp::default());
-    // What the wrapper writes for a source with no git in it: both variables
-    // set, both empty. The flake refuses to emit a time without a rev, because
-    // `lastModified` on such a source is a directory mtime, and an empty
-    // string has to read the same way here as an unset variable or the refusal
-    // would only have moved the problem.
+    // What the flake writes for a source with no git in it: both files present,
+    // both empty. The flake refuses to emit a time without a rev, because
+    // `lastModified` on such a source is a directory mtime, and an empty file
+    // has to read the same way here as an absent one or the refusal would only
+    // have moved the problem.
     assert_eq!(
         BuildStamp::parse(Some(""), Some(""), Some("0")),
         BuildStamp::default()
     );
-    // Anything but exactly `1` is clean, so a wrapper that writes `false` or
+    // Anything but exactly `1` is clean, so a deploy that writes `false` or
     // `no` does not accidentally mark every build dirty.
     assert!(!BuildStamp::parse(None, None, Some("true")).dirty);
 }
 
-/// The date arithmetic, at the instants that break a wrong implementation.
-///
-/// A leap day, a century that is not a leap year, and a time before the epoch:
-/// each of the three is a different way to get the arithmetic wrong, and none
-/// of them is reachable by a test that only uses today's date.
+// ---------------------------------------------------------------------------
+// how often it says it
+// ---------------------------------------------------------------------------
+
+/// Each unit, and the second on either side of every boundary between them.
 #[test]
-fn the_clock_is_utc_and_survives_the_awkward_dates() {
-    assert_eq!(utc_minute(0), "1970-01-01 00:00 UTC");
-    assert_eq!(utc_minute(1_000_000_000), "2001-09-09 01:46 UTC");
-    assert_eq!(utc_minute(1_785_348_240), "2026-07-29 18:04 UTC");
-    // 2000 is divisible by 400, so it has a 29th of February.
-    assert_eq!(utc_minute(951_782_400), "2000-02-29 00:00 UTC");
-    // 2100 is divisible by 100 and not by 400, so it does not.
-    assert_eq!(utc_minute(4_107_542_400), "2100-03-01 00:00 UTC");
-    // Before the epoch, which is where a truncating division goes wrong.
-    assert_eq!(utc_minute(-1), "1969-12-31 23:59 UTC");
+fn the_age_reads_in_the_coarsest_unit_that_still_says_something() {
+    assert_eq!(relative_age(COMMITTED_AT, COMMITTED_AT), "just now");
+    assert_eq!(relative_age(COMMITTED_AT, COMMITTED_AT + 59), "just now");
+    assert_eq!(relative_age(COMMITTED_AT, COMMITTED_AT + MINUTE), "1m ago");
+    assert_eq!(
+        relative_age(COMMITTED_AT, COMMITTED_AT + HOUR - 1),
+        "59m ago"
+    );
+    assert_eq!(relative_age(COMMITTED_AT, COMMITTED_AT + HOUR), "1h ago");
+    assert_eq!(
+        relative_age(COMMITTED_AT, COMMITTED_AT + DAY - 1),
+        "23h ago"
+    );
+    assert_eq!(relative_age(COMMITTED_AT, COMMITTED_AT + DAY), "1d ago");
+    assert_eq!(
+        relative_age(COMMITTED_AT, COMMITTED_AT + 90 * DAY),
+        "90d ago"
+    );
+}
+
+/// A host whose clock is behind the machine that made the commit reads the
+/// build as being from the future. `in -3m` on a boss bar is a worse answer
+/// than a slightly early "just now".
+#[test]
+fn a_build_from_the_future_reads_as_just_now() {
+    assert_eq!(relative_age(COMMITTED_AT, COMMITTED_AT - DAY), "just now");
+    assert_eq!(relative_age(COMMITTED_AT, i64::MIN), "just now");
+}
+
+/// The packet budget, as arithmetic anybody can check.
+///
+/// This is the claim `module::build_stamp`'s own documentation makes -- at most
+/// 60 packets per viewer in the first hour, 23 more across the rest of the
+/// first day, one a day after -- restated as the number of distinct strings the
+/// wording takes, because `show_build_stamp` sends exactly when that string
+/// changes. Sampled every second, which is finer than the finest unit, so a
+/// wording that read to the second would fail this by a factor of sixty.
+#[test]
+fn the_wording_changes_at_most_sixty_times_in_the_first_hour() {
+    let distinct = |from: i64, to: i64| {
+        let mut seen: Vec<String> = Vec::new();
+        for second in from..to {
+            let rendered = relative_age(COMMITTED_AT, COMMITTED_AT + second);
+            if seen.last() != Some(&rendered) {
+                seen.push(rendered);
+            }
+        }
+        seen.len()
+    };
+
+    // "just now", then one string per minute for the other fifty-nine.
+    assert_eq!(distinct(0, HOUR), 60);
+    // Twenty-three more for the rest of the day.
+    assert_eq!(distinct(HOUR, DAY), 23);
+    // And one for the whole of the second day.
+    assert_eq!(distinct(DAY, 2 * DAY), 1);
 }
 
 // ---------------------------------------------------------------------------
-// that it reaches a player, once
+// that it reaches a player
 // ---------------------------------------------------------------------------
 
 /// Every stamp a player was sent, in order.
@@ -169,25 +243,47 @@ fn stamps_to(game: &Game, player: PlayerId) -> Vec<String> {
 #[test]
 fn a_player_is_told_what_build_they_are_standing_in() {
     let mut game = Game::new();
-    game.world.set(clean());
+    game.world.set(timeless());
     game.player("p", Vec3::new(0.0, 100.0, 0.0));
     game.advance(0.05, 1);
 
     assert_eq!(stamps_to(&game, PlayerId(1)), vec![
-        "build 8f3a21c \u{b7} 2026-07-29 18:04 UTC".to_owned()
+        "build 8f3a21c".to_owned()
     ]);
+}
+
+/// The age is on the bar a real player receives, and not only in the pure
+/// function's return value.
+///
+/// The age itself cannot be pinned here -- it is measured against the wall
+/// clock, so the exact string depends on when the test runs -- but its shape
+/// can, and its shape is what would be missing if the system rendered the
+/// stamp without a clock.
+#[test]
+fn the_bar_a_player_receives_carries_an_age() {
+    let mut game = Game::new();
+    game.world.set(clean());
+    game.player("p", Vec3::new(0.0, 100.0, 0.0));
+    game.advance(0.05, 1);
+
+    let stamps = stamps_to(&game, PlayerId(1));
+    let [only] = stamps.as_slice() else {
+        panic!("expected exactly one stamp, got {stamps:?}");
+    };
+    assert!(only.starts_with("build 8f3a21c \u{b7} "), "{only}");
+    assert!(only.ends_with(" ago"), "{only}");
 }
 
 /// Once, and not once a tick.
 ///
 /// Four hundred ticks with a lobby short enough to run a whole match inside
 /// them, so the run crosses every phase change the game has and the match bar
-/// beside this one is rewritten hundreds of times. The stamp is still one
-/// call, because the tag the system adds is what stops the query matching.
+/// beside this one is rewritten hundreds of times. The stamp is still one call,
+/// because the system compares what it would send against what it sent.
 #[test]
 fn the_stamp_is_sent_once_and_not_once_a_tick() {
     let mut game = Game::new();
-    game.world.set(clean());
+    game.world.set(timeless());
     game.world.set(LobbyConfig {
         min_players: 2,
         full_players: 4,
@@ -218,9 +314,9 @@ fn the_stamp_is_sent_once_and_not_once_a_tick() {
 
     for player in [PlayerId(1), PlayerId(2)] {
         let stamps = stamps_to(&game, player);
-        // The count and one example, not the whole run: a bar resent every
-        // tick produces four hundred identical strings, and a failure nobody
-        // can read is one nobody acts on.
+        // The count and one example, not the whole run: a bar resent every tick
+        // produces four hundred identical strings, and a failure nobody can
+        // read is one nobody acts on.
         assert_eq!(
             stamps.len(),
             1,
@@ -239,7 +335,7 @@ fn the_stamp_is_sent_once_and_not_once_a_tick() {
 #[test]
 fn a_late_joiner_gets_the_stamp_and_nobody_else_gets_it_twice() {
     let mut game = Game::new();
-    game.world.set(clean());
+    game.world.set(timeless());
     game.player("early", Vec3::new(0.0, 100.0, 0.0));
     game.advance(1.0, 20);
     assert_eq!(stamps_to(&game, PlayerId(1)).len(), 1);
@@ -260,19 +356,52 @@ fn a_late_joiner_gets_the_stamp_and_nobody_else_gets_it_twice() {
     );
 }
 
-/// Every slot is in `BarSlot::ALL`, and its index is a place inside an array
-/// of `BarSlot::COUNT`.
+/// A reload changes the stamp under a standing player, and their bar follows.
 ///
-/// `adapter::PlayerBars` is `[Option<Entity>; BarSlot::COUNT]` and is written
-/// at `slot.index()`, in a system in the server's `PostUpdate`. If those two
-/// ever disagree the failure is an out-of-bounds panic on a live server the
-/// first tick anybody writes the new slot, which is the worst place to find
-/// out and is why this is pinned here rather than trusted.
+/// This is the behaviour hot reload needs and the old once-per-player tag could
+/// not express: `init_game` re-reads `--build-stamp` on every accepted reload
+/// and writes this singleton, and every player standing there has to end up
+/// reading the new build rather than the one they joined under. The same
+/// comparison is what makes the age advance on its own, and there is no way to
+/// exercise that here without controlling the wall clock -- so it is exercised
+/// through the other thing that changes the rendered string.
+#[test]
+fn a_stamp_that_changes_reaches_the_players_already_standing_there() {
+    let mut game = Game::new();
+    game.world.set(timeless());
+    game.player("a", Vec3::new(0.0, 100.0, 0.0));
+    game.player("b", Vec3::new(4.0, 100.0, 0.0));
+    game.advance(1.0, 20);
+    game.server.take();
+
+    game.world.set(BuildStamp {
+        rev: Some("deadbee".to_owned()),
+        ..timeless()
+    });
+    game.advance(1.0, 20);
+
+    for player in [PlayerId(1), PlayerId(2)] {
+        assert_eq!(
+            stamps_to(&game, player),
+            vec!["build deadbee".to_owned()],
+            "{player:?} is still being told about the build they joined under"
+        );
+    }
+}
+
+/// Every slot is in `BarSlot::ALL`, and its index is a place inside an array of
+/// `BarSlot::COUNT`.
+///
+/// `adapter::PlayerBars` is `[Option<Entity>; BarSlot::COUNT]` and is written at
+/// `slot.index()`, in a system in the server's `PostUpdate`. If those two ever
+/// disagree the failure is an out-of-bounds panic on a live server the first
+/// tick anybody writes the new slot, which is the worst place to find out and is
+/// why this is pinned here rather than trusted.
 #[test]
 fn every_slot_is_in_all_and_indexes_into_it() {
-    // Exhaustive on purpose. A new variant makes this match fail to compile,
-    // so whoever adds one is sent here, and here is where `BarSlot::ALL` is
-    // checked to have grown with it.
+    // Exhaustive on purpose. A new variant makes this match fail to compile, so
+    // whoever adds one is sent here, and here is where `BarSlot::ALL` is checked
+    // to have grown with it.
     let listed: Vec<BarSlot> = vec![BarSlot::Hud, BarSlot::Build]
         .into_iter()
         .inspect(|slot| match slot {
@@ -297,13 +426,13 @@ fn every_slot_is_in_all_and_indexes_into_it() {
 
 /// The stamp goes to its own slot, so it can never overwrite the match bar.
 ///
-/// Both bars are pushed on the tick a player joins. Without the slot the
-/// second of the two would replace the first on the client, and which one
-/// survived would depend on the order two systems happened to be declared in.
+/// Both bars are pushed on the tick a player joins. Without the slot the second
+/// of the two would replace the first on the client, and which one survived
+/// would depend on the order two systems happened to be declared in.
 #[test]
 fn the_stamp_and_the_match_bar_are_different_bars() {
     let mut game = Game::new();
-    game.world.set(clean());
+    game.world.set(timeless());
     game.player("p", Vec3::new(0.0, 100.0, 0.0));
     game.advance(0.05, 1);
 

--- a/flake.nix
+++ b/flake.nix
@@ -1248,10 +1248,13 @@
 
           # Named once and used by both `packages` and the sandboxed checks, so
           # a gate runs the same binary the flake publishes rather than a second
-          # build of it. `packages.smash` wraps this one in the build stamp's
-          # environment rather than replacing it: the executable a gate runs and
-          # the executable a host runs are the same file, and what differs is
-          # three variables. See `stamped` for why the gates are left unwrapped.
+          # build of it.
+          #
+          # These are `cargoUnit` builds with no `-C prefer-dynamic`, so they
+          # link nothing from the workspace dynamically and a module loaded into
+          # one would get its own component-index pool. They are the developer's
+          # server and the gates' server; what a host runs is
+          # `hotReloadPackages.<event>-server`. See nix/hot-reload/packaging.nix.
           gameBinaries = {
             bedwars = named "bedwars" workspace.binaries.bedwars;
             smash = named "smash" workspace.binaries.smash;
@@ -1265,102 +1268,6 @@
             bedwars = named "bedwars" devWorkspace.binaries.bedwars;
             smash = named "smash" devWorkspace.binaries.smash;
           };
-
-          # What build this is, for the strip across a player's screen. Read by
-          # `events/smash/src/module/build_stamp.rs`.
-          buildStamp =
-            let
-              # `self.shortRev` exists only on a clean tree and
-              # `self.dirtyShortRev` only on a dirty one, and a source with no
-              # git in it -- a plain directory, a tarball -- has neither.
-              # Dirtiness is carried by its own variable rather than by the
-              # `-dirty` suffix nix appends, so the game states the fact instead
-              # of parsing a string for it, and so the rev on screen is a hash a
-              # person can paste into `git show`.
-              rev = self.shortRev or (lib.removeSuffix "-dirty" (self.dirtyShortRev or ""));
-            in
-            {
-              inherit rev;
-
-              # `self.lastModified` is the commit's COMMITTER date, and it is
-              # the same number on a dirty tree as on a clean one: nix asks git
-              # for the commit either way rather than falling back to a file
-              # mtime. Measured on this repo at d55a336 -- 1785386760 clean,
-              # 1785386760 dirty, `git log -1 --format=%ct` 1785386760.
-              #
-              # Committer and not author, which are 1785385579 and 1785386760 on
-              # that same commit because it was amended. So a rebased commit's
-              # bar reads when the rebase landed rather than when the work was
-              # written. That is the right answer for the question this bar
-              # exists for -- which build is deployed, and how long ago did that
-              # build come into being -- and it is the wrong answer for "when
-              # was this change authored", which the bar does not claim.
-              #
-              # Nothing at all when there is no rev, and that is the point of
-              # the conditional rather than a nicety. `lastModified` on a
-              # non-git source is the directory's mtime, so without this the bar
-              # renders `build unpackaged build · 2026-07-29 20:41 UTC`: a stamp
-              # that has just admitted it does not know what it is, timed to the
-              # minute. An empty string parses as absent in `BuildStamp::parse`
-              # and the bar drops the whole clause.
-              time = if rev == "" then "" else toString (self.lastModified or 0);
-
-              dirty = if self ? dirtyShortRev then "1" else "0";
-            };
-
-          # The stamp, as an environment a binary is started in.
-          #
-          # A wrapper and not `env!` in a build script, and the difference is
-          # the whole reason this exists: a commit hash compiled into a crate
-          # invalidates that crate and everything downstream on every commit, so
-          # every push would rebuild the workspace. This derivation is a symlink
-          # and three assignments, and it is the only thing a new commit
-          # rebuilds.
-          #
-          # Applied to `packages` and deliberately NOT to the binaries the e2e
-          # gates run. cargoUnit content-addresses every crate unit, so a commit
-          # that changes no smash source leaves the gate's binary bit for bit
-          # identical and the whole gate is reused from the store. Stamping it
-          # would move its path on every commit and re-run all fourteen e2e
-          # gates for a string none of them reads. The gates cover the *reading*
-          # of these variables instead, which is the half that can be wrong in
-          # Rust; `checks.build-stamp` below covers the writing.
-          #
-          # THE COST, AND IT LANDS ON PLAYERS RATHER THAN ON CI. This wrapper's
-          # store path moves on every commit, `packages.smash` is it, and
-          # `nix/modules/game-server.nix` builds `ExecStart` out of
-          # `packages.smash`. So the unit file changes on every commit and
-          # `switch-to-configuration` restarts `hyperion-game-server` on every
-          # deploy -- including deploys of commits that touch nothing in smash,
-          # which used to leave `ExecStart` byte-identical and the running
-          # server alone. A restart drops every connected player.
-          #
-          # The restart is required by the feature: a server cannot report a
-          # commit it was not started with. The SCOPE is not. Narrowing it means
-          # decoupling the stamp from the unit -- an `EnvironmentFile` the
-          # deploy writes, or a stamp read from a path rather than baked into
-          # `ExecStart` -- and that is a different change with its own failure
-          # mode, namely a stamp that can disagree with the binary beside it.
-          # Written down here rather than left to be discovered, because with
-          # continuous apply on, "redeployed as main moves" now means every
-          # player is dropped as main moves.
-          stamped = drv:
-            let
-              main = drv.meta.mainProgram;
-            in
-            pkgs.runCommand "${drv.name}-stamped"
-              {
-                inherit (drv) meta;
-                nativeBuildInputs = [ pkgs.makeWrapper ];
-                passthru = (drv.passthru or { }) // { unstamped = drv; };
-              }
-              ''
-                makeWrapper ${drv}/bin/${main} "$out/bin/${main}" \
-                  --set HYPERION_BUILD_REV ${lib.escapeShellArg buildStamp.rev} \
-                  --set HYPERION_BUILD_TIME ${lib.escapeShellArg buildStamp.time} \
-                  --set HYPERION_BUILD_DIRTY ${lib.escapeShellArg buildStamp.dirty}
-              '';
-
           # `nix run .#fmt -- --check` and `nix run .#lint`, as derivations the
           # gate realises. ENG-11424.
           #
@@ -1503,6 +1410,148 @@
                     touch $out
                   ''
                 );
+
+            # THE PACKAGED SERVER STARTS. Nothing else here runs it.
+            #
+            # Every gate that boots a game server boots `gameBinaries.smash`, a
+            # `cargoUnit` build with no `-C prefer-dynamic`. The binary a host
+            # actually runs is `smash-server`, and until this check existed it
+            # was only ever `readelf`-ed, `ldd`-ed and store-path-diffed --
+            # never executed. It had been segfaulting on startup since the day
+            # it was first built, in every build, and every gate was green
+            # (ENG-12112): a `#[global_allocator]` cannot coexist with the
+            # dylib split, because rustc makes each dylib's `__rust_alloc`
+            # local and the process ends up with two allocators.
+            #
+            # `--help` is the whole test, and that is the point: it costs
+            # milliseconds, it needs no certificates, no world and no network,
+            # and it exercises the dynamic loader, every static initialiser and
+            # the first few thousand allocations -- which is where a binary
+            # that cannot start dies.
+            hot-reload-server-starts =
+              pkgs.runCommand "hyperion-hot-reload-server-starts" { }
+                (
+                  lib.concatMapStrings (event: ''
+                    server=${hotReload.events.${event.name}.server}
+                    main=${hotReload.events.${event.name}.server.meta.mainProgram}
+                    echo "starting ${event.name}: $server/bin/$main --help"
+                    if ! "$server/bin/$main" --help > help.txt 2>&1; then
+                      status=$?
+                      echo "${event.name}-server could not even print its usage" >&2
+                      echo "(exit $status; 139 is SIGSEGV). See ENG-12112." >&2
+                      cat help.txt >&2
+                      exit 1
+                    fi
+                    # A binary that exits 0 having printed nothing is not one
+                    # that started; `--help` has to have reached clap.
+                    grep -q -- "--reload-socket" help.txt || {
+                      echo "${event.name}-server printed usage without the" >&2
+                      echo "deployment flags, so it is not the binary the" >&2
+                      echo "NixOS module builds an ExecStart out of." >&2
+                      cat help.txt >&2
+                      exit 1
+                    }
+                  '') hotReloadEvents
+                  + ''
+                    touch "$out"
+                  ''
+                );
+
+            # The other half of the boundary, one layer up. `source-split`
+            # proves a rules edit moves only the rules derivation; this proves
+            # that a moved rules derivation reaches a running server as a reload
+            # rather than as a restart.
+            #
+            # `switch-to-configuration` reloads a unit whose `[Service]` section
+            # is byte-identical and whose `X-Reload-Triggers` moved, and restarts
+            # it otherwise. So the property is not "the dylib is mentioned in the
+            # right place" -- nixpkgs hashes the triggers into a file of their
+            # own and the unit names that file, so the dylib path is not in the
+            # unit at all. The property is that changing the dylib moves exactly
+            # that one line. One stray reference anywhere else turns every
+            # invisible deploy into a mass disconnection, with every other gate
+            # green, the apply exiting 0 and the server coming back up.
+            #
+            # Costs an evaluation and not a build: `hello` stands in for the game
+            # binary, and each rendered unit's string context is discarded, so
+            # nothing here realises the engine or the event.
+            hot-reload-unit-split =
+              let
+                unitWithRules =
+                  rules:
+                  builtins.unsafeDiscardStringContext
+                    (nixpkgs.lib.nixosSystem {
+                      system = "x86_64-linux";
+                      modules = [
+                        self.nixosModules.game-server
+                        {
+                          boot.loader.grub.enable = false;
+                          fileSystems."/" = {
+                            device = "/dev/disk/by-label/nixos";
+                            fsType = "ext4";
+                          };
+                          system.stateVersion = "25.05";
+                          nixpkgs.hostPlatform = "x86_64-linux";
+
+                          services.hyperion-game-server = {
+                            inherit rules;
+                            enable = true;
+                            event = "under-test";
+                            # Stand-ins, so this check answers a question about
+                            # an ini file without waiting thirteen minutes for a
+                            # build. What it must NOT stand in for is the thing
+                            # under test: `rules` is the only option that differs
+                            # between the two renderings below.
+                            package = pkgs.hello;
+                            reloadClient = pkgs.hello;
+                            pki = {
+                              rootCaCert = "/var/lib/hyperion-pki/root_ca.crt";
+                              cert = "/var/lib/hyperion-pki/node.crt";
+                              privateKey = "/var/lib/hyperion-pki/node_private_key.pem";
+                            };
+                          };
+                        }
+                      ];
+                    }).config.systemd.units."hyperion-game-server.service".text;
+              in
+              pkgs.runCommand "hyperion-hot-reload-unit-split"
+                {
+                  before = unitWithRules "/nix/store/00000000000000000000000000000000-rules-before/lib/librules.so";
+                  after = unitWithRules "/nix/store/11111111111111111111111111111111-rules-after/lib/librules.so";
+                }
+                ''
+                  printf '%s\n' "$before" > before.ini
+                  printf '%s\n' "$after" > after.ini
+
+                  # The control. Two identical units would satisfy every
+                  # assertion below about what did not change, so the one thing
+                  # that has to move is checked first.
+                  if cmp -s before.ini after.ini; then
+                    echo "a new build of the rules did not change the unit at all," >&2
+                    echo "so systemd would never be told to reload it." >&2
+                    exit 1
+                  fi
+
+                  if ! diff before.ini after.ini > delta; then :; fi
+                  if grep -E '^[<>]' delta | grep -v '^[<>] X-Reload-Triggers='; then
+                    echo "" >&2
+                    echo "a new build of the rules moved something other than" >&2
+                    echo "X-Reload-Triggers. switch-to-configuration restarts a unit" >&2
+                    echo "whose [Service] changed, so this deploy would drop every" >&2
+                    echo "connected player. See nix/modules/game-server.nix." >&2
+                    exit 1
+                  fi
+
+                  # A reload trigger with nothing to run it is a restart with
+                  # extra steps: systemd refuses `systemctl reload` on a unit
+                  # with no ExecReload.
+                  grep -q '^ExecReload=' before.ini || {
+                    echo "the unit has no ExecReload, so a reload cannot happen." >&2
+                    exit 1
+                  }
+
+                  cp before.ini "$out"
+                '';
 
             hot-reload-index-probe = pkgs.runCommandCC "hyperion-hot-reload-index-probe" {
               inherit nativeBuildInputs;
@@ -1889,77 +1938,6 @@
             e2e-ports-distinct = e2ePortsDistinct;
             test-util-is-dev-only = testUtilIsDevOnly;
 
-            # The deployed smash binary starts in an environment that says what
-            # build it is. See `stamped` and
-            # `events/smash/src/module/build_stamp.rs`.
-            #
-            # The Rust half is covered by `cargo test -p smash --test
-            # build_stamp`, which pins what each of these three values turns
-            # into on screen. Nothing covered that half's *input* until this:
-            # a rename, a dropped `--set`, or a `buildStamp` attribute that
-            # stopped being threaded all read as a server quietly saying
-            # "unpackaged build" to every player, which is exactly the state
-            # this whole change exists to end and is invisible from any test
-            # that does not look at the wrapper.
-            build-stamp =
-              pkgs.runCommand "hyperion-build-stamp"
-                {
-                  wrapper = lib.getExe (stamped gameBinaries.smash);
-                  binary = lib.getExe gameBinaries.smash;
-                  inherit (buildStamp) rev time dirty;
-                }
-                ''
-                  fail() { echo "FAIL: $1" >&2; exit 1; }
-
-                  # The control. Everything below is a grep, and a grep against
-                  # a file that is not there, or is a binary, or is empty,
-                  # fails for reasons that have nothing to do with the stamp.
-                  [ -f "$wrapper" ] || fail "no wrapper at $wrapper"
-                  grep -qF -- "$binary" "$wrapper" \
-                    || fail "the wrapper does not exec $binary"
-
-                  for name in REV TIME DIRTY; do
-                    grep -q "HYPERION_BUILD_$name=" "$wrapper" \
-                      || fail "the wrapper sets no HYPERION_BUILD_$name"
-                  done
-
-                  # A rev is empty exactly when nix had no git to ask, which is
-                  # true of a tarball and of a plain directory, and is not a
-                  # failure.
-                  if [ -n "$rev" ]; then
-                    # Hex and nothing else. Every other assertion here compares
-                    # the wrapper against the same expression that built it, so
-                    # on VALUES they are tautologies -- if nix changed the
-                    # suffix `removeSuffix` strips, both sides would move
-                    # together and this file would stay green while the bar read
-                    # `abc1234-dirty + uncommitted changes`. What a short commit
-                    # hash looks like is the one property of the value that does
-                    # not come from the expression, so it is the only thing here
-                    # that can catch a wrong one.
-                    case "$rev" in
-                      *[!0-9a-f]*)
-                        fail "the rev is not a short commit hash: $rev" ;;
-                    esac
-                    [ -n "$time" ] \
-                      || fail "there is a rev but no timestamp beside it"
-                    grep -q "HYPERION_BUILD_REV=.*$rev" "$wrapper" \
-                      || fail "the wrapper does not carry the rev $rev"
-                    grep -q "HYPERION_BUILD_TIME=.*$time" "$wrapper" \
-                      || fail "the wrapper does not carry the timestamp $time"
-                  else
-                    # And no timestamp either. A precise minute next to a stamp
-                    # that has just said it does not know what build it is comes
-                    # from `lastModified` falling back to a directory mtime, and
-                    # is worse than saying nothing.
-                    [ -z "$time" ] \
-                      || fail "no rev, but a timestamp of $time: that is a directory mtime dressed as a commit"
-                    echo "no rev: this flake source is not a git tree" >&2
-                  fi
-                  grep -q "HYPERION_BUILD_DIRTY=.*'$dirty'" "$wrapper" \
-                    || fail "the wrapper does not carry dirty=$dirty"
-
-                  echo "rev=$rev time=$time dirty=$dirty" > "$out"
-                '';
 
             # A colour reaches a client as a component field or not at all.
             smash-text-no-legacy-formatting = textGate;
@@ -2099,12 +2077,11 @@
 
           packages = hotReloadPackages // {
             default = gameBinaries.bedwars;
-            # smash is stamped and the other two are not, because smash is the
-            # only one that reads the stamp: `nix/modules/game-server.nix`
-            # builds its ExecStart out of this package, so this is what puts a
-            # commit on a player's screen on the deployed server.
-            smash = stamped gameBinaries.smash;
-            inherit (gameBinaries) bedwars hyperion-proxy;
+            # `nix run .#smash` and the e2e gates. It says "unpackaged build" on
+            # its boss bar, which is the truth: the stamp is three files in a
+            # directory a deployment names on the command line, and nobody named
+            # one. `packages.smash-server` is what a host runs.
+            inherit (gameBinaries) smash bedwars hyperion-proxy;
             rust-mc-bot = named "rust-mc-bot" workspace.binaries.rust-mc-bot;
             inherit (hotReload) hyperion-dylibs;
 
@@ -2152,12 +2129,65 @@
       # machine evaluates them. Taken from `mkSystem` rather than from
       # `self.packages` so the fleet does not depend on the attribute set it
       # contributes to.
+      # What build this is, for the strip across a player's screen. Written into
+      # `/etc/hyperion` by `nix/modules/game-server.nix` and read at runtime by
+      # `events/smash/src/module/build_stamp.rs`.
+      #
+      # Out here rather than inside `mkSystem` because it is a property of this
+      # source and not of any machine, and because the fleet needs it: a stamp
+      # that were computed per system could disagree with itself across two
+      # evaluations of the same commit.
+      #
+      # FILES AND NOT AN ENVIRONMENT, and the difference is the whole reason
+      # this moved. It used to be three `--set`s on a `makeWrapper` around the
+      # smash binary, which put a per-commit store path inside `ExecStart` and
+      # therefore restarted the game server on every deploy -- including deploys
+      # of commits that touch nothing in smash. A restart drops every connected
+      # player. Now the stamp is beside the unit rather than inside it, so a
+      # commit can change what the bar says without changing `[Service]`.
+      buildStamp =
+        let
+          # `self.shortRev` exists only on a clean tree and `self.dirtyShortRev`
+          # only on a dirty one, and a source with no git in it -- a plain
+          # directory, a tarball -- has neither. Dirtiness is carried on its own
+          # rather than by the `-dirty` suffix nix appends, so the game states
+          # the fact instead of parsing a string for it, and so the rev on
+          # screen is a hash a person can paste into `git show`.
+          rev = self.shortRev or (nixpkgs.lib.removeSuffix "-dirty" (self.dirtyShortRev or ""));
+        in
+        {
+          inherit rev;
+
+          # `self.lastModified` is the commit's COMMITTER date, and it is the
+          # same number on a dirty tree as on a clean one: nix asks git for the
+          # commit either way rather than falling back to a file mtime. Measured
+          # on this repo at d55a336 -- 1785386760 clean, 1785386760 dirty,
+          # `git log -1 --format=%ct` 1785386760.
+          #
+          # Committer and not author, which are 1785385579 and 1785386760 on
+          # that same commit because it was amended. So a rebased commit's bar
+          # reads when the rebase landed rather than when the work was written.
+          # That is the right answer for the question this bar exists for --
+          # which build is deployed, and how long ago did that build come into
+          # being -- and it is the wrong answer for "when was this change
+          # authored", which the bar does not claim.
+          #
+          # Null when there is no rev, and that is the point of the conditional
+          # rather than a nicety. `lastModified` on a non-git source is the
+          # directory's mtime, so without this the bar renders `build unpackaged
+          # build · 3d ago`: a stamp that has just admitted it does not know what
+          # it is, aged to the day.
+          committedAt = if rev == "" then null else self.lastModified or 0;
+
+          dirty = self ? dirtyShortRev;
+        };
+
       fleet =
         let
           guest = mkSystem "x86_64-linux";
         in
         import ./nix/fleet {
-          inherit index;
+          inherit index buildStamp;
           guestPackages = guest.packages;
           guestDevEnvironment = guest.devEnvironment;
           inherit (self) nixosModules;

--- a/nix/fleet/README.md
+++ b/nix/fleet/README.md
@@ -647,8 +647,8 @@ looking like it recovers the current one.
 
 ## Apply from a checkout of `main`, not from a branch
 
-`nix build` and `ix apply` from a feature branch stamp that branch's commit into
-`HYPERION_BUILD_REV`, and the game puts it on a boss bar in front of every
+`nix build` and `ix apply` from a feature branch write that branch's commit into
+`/etc/hyperion/build-rev`, and the game puts it on a boss bar in front of every
 player. A branch commit is not reachable from `main`, so `git show <rev>` on a
 fresh clone returns nothing and the natural conclusion is that the clone is
 stale rather than that the stamp is meaningless.
@@ -656,17 +656,23 @@ stale rather than that the stamp is meaningless.
 It happened on 2026-07-30: the live server advertised `33e0d33` for ten minutes.
 **Every other signal was green** -- apply exit 0, four `✓ ready`,
 `NRestarts=0`, the `drv^out` identity check matching, the endpoint serving.
-Nothing surfaces this except reading the deployed wrapper:
+Nothing surfaces this except reading the stamp on the host:
 
 ```sh
-ix shell hyperion-game -- sh -c \
-  'E=$(systemctl cat hyperion-game-server.service | grep -o "/nix/store/[^ ]*-smash-0.1.0-stamped");
-   grep -o "HYPERION_BUILD_[A-Z]*=.[^\x27]*." "$E/bin/smash"'
+ix shell hyperion-game -- sh -c 'head -n1 /etc/hyperion/build-rev'
 ```
 
 Treat that as a standing post-apply check, and confirm the rev is one
 `git merge-base --is-ancestor <rev> origin/main` accepts. ENG-11491 tracks
 making the apply refuse an unreachable rev rather than relying on the habit.
+
+**The file is what the deploy wrote; the bar is what the server has read.** They
+are the same as of the last reload or restart, and only then. A deploy whose
+rules dylib did not move still reloads -- the stamp is one of the unit's reload
+triggers for exactly this reason -- so in practice the two agree within a
+second of the apply. If they disagree for longer, the reload was refused, and
+`journalctl -u hyperion-game-server -p err` has the reason in the gate's own
+words.
 
 ## A dev machine in the fleet
 

--- a/nix/fleet/default.nix
+++ b/nix/fleet/default.nix
@@ -58,6 +58,10 @@
   # binding rather than two lists, so a VM built to develop hyperion on cannot
   # end up with a different compiler than `nix develop` hands a contributor.
   guestDevEnvironment,
+  # What commit this is, and when it was made. Lands in `/etc/hyperion` on the
+  # game node rather than in the unit, which is what lets a deploy change the
+  # build without restarting the server. See flake.nix.
+  buildStamp,
 }:
 index.lib.mkFleet {
   # One private segment. A VM outside it has no route to the game server,
@@ -66,9 +70,16 @@ index.lib.mkFleet {
     {ix.networking.groups = ["hyperion"];}
     {
       _module.args = {
-        hyperionGameServer = guestPackages.smash;
+        # `smash-server` and not `smash`: the latter is a `cargoUnit` build that
+        # links nothing from the workspace dynamically, so a rules dylib loaded
+        # into it would get its own component-index pool. Only this pair shares
+        # one engine image. See nix/hot-reload/packaging.nix.
+        hyperionGameServer = guestPackages.smash-server;
+        hyperionRules = guestPackages.smash-rules;
+        hyperionReloadClient = guestPackages.hyperion-dylibs;
         hyperionProxy = guestPackages.hyperion-proxy;
         hyperionDevEnvironment = guestDevEnvironment;
+        inherit buildStamp;
       };
     }
     ./pki.nix

--- a/nix/fleet/game.nix
+++ b/nix/fleet/game.nix
@@ -2,7 +2,11 @@
 # group, and a VM outside the group has no route here at all.
 {
   config,
+  lib,
   hyperionGameServer,
+  hyperionRules,
+  hyperionReloadClient,
+  buildStamp,
   ...
 }: let
   port = 35565;
@@ -43,6 +47,22 @@ in {
   services.hyperion-game-server = {
     enable = true;
     package = hyperionGameServer;
+    event = "smash";
+
+    # The one store path that is allowed to move on a rules-only deploy. The
+    # module puts it in `X-Reload-Triggers` and nowhere else, so a build that
+    # changes only this reaches the running server as `systemctl reload` and
+    # nobody is disconnected. Everything else -- a component's layout, the
+    # engine -- moves `ExecStart` instead and is a restart, which is correct: a
+    # system compiled against a layout the world no longer holds is memory
+    # corruption rather than a stale build.
+    rules = "${hyperionRules}/lib/${hyperionRules.dylibName}";
+    reloadClient = hyperionReloadClient;
+
+    buildStamp = {
+      inherit (buildStamp) rev committedAt dirty;
+    };
+
     inherit port;
     pki = {
       rootCaCert = "/var/lib/hyperion-pki/root_ca.crt";

--- a/nix/hot-reload/packaging.nix
+++ b/nix/hot-reload/packaging.nix
@@ -114,7 +114,18 @@ let
   # The engine packages every event links, ahead of the events themselves so
   # that a one-event workspace produces the selection string this was measured
   # against.
-  enginePackages = [ "hyperion" "hyperion-hot-reload" ];
+  #
+  # `hyperion-reload-client` is here rather than in its own derivation because
+  # it has to be built under the same selection string as everything else -- see
+  # `selection` below, which is a property of the whole list and not of any one
+  # package. It links none of the engine (it has no dependencies at all), so
+  # putting it in this list costs a compile of one small binary and buys the
+  # guarantee that adding it did not move anybody else's `-C metadata`.
+  enginePackages = [ "hyperion" "hyperion-hot-reload" "hyperion-reload-client" ];
+
+  # What `ExecReload` runs. Named once so the NixOS module and this file cannot
+  # disagree about it.
+  reloadClient = "hyperion-reload-client";
   eventPackages = lib.concatMap (event: [
     (packageNameOf event.hostCrate)
     (packageNameOf event.rulesCrate)
@@ -286,7 +297,14 @@ let
       fi
     done
 
-    mkdir -p "$out/lib" "$out/share"
+    mkdir -p "$out/bin" "$out/lib" "$out/share"
+
+    # The reload client ships from here, with the engine, and not from an
+    # event's derivation. `ExecReload` names it, and `[Service]` moving is
+    # exactly what turns a reload into a restart -- so the path in it must not
+    # be a function of any event's source. This output moves only on an engine
+    # change, which moves `ExecStart` too and is a restart anyway.
+    cp target/${profile}/${reloadClient} "$out/bin/${reloadClient}"
     # `deps/` as well as the profile directory: cargo leaves an unhashed copy of
     # a workspace member's dylib in `target/${profile}`, but a dependency's
     # dylib only in `deps/`, under the metadata hash DT_NEEDED actually names.
@@ -305,6 +323,9 @@ let
         patchelf --set-rpath '$ORIGIN':${sysrootLib} "$shared"
       done
     ''}
+    ${setRunPath [ ] ''"$out/bin/${reloadClient}"''}
+    ${requireResolved ''"$out/bin/${reloadClient}"''}
+
     tar -C target -cf "$out/share/cargo-target.tar" ${profile}
   '';
 
@@ -350,7 +371,11 @@ let
 
       # What `X-Reload-Triggers` names, and the only path a rules-only change is
       # allowed to move.
-      rules = pkgs.runCommandCC "${event.name}-rules" common ''
+      #
+      # `dylibName` is passthru rather than a convention a consumer has to know,
+      # because cargo spells the file after the crate and `nix/fleet` would
+      # otherwise be a second place that has to agree with cargo about it.
+      rules = pkgs.runCommandCC "${event.name}-rules" (common // { passthru.dylibName = rulesLib; }) ''
         ${setup rulesSource}
         ${seed}
         export RUSTFLAGS=${lib.escapeShellArg rustFlags}
@@ -373,7 +398,7 @@ let
     };
 in
 {
-  inherit hyperion-dylibs dylibSource;
+  inherit hyperion-dylibs dylibSource reloadClient;
   # Keyed by event name so a consumer names the game rather than a path.
   events = lib.listToAttrs (
     map (event: lib.nameValuePair event.name (forEvent event)) events

--- a/nix/modules/game-server.nix
+++ b/nix/modules/game-server.nix
@@ -5,12 +5,42 @@
 # game server, not the other way round, so this node needs one address its
 # proxies can reach and nothing else. Put it on a private network and give the
 # proxies the public ones.
+#
+# ---------------------------------------------------------------------------
+# RELOAD, AND THE ONE RULE THAT MAKES IT WORK
+# ---------------------------------------------------------------------------
+#
+# `switch-to-configuration` reloads a unit whose `[Service]` section is
+# byte-identical and whose `X-Reload-Triggers` differs, and restarts it
+# otherwise. So the rules dylib's store path may appear in exactly one place in
+# this file -- `reloadTriggers` -- and `ExecStart` must reach the same file
+# through a path that does not move, which is what `/etc/hyperion` is for.
+#
+# That is a property worth checking rather than trusting, because getting it
+# wrong is invisible: every gate passes, the deploy succeeds, and the only
+# symptom is that players were dropped on a deploy that should have been
+# invisible to them. `checks.hot-reload-unit-split` renders this unit for two
+# builds of the rules and asserts that `[Service]` did not move.
 { hyperionPackages }:
 { config, lib, pkgs, ... }:
 let
   cfg = config.services.hyperion-game-server;
   common = import ./common.nix { inherit lib; };
-  inherit (lib) mkOption mkEnableOption mkIf types escapeShellArgs;
+  inherit (lib) mkOption mkEnableOption mkIf types escapeShellArgs optionals;
+
+  # Where the deploy writes what the server reads, and where the server reads it
+  # from. One directory, named after the engine rather than after a game,
+  # because a host runs one game server and the build stamp in it is the host's.
+  etcDir = "hyperion";
+  rulesFile = "/etc/${etcDir}/${cfg.event}-rules.so";
+  stampDir = "/etc/${etcDir}";
+
+  # `RuntimeDirectory` below is what creates this, and `ProtectSystem = strict`
+  # is what makes it the only writable place the unit has.
+  runtimeDir = "hyperion-game-server";
+  socket = "/run/${runtimeDir}/reload.sock";
+
+  reloadable = cfg.rules != null;
 in
 {
   options.services.hyperion-game-server = {
@@ -24,6 +54,88 @@ in
         The event to run. One binary is one game: `bedwars` and `smash` are
         separate packages rather than a flag, because an event is compiled in.
       '';
+    };
+
+    event = mkOption {
+      type = types.str;
+      default = "hyperion";
+      description = ''
+        What this deployment calls the game. Used only to name the rules file
+        in `/etc/hyperion`, so that somebody reading that directory on a host
+        can tell which game's rules are sitting in it.
+      '';
+      example = "smash";
+    };
+
+    rules = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        The reloadable rules dylib, as a full path to the `.so` inside its
+        store path. `null` runs the server with no reloadable rules at all, and
+        every deploy is then a restart.
+
+        This store path is put in `X-Reload-Triggers` and **nowhere else in the
+        unit**. That is the whole mechanism: a deploy that changes only this
+        leaves `[Service]` untouched, and a unit whose `[Service]` did not move
+        is one systemd reloads instead of restarting.
+      '';
+      example = lib.literalExpression ''"''${hyperionPackages.x86_64-linux.smash-rules}/lib/libsmash_rules.so"'';
+    };
+
+    reloadClient = mkOption {
+      type = types.package;
+      default = hyperionPackages.${pkgs.stdenv.hostPlatform.system}.hyperion-dylibs;
+      defaultText = "the engine dylib set for this system, which ships the client";
+      description = ''
+        The package providing `hyperion-reload-client`, which is what
+        `ExecReload` runs. It ships with the engine rather than with an event
+        because `ExecReload` is part of `[Service]`: a path that moved when an
+        event's rules moved would restart the server on exactly the deploys
+        this whole feature exists to make invisible.
+      '';
+    };
+
+    buildStamp = mkOption {
+      description = ''
+        What build this deployment is, written into `/etc/hyperion` for the
+        server to read at runtime.
+
+        Files rather than environment variables, and that is the point: a
+        process's environment is fixed at `exec`, so a server that reloaded its
+        rules without restarting would report the build it started as forever.
+        See `events/smash/src/module/build_stamp.rs`.
+      '';
+      default = { };
+      type = types.submodule {
+        options = {
+          rev = mkOption {
+            type = types.str;
+            default = "";
+            description = "The short commit hash, or empty when nothing knows.";
+          };
+          committedAt = mkOption {
+            type = types.nullOr types.int;
+            default = null;
+            description = ''
+              When that commit was made, in whole seconds since the unix epoch.
+              `null` when there is no commit to date, which is the only honest
+              answer for a source with no git in it -- a directory's mtime is
+              not a commit date, and a bar reading `unpackaged build · 2h ago`
+              would be a stamp that had just admitted it does not know what it
+              is, timed to the minute.
+            '';
+          };
+          dirty = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              The working tree had uncommitted changes, so `rev` names a tree
+              this build was not made from. The game draws the bar in red.
+            '';
+          };
+        };
+      };
     };
 
     address = mkOption {
@@ -52,6 +164,18 @@ in
   };
 
   config = mkIf cfg.enable {
+    # Read by the server at startup and on every reload. Nothing here reaches
+    # the unit file, which is why a new build of the rules can land without
+    # `[Service]` changing.
+    environment.etc = {
+      "${etcDir}/build-rev".text = cfg.buildStamp.rev;
+      "${etcDir}/build-time".text =
+        if cfg.buildStamp.committedAt == null then "" else toString cfg.buildStamp.committedAt;
+      "${etcDir}/build-dirty".text = if cfg.buildStamp.dirty then "1" else "0";
+    } // lib.optionalAttrs reloadable {
+      "${etcDir}/${cfg.event}-rules.so".source = cfg.rules;
+    };
+
     systemd.services.hyperion-game-server = {
       description = "hyperion game server";
       # network-online rather than network: the bind fails outright if the
@@ -60,6 +184,24 @@ in
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
+
+      # THE ONLY PLACE THE RULES STORE PATH MAY APPEAR. See the header.
+      #
+      # The build stamp is in here too, and for a reason that is not obvious: a
+      # commit that changes nothing the server links -- documentation, CI, the
+      # proxy -- still changes what `/etc/hyperion/build-rev` says, and without
+      # a reload the running server would go on telling players about the commit
+      # before it. That is the exact question the bar exists to answer, so it
+      # has to stay true. Such a reload re-opens a byte-identical dylib and
+      # rewrites nothing; it is the code-only case `docs/hot-reload.md` measured
+      # at a few milliseconds, and it cannot be refused, because a schema can
+      # only move when the dylib does.
+      reloadTriggers = optionals reloadable [
+        cfg.rules
+        cfg.buildStamp.rev
+        (toString cfg.buildStamp.committedAt)
+        (if cfg.buildStamp.dirty then "dirty" else "clean")
+      ];
 
       serviceConfig = common.hardening // {
         Type = "simple";
@@ -70,7 +212,14 @@ in
           "--root-ca-cert" (toString cfg.pki.rootCaCert)
           "--cert" (toString cfg.pki.cert)
           "--private-key" (toString cfg.pki.privateKey)
+        ] ++ optionals reloadable [
+          # Stable paths, every one of them. Nothing on this line moves when a
+          # new build of the rules is deployed.
+          "--rules" rulesFile
+          "--reload-socket" socket
+          "--build-stamp" stampDir
         ] ++ cfg.extraArgs);
+
         Restart = "on-failure";
         RestartSec = "2s";
         StateDirectory = "hyperion-game-server";
@@ -79,6 +228,28 @@ in
         # connections' worth of buffers, so the default 1024 descriptors runs
         # out long before anything else does.
         LimitNOFILE = 1048576;
+      } // lib.optionalAttrs reloadable {
+        # The request carries no arguments -- the module path and the stamp
+        # directory were fixed at startup -- so this is a constant string, and a
+        # constant string is one that cannot move a deploy from reload back to
+        # restart. The client exits non-zero on a refusal, which fails the
+        # `systemctl reload` that asked rather than leaving the reason in a log
+        # nobody reads.
+        ExecReload = escapeShellArgs [
+          (lib.getExe' cfg.reloadClient "hyperion-reload-client")
+          socket
+        ];
+
+        # Where the reload socket lives. `ProtectSystem = strict` leaves the
+        # unit nothing else it may write to.
+        RuntimeDirectory = runtimeDir;
+
+        # AF_UNIX for that socket. `common.hardening` grants the two IP families
+        # and nothing else, so without this the server dies at startup on
+        # `socket(AF_UNIX): Address family not supported by protocol` -- and
+        # only on a real host, because nothing in a test or a gate runs under
+        # this filter.
+        RestrictAddressFamilies = common.hardening.RestrictAddressFamilies ++ [ "AF_UNIX" ];
       };
     };
   };


### PR DESCRIPTION
Third and last increment of hot reload, on top of #1116 and #1117. `ix apply` of a rules-only change now reaches the running server as `systemctl reload`, and this is what that looks like on dev-compute-6 with a player standing in the world:

```
=== before ===
MainPID=753472
NRestarts=0
$ sudo systemctl reload hyperion-proof.service      # exit 0
=== after ===
MainPID=753472
NRestarts=0

journal: INFO hot reload accepted module=smash-rules revision="c0ffee1" migrated_instances=0
journal: INFO smash rules heartbeat RELOADED-B        <- the new build's own string
player:  joined at 0.26s
player:  TITLE at 20.14s: Reloading to build c0ffee1
player:  SURVIVED 60s: keep_alives=30 last_packet=60.16s titles=1
```

Same process, no restart, the new code running, and the player who was mid-session got a title and stayed. The reload itself measured 0.058-0.091 s of wall clock across three runs.

## The wiring was the small half

Everything below the first heading is what starting the server on a real host taught. All three were already on main, all three were invisible to every gate, and none of them is caused by this change.

### `packages.smash-server` segfaulted on startup, in every build ever made of it (ENG-12112)

```
$ for p in /nix/store/*-smash-server; do printf "%s " "$p"; $p/bin/smash --help >/dev/null 2>&1; echo "rc=$?"; done
/nix/store/4gr35p3sxpv1nsssqysj5b8rkk5azfvz-smash-server rc=139
/nix/store/5z9q6905qxym21whcybg2ziw5ynn329a-smash-server rc=139
/nix/store/d8wq0jp0nmr0jqk8bi7wp1fk0533msmm-smash-server rc=139
/nix/store/wdwm2419pg3ng55dn4c9a9qf79sa7c3m-smash-server rc=139
```

139 is SIGSEGV, on `--help`: no certificates, no world, no network.

```
#0  _rjem_je_rtree_leaf_elm_lookup_hard ()
#1  do_rallocx ()
#2  <alloc::raw_vec::RawVecInner>::finish_grow ()
#4  <clap_builder::builder::arg_group::ArgGroup>::args ()
#5  <hyperion_event_runner::Args as clap_builder::derive::Args>::augment_args ()
```

jemalloc reallocating a pointer it does not own. A `#[global_allocator]` and `-C prefer-dynamic` are mutually exclusive: rustc gives every Rust dylib a version script ending `local: *` — the same fact #1116 documented for LMDB — so each dylib's `__rust_alloc` is LOCAL and uninterposable, and the process ends up with the system allocator inside the dylibs and jemalloc inside the binary.

`#[global_allocator]` is removed from both event mains, with the reason written out in `events/smash/src/main.rs`. bedwars is not packaged this way yet, but adding an event to `hotReloadEvents` is meant to be one attrset, so the landmine goes rather than waits.

**Why nothing caught it.** The fourteen e2e gates boot `gameBinaries.smash`, a cargoUnit build with no dylibs. `smash-server` was `readelf`-ed, `ldd`-ed and store-path-diffed and never executed — #1116's evidence section is entirely static analysis, and static analysis is what it was correct about. New gate `checks.hot-reload-server-starts` runs `<event>-server/bin/<main> --help` and greps for `--reload-socket`. Milliseconds, no fixtures.

### The reload loaded nothing and answered `accepted` (ENG-12113)

With the segfault fixed, the first live reload looked perfect — `MainPID` unchanged, `NRestarts` unchanged, `hot reload accepted` in the journal, `accepted smash-rules bbbbbbb` back to the client, the `/etc` symlink pointing at the new build. And:

```
$ sudo grep -o '/nix/store/[^ ]*smash_rules[^ ]*' /proc/702303/maps | sort -u
/nix/store/3b5dmnx427smmc79qpwd5zjzmagydlj9-smash-rules/lib/libsmash_rules.so   <- only the OLD one
```

The new build's heartbeat string never appeared. `dlopen` searches its list of loaded objects **by name** before it stats the file, and `HotReloader` deliberately never `dlclose`s (flecs keeps `dtor` pointers into a module's text), so the second load through `/etc/hyperion/<event>-rules.so` returned the image from the first.

The trigger is the thing that makes the whole feature work: the path has to be stable, because a path that moves is a `[Service]` that moves and a restart instead of a reload. So the deployed configuration is exactly the one `dlopen` dedupes.

`HotReloader::load` now copies each candidate to a fresh name under `temp_dir()` first. Deliberately not `canonicalize`, which works here only because the nix store gives each build its own path and would keep the bug for anyone rebuilding to a fixed path — a developer's inner loop — with the same silence. After the fix, both images are mapped:

```
/tmp/hyperion-hot-reload-753472/0-smash-rules.so
/tmp/hyperion-hot-reload-753472/1-smash-rules.so
```

**And the reload path can no longer lie about it.** The copy is a fix; on its own it leaves the silent-success state reachable again the day somebody "simplifies" the copy away. So the loader also records the address of every module entry point it has ever been handed, and refuses a load whose entry point it has seen before — nothing is unloaded, so two genuinely distinct images cannot share one. Watched failing on the node, with staging stubbed out to return the caller's path:

```
$ sudo systemctl reload hyperion-proof.service
Job for hyperion-proof.service failed.
systemctl reload exit=1

journal: ERROR hot reload refused, the world is unchanged: the loader was handed
         back a module image it had already loaded, so this build's code would
         never have run. `dlopen` matches on the name it is given before it looks
         at the file, so a candidate must reach it under a name nothing has used yet
```

The deploy now fails loudly where it used to succeed silently. With staging restored, the same reload is accepted, the new build's string reaches the journal, and the connected player gets the title — so the guard has been watched in both directions, which is the half that catches a false positive.

### The deployed server logged nothing at all

`EnvFilter::from_default_env()` with `RUST_LOG` unset builds a filter with no directives, which passes nothing, and a unit sets no `RUST_LOG`. Measured on the same binary and unit, with and without: zero journal lines against every line. So `hot reload accepted` — the one line that says an invisible deploy landed — would never have been visible.

`setup_logging` now defaults to `INFO` (`RUST_LOG` still wins) and drops ANSI when stdout is not a terminal, because the service was writing `\x1b[32m INFO\x1b[0m` into the journal and every severity grep over it matched nothing.

Volume at the new default, one player connected, sixty seconds: **63 lines**, 59 of them the trivial rules module's own once-a-second heartbeat, which exists for this proof and goes when smash's real rules migrate in. hyperion itself is quiet in steady state.

## What changed, by layer

**The tick loop.** `events/smash`'s `init_game` no longer calls `app.run()`. `hyperion::tick_loop::prepare` reproduces what `ecs_app_run` does to a world before its own loop, read out of flecs's `addons/app.c` and tabulated in the module docs. Two rows are deliberately absent: `set_threads`, because `HyperionCore` already calls it with the same expression and `flecs_set_threads_internal` returns early when the stage count matches, making the event's call a provable no-op; and `set_target_fps`, because `HyperionCore` sets it and `prepare` now **refuses** a world with none rather than substituting 60 the way `App::new` did — a target rate of zero does not run slowly, it spins a core per stage.

`service::run` takes `Option<&mut ReloadService>`, so a server with no rules dylib uses the same loop rather than a second one.

**The client.** `crates/hyperion-reload-client`, with zero dependencies — not just no flecs. It is what `ExecReload` runs, so it has to be a thing that can always start; a rules dylib built against the wrong engine must not turn "here is the reason" into "the client failed to start".

**The stamp.** Three files in a directory named by `--build-stamp`, re-read on every accepted reload. Environment variables cannot work here: a process's environment is fixed at `exec` and not restarting is the entire point. `stamped`, `packages.smash`'s wrapper and `checks.build-stamp` are deleted; that wrapper is what put a per-commit store path inside `ExecStart` and restarted the server on every deploy.

**The bar.** `build 8f3a21c · 2h ago`, coarsening minutes → hours → days. The absolute UTC minute it replaced did not answer the question it was on screen for, which is about elapsed time. `show_build_stamp` compares the rendered string against what that player was last sent, so the packet cost is a function of the wording rather than of the tick rate: at most 60 per viewer in the first hour, 23 more that day, one a day after, one per viewer per hour in steady state. The module doc no longer argues one-packet-forever; it states the new bargain.

**The unit.** `reloadTriggers`, `/etc/hyperion/<event>-rules.so` and the stamp via `environment.etc`, a fixed-string `ExecReload`, `RuntimeDirectory`. Options keyed by `event`; no smash anywhere (ENG-12067). The fleet now deploys `smash-server` rather than `packages.smash`, which was a cargoUnit build that links nothing dynamically and could never have loaded a module at all.

Two things in there are not obvious:

- **`AF_UNIX` had to be granted.** `nix/modules/common.nix` hardens down to `AF_INET`/`AF_INET6`. The reload socket is a unix socket, so without this the server dies at startup on `Address family not supported by protocol` — on a real host and nowhere else, because nothing in a test or a gate runs under that filter.
- **The build stamp is a reload trigger too.** A commit that changes nothing the server links still changes `/etc/hyperion/build-rev`, and without a reload the bar would go on naming the previous commit. That reload re-opens a byte-identical dylib and cannot be refused, because a schema can only move when the dylib does.

## Guards, each broken and watched failing

| gate | broken by | what it printed |
| --- | --- | --- |
| `checks.hot-reload-unit-split` | `ExecStart` naming the store path | the two differing `ExecStart` lines, and "would drop every connected player" |
| `checks.hot-reload-server-starts` | (the bug itself, before the fix) | exit 139 |
| the entry-address assert | `stage` returning its input | `systemctl reload` exit 1 and an `error` naming the dedup trap |
| `one_path_loaded_twice_becomes_two_names` | `stage` returning its input | the same path twice |
| `the_wording_changes_at_most_sixty_times_in_the_first_hour` | second-granular ages | `left: 119, right: 60` |
| `a_stamp_that_changes_reaches_the_players_already_standing_there` | tag-only "have they been told" | `left: [], right: ["build deadbee"]` |

`hot-reload-unit-split` is a two-render diff rather than the obvious "is the dylib in the right line", because nixpkgs hashes `reloadTriggers` into a file of its own and the dylib path is not in the unit at all. The checkable property is that changing the dylib moves exactly one line.

## One design reversal, recorded because the first answer looked right

`hyperion` and `hyperion-hot-reload` are both dylibs and neither depends on the other, so under `prefer-dynamic` each statically included its own `tracing` and the binary was refused:

```
error: cannot satisfy dependencies so `tracing` only shows up once
error: cannot satisfy dependencies so `tracing_core` only shows up once
error: cannot satisfy dependencies so `once_cell` only shows up once
error: cannot satisfy dependencies so `pin_project_lite` only shows up once
```

Making `hyperion` depend on `hyperion-hot-reload` fixes that and breaks a plain build: `cargo test -p hyperion-hot-reload -p smash` then builds `libhyperion.so` against `libhyperion_hot_reload.so`, neither with `prefer-dynamic`, and duplicates `std`. That subset passes on main and fails with the chain, so it was a regression, and it is reverted.

What landed instead: `hyperion-hot-reload` drops `tracing`. Those four crates were the entire conflict list — everything else it uses arrives inside `libflecs_ecs.so`, which is a dylib and therefore one copy. The crate now returns `service::Outcome::{Applied, Refused}` and the host logs it, refusal at `error` and accepted at `info`. Better layering anyway: a library that logs has decided your format. ENG-12102 carries the general rule — two sibling dylibs may not share an rlib.

## Green

On dev-compute-6 (x86_64-linux), after the rebase: `packages.{smash-server,smash-rules}` and `checks.{hot-reload-server-starts,hot-reload-unit-split,hot-reload-source-split,hot-reload-index-probe,fleet-eval,nixos-modules,clippy,fmt,smash-rules}`. Locally: `cargo clippy --workspace --all-targets`, `cargo fmt --check`, and the affected suites.

The live proof was re-run on the rebased build, and the numbers at the top of this description are that run. The source split held across it: editing one string in `events/smash-rules` moved `smash-rules` from `yhds1g30...` to `qlrgwjg2...` and left `smash-server` at `xq1jvvgl...`.

Rebased onto `77aaf40` and re-verified there. I had carried a one-line `cargo fmt` of `crates/hyperion/build.rs` for the `fmt` red I hit on `origin/main` (ENG-12101); #1126 landed the same fix first, so the rebase dropped mine and this PR no longer touches that file.

## What this does NOT do

- **No `ix apply` was run, and no fleet VM was touched.** The dev node has no `IX_TOKEN` and the only real fleet is production. The proof above is the deployed unit's own `[Service]` properties — including the full hardening set, `DynamicUser` and the `AF_UNIX` grant — reproduced through `sudo systemd-run` on dev-compute-6, with certificates minted the way `nix/e2e.nix` mints them. What that leaves unproven is `switch-to-configuration`'s reload-versus-restart decision itself, which is why `checks.hot-reload-unit-split` exists and is a rendered-unit diff rather than a story.
- **The component-layout restart was not exercised live**, for the same reason. It is covered by the unit-split check (a `[Service]` change is a restart by construction) and by #1116's derivation table showing a host edit moving `smash-server`.
- **The rules are still the trivial heartbeat module.** Migrating smash's real rules into `events/smash-rules` is the next change, and it is the one with no unknowns.
- **A reload that provably changed nothing still answers `accepted`.** `Applied` carries `migrated_instances` but nothing that distinguishes "loaded a new image" from "loaded the same one". Noted in ENG-12113.
- **The staged copies accumulate** in the unit's private `/tmp`, one per reload, matching the existing "libraries are leaked, never closed" policy.
- **`checks.fleet-eval` cannot run on darwin** — a cargo-unit-planner IFD wants x86_64-linux. Confirmed identical on `origin/main`, so it predates this.

Authored by Claude Opus via Claude Code.
