### PR TITLE
test(hyperion): differentially test what an arrow hits, not only how it flies

### DIFF
--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -527,7 +527,7 @@ impl Module for EntityStateSyncModule {
         .each_iter(
             |it,
              row,
-             (position, velocity, owner, connection_id, yaw, pitch, in_ground, mut shake)| {
+             (position, velocity, owner, connection_id, mut yaw, mut pitch, in_ground, mut shake)| {
                 if let Some(_connection_id) = connection_id {
                     return;
                 }
@@ -578,6 +578,33 @@ impl Module for EntityStateSyncModule {
                     // it got there.
                     let ray = geometry::ray::Ray::new(center, velocity.0);
 
+                    // A projectile points where it is going, re-aimed off its
+                    // velocity every tick. Without this an arrow keeps its
+                    // launch orientation for its whole flight: the arc is right
+                    // but it renders frozen at its loosed angle rather than
+                    // nosing over as it falls.
+                    //
+                    // *When* it is re-aimed differs by integrator, and the
+                    // difference is only visible on the tick a projectile stops.
+                    // `AbstractArrow.tick` aims at lines 212-215, from the
+                    // velocity it entered the tick with and **before** the clip
+                    // at line 218 -- so an arrow that meets a wall this tick
+                    // still turns to face the way it was going, and then holds
+                    // that heading, because the in-ground branch returns at line
+                    // 199 without reaching the rotation again.
+                    // `ThrowableProjectile.tick:56` aims after its move instead.
+                    //
+                    // Doing this inside the miss branch, as it used to be, left
+                    // the heading a tick stale on every arrow that landed. The
+                    // differential gate caught it: `arrow-into-wall` pitch was
+                    // -0.542 against vanilla's -1.018, exactly one `lerpRotation`
+                    // step behind.
+                    let aims_before_moving = motion
+                        .is_some_and(|motion| motion.order == MotionOrder::MoveThenDecay);
+                    if aims_before_moving {
+                        aim_along(yaw.as_deref_mut(), pitch.as_deref_mut(), velocity.0);
+                    }
+
                     let Some(collision) = get_first_collision(ray, &world, Some(owner.entity))
                     else {
                         // Vanilla's own integration, per kind, rather than one
@@ -586,34 +613,16 @@ impl Module for EntityStateSyncModule {
                         // statements. `crates/hyperion/tests/differential.rs`
                         // holds this against a recording of the real server.
                         if let Some(motion) = motion {
-                            // A projectile points where it is going, re-aimed off
-                            // its velocity every tick. Without this an arrow keeps
-                            // its launch orientation for its whole flight: the arc
-                            // is right but it renders frozen at its loosed angle
-                            // rather than nosing over as it falls. Vanilla reads
-                            // the velocity at the moment its own tick calls
-                            // `updateRotation`, and that moment differs by
-                            // integrator: `AbstractArrow.tick` aims from the
-                            // velocity it entered the tick with, before the move
-                            // and decay, while `ThrowableProjectile.tick` applies
-                            // gravity and drag first and aims from the result. So
-                            // the arrow is aimed before the step and the thrown
-                            // kind after it.
-                            // The rotation easing still runs (it keeps the
-                            // stored facing correct for anything server-side
-                            // that reads it) but is no longer sent: the client
-                            // re-derives an arrow's heading from its velocity.
-                            let _rotation = match motion.order {
-                                MotionOrder::MoveThenDecay => {
-                                    let rotation = aim_along(yaw, pitch, velocity.0);
-                                    motion.step(position, &mut velocity.0);
-                                    rotation
-                                }
-                                MotionOrder::DecayThenMove => {
-                                    motion.step(position, &mut velocity.0);
-                                    aim_along(yaw, pitch, velocity.0)
-                                }
-                            };
+                            motion.step(position, &mut velocity.0);
+                            // The thrown kinds aim here, from the velocity the
+                            // step left behind. The rotation easing still runs
+                            // for both (it keeps the stored facing correct for
+                            // anything server-side that reads it) but is not
+                            // sent: the client re-derives a projectile's heading
+                            // from its velocity.
+                            if !aims_before_moving {
+                                aim_along(yaw, pitch, velocity.0);
+                            }
 
                             // Tell every client watching this arrow how fast it
                             // is going, every tick, and let the client dead-reckon

--- a/crates/hyperion/tests/differential.rs
+++ b/crates/hyperion/tests/differential.rs
@@ -14,19 +14,23 @@
     reason = "a failing comparison is only useful if it prints the tick and the numbers"
 )]
 
-use std::{fs, path::Path};
+use std::{collections::BTreeSet, fs, path::Path};
 
 use flecs_ecs::{
-    core::{EntityViewGet, World},
+    core::{EntityViewGet, World, WorldGet},
     macros::Component,
     prelude::Module,
 };
 use hyperion::{
-    glam::Vec3,
+    BlockKind, BlockState,
+    glam::{I16Vec2, IVec3, Vec3},
+    runtime::AsyncRuntime,
     simulation::{
         Owner, Pitch, Position, Velocity, Yaw,
+        blocks::Blocks,
         entity_kind::EntityKind,
-        projectile_motion::{SIMULATED, look_angles},
+        metadata::{Metadata, arrow::InGround},
+        projectile_motion::{SIMULATED, ShakeTime, look_angles},
     },
     spatial::SpatialModule,
 };
@@ -58,7 +62,32 @@ struct Scenario {
     #[expect(dead_code, reason = "consumed by the recorder, not by this test")]
     seed: i64,
     entities: Vec<EntitySpec>,
+    /// Terrain the scenario wants, and nothing else.
+    ///
+    /// Absent from every scenario that flies through open sky, which is what
+    /// keeps their traces byte-identical: the recorder places nothing and this
+    /// replay stamps nothing, so the world both sides run in is the one they
+    /// always ran in. A scenario that names blocks opts *itself* into terrain;
+    /// there is no global flat-world switch to get wrong.
+    #[serde(default)]
+    blocks: Vec<BlockSpec>,
     compare: Tolerance,
+}
+
+/// One block the scenario puts in the world before anything is fired.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BlockSpec {
+    position: [i32; 3],
+    /// A block name, and only a name: `minecraft:stone`, not
+    /// `minecraft:stone_slab[type=top]`.
+    ///
+    /// Both sides place the block's *default* state, which means the two
+    /// registries' defaults have to agree. That is not taken on trust -- it is
+    /// what the comparison itself checks. A slab that came out `top` on one
+    /// side and `bottom` on the other moves the arrow's resting height half a
+    /// block, four orders of magnitude outside any tolerance here.
+    state: String,
 }
 
 #[derive(Deserialize)]
@@ -111,6 +140,18 @@ struct Trace {
     )]
     seed: i64,
     ticks: usize,
+    /// The wire index of `AbstractArrow.IN_GROUND`, read out of the jar by the
+    /// recorder rather than transcribed.
+    ///
+    /// This is the one number in `metadata::arrow` that nothing else can check.
+    /// A field index never appears on the wire, so no packet capture recovers
+    /// it, and getting it wrong does not fail to compile or to send -- it sends
+    /// a boolean to whichever field Mojang moved into slot 10, and the arrow
+    /// quietly does something else on the client. Recording it here costs the
+    /// recorder one reflective read and turns a hand-transcribed constant into
+    /// one the jar has to agree with. See ENG-12106 for the general case.
+    #[serde(rename = "inGroundFieldIndex")]
+    in_ground_field_index: u8,
     samples: Vec<Sample>,
 }
 
@@ -135,6 +176,17 @@ struct State {
         reason = "recorded so a scenario can one day assert a despawn"
     )]
     removed: bool,
+    /// `AbstractArrow.isInGround`, present only for the kinds that have it.
+    ///
+    /// The reason a terrain scenario can assert anything at all. A resting
+    /// position on its own cannot tell "stopped by the wall" from "still
+    /// flying and happening to be there this tick"; this can.
+    #[serde(default, rename = "inGround")]
+    in_ground: Option<bool>,
+    /// `AbstractArrow.shakeTime`, which counts down from seven and so pins the
+    /// tick the arrow landed on rather than merely that it did.
+    #[serde(default, rename = "shakeTime")]
+    shake_time: Option<u8>,
 }
 
 /// Narrows a recorded double to the `f32` this server stores.
@@ -184,6 +236,80 @@ fn kind_for(entity_type: &str) -> EntityKind {
         })
 }
 
+/// Puts a scenario's declared blocks into the replay world.
+///
+/// `HyperionCore` installs `Blocks::empty`, so the replay world starts with no
+/// chunks at all -- and `set_block` on an unloaded chunk returns
+/// `ChunkNotLoaded` rather than placing anything, which would leave a scenario
+/// whose wall silently was not there and a comparison that then blamed the
+/// physics. Each chunk is loaded first, through the same `block_and_load` the
+/// server uses.
+///
+/// Nothing happens for a scenario with no blocks, which is every scenario that
+/// flies through open sky: their replay world is untouched by this and their
+/// committed traces are unchanged.
+fn stamp_terrain(world: &World, blocks: &[BlockSpec]) {
+    set_terrain(world, blocks, |spec| block_state(&spec.state));
+}
+
+/// Takes it back out again.
+///
+/// Every scenario shares one world -- `HyperionCore` can only be imported once
+/// per process -- so a wall left standing would be in the next scenario's sky.
+/// Vanilla records each scenario in a fresh level, and this is what makes the
+/// replay side match that. The scenarios are also written not to overlap, but
+/// relying on that would make every future scenario's author responsible for
+/// every past one's geometry.
+fn clear_terrain(world: &World, blocks: &[BlockSpec]) {
+    set_terrain(world, blocks, |_| BlockState::AIR);
+}
+
+fn set_terrain(world: &World, blocks: &[BlockSpec], state_for: impl Fn(&BlockSpec) -> BlockState) {
+    if blocks.is_empty() {
+        return;
+    }
+
+    // Deduplicated and ordered, so a scenario naming twenty blocks in one
+    // chunk loads it once and the loads happen in a fixed order. `I16Vec2` is
+    // not `Ord`, so the pair is the key and the vector is rebuilt from it.
+    let chunks: BTreeSet<(i16, i16)> = blocks
+        .iter()
+        .map(|spec| {
+            (
+                i16::try_from(spec.position[0] >> 4).expect("block x is inside the world limit"),
+                i16::try_from(spec.position[2] >> 4).expect("block z is inside the world limit"),
+            )
+        })
+        .collect();
+
+    let runtime = world.get::<&AsyncRuntime>(AsyncRuntime::clone);
+    world.get::<&mut Blocks>(|store| {
+        for (x, z) in chunks {
+            store.block_and_load(I16Vec2::new(x, z), &runtime);
+        }
+        for spec in blocks {
+            let state = state_for(spec);
+            let position = IVec3::new(spec.position[0], spec.position[1], spec.position[2]);
+            store
+                .set_block(position, state)
+                .unwrap_or_else(|error| panic!("could not place {} at {position}: {error:?}", spec.state));
+        }
+    });
+}
+
+/// The default state of a block named the way a scenario names it.
+///
+/// A name and nothing else, so `minecraft:stone`, not
+/// `minecraft:stone_slab[type=top]`. See [`BlockSpec::state`] for why the two
+/// registries' defaults agreeing is checked by the comparison rather than
+/// asserted here.
+fn block_state(name: &str) -> BlockState {
+    let bare = name.strip_prefix("minecraft:").unwrap_or(name);
+    let kind = BlockKind::from_str(bare)
+        .unwrap_or_else(|| panic!("no such block in this server's tables: {name}"));
+    BlockState::from_kind(kind)
+}
+
 /// Replays one scenario and reports the first tick that disagrees.
 ///
 /// Returns the failure as a string rather than asserting, so the caller can
@@ -210,6 +336,20 @@ fn replay(world: &World, scenario: &Scenario, trace: &Trace) -> Result<Headroom,
         scenario.ticks + 1,
         "a trace carries the state before the first tick plus one sample per tick"
     );
+
+    assert_eq!(
+        trace.in_ground_field_index,
+        InGround::INDEX,
+        "the pinned jar puts AbstractArrow's IN_GROUND at index {}, and \
+         hyperion::simulation::metadata::arrow says {}; every arrow this server sends is \
+         writing the wrong tracked field",
+        trace.in_ground_field_index,
+        InGround::INDEX,
+    );
+
+    // Terrain first, before anything is spawned to fly into it. The recorder
+    // does the same, in `VanillaTrace.placeBlocks`.
+    stamp_terrain(world, &scenario.blocks);
 
     // The owner exists only so the ray cast can exclude the shooter, which is
     // what `update_projectile_positions` does with it.
@@ -328,6 +468,35 @@ fn replay(world: &World, scenario: &Scenario, trace: &Trace) -> Result<Headroom,
                 }
             }
 
+            // The impact state, compared exactly. No tolerance, and none is
+            // possible: these are a flag and a countdown, so "close" has no
+            // meaning. An arrow that lands one tick early agrees on position to
+            // well inside the tolerance and disagrees here, which is the whole
+            // reason they are recorded.
+            //
+            // Only where vanilla recorded them. A trace of a snowball carries
+            // neither, because `ThrowableProjectile` has no such state.
+            if let Some(expected_in_ground) = expected.in_ground {
+                let in_ground = entity.try_get::<&InGround>(|flag| **flag);
+                if in_ground != Some(expected_in_ground) {
+                    outcome = Err(format!(
+                        "{}: {id} inGround diverges at tick {}\n  vanilla:  {expected_in_ground}\n  \
+                         hyperion: {in_ground:?}",
+                        scenario.name, sample.tick,
+                    ));
+                }
+            }
+            if let Some(expected_shake) = expected.shake_time {
+                let shake = entity.try_get::<&ShakeTime>(|shake| shake.0);
+                if shake != Some(expected_shake) {
+                    outcome = Err(format!(
+                        "{}: {id} shakeTime diverges at tick {}\n  vanilla:  {expected_shake}\n  \
+                         hyperion: {shake:?}",
+                        scenario.name, sample.tick,
+                    ));
+                }
+            }
+
             // The heading, in the same shape. Yaw and pitch rather than three
             // axes, and the shorter arc between the two angles so a reading of
             // 179 against -179 is two degrees apart, not 358.
@@ -362,6 +531,7 @@ fn replay(world: &World, scenario: &Scenario, trace: &Trace) -> Result<Headroom,
         entity.destruct();
     }
     owner.destruct();
+    clear_terrain(world, &scenario.blocks);
 
     outcome
 }

--- a/crates/hyperion/tests/differential/scenarios/arrow-grazing-slab.json
+++ b/crates/hyperion/tests/differential/scenarios/arrow-grazing-slab.json
@@ -1,0 +1,28 @@
+{
+  "name": "arrow-grazing-slab",
+  "description": "A fully drawn bow fired level over a bottom slab and into a wall behind it. The slab's top face is at y=120.5 and the arrow crosses its cell at about y=120.8, so a collider that treated the slab as a full cube would stop the arrow ten blocks early. It stops at the wall instead.",
+  "ticks": 20,
+  "seed": 4242,
+  "blocks": [
+    { "position": [0, 120, 10], "state": "minecraft:stone_slab" },
+    { "position": [0, 120, 11], "state": "minecraft:stone_slab" },
+    { "position": [0, 118, 20], "state": "minecraft:stone" },
+    { "position": [0, 119, 20], "state": "minecraft:stone" },
+    { "position": [0, 120, 20], "state": "minecraft:stone" },
+    { "position": [0, 121, 20], "state": "minecraft:stone" },
+    { "position": [0, 122, 20], "state": "minecraft:stone" }
+  ],
+  "entities": [
+    {
+      "id": "arrow",
+      "type": "minecraft:arrow",
+      "position": [0.5, 121.0, 0.5],
+      "launch": { "yaw": 0.0, "pitch": 0.0, "power": 3.0 }
+    }
+  ],
+  "compare": {
+    "position": 1.0e-4,
+    "velocity": 3.0e-6,
+    "rotation": 2.0e-1
+  }
+}

--- a/crates/hyperion/tests/differential/scenarios/arrow-into-floor.json
+++ b/crates/hyperion/tests/differential/scenarios/arrow-into-floor.json
@@ -1,0 +1,30 @@
+{
+  "name": "arrow-into-floor",
+  "description": "A fully drawn bow fired straight down onto a stone floor seven blocks below. The arrow spends three ticks in the air and seventeen embedded in the block it hit, which is where inGround and the shake countdown are read.",
+  "ticks": 20,
+  "seed": 4242,
+  "blocks": [
+    { "position": [-1, 120, -1], "state": "minecraft:stone" },
+    { "position": [-1, 120, 0], "state": "minecraft:stone" },
+    { "position": [-1, 120, 1], "state": "minecraft:stone" },
+    { "position": [0, 120, -1], "state": "minecraft:stone" },
+    { "position": [0, 120, 0], "state": "minecraft:stone" },
+    { "position": [0, 120, 1], "state": "minecraft:stone" },
+    { "position": [1, 120, -1], "state": "minecraft:stone" },
+    { "position": [1, 120, 0], "state": "minecraft:stone" },
+    { "position": [1, 120, 1], "state": "minecraft:stone" }
+  ],
+  "entities": [
+    {
+      "id": "arrow",
+      "type": "minecraft:arrow",
+      "position": [0.5, 128.0, 0.5],
+      "launch": { "yaw": 0.0, "pitch": 90.0, "power": 3.0 }
+    }
+  ],
+  "compare": {
+    "position": 2.0e-4,
+    "velocity": 3.0e-6,
+    "rotation": 2.0e-1
+  }
+}

--- a/crates/hyperion/tests/differential/scenarios/arrow-into-wall.json
+++ b/crates/hyperion/tests/differential/scenarios/arrow-into-wall.json
@@ -1,0 +1,29 @@
+{
+  "name": "arrow-into-wall",
+  "description": "A fully drawn bow fired dead level into a stone wall ten blocks along +Z. The arrow reaches it on its fourth tick, having already dropped a fifth of a block, so where it stops depends on the vertical face being clipped rather than on the cell being entered.",
+  "ticks": 20,
+  "seed": 4242,
+  "blocks": [
+    { "position": [0, 126, 10], "state": "minecraft:stone" },
+    { "position": [0, 127, 10], "state": "minecraft:stone" },
+    { "position": [0, 128, 10], "state": "minecraft:stone" },
+    { "position": [0, 129, 10], "state": "minecraft:stone" },
+    { "position": [1, 127, 10], "state": "minecraft:stone" },
+    { "position": [1, 128, 10], "state": "minecraft:stone" },
+    { "position": [-1, 127, 10], "state": "minecraft:stone" },
+    { "position": [-1, 128, 10], "state": "minecraft:stone" }
+  ],
+  "entities": [
+    {
+      "id": "arrow",
+      "type": "minecraft:arrow",
+      "position": [0.5, 128.0, 0.5],
+      "launch": { "yaw": 0.0, "pitch": 0.0, "power": 3.0 }
+    }
+  ],
+  "compare": {
+    "position": 2.0e-4,
+    "velocity": 3.0e-6,
+    "rotation": 2.0e-1
+  }
+}

--- a/crates/hyperion/tests/differential/traces/arrow-arced-shot.json
+++ b/crates/hyperion/tests/differential/traces/arrow-arced-shot.json
@@ -3,6 +3,7 @@
   "minecraftVersion": "26.2",
   "seed": 4242,
   "ticks": 60,
+  "inGroundFieldIndex": 10,
   "samples": [
     {
       "tick": 0,
@@ -22,7 +23,9 @@
             -34.996964,
             19.995613
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -44,7 +47,9 @@
             -34.996964,
             19.995613
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -66,7 +71,9 @@
             -34.996964,
             19.813335
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -88,7 +95,9 @@
             -34.996967,
             19.481285
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -110,7 +119,9 @@
             -34.99697,
             19.025505
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -132,7 +143,9 @@
             -34.996975,
             18.46682
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -154,7 +167,9 @@
             -34.996983,
             17.821873
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -176,7 +191,9 @@
             -34.99699,
             17.10403
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -198,7 +215,9 @@
             -34.996994,
             16.32395
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -220,7 +239,9 @@
             -34.996998,
             15.49028
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -242,7 +263,9 @@
             -34.997,
             14.609881
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -264,7 +287,9 @@
             -34.997005,
             13.688354
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -286,7 +311,9 @@
             -34.99701,
             12.730326
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -308,7 +335,9 @@
             -34.997013,
             11.73944
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -330,7 +359,9 @@
             -34.997013,
             10.718781
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -352,7 +383,9 @@
             -34.997013,
             9.670868
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -374,7 +407,9 @@
             -34.997013,
             8.597973
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -396,7 +431,9 @@
             -34.99701,
             7.50199
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -418,7 +455,9 @@
             -34.997005,
             6.3845887
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -440,7 +479,9 @@
             -34.997,
             5.247239
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -462,7 +503,9 @@
             -34.996998,
             4.091386
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -484,7 +527,9 @@
             -34.996994,
             2.918315
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -506,7 +551,9 @@
             -34.99699,
             1.7293063
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -528,7 +575,9 @@
             -34.996983,
             0.52562296
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -550,7 +599,9 @@
             -34.99698,
             -0.6915208
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -572,7 +623,9 @@
             -34.996975,
             -1.9208813
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -594,7 +647,9 @@
             -34.99697,
             -3.161223
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -616,7 +671,9 @@
             -34.996967,
             -4.411284
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -638,7 +695,9 @@
             -34.996964,
             -5.669786
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -660,7 +719,9 @@
             -34.99696,
             -6.935432
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -682,7 +743,9 @@
             -34.99696,
             -8.206909
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -704,7 +767,9 @@
             -34.99696,
             -9.482889
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -726,7 +791,9 @@
             -34.996964,
             -10.7620325
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -748,7 +815,9 @@
             -34.996967,
             -12.042995
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -770,7 +839,9 @@
             -34.996975,
             -13.324432
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -792,7 +863,9 @@
             -34.996986,
             -14.605002
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -814,7 +887,9 @@
             -34.996994,
             -15.883383
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -836,7 +911,9 @@
             -34.997,
             -17.158262
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -858,7 +935,9 @@
             -34.997005,
             -18.428358
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -880,7 +959,9 @@
             -34.99701,
             -19.692421
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -902,7 +983,9 @@
             -34.997005,
             -20.94924
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -924,7 +1007,9 @@
             -34.996998,
             -22.197643
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -946,7 +1031,9 @@
             -34.99699,
             -23.436512
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -968,7 +1055,9 @@
             -34.996983,
             -24.664776
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -990,7 +1079,9 @@
             -34.996975,
             -25.88143
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1012,7 +1103,9 @@
             -34.99697,
             -27.08552
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1034,7 +1127,9 @@
             -34.996967,
             -28.276163
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1056,7 +1151,9 @@
             -34.996967,
             -29.452538
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1078,7 +1175,9 @@
             -34.996967,
             -30.61389
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1100,7 +1199,9 @@
             -34.99697,
             -31.759533
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1122,7 +1223,9 @@
             -34.996975,
             -32.88885
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1144,7 +1247,9 @@
             -34.996983,
             -34.001293
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1166,7 +1271,9 @@
             -34.99699,
             -35.096375
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1188,7 +1295,9 @@
             -34.996994,
             -36.17367
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1210,7 +1319,9 @@
             -34.997,
             -37.232834
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1232,7 +1343,9 @@
             -34.997005,
             -38.273563
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1254,7 +1367,9 @@
             -34.99701,
             -39.295624
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1276,7 +1391,9 @@
             -34.997013,
             -40.298836
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1298,7 +1415,9 @@
             -34.997017,
             -41.28307
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1320,7 +1439,9 @@
             -34.99702,
             -42.248253
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1342,7 +1463,9 @@
             -34.99702,
             -43.194324
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     }

--- a/crates/hyperion/tests/differential/traces/arrow-crosswind-shot.json
+++ b/crates/hyperion/tests/differential/traces/arrow-crosswind-shot.json
@@ -3,6 +3,7 @@
   "minecraftVersion": "26.2",
   "seed": 4242,
   "ticks": 30,
+  "inGroundFieldIndex": 10,
   "samples": [
     {
       "tick": 0,
@@ -22,7 +23,9 @@
             -89.99999,
             0.0
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -44,7 +47,9 @@
             -89.99999,
             0.0
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -66,7 +71,9 @@
             -89.99999,
             -0.19288321
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -88,7 +95,9 @@
             -89.99999,
             -0.54195017
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -110,7 +119,9 @@
             -89.99999,
             -1.0176632
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -132,7 +143,9 @@
             -89.99999,
             -1.5963333
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -154,7 +167,9 @@
             -89.99999,
             -2.258918
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -176,7 +191,9 @@
             -89.99999,
             -2.9900265
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -198,7 +215,9 @@
             -89.99999,
             -3.7772586
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -220,7 +239,9 @@
             -89.99999,
             -4.6105394
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -242,7 +263,9 @@
             -89.99999,
             -5.481715
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -264,7 +287,9 @@
             -89.99999,
             -6.384083
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -286,7 +311,9 @@
             -89.99999,
             -7.312202
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -308,7 +335,9 @@
             -89.99999,
             -8.261508
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -330,7 +359,9 @@
             -89.99999,
             -9.228291
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -352,7 +383,9 @@
             -89.99999,
             -10.209342
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -374,7 +407,9 @@
             -89.99999,
             -11.202055
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -396,7 +431,9 @@
             -89.99999,
             -12.204084
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -418,7 +455,9 @@
             -89.99999,
             -13.213527
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -440,7 +479,9 @@
             -89.99999,
             -14.228587
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -462,7 +503,9 @@
             -89.99999,
             -15.247816
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -484,7 +527,9 @@
             -89.99999,
             -16.269773
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -506,7 +551,9 @@
             -89.99999,
             -17.293232
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -528,7 +575,9 @@
             -89.99999,
             -18.317074
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -550,7 +599,9 @@
             -89.99999,
             -19.340343
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -572,7 +623,9 @@
             -89.99999,
             -20.361996
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -594,7 +647,9 @@
             -89.99999,
             -21.38114
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -616,7 +671,9 @@
             -89.99999,
             -22.396942
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -638,7 +695,9 @@
             -89.99999,
             -23.408617
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -660,7 +719,9 @@
             -89.99999,
             -24.415424
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -682,7 +743,9 @@
             -89.99999,
             -25.416664
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     }

--- a/crates/hyperion/tests/differential/traces/arrow-grazing-slab.json
+++ b/crates/hyperion/tests/differential/traces/arrow-grazing-slab.json
@@ -1,0 +1,513 @@
+{
+  "scenario": "arrow-grazing-slab",
+  "minecraftVersion": "26.2",
+  "seed": 4242,
+  "ticks": 20,
+  "inGroundFieldIndex": 10,
+  "samples": [
+    {
+      "tick": 0,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.0,
+            0.5
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            3.0
+          ],
+          "rotation": [
+            0.0,
+            0.0
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 1,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.0,
+            3.5
+          ],
+          "velocity": [
+            0.0,
+            -0.05,
+            2.9700000286102295
+          ],
+          "rotation": [
+            0.0,
+            0.0
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 2,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.95,
+            6.4700000286102295
+          ],
+          "velocity": [
+            0.0,
+            -0.09950000047683716,
+            2.9403000566482547
+          ],
+          "rotation": [
+            0.0,
+            -0.19288321
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 3,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.85049999952317,
+            9.410300085258484
+          ],
+          "velocity": [
+            0.0,
+            -0.14850500142097472,
+            2.9108970841226585
+          ],
+          "rotation": [
+            0.0,
+            -0.54195017
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 4,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.7019949981022,
+            12.321197169381144
+          ],
+          "velocity": [
+            0.0,
+            -0.19701995282301904,
+            2.88178814104191
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 5,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.50497504527918,
+            15.202985310423053
+          ],
+          "velocity": [
+            0.0,
+            -0.24504975517371752,
+            2.8529702871143643
+          ],
+          "rotation": [
+            0.0,
+            -1.5963333
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 6,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.25992529010546,
+            18.055955597537416
+          ],
+          "velocity": [
+            0.0,
+            -0.2925992599589569,
+            2.8244406114512657
+          ],
+          "rotation": [
+            0.0,
+            -2.258918
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 7,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 7
+        }
+      }
+    },
+    {
+      "tick": 8,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 6
+        }
+      }
+    },
+    {
+      "tick": 9,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 5
+        }
+      }
+    },
+    {
+      "tick": 10,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 4
+        }
+      }
+    },
+    {
+      "tick": 11,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 3
+        }
+      }
+    },
+    {
+      "tick": 12,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 2
+        }
+      }
+    },
+    {
+      "tick": 13,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 1
+        }
+      }
+    },
+    {
+      "tick": 14,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 15,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 16,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 17,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 18,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 19,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 20,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            120.10853109223233,
+            19.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -2.9900265
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    }
+  ]
+}

--- a/crates/hyperion/tests/differential/traces/arrow-into-floor.json
+++ b/crates/hyperion/tests/differential/traces/arrow-into-floor.json
@@ -1,0 +1,513 @@
+{
+  "scenario": "arrow-into-floor",
+  "minecraftVersion": "26.2",
+  "seed": 4242,
+  "ticks": 20,
+  "inGroundFieldIndex": 10,
+  "samples": [
+    {
+      "tick": 0,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            128.0,
+            0.5
+          ],
+          "velocity": [
+            0.0,
+            -3.0,
+            3.6739405577555036E-16
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 1,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            125.0,
+            0.5000000000000003
+          ],
+          "velocity": [
+            0.0,
+            -3.0200000286102293,
+            3.637201187215376E-16
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 2,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.97999997138977,
+            0.5000000000000007
+          ],
+          "velocity": [
+            0.0,
+            -3.0398000571250914,
+            3.6008292100302756E-16
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 3,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 7
+        }
+      }
+    },
+    {
+      "tick": 4,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 6
+        }
+      }
+    },
+    {
+      "tick": 5,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 5
+        }
+      }
+    },
+    {
+      "tick": 6,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 4
+        }
+      }
+    },
+    {
+      "tick": 7,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 3
+        }
+      }
+    },
+    {
+      "tick": 8,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 2
+        }
+      }
+    },
+    {
+      "tick": 9,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 1
+        }
+      }
+    },
+    {
+      "tick": 10,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 11,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 12,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 13,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 14,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 15,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 16,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 17,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 18,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 19,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 20,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            121.05000000074506,
+            0.4499999992549427
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -89.99999
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    }
+  ]
+}

--- a/crates/hyperion/tests/differential/traces/arrow-into-wall.json
+++ b/crates/hyperion/tests/differential/traces/arrow-into-wall.json
@@ -1,0 +1,513 @@
+{
+  "scenario": "arrow-into-wall",
+  "minecraftVersion": "26.2",
+  "seed": 4242,
+  "ticks": 20,
+  "inGroundFieldIndex": 10,
+  "samples": [
+    {
+      "tick": 0,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            128.0,
+            0.5
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            3.0
+          ],
+          "rotation": [
+            0.0,
+            0.0
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 1,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            128.0,
+            3.5
+          ],
+          "velocity": [
+            0.0,
+            -0.05,
+            2.9700000286102295
+          ],
+          "rotation": [
+            0.0,
+            0.0
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 2,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.95,
+            6.4700000286102295
+          ],
+          "velocity": [
+            0.0,
+            -0.09950000047683716,
+            2.9403000566482547
+          ],
+          "rotation": [
+            0.0,
+            -0.19288321
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 3,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.85049999952317,
+            9.410300085258484
+          ],
+          "velocity": [
+            0.0,
+            -0.14850500142097472,
+            2.9108970841226585
+          ],
+          "rotation": [
+            0.0,
+            -0.54195017
+          ],
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 4,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 7
+        }
+      }
+    },
+    {
+      "tick": 5,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 6
+        }
+      }
+    },
+    {
+      "tick": 6,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 5
+        }
+      }
+    },
+    {
+      "tick": 7,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 4
+        }
+      }
+    },
+    {
+      "tick": 8,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 3
+        }
+      }
+    },
+    {
+      "tick": 9,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 2
+        }
+      }
+    },
+    {
+      "tick": 10,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 1
+        }
+      }
+    },
+    {
+      "tick": 11,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 12,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 13,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 14,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 15,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 16,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 17,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 18,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 19,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    },
+    {
+      "tick": 20,
+      "entities": {
+        "arrow": {
+          "position": [
+            0.5,
+            127.87041532734925,
+            9.949999999254942
+          ],
+          "velocity": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "rotation": [
+            0.0,
+            -1.0176632
+          ],
+          "removed": false,
+          "inGround": true,
+          "shakeTime": 0
+        }
+      }
+    }
+  ]
+}

--- a/crates/hyperion/tests/differential/traces/arrow-level-shot.json
+++ b/crates/hyperion/tests/differential/traces/arrow-level-shot.json
@@ -3,6 +3,7 @@
   "minecraftVersion": "26.2",
   "seed": 4242,
   "ticks": 60,
+  "inGroundFieldIndex": 10,
   "samples": [
     {
       "tick": 0,
@@ -22,7 +23,9 @@
             0.0,
             0.0
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -44,7 +47,9 @@
             0.0,
             0.0
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -66,7 +71,9 @@
             0.0,
             -0.19288321
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -88,7 +95,9 @@
             0.0,
             -0.54195017
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -110,7 +119,9 @@
             0.0,
             -1.0176632
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -132,7 +143,9 @@
             0.0,
             -1.5963333
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -154,7 +167,9 @@
             0.0,
             -2.258918
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -176,7 +191,9 @@
             0.0,
             -2.9900265
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -198,7 +215,9 @@
             0.0,
             -3.7772586
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -220,7 +239,9 @@
             0.0,
             -4.6105394
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -242,7 +263,9 @@
             0.0,
             -5.481715
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -264,7 +287,9 @@
             0.0,
             -6.384083
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -286,7 +311,9 @@
             0.0,
             -7.312202
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -308,7 +335,9 @@
             0.0,
             -8.261508
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -330,7 +359,9 @@
             0.0,
             -9.228291
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -352,7 +383,9 @@
             0.0,
             -10.209342
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -374,7 +407,9 @@
             0.0,
             -11.202055
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -396,7 +431,9 @@
             0.0,
             -12.204084
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -418,7 +455,9 @@
             0.0,
             -13.213527
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -440,7 +479,9 @@
             0.0,
             -14.228587
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -462,7 +503,9 @@
             0.0,
             -15.247816
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -484,7 +527,9 @@
             0.0,
             -16.269773
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -506,7 +551,9 @@
             0.0,
             -17.293232
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -528,7 +575,9 @@
             0.0,
             -18.317074
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -550,7 +599,9 @@
             0.0,
             -19.340343
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -572,7 +623,9 @@
             0.0,
             -20.361996
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -594,7 +647,9 @@
             0.0,
             -21.38114
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -616,7 +671,9 @@
             0.0,
             -22.396942
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -638,7 +695,9 @@
             0.0,
             -23.408617
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -660,7 +719,9 @@
             0.0,
             -24.415424
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -682,7 +743,9 @@
             0.0,
             -25.416664
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -704,7 +767,9 @@
             0.0,
             -26.411594
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -726,7 +791,9 @@
             0.0,
             -27.39969
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -748,7 +815,9 @@
             0.0,
             -28.380362
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -770,7 +839,9 @@
             0.0,
             -29.352968
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -792,7 +863,9 @@
             0.0,
             -30.317091
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -814,7 +887,9 @@
             0.0,
             -31.272158
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -836,7 +911,9 @@
             0.0,
             -32.217728
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -858,7 +935,9 @@
             0.0,
             -33.153397
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -880,7 +959,9 @@
             0.0,
             -34.078873
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -902,7 +983,9 @@
             0.0,
             -34.993706
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -924,7 +1007,9 @@
             0.0,
             -35.897583
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -946,7 +1031,9 @@
             0.0,
             -36.790222
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -968,7 +1055,9 @@
             0.0,
             -37.67128
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -990,7 +1079,9 @@
             0.0,
             -38.540638
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1012,7 +1103,9 @@
             0.0,
             -39.398094
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1034,7 +1127,9 @@
             0.0,
             -40.24339
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1056,7 +1151,9 @@
             0.0,
             -41.076477
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1078,7 +1175,9 @@
             0.0,
             -41.897236
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1100,7 +1199,9 @@
             0.0,
             -42.70548
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1122,7 +1223,9 @@
             0.0,
             -43.501217
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1144,7 +1247,9 @@
             0.0,
             -44.28432
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1166,7 +1271,9 @@
             0.0,
             -45.05477
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1188,7 +1295,9 @@
             0.0,
             -45.812634
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1210,7 +1319,9 @@
             0.0,
             -46.557846
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1232,7 +1343,9 @@
             0.0,
             -47.29045
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1254,7 +1367,9 @@
             0.0,
             -48.010548
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1276,7 +1391,9 @@
             0.0,
             -48.718136
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1298,7 +1415,9 @@
             0.0,
             -49.4133
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1320,7 +1439,9 @@
             0.0,
             -50.096134
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     },
@@ -1342,7 +1463,9 @@
             0.0,
             -50.766773
           ],
-          "removed": false
+          "removed": false,
+          "inGround": false,
+          "shakeTime": 0
         }
       }
     }

--- a/crates/hyperion/tests/differential/traces/snowball-throw.json
+++ b/crates/hyperion/tests/differential/traces/snowball-throw.json
@@ -3,6 +3,7 @@
   "minecraftVersion": "26.2",
   "seed": 4242,
   "ticks": 40,
+  "inGroundFieldIndex": 10,
   "samples": [
     {
       "tick": 0,

--- a/docs/differential-testing.md
+++ b/docs/differential-testing.md
@@ -32,6 +32,9 @@ the wrong recording.
   "description": "A fully drawn bow fired dead level along +Z.",
   "ticks": 60,
   "seed": 4242,
+  "blocks": [
+    { "position": [0, 120, 10], "state": "minecraft:stone" }
+  ],
   "entities": [
     {
       "id": "arrow",
@@ -57,6 +60,9 @@ the wrong recording.
 | `entities[].id` | Names this entity in the trace and in a failure message. |
 | `entities[].type` | A protocol entity type. It must appear in `hyperion::simulation::projectile_motion::SIMULATED`, or there is nothing here to compare. |
 | `entities[].position` | Where it starts. |
+| `blocks` | Optional. Terrain to put in the world before anything is fired. |
+| `blocks[].position` | Integer block coordinates. |
+| `blocks[].state` | A block name and nothing else: `minecraft:stone`, not `minecraft:stone_slab[type=top]`. Both sides place the block's default state. |
 | `compare.position` | Tolerance in blocks. |
 | `compare.velocity` | Tolerance in blocks per tick. |
 | `compare.rotation` | Tolerance in degrees, for the arrow's client-facing yaw and pitch. |
@@ -70,6 +76,51 @@ scenario:
 - `"motion": [x, y, z]` sets the delta movement directly.
 - `"knockback": { "power", "fromX", "fromZ", "damage", "onGround" }` runs
   `LivingEntity.knockback`, for entities that have one.
+
+### Terrain is opt-in, per scenario
+
+A scenario with no `blocks` runs in an empty world on both sides and its trace
+is unchanged by any of this: the recorder places nothing and the replay stamps
+nothing. There is no global "load a flat world" switch to get wrong, and adding
+the terrain scenarios changed the four sky scenarios' recorded numbers not at
+all -- the only difference in those files is the two impact fields and the
+header index described below.
+
+A scenario that *does* name blocks gets them in both places before any entity
+exists. `VanillaTrace.placeBlocks` calls `setBlock` with `Block.UPDATE_CLIENTS`
+rather than `UPDATE_ALL`, because a neighbour update runs block logic and block
+logic is where a recording would start consuming randomness. On the hyperion
+side `stamp_terrain` loads each containing chunk first -- `HyperionCore`
+installs `Blocks::empty`, and `set_block` on an unloaded chunk quietly places
+nothing -- and clears them again afterwards, because every scenario shares one
+world where vanilla records each in a fresh level.
+
+Default states only. That means the two registries' defaults have to agree, and
+that is checked rather than trusted: a slab that came out `top` on one side and
+`bottom` on the other moves the arrow's resting height by half a block, four
+orders of magnitude outside any tolerance here.
+
+### The impact state, and the field index that rides with it
+
+An arrow's trace also carries `inGround` and `shakeTime`, and they are compared
+exactly, with no tolerance -- a flag and a countdown have no notion of "close".
+They are the reason a terrain scenario can assert anything at all: a resting
+position on its own cannot tell "stopped by the wall" from "still flying and
+happening to be there this tick". A snowball's trace carries neither, because
+`ThrowableProjectile` has no such state.
+
+`inGround` is read from the *synched* data rather than from `isInGround()`,
+which is `protected` -- so it is the value a client is actually sent, which is
+what `metadata::arrow::InGround` mirrors. Getting the accessor means reflection,
+and since the reflection is happening anyway the trace header records
+`inGroundFieldIndex` as well. That number is the one thing in
+`crates/hyperion/src/simulation/metadata/` nothing else can check: a field index
+never appears on the wire, so no packet capture recovers it, and getting it
+wrong neither fails to compile nor fails to send -- it writes a boolean into
+whichever field Mojang moved into slot 10 and the arrow quietly does something
+else on the client. The replay asserts it against `InGround::INDEX` before it
+compares a single tick. ENG-12106 is the general version of this for every other
+hand-transcribed index.
 
 ## What is deterministic, and how that is known rather than assumed
 
@@ -107,9 +158,10 @@ since it is a property of the runtime and not of anything in this repository.
   by inaccuracy, and a real bow shot passes inaccuracy 1.0. Scenarios pass 0.0,
   so the spread distribution is untested. What is tested is the flight, from
   whatever state vanilla started it in.
-- **Anything the arrow hits.** Every committed scenario flies through empty air.
-  Block and entity collision, `inGround`, and despawn are recorded in the trace
-  (`removed`) but no scenario exercises them yet.
+- **Entity collision, and despawn.** `removed` is recorded and nothing asserts
+  on it, and no scenario puts a second entity in an arrow's path. Block
+  collision *is* covered now -- see the three terrain scenarios -- but what an
+  arrow does when it meets a player is not.
 - **Water, lava, portals, bubble columns, levitation.** All change the
   integration and none appear in a flat world's sky.
 - **Player movement, and so knockback as Super Smash Mobs uses it.** Two
@@ -148,6 +200,26 @@ ok: snowball-throw (40 ticks); worst position delta 1.4786633116159464e-5 of 4e-
 
 Both sit about an order of magnitude inside the bound, which says the rounding
 errors are not accumulating in one direction.
+
+The terrain scenarios are twenty ticks and reach 128 blocks (121 for the slab),
+so the same arithmetic gives `20 * 2^-17 = 1.5e-4` and `20 * 2^-18 = 7.6e-5`;
+the committed tolerances are `2e-4` and `1e-4`. What they actually measure is
+smaller again, and this is the number worth reading, because the question going
+in was whether a swept clip against block shapes would open a bigger gap than
+free flight does:
+
+```
+ok: arrow-into-floor (20 ticks);   worst position delta 3.386e-6 of 2e-4
+ok: arrow-into-wall (20 ticks);    worst position delta 5.615e-6 of 2e-4
+ok: arrow-grazing-slab (20 ticks); worst position delta 8.309e-6 of 1e-4
+```
+
+It does not. Those are *tighter* than the sixty-tick sky shots (3.4e-5 to
+5.0e-5), for the ordinary reason that they run a third as long. The clip itself
+contributes nothing measurable: `geometry::sweep::first_block_hit` computes in
+`f64` internally, so the only rounding on the impact path is the `f32` the
+segment's endpoints arrive as -- the same single source of disagreement free
+flight has. **The residual gap is hyperion's `f32` positions, and nothing else.**
 
 **This tolerance is larger than the wire can express, and that is a real
 finding rather than a detail.** Entity position deltas go on the wire in units
@@ -257,3 +329,31 @@ column of every trace keeps them honest. Hyperion aims with `f32::atan2` where
 vanilla uses `Mth.atan2`, a table approximation; the two agree to under a
 thousandth of a degree across every committed scenario, which is why the
 rotation tolerance is a fifth of a degree rather than zero.
+
+### The heading of an arrow that stops
+
+The terrain scenarios found this on their first run, which is the reason to
+write them.
+
+`AbstractArrow.tick` aims the arrow at lines 212-215, from the velocity it
+entered the tick with, and **before** the clip at line 218. So an arrow that
+meets a wall this tick still turns to face the way it was going, and then holds
+that heading for as long as it stays embedded, because the in-ground branch
+returns at line 199 without reaching the rotation again.
+
+Hyperion did the aiming inside the *miss* branch of
+`update_projectile_positions`, so an arrow that landed kept the heading it had
+one tick earlier -- exactly one `lerpRotation` step behind, forever:
+
+```
+arrow-into-wall: arrow pitch diverges at tick 4
+  vanilla:  -1.0176632
+  hyperion: -0.5419483780860901
+  delta:    4.757e-1 (tolerance 2e-1)
+```
+
+Nothing else could have found it. It is invisible in flight, where the next tick
+corrects it; it is invisible to every sky scenario, because they never stop; and
+it is invisible to the bow e2e checks, which read velocity rather than
+orientation. The fix is one line moved above the clip, and the comment there
+names the vanilla lines rather than the symptom.

--- a/nix/java/VanillaTrace.java
+++ b/nix/java/VanillaTrace.java
@@ -52,6 +52,7 @@ import java.net.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -72,6 +73,7 @@ import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.gizmos.GizmoCollector;
 import net.minecraft.gizmos.Gizmos;
 import net.minecraft.resources.Identifier;
@@ -103,11 +105,14 @@ import net.minecraft.world.entity.EntitySpawnReason;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.entity.projectile.arrow.AbstractArrow;
 import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.DataPackConfig;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.LevelSettings;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.WorldDataConfiguration;
 import net.minecraft.world.level.dimension.LevelStem;
 import net.minecraft.world.level.gamerules.GameRuleMap;
@@ -422,6 +427,13 @@ public final class VanillaTrace extends MinecraftServer {
                 }
             }
         }
+        // A declared block outside every entity's radius would be placed into a
+        // chunk that is not loaded, which `setBlock` answers by doing nothing
+        // and returning false -- a scenario whose wall silently is not there.
+        // Claiming its chunk is cheaper than detecting that later.
+        for (Scenario.BlockSpec spec : scenario.blocks) {
+            forced.add(new ChunkPos(spec.position[0] >> 4, spec.position[2] >> 4));
+        }
         for (ChunkPos pos : forced) {
             level.setChunkForced(pos.x(), pos.z(), true);
         }
@@ -435,6 +447,37 @@ public final class VanillaTrace extends MinecraftServer {
             }
         }
         return true;
+    }
+
+    /// Puts the scenario's declared blocks into the level, before any entity
+    /// exists to fly into them.
+    ///
+    /// `Block.UPDATE_CLIENTS` rather than `UPDATE_ALL`: a neighbour update runs
+    /// block logic, and block logic is where a recording would start consuming
+    /// randomness. There are no clients either way. The recorder's three-seed
+    /// agreement check is what would catch it if this were wrong.
+    ///
+    /// Default states only, deliberately. Naming a property here would mean
+    /// hyperion's replay parsing the same property string out of valence's
+    /// 1.20.1 tables, and the two default states agreeing is not something this
+    /// has to take on trust: a slab that came out `top` on one side and
+    /// `bottom` on the other moves the arrow's resting height half a block,
+    /// which is four orders of magnitude outside the position tolerance.
+    private void placeBlocks(ServerLevel level) {
+        for (Scenario.BlockSpec spec : scenario.blocks) {
+            Block block = BuiltInRegistries.BLOCK.getValue(Identifier.parse(spec.state));
+            if (block == null) {
+                throw new IllegalArgumentException("no such block: " + spec.state);
+            }
+            BlockPos pos = new BlockPos(spec.position[0], spec.position[1], spec.position[2]);
+            BlockState state = block.defaultBlockState();
+            if (!level.setBlock(pos, state, Block.UPDATE_CLIENTS)) {
+                throw new IllegalStateException("level refused the block " + spec.state + " at " + pos);
+            }
+        }
+        if (!scenario.blocks.isEmpty()) {
+            LOGGER.info("placed {} blocks", scenario.blocks.size());
+        }
     }
 
     private Entity spawn(ServerLevel level, Scenario.EntitySpec spec) {
@@ -514,6 +557,7 @@ public final class VanillaTrace extends MinecraftServer {
         if (tracked.isEmpty()) {
             warmup++;
             if (chunksReady(level)) {
+                placeBlocks(level);
                 for (Scenario.EntitySpec spec : scenario.entities) {
                     tracked.put(spec.id, spawn(level, spec));
                 }
@@ -532,6 +576,36 @@ public final class VanillaTrace extends MinecraftServer {
             halt(false);
         }
     }
+
+    /// `AbstractArrow.IN_GROUND`, the tracked field the client is told about.
+    ///
+    /// Reflected rather than read through `isInGround()`, which is `protected`,
+    /// and deliberately the *synched* value rather than a private boolean: it
+    /// is the thing that reaches a client, and it is what hyperion's
+    /// `metadata::arrow::InGround` mirrors. Its index rides along in the trace
+    /// header, so the field number hyperion hand-transcribes is checked against
+    /// the jar on every recording instead of being trusted (ENG-12106).
+    ///
+    /// Resolved on first use rather than in a static initialiser, and that is
+    /// not style: reading the field forces `AbstractArrow`'s superclass to
+    /// initialise, and `Entity.<clinit>` reaches `BuiltInRegistries` and throws
+    /// `Not bootstrapped`. A `static final` here runs before `main` has called
+    /// `Bootstrap.bootStrap()`, so it cannot work.
+    @SuppressWarnings("unchecked")
+    private static synchronized EntityDataAccessor<Boolean> arrowInGround() {
+        if (arrowInGround == null) {
+            try {
+                Field field = AbstractArrow.class.getDeclaredField("IN_GROUND");
+                field.setAccessible(true);
+                arrowInGround = (EntityDataAccessor<Boolean>) field.get(null);
+            } catch (ReflectiveOperationException error) {
+                throw new IllegalStateException("AbstractArrow no longer has an IN_GROUND accessor", error);
+            }
+        }
+        return arrowInGround;
+    }
+
+    private static EntityDataAccessor<Boolean> arrowInGround;
 
     private void sample() {
         JsonObject entities = new JsonObject();
@@ -552,6 +626,19 @@ public final class VanillaTrace extends MinecraftServer {
             rotation.add(entity.getXRot());
             state.add("rotation", rotation);
             state.addProperty("removed", entity.isRemoved());
+            // The impact state, and the reason a block scenario can assert
+            // anything at all. An arrow's resting position alone cannot tell
+            // "stopped by the wall" from "still flying and happening to be
+            // there this tick"; `inGround` can, and `shakeTime` pins the tick
+            // it landed on, since it counts down from seven.
+            //
+            // Absent for anything that is not an arrow rather than defaulted:
+            // `ThrowableProjectile` has no such state, and writing a false
+            // would claim a snowball was known not to be in the ground.
+            if (entity instanceof AbstractArrow arrow) {
+                state.addProperty("inGround", arrow.getEntityData().get(arrowInGround()));
+                state.addProperty("shakeTime", arrow.shakeTime);
+            }
             entities.add(entry.getKey(), state);
         }
         JsonObject sample = new JsonObject();
@@ -620,6 +707,7 @@ public final class VanillaTrace extends MinecraftServer {
         trace.addProperty("minecraftVersion", SharedConstants.getCurrentVersion().name());
         trace.addProperty("seed", seed);
         trace.addProperty("ticks", scenario.ticks);
+        trace.addProperty("inGroundFieldIndex", arrowInGround().id());
         JsonArray array = new JsonArray();
         samples.forEach(array::add);
         trace.add("samples", array);
@@ -640,6 +728,15 @@ public final class VanillaTrace extends MinecraftServer {
         private int ticks;
         private long seed;
         private List<EntitySpec> entities = List.of();
+        /// Terrain the scenario wants, and nothing else. Empty for every
+        /// scenario that flies through open sky, which is what keeps their
+        /// recordings byte-identical across this change.
+        private List<BlockSpec> blocks = List.of();
+
+        private static final class BlockSpec {
+            private int[] position;
+            private String state;
+        }
 
         private static final class EntitySpec {
             private String id;
@@ -693,6 +790,13 @@ public final class VanillaTrace extends MinecraftServer {
             }
             if (scenario.entities.isEmpty()) {
                 throw new IllegalArgumentException(scenario.name + ": no entities to record");
+            }
+            for (BlockSpec spec : scenario.blocks) {
+                Objects.requireNonNull(spec.state, scenario.name + ": block is missing a state");
+                if (spec.position == null || spec.position.length != 3) {
+                    throw new IllegalArgumentException(
+                            scenario.name + ": block position must be three integers");
+                }
             }
             for (EntitySpec spec : scenario.entities) {
                 Objects.requireNonNull(spec.id, "entity is missing an id");


### PR DESCRIPTION
Follows #1125, which is merged; this branch is rebased onto it.

## What was missing

Every committed differential scenario flew through empty air. So the whole of the block-collision work — the 26.2 shape tables (#1118), the vanilla `clip` transcription (#1122), and `onHitBlock` (#1125) — was checked against unit tests and against a real client, and against Mojang's own answers not at all. `docs/differential-testing.md` said exactly that under "what this therefore does not prove":

> **Anything the arrow hits.** Every committed scenario flies through empty air. Block and entity collision, `inGround`, and despawn are recorded in the trace (`removed`) but no scenario exercises them yet.

## Three scenarios

| scenario | what it is for |
| --- | --- |
| `arrow-into-floor` | Straight down onto stone seven blocks below. Three ticks of flight, seventeen embedded, which is where the shake countdown is read. |
| `arrow-into-wall` | Dead level into a wall ten blocks along +Z, reached on the fourth tick after the arrow has already dropped a fifth of a block — so where it stops depends on clipping a vertical face, not on entering a cell. |
| `arrow-grazing-slab` | Level over a bottom slab and into a wall ten blocks behind it. A slab treated as a full cube stops the arrow at `z=9.95` instead of `z=19.95`. |

`arrow-into-floor` is worth reading for one detail. Vanilla's recorded resting position is `[0.5, 121.05, 0.45]`. The `y` is the surface plus the `0.05` back-off, as expected — but `z` moved by a full `0.05` too, on a shot fired straight down. `Mth.cos(90°)` is not exactly zero in vanilla's sine table, so `movement.z` is a hair positive, and `onHitBlock` scales `signum(movement)`, not the movement. hyperion agrees with it, which is #1125's `java_signum` earning its keep in a way no test written by hand would have thought to check.

## Terrain is opt-in, and the sky scenarios did not move

A scenario names the blocks it wants; one that names none runs in the empty world both sides always ran in. The four existing scenarios' recorded numbers are unchanged to the last digit — the only difference in those files is the two new impact fields and the header index, and their measured headroom is byte-identical to what it was before this branch:

```
ok: arrow-level-shot (60 ticks); worst position delta 4.964110533478561e-5 of 5e-4, ...
ok: snowball-throw (40 ticks);   worst position delta 1.4786633116159464e-5 of 4e-4, ...
```

That is checkable rather than asserted — strip the two new keys from the new files and they are the old files:

```python
new.pop("inGroundFieldIndex")
for s in new["samples"]:
    for e in s["entities"].values():
        e.pop("inGround"); e.pop("shakeTime")
assert old == new     # true for all four
```

The determinism claim covers them too, and it is checked rather than argued: the recorder replays every scenario under three different world seeds and refuses to emit a trace unless all three agree byte for byte. It emitted, so placing blocks reached nothing that consumes randomness.

Two implementation notes that are load bearing rather than incidental:

- **`setBlock` with `Block.UPDATE_CLIENTS`, not `UPDATE_ALL`.** A neighbour update runs block logic, and block logic is where a recording would start consuming randomness. There are no clients either way.
- **The replay loads the chunk before it places anything, and clears the blocks afterwards.** `HyperionCore` installs `Blocks::empty`, and `set_block` on an unloaded chunk quietly places nothing — a scenario whose wall silently was not there, with the comparison then blaming the physics. And every scenario shares one world (`HyperionCore` can only be imported once per process, ENG-12107) where vanilla records each in a fresh level, so a wall left standing would be in the next scenario's sky.

## The impact state, and a field index that now has to agree with the jar

An arrow's samples carry `inGround` and `shakeTime`, compared **exactly** — a flag and a countdown have no notion of "close". They are why a terrain scenario can assert anything at all: a resting position on its own cannot tell "stopped by the wall" from "still flying and happening to be there this tick".

`inGround` is read from the synched data rather than from `isInGround()`, which is `protected`. That means it is the value a client is actually sent, which is what `metadata::arrow::InGround` mirrors — and reaching the accessor means reflection. Since the reflection is happening anyway, the trace header records `inGroundFieldIndex`, and the replay asserts it against `InGround::INDEX` before it compares a single tick.

That number is the one thing in `crates/hyperion/src/simulation/metadata/` nothing else could check. A field index never appears on the wire, so no packet capture recovers it; getting it wrong neither fails to compile nor fails to send — it writes a boolean into whichever field Mojang moved into slot 10 and the arrow quietly does something else on the client. ENG-12106 is the general version for every other hand-transcribed index; this closes it for the one index this branch adds.

## What the gate found on its first run

`AbstractArrow.tick` aims the arrow at lines 212-215, from the velocity it entered the tick with, and **before** the clip at line 218. So an arrow that meets a wall this tick still turns to face the way it was going, and then holds that heading for as long as it stays embedded, because the in-ground branch returns at line 199 without reaching the rotation again.

hyperion did the aiming inside the *miss* branch of `update_projectile_positions`, so an arrow that landed kept the heading it had one tick earlier — exactly one `lerpRotation` step behind, forever:

```
arrow-into-wall: arrow pitch diverges at tick 4
  vanilla:  -1.0176632
  hyperion: -0.5419483780860901
  delta:    4.757e-1 (tolerance 2e-1)

arrow-grazing-slab: arrow pitch diverges at tick 7
  vanilla:  -2.9900265
  hyperion: -2.258925437927246
  delta:    7.311e-1 (tolerance 2e-1)
```

Nothing else could have found it. It is invisible in flight, where the next tick corrects it; invisible to every sky scenario, because they never stop; and invisible to both bow e2e checks, which read velocity rather than orientation. The fix is one aim moved above the clip.

## The residual gap, measured rather than assumed

The open question going in was whether a swept clip against block shapes would open a bigger gap than free flight does. It does not:

```
ok: arrow-into-floor (20 ticks);   worst position delta 3.386e-6 of 2e-4, velocity 1.285e-7 of 3e-6
ok: arrow-into-wall (20 ticks);    worst position delta 5.615e-6 of 2e-4, velocity 6.886e-8 of 3e-6
ok: arrow-grazing-slab (20 ticks); worst position delta 8.309e-6 of 1e-4, velocity 1.638e-7 of 3e-6
```

Those are *tighter* than the sixty-tick sky shots (3.4e-5 to 5.0e-5), for the ordinary reason that they run a third as long. `geometry::sweep::first_block_hit` computes in `f64` internally, so the only rounding on the impact path is the `f32` the segment's endpoints arrive as — the same single source of disagreement free flight has. **The residual gap is hyperion's `f32` positions and nothing else.**

The tolerances are the doc's own bound, `n * ulp(max |value|) / 2`, not a number tuned until it went green: twenty ticks at 128 blocks is `20 * 2^-17 = 1.5e-4` (committed `2e-4`), and at 121 blocks `20 * 2^-18 = 7.6e-5` (committed `1e-4`).

## Evidence

All on `aarch64-darwin`, on the branch head, rebased onto `main` after #1125 merged.

| gate | result |
| --- | --- |
| `cargo test -p hyperion` | green, 18 binaries |
| `cargo test -p smash` | green, 30 binaries |
| `checks.aarch64-darwin.clippy` | green |
| `checks.aarch64-darwin.rustfmt` | green |
| `checks.aarch64-darwin.differential-traces` | green — `recorded 7 scenarios under 3 seeds each`, and the committed copies match |
| `checks.aarch64-darwin.smash-dev-boot-e2e` | green — the dev profile boots and a real client joins |
| `checks.aarch64-darwin.bedwars-dev-boot-e2e` | green — same, and it is the event whose bow this touches |

The traces gate is the one to read twice. It re-records every scenario under three world seeds and refuses to emit unless all three agree byte for byte, then diffs the result against what is committed. Green means both that the terrain scenarios reached nothing random and that the committed recordings are the jar's current answer.

```
ok: arrow-arced-shot (60 ticks);     worst position delta 3.362e-5 of 5e-4, velocity 7.908e-7 of 1e-5, rotation 1.470e-4 of 2e-1
ok: arrow-crosswind-shot (30 ticks); worst position delta 2.068e-5 of 5e-4, velocity 3.783e-7 of 1e-5, rotation 8.375e-5 of 2e-1
ok: arrow-grazing-slab (20 ticks);   worst position delta 8.309e-6 of 1e-4, velocity 1.638e-7 of 3e-6, rotation 1.365e-5 of 2e-1
ok: arrow-into-floor (20 ticks);     worst position delta 3.386e-6 of 2e-4, velocity 1.285e-7 of 3e-6, rotation 1.000e-5 of 2e-1
ok: arrow-into-wall (20 ticks);      worst position delta 5.615e-6 of 2e-4, velocity 6.886e-8 of 3e-6, rotation 1.365e-5 of 2e-1
ok: arrow-level-shot (60 ticks);     worst position delta 4.964e-5 of 5e-4, velocity 1.420e-6 of 1e-5, rotation 1.140e-4 of 2e-1
ok: snowball-throw (40 ticks);       worst position delta 1.479e-5 of 4e-4, velocity 5.365e-7 of 3e-6, rotation 8.602e-5 of 2e-1
```

### Guards broken and watched failing

| broken | what happened |
| --- | --- |
| `metadata::arrow::InGround`'s index 10 → 9 | `the pinned jar puts AbstractArrow's IN_GROUND at index 10, and hyperion::simulation::metadata::arrow says 9; every arrow this server sends is writing the wrong tracked field` |
| the replay places `stone` where the scenario says `stone_slab` | `arrow-grazing-slab: arrow shakeTime diverges at tick 4 — vanilla: 0, hyperion: Some(7)`: hyperion embedded in the slab three ticks before vanilla reached the wall |
| `**in_ground = true` on impact deleted | `arrow-into-floor: arrow inGround diverges at tick 3 — vanilla: true, hyperion: Some(false)` |

## Not done

- **Entity collision and despawn.** `removed` is still recorded and still unasserted, and no scenario puts a second entity in an arrow's path. The doc's not-proven list now says exactly that instead of claiming nothing an arrow hits is covered.
- **Block states with properties.** A scenario names a block and both sides place its default state. Naming `minecraft:stone_slab[type=top]` would mean the replay parsing property strings out of valence's 1.20.1 tables; nothing needs it yet, and a default that disagreed between the two registries is caught by the comparison rather than trusted.
- **Water, lava, portals** — unchanged from the existing list.

AI disclosure: written by Claude Opus via Claude Code.
