### PR TITLE
docs(ci): retire the bedwars-bow-e2e flake term, which was never a flake

### DIFF
--- a/nix/ci/flake-gate.nix
+++ b/nix/ci/flake-gate.nix
@@ -57,6 +57,29 @@
 #      bisection retries carry the same rate. `delta-gate.sh flake-rate` reports
 #      this against the instability record.
 #
+#      The `bedwars-bow-e2e 11%` term is retired, and it was never a flake.
+#      The measurement stands as a measurement -- it is what those 18 runs did
+#      -- but what it measured was a check asserting on a packet that never
+#      described an impact, which passed or failed on whether a channel
+#      subscription happened to be answered before or after the arrow stopped.
+#      It read 11% here and ~75% two days later on the same tree for that
+#      reason. #1125 replaced the assertion; six forced-rebuild runs on
+#      e637f712 passed six times, with the per-run broadcast count varying 23
+#      to 37, which is the same timing spread the old check was keyed on and
+#      the new one is not. Re-measure before quoting a rate for it. ENG-12085.
+#
+#      Whoever re-measures LOCALLY: force every repeat. `nix build` of an
+#      already-successful check is answered from the store and does not run
+#      anything -- one sample in the six above came back rc=0 with three lines
+#      of log and had to be discarded -- so `--rebuild` on every repeat, and
+#      print the log length beside each result, or a stuck pass reads as a
+#      streak. Failures are not cached and do re-execute, which is exactly why
+#      an uncorrected count skews optimistic. Whether the same hazard reaches
+#      the CI-fed record below is untested: `dg_merge_instability` folds one
+#      run's results per CI run, and if that pipeline can substitute a check's
+#      output rather than build it, a substituted pass enters the record as a
+#      sample that never ran. Unverified, so not claimed -- ENG-12120.
+#
 #   2. AT LEAST 30 RUNS in the instability record. P(a check flaking at rate q
 #      is proven within n same-derivation samples) is 1 - q^n - (1-q)^n. At
 #      n=18 an 11% flake is still 12% likely to be unproven; n=30 puts anything


### PR DESCRIPTION
Comment-only change to one file. Amends the record the team lead asked me to correct after the pre-#1111 bisect.

## Why

`nix/ci/flake-gate.nix`'s first entry criterion names three checks that "fail at random", and one of them did not:

```
(smash-hud-e2e 44%, differential-traces 39%, bedwars-bow-e2e 11%)
```

`bedwars-bow-e2e` was asserting on a *second* `AddEntity` packet, on the stated grounds that the server re-sends a pinned arrow. It does not. That packet is `send_subscribe_channel_packets` replaying the spawn for a client that has just subscribed, and it carries whatever the arrow's velocity happens to be at that moment — so the check passed or failed on whether the subscription was answered before or after the arrow stopped. That is why it read 11% here and ~75% two days later on the same tree (ENG-12085).

The bisect is what settled it. Pre-#1111 (`11381fe`) it was 3/3 green, and the packet trace says why:

```
3.40s <- AddEntity id=850 at (5.50, 24.62,  3.00) motion=(0,0,3.000)
3.40s <- AddEntity id=850 at (0.50,  4.00, 40.00) motion=(0,0,0.000)
```

Muzzle at `z=3.00`, "impact" at `z=40.00` — 37 blocks downrange, in the same 10 ms, at 3 blocks a tick. `x` varies and `y` drops 20, but `z` is exactly `40.00` every time. That is the overlong-ray teleport #1111's own commit message describes removing. **The green was produced by the bug #1111 fixed**, so this is not a server regression and should not be recorded as one.

#1125 replaced the assertion. Six forced-rebuild runs on `e637f712` passed six times, with the per-run broadcast count varying 23 to 37 — the same timing spread the old check was keyed on, and the new one is not.

## What changed, and what deliberately did not

**The 11% stays.** It is what those 18 runs did, and rewriting a dated measurement to match a later understanding would falsify the record rather than correct it. What is added is that the term is retired and wants re-measuring before anyone quotes a rate for it.

**The second paragraph is the part that outlives this one check.** A local re-measurement has to force every repeat:

```
run 1 (234 lines): RESULT: ok
run 2  (83 lines): RESULT: ok
run 3   (3 lines): rc=0, no build log at all -- the cache answered
run 4  (82 lines): RESULT: ok
```

Run 3 exits 0 and is indistinguishable from a real pass except by log length. `nix build` of an already-successful check is answered from the store and executes nothing. The skew has a direction worth stating: failures are never cached and always re-execute, so an uncorrected repeat-count is *optimistic*, not merely noisy.

Whether the same hazard reaches the CI-fed instability record — `dg_merge_instability` folds one run's results per CI run, keyed on `drvPath` — is **untested**, so the comment says so rather than claiming it. ENG-12120 says what would settle it, and why the cheap first step (record whether a result was built or substituted) is worth doing regardless of the answer.

## Evidence

`checks.aarch64-darwin.fmt`, `checks.aarch64-darwin.lint` and `nix eval .#checks.aarch64-darwin.bedwars-bow-e2e.drvPath` all green on this branch. No derivation changes — the diff is comment text in one file.

Refs ENG-12085, ENG-12120.

AI disclosure: written by Claude Opus via Claude Code.
