### PR TITLE
style(hyperion): fix the second fmt red on main today (ENG-12122 instance)

### DIFF
--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -527,7 +527,16 @@ impl Module for EntityStateSyncModule {
         .each_iter(
             |it,
              row,
-             (position, velocity, owner, connection_id, mut yaw, mut pitch, in_ground, mut shake)| {
+             (
+                position,
+                velocity,
+                owner,
+                connection_id,
+                mut yaw,
+                mut pitch,
+                in_ground,
+                mut shake,
+            )| {
                 if let Some(_connection_id) = connection_id {
                     return;
                 }
@@ -599,8 +608,8 @@ impl Module for EntityStateSyncModule {
                     // differential gate caught it: `arrow-into-wall` pitch was
                     // -0.542 against vanilla's -1.018, exactly one `lerpRotation`
                     // step behind.
-                    let aims_before_moving = motion
-                        .is_some_and(|motion| motion.order == MotionOrder::MoveThenDecay);
+                    let aims_before_moving =
+                        motion.is_some_and(|motion| motion.order == MotionOrder::MoveThenDecay);
                     if aims_before_moving {
                         aim_along(yaw.as_deref_mut(), pitch.as_deref_mut(), velocity.0);
                     }

--- a/crates/hyperion/tests/differential.rs
+++ b/crates/hyperion/tests/differential.rs
@@ -290,9 +290,9 @@ fn set_terrain(world: &World, blocks: &[BlockSpec], state_for: impl Fn(&BlockSpe
         for spec in blocks {
             let state = state_for(spec);
             let position = IVec3::new(spec.position[0], spec.position[1], spec.position[2]);
-            store
-                .set_block(position, state)
-                .unwrap_or_else(|error| panic!("could not place {} at {position}: {error:?}", spec.state));
+            store.set_block(position, state).unwrap_or_else(|error| {
+                panic!("could not place {} at {position}: {error:?}", spec.state)
+            });
         }
     });
 }
@@ -341,8 +341,8 @@ fn replay(world: &World, scenario: &Scenario, trace: &Trace) -> Result<Headroom,
         trace.in_ground_field_index,
         InGround::INDEX,
         "the pinned jar puts AbstractArrow's IN_GROUND at index {}, and \
-         hyperion::simulation::metadata::arrow says {}; every arrow this server sends is \
-         writing the wrong tracked field",
+         hyperion::simulation::metadata::arrow says {}; every arrow this server sends is writing \
+         the wrong tracked field",
         trace.in_ground_field_index,
         InGround::INDEX,
     );
@@ -480,8 +480,8 @@ fn replay(world: &World, scenario: &Scenario, trace: &Trace) -> Result<Headroom,
                 let in_ground = entity.try_get::<&InGround>(|flag| **flag);
                 if in_ground != Some(expected_in_ground) {
                     outcome = Err(format!(
-                        "{}: {id} inGround diverges at tick {}\n  vanilla:  {expected_in_ground}\n  \
-                         hyperion: {in_ground:?}",
+                        "{}: {id} inGround diverges at tick {}\n  vanilla:  \
+                         {expected_in_ground}\n  hyperion: {in_ground:?}",
                         scenario.name, sample.tick,
                     ));
                 }


### PR DESCRIPTION
cargo fmt output on the two files #1125/#1129's squashes left drifted. checks.fmt rc=0 on this branch; cargo nextest -p hyperion green. The class fix (required_status_checks on the ruleset + a pull_request-triggered workflow) is ENG-12122 and needs Andrew's call.

(authored by Claude Fable 5 via Claude Code)