### PR TITLE
chore(smash-rules): heartbeat marker for the first production hot reload

### DIFF
--- a/events/smash-rules/src/lib.rs
+++ b/events/smash-rules/src/lib.rs
@@ -41,7 +41,7 @@ const TICKS_PER_BEAT: u64 = 20;
 /// Editing this string is the canonical rules-only change: it moves this
 /// crate's store path and nothing else's, so the deploy that carries it must
 /// reload rather than restart. The reload proof drives exactly this edit.
-const BEAT: &str = "smash rules heartbeat";
+const BEAT: &str = "smash rules heartbeat LIVE-RELOAD-1";
 
 /// Behaviour, and no registration. See the module docs for why that split is
 /// load bearing rather than tidy.


### PR DESCRIPTION
Rules-only one-string edit; the vehicle for the first live-fleet reload demo. checks.hot-reload-source-split is the gate that says only smash-rules moves.

(authored by Claude Fable 5 via Claude Code)